### PR TITLE
Added more prefixes for electric potential

### DIFF
--- a/Src/Scripts/UnitDefinitions/ElectricPotential.json
+++ b/Src/Scripts/UnitDefinitions/ElectricPotential.json
@@ -8,7 +8,7 @@
             "PluralName": "Volts",
             "FromUnitToBaseFunc": "x",
             "FromBaseToUnitFunc": "x",
-            "Prefixes": ["Micro","Milli","Kilo"],
+            "Prefixes": ["Micro","Milli","Kilo","Mega"],
             "Localization": [
                 {
                     "Culture": "en-US",

--- a/Src/UnitsNet/GeneratedCode/Enums/ElectricPotentialUnit.g.cs
+++ b/Src/UnitsNet/GeneratedCode/Enums/ElectricPotentialUnit.g.cs
@@ -26,6 +26,7 @@ namespace UnitsNet.Units
     {
         Undefined = 0,
         Kilovolt,
+        Megavolt,
         Microvolt,
         Millivolt,
         Volt,

--- a/Src/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
+++ b/Src/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
@@ -56,6 +56,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get ElectricPotential in Megavolts.
+        /// </summary>
+        public double Megavolts
+        {
+            get { return (_volts) / 1e6d; }
+        }
+
+        /// <summary>
         ///     Get ElectricPotential in Microvolts.
         /// </summary>
         public double Microvolts
@@ -97,6 +105,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get ElectricPotential from Megavolts.
+        /// </summary>
+        public static ElectricPotential FromMegavolts(double megavolts)
+        {
+            return new ElectricPotential((megavolts) * 1e6d);
+        }
+
+        /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
         public static ElectricPotential FromMicrovolts(double microvolts)
@@ -133,6 +149,8 @@ namespace UnitsNet
             {
                 case ElectricPotentialUnit.Kilovolt:
                     return FromKilovolts(value);
+                case ElectricPotentialUnit.Megavolt:
+                    return FromMegavolts(value);
                 case ElectricPotentialUnit.Microvolt:
                     return FromMicrovolts(value);
                 case ElectricPotentialUnit.Millivolt:
@@ -274,6 +292,8 @@ namespace UnitsNet
             {
                 case ElectricPotentialUnit.Kilovolt:
                     return Kilovolts;
+                case ElectricPotentialUnit.Megavolt:
+                    return Megavolts;
                 case ElectricPotentialUnit.Microvolt:
                     return Microvolts;
                 case ElectricPotentialUnit.Millivolt:

--- a/Src/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/Src/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -187,6 +187,12 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("en-US", "kV"),
                                 new AbbreviationsForCulture("ru-RU", "kВ"),
                             }),
+                        new CulturesForEnumValue((int) ElectricPotentialUnit.Megavolt,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "MV"),
+                                new AbbreviationsForCulture("ru-RU", "MВ"),
+                            }),
                         new CulturesForEnumValue((int) ElectricPotentialUnit.Microvolt,
                             new[]
                             {

--- a/Tests/CustomCode/ElectricPotentialTests.cs
+++ b/Tests/CustomCode/ElectricPotentialTests.cs
@@ -42,5 +42,10 @@ namespace UnitsNet.Tests.CustomCode
         {
             get { return 1e-3; }
         }
+
+        protected override double MegavoltsInOneVolt
+        {
+            get { return 1e-6; }
+        }
     }
 }

--- a/Tests/GeneratedCode/ElectricPotentialTestsBase.g.cs
+++ b/Tests/GeneratedCode/ElectricPotentialTestsBase.g.cs
@@ -37,12 +37,14 @@ namespace UnitsNet.Tests
     public abstract partial class ElectricPotentialTestsBase
     {
         protected abstract double KilovoltsInOneVolt { get; }
+        protected abstract double MegavoltsInOneVolt { get; }
         protected abstract double MicrovoltsInOneVolt { get; }
         protected abstract double MillivoltsInOneVolt { get; }
         protected abstract double VoltsInOneVolt { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double KilovoltsTolerance { get { return 1e-5; } }
+        protected virtual double MegavoltsTolerance { get { return 1e-5; } }
         protected virtual double MicrovoltsTolerance { get { return 1e-5; } }
         protected virtual double MillivoltsTolerance { get { return 1e-5; } }
         protected virtual double VoltsTolerance { get { return 1e-5; } }
@@ -53,6 +55,7 @@ namespace UnitsNet.Tests
         {
             ElectricPotential volt = ElectricPotential.FromVolts(1);
             Assert.AreEqual(KilovoltsInOneVolt, volt.Kilovolts, KilovoltsTolerance);
+            Assert.AreEqual(MegavoltsInOneVolt, volt.Megavolts, MegavoltsTolerance);
             Assert.AreEqual(MicrovoltsInOneVolt, volt.Microvolts, MicrovoltsTolerance);
             Assert.AreEqual(MillivoltsInOneVolt, volt.Millivolts, MillivoltsTolerance);
             Assert.AreEqual(VoltsInOneVolt, volt.Volts, VoltsTolerance);
@@ -62,6 +65,7 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             Assert.AreEqual(1, ElectricPotential.From(1, ElectricPotentialUnit.Kilovolt).Kilovolts, KilovoltsTolerance);
+            Assert.AreEqual(1, ElectricPotential.From(1, ElectricPotentialUnit.Megavolt).Megavolts, MegavoltsTolerance);
             Assert.AreEqual(1, ElectricPotential.From(1, ElectricPotentialUnit.Microvolt).Microvolts, MicrovoltsTolerance);
             Assert.AreEqual(1, ElectricPotential.From(1, ElectricPotentialUnit.Millivolt).Millivolts, MillivoltsTolerance);
             Assert.AreEqual(1, ElectricPotential.From(1, ElectricPotentialUnit.Volt).Volts, VoltsTolerance);
@@ -72,6 +76,7 @@ namespace UnitsNet.Tests
         {
             var volt = ElectricPotential.FromVolts(1);
             Assert.AreEqual(KilovoltsInOneVolt, volt.As(ElectricPotentialUnit.Kilovolt), KilovoltsTolerance);
+            Assert.AreEqual(MegavoltsInOneVolt, volt.As(ElectricPotentialUnit.Megavolt), MegavoltsTolerance);
             Assert.AreEqual(MicrovoltsInOneVolt, volt.As(ElectricPotentialUnit.Microvolt), MicrovoltsTolerance);
             Assert.AreEqual(MillivoltsInOneVolt, volt.As(ElectricPotentialUnit.Millivolt), MillivoltsTolerance);
             Assert.AreEqual(VoltsInOneVolt, volt.As(ElectricPotentialUnit.Volt), VoltsTolerance);
@@ -82,6 +87,7 @@ namespace UnitsNet.Tests
         {
             ElectricPotential volt = ElectricPotential.FromVolts(1);
             Assert.AreEqual(1, ElectricPotential.FromKilovolts(volt.Kilovolts).Volts, KilovoltsTolerance);
+            Assert.AreEqual(1, ElectricPotential.FromMegavolts(volt.Megavolts).Volts, MegavoltsTolerance);
             Assert.AreEqual(1, ElectricPotential.FromMicrovolts(volt.Microvolts).Volts, MicrovoltsTolerance);
             Assert.AreEqual(1, ElectricPotential.FromMillivolts(volt.Millivolts).Volts, MillivoltsTolerance);
             Assert.AreEqual(1, ElectricPotential.FromVolts(volt.Volts).Volts, VoltsTolerance);


### PR DESCRIPTION
Millivolts and kilovolts are very commonly used. Microvolts are less common but still useful in certain situations.
