### PR TITLE
Feature: Amplitude (voltage) ratio

### DIFF
--- a/Src/Scripts/UnitDefinitions/AmplitudeRatio.json
+++ b/Src/Scripts/UnitDefinitions/AmplitudeRatio.json
@@ -1,0 +1,45 @@
+﻿{
+    "Name": "AmplitudeRatio",
+    "BaseUnit": "DecibelVolt",
+    "Logarithmic" : "True",
+    "LogarithmicScalingFactor" : "2",
+    "XmlDoc": "The strength of a signal expressed in decibels (dB) relative to one volt RMS.",
+    "Units": [
+        {
+            "SingularName": "DecibelVolt",
+            "PluralName": "DecibelVolts",
+            "FromUnitToBaseFunc": "x",
+            "FromBaseToUnitFunc": "x",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": ["dBV"]
+                }
+            ]
+        },
+        {
+            "SingularName": "DecibelMicrovolt",
+            "PluralName": "DecibelMicrovolts",
+            "FromUnitToBaseFunc": "x - 120",
+            "FromBaseToUnitFunc": "x + 120",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": ["dBµV"]
+                }
+            ]
+        },
+        {
+            "SingularName": "DecibelMillivolt",
+            "PluralName": "DecibelMillivolts",
+            "FromUnitToBaseFunc": "x - 60",
+            "FromBaseToUnitFunc": "x + 60",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": ["dBmV"]
+                }
+            ]
+        }
+    ]
+}

--- a/Src/UnitsNet/CustomCode/UnitClasses/AmplitudeRatio.extra.cs
+++ b/Src/UnitsNet/CustomCode/UnitClasses/AmplitudeRatio.extra.cs
@@ -1,0 +1,124 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace UnitsNet
+{
+    using System;
+
+    /// <summary>
+    /// Extension methods for <see cref="AmplitudeRatio"/>.
+    /// </summary>
+    public static class AmplitudeRatioExtensions
+    {
+        /// <summary>
+        ///     Gets an <see cref="ElectricPotential"/> from <see cref="AmplitudeRatio"/>.
+        /// </summary>
+        /// <paramref name="amplitudeRatio">The amplitude ratio to convert.</paramref>
+        /// <remarks>
+        /// Provides a nicer syntax for converting an amplitude ratio back to a voltage.
+        /// <example><c>var voltage = voltageRatio.ToElectricPotential();</c></example>
+        /// </remarks>
+        public static ElectricPotential ToElectricPotential(this AmplitudeRatio amplitudeRatio)
+        {
+            return AmplitudeRatio.ToElectricPotential(amplitudeRatio);
+        }
+
+        /// <summary>
+        ///     Converts a <see cref="AmplitudeRatio"/> to a <see cref="PowerRatio"/>.
+        /// </summary>
+        /// <param name="amplitudeRatio">The amplitude ratio to convert.</param>
+        /// <param name="impedance">The input impedance of the load. This is usually 50, 75 or 600 ohms.</param>
+        /// <remarks>http://www.maximintegrated.com/en/app-notes/index.mvp/id/808</remarks>
+        public static PowerRatio ToPowerRatio(this AmplitudeRatio amplitudeRatio, ElectricResistance impedance)
+        {
+            return AmplitudeRatio.ToPowerRatio(amplitudeRatio, impedance);
+        }
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="ElectricPotential"/>.
+    /// </summary>
+    public static class ElectricPotentialExtensions
+    {
+        /// <summary>
+        ///     Gets an <see cref="AmplitudeRatio"/> in decibels (dB) relative to 1 volt RMS from an <see cref="ElectricPotential"/>.
+        /// </summary>
+        /// <remarks>
+        /// Provides a nicer syntax for converting a voltage to an amplitude ratio (relative to 1 volt RMS).
+        /// <example><c>var voltageRatio = voltage.ToAmplitudeRatio();</c></example>
+        /// </remarks>
+        public static AmplitudeRatio ToAmplitudeRatio(this ElectricPotential voltage)
+        {
+            return AmplitudeRatio.FromElectricPotential(voltage);
+        }
+    }
+
+    public partial struct AmplitudeRatio
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AmplitudeRatio"/> struct from the specified electric potential 
+        /// referenced to one volt RMS. This assumes both the specified electric potential and the one volt reference have the same 
+        /// resistance.
+        /// </summary>
+        /// <param name="voltage">The electric potential referenced to one volt.</param>
+        public AmplitudeRatio(ElectricPotential voltage)
+            : this()
+        {
+            if (voltage.Volts <= 0)
+                throw new ArgumentOutOfRangeException(
+                    "voltage", "The base-10 logarithm of a number ≤ 0 is undefined. Voltage must be greater than 0 V.");
+
+            // E(dBV) = 20*log10(value(V)/reference(V))
+            _decibelVolts = 20 * Math.Log10(voltage / ElectricPotential.FromVolts(1));
+        }
+
+        /// <summary>
+        ///     Gets an <see cref="AmplitudeRatio"/> in decibels (dB) relative to 1 volt RMS from an <see cref="ElectricPotential"/>.
+        /// </summary>
+        /// <param name="voltage">The voltage (electric potential) relative to one volt RMS.</param>
+        public static AmplitudeRatio FromElectricPotential(ElectricPotential voltage)
+        {
+            return new AmplitudeRatio(voltage);
+        }
+
+        /// <summary>
+        ///     Gets an <see cref="ElectricPotential"/> from <see cref="AmplitudeRatio"/>.
+        /// </summary>
+        /// <param name="voltageRatio">The voltage ratio to convert to voltage (electric potential).</param>
+        public static ElectricPotential ToElectricPotential(AmplitudeRatio voltageRatio)
+        {
+            // E(V) = 1V * 10^(E(dBV)/20)
+            return ElectricPotential.FromVolts(Math.Pow(10, voltageRatio._decibelVolts / 20));
+        }
+
+        /// <summary>
+        ///     Converts a <see cref="AmplitudeRatio"/> to a <see cref="PowerRatio"/>.
+        /// </summary>
+        /// <param name="amplitudeRatio">The amplitude ratio to convert.</param>
+        /// <param name="impedance">The input impedance of the load. This is usually 50, 75 or 600 ohms.</param>
+        /// <remarks>http://www.maximintegrated.com/en/app-notes/index.mvp/id/808</remarks>
+        public static PowerRatio ToPowerRatio(AmplitudeRatio amplitudeRatio, ElectricResistance impedance)
+        {
+            // P(dBW) = E(dBV) - 10*log10(Z(Ω)/1)
+            return PowerRatio.FromDecibelWatts(amplitudeRatio.DecibelVolts - 10 * Math.Log10(impedance.Ohms / 1));
+        }
+    }
+}

--- a/Src/UnitsNet/CustomCode/UnitClasses/PowerRatio.extra.cs
+++ b/Src/UnitsNet/CustomCode/UnitClasses/PowerRatio.extra.cs
@@ -39,6 +39,16 @@ namespace UnitsNet
         {
             return PowerRatio.ToPower(powerRatio);
         }
+
+        /// <summary>
+        ///     Gets a <see cref="AmplitudeRatio"/> from a <see cref="PowerRatio"/>.
+        /// </summary>
+        /// <param name="powerRatio">The power ratio.</param>
+        /// <param name="impedance">The input impedance of the load. This is usually 50, 75 or 600 ohms.</param>
+        public static AmplitudeRatio ToAmplitudeRatio(this PowerRatio powerRatio, ElectricResistance impedance)
+        {
+            return PowerRatio.ToAmplitudeRatio(powerRatio, impedance);
+        }
     }
 
     /// <summary>
@@ -93,6 +103,18 @@ namespace UnitsNet
         {
             // P(W) = 1W * 10^(P(dBW)/10)
             return Power.FromWatts(Math.Pow(10, powerRatio._decibelWatts / 10));
+        }
+
+        /// <summary>
+        ///     Gets a <see cref="AmplitudeRatio"/> from a <see cref="PowerRatio"/>.
+        /// </summary>
+        /// <param name="powerRatio">The power ratio.</param>
+        /// <param name="impedance">The input impedance of the load. This is usually 50, 75 or 600 ohms.</param>
+        /// <remarks>http://www.maximintegrated.com/en/app-notes/index.mvp/id/808</remarks>
+        public static AmplitudeRatio ToAmplitudeRatio(PowerRatio powerRatio, ElectricResistance impedance)
+        {
+            // E(dBV) = 10*log10(Z(Ω)/1) + P(dBW)
+            return AmplitudeRatio.FromDecibelVolts(10 * Math.Log10(impedance.Ohms / 1) + powerRatio.DecibelWatts);
         }
     }
 }

--- a/Src/UnitsNet/GeneratedCode/Enums/AmplitudeRatioUnit.g.cs
+++ b/Src/UnitsNet/GeneratedCode/Enums/AmplitudeRatioUnit.g.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// ReSharper disable once CheckNamespace
+namespace UnitsNet.Units
+{
+    public enum AmplitudeRatioUnit
+    {
+        Undefined = 0,
+        DecibelMicrovolt,
+        DecibelMillivolt,
+        DecibelVolt,
+    }
+}

--- a/Src/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
+++ b/Src/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
@@ -1,0 +1,319 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using JetBrains.Annotations;
+using UnitsNet.Units;
+
+// ReSharper disable once CheckNamespace
+
+namespace UnitsNet
+{
+    /// <summary>
+    ///     The strength of a signal expressed in decibels (dB) relative to one volt RMS.
+    /// </summary>
+    // ReSharper disable once PartialTypeWithSinglePart
+    public partial struct AmplitudeRatio : IComparable, IComparable<AmplitudeRatio>
+    {
+        /// <summary>
+        ///     Base unit of AmplitudeRatio.
+        /// </summary>
+        private readonly double _decibelVolts;
+
+        public AmplitudeRatio(double decibelvolts) : this()
+        {
+            _decibelVolts = decibelvolts;
+        }
+
+        #region Properties
+
+        /// <summary>
+        ///     Get AmplitudeRatio in DecibelMicrovolts.
+        /// </summary>
+        public double DecibelMicrovolts
+        {
+            get { return _decibelVolts + 120; }
+        }
+
+        /// <summary>
+        ///     Get AmplitudeRatio in DecibelMillivolts.
+        /// </summary>
+        public double DecibelMillivolts
+        {
+            get { return _decibelVolts + 60; }
+        }
+
+        /// <summary>
+        ///     Get AmplitudeRatio in DecibelVolts.
+        /// </summary>
+        public double DecibelVolts
+        {
+            get { return _decibelVolts; }
+        }
+
+        #endregion
+
+        #region Static 
+
+        public static AmplitudeRatio Zero
+        {
+            get { return new AmplitudeRatio(); }
+        }
+
+        /// <summary>
+        ///     Get AmplitudeRatio from DecibelMicrovolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMicrovolts(double decibelmicrovolts)
+        {
+            return new AmplitudeRatio(decibelmicrovolts - 120);
+        }
+
+        /// <summary>
+        ///     Get AmplitudeRatio from DecibelMillivolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMillivolts(double decibelmillivolts)
+        {
+            return new AmplitudeRatio(decibelmillivolts - 60);
+        }
+
+        /// <summary>
+        ///     Get AmplitudeRatio from DecibelVolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelVolts(double decibelvolts)
+        {
+            return new AmplitudeRatio(decibelvolts);
+        }
+
+
+        /// <summary>
+        ///     Dynamically convert from value and unit enum <see cref="AmplitudeRatioUnit" /> to <see cref="AmplitudeRatio" />.
+        /// </summary>
+        /// <param name="value">Value to convert from.</param>
+        /// <param name="fromUnit">Unit to convert from.</param>
+        /// <returns>AmplitudeRatio unit value.</returns>
+        public static AmplitudeRatio From(double value, AmplitudeRatioUnit fromUnit)
+        {
+            switch (fromUnit)
+            {
+                case AmplitudeRatioUnit.DecibelMicrovolt:
+                    return FromDecibelMicrovolts(value);
+                case AmplitudeRatioUnit.DecibelMillivolt:
+                    return FromDecibelMillivolts(value);
+                case AmplitudeRatioUnit.DecibelVolt:
+                    return FromDecibelVolts(value);
+
+                default:
+                    throw new NotImplementedException("fromUnit: " + fromUnit);
+            }
+        }
+
+        /// <summary>
+        ///     Get unit abbreviation string.
+        /// </summary>
+        /// <param name="unit">Unit to get abbreviation for.</param>
+        /// <param name="culture">Culture to use for localization. Defaults to Thread.CurrentUICulture.</param>
+        /// <returns>Unit abbreviation string.</returns>
+        [UsedImplicitly]
+        public static string GetAbbreviation(AmplitudeRatioUnit unit, CultureInfo culture = null)
+        {
+            return UnitSystem.GetCached(culture).GetDefaultAbbreviation(unit);
+        }
+
+        #endregion
+
+        #region Logarithmic Arithmetic Operators
+
+        public static AmplitudeRatio operator -(AmplitudeRatio right)
+        {
+            return new AmplitudeRatio(-right._decibelVolts);
+        }
+
+        public static AmplitudeRatio operator +(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            // Logarithmic addition
+            // Formula: 20*log10(10^(x/20) + 10^(y/20))
+            return new AmplitudeRatio(20*Math.Log10(Math.Pow(10, left._decibelVolts/20) + Math.Pow(10, right._decibelVolts/20)));
+        }
+
+        public static AmplitudeRatio operator -(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            // Logarithmic subtraction 
+            // Formula: 20*log10(10^(x/20) - 10^(y/20))
+            return new AmplitudeRatio(20*Math.Log10(Math.Pow(10, left._decibelVolts/20) - Math.Pow(10, right._decibelVolts/20)));
+        }
+
+        public static AmplitudeRatio operator *(double left, AmplitudeRatio right)
+        {
+            // Logarithmic multiplication = addition
+            return new AmplitudeRatio(left + right._decibelVolts);
+        }
+
+        public static AmplitudeRatio operator *(AmplitudeRatio left, double right)
+        {
+            // Logarithmic multiplication = addition
+            return new AmplitudeRatio(left._decibelVolts + (double)right);
+        }
+
+        public static AmplitudeRatio operator /(AmplitudeRatio left, double right)
+        {
+            // Logarithmic division = subtraction
+            return new AmplitudeRatio(left._decibelVolts - (double)right);
+        }
+
+        public static double operator /(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            // Logarithmic division = subtraction
+            return Convert.ToDouble(left._decibelVolts - right._decibelVolts);
+        }
+
+        #endregion
+
+        #region Equality / IComparable
+
+        public int CompareTo(object obj)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            if (!(obj is AmplitudeRatio)) throw new ArgumentException("Expected type AmplitudeRatio.", "obj");
+            return CompareTo((AmplitudeRatio) obj);
+        }
+
+        public int CompareTo(AmplitudeRatio other)
+        {
+            return _decibelVolts.CompareTo(other._decibelVolts);
+        }
+
+        public static bool operator <=(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            return left._decibelVolts <= right._decibelVolts;
+        }
+
+        public static bool operator >=(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            return left._decibelVolts >= right._decibelVolts;
+        }
+
+        public static bool operator <(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            return left._decibelVolts < right._decibelVolts;
+        }
+
+        public static bool operator >(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            return left._decibelVolts > right._decibelVolts;
+        }
+
+        public static bool operator ==(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return left._decibelVolts == right._decibelVolts;
+        }
+
+        public static bool operator !=(AmplitudeRatio left, AmplitudeRatio right)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return left._decibelVolts != right._decibelVolts;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return _decibelVolts.Equals(((AmplitudeRatio) obj)._decibelVolts);
+        }
+
+        public override int GetHashCode()
+        {
+            return _decibelVolts.GetHashCode();
+        }
+
+        #endregion
+
+        #region Conversion
+
+        /// <summary>
+        ///     Convert to the unit representation <paramref name="unit" />.
+        /// </summary>
+        /// <returns>Value in new unit if successful, exception otherwise.</returns>
+        /// <exception cref="NotImplementedException">If conversion was not successful.</exception>
+        public double As(AmplitudeRatioUnit unit)
+        {
+            switch (unit)
+            {
+                case AmplitudeRatioUnit.DecibelMicrovolt:
+                    return DecibelMicrovolts;
+                case AmplitudeRatioUnit.DecibelMillivolt:
+                    return DecibelMillivolts;
+                case AmplitudeRatioUnit.DecibelVolt:
+                    return DecibelVolts;
+
+                default:
+                    throw new NotImplementedException("unit: " + unit);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        ///     Get string representation of value and unit.
+        /// </summary>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <returns>String representation.</returns>
+        [UsedImplicitly]
+        public string ToString(AmplitudeRatioUnit unit, CultureInfo culture = null)
+        {
+            return ToString(unit, culture, "{0:0.##} {1}");
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit.
+        /// </summary>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <param name="format">String format to use. Default:  "{0:0.##} {1} for value and unit abbreviation respectively."</param>
+        /// <param name="args">Arguments for string format. Value and unit are implictly included as arguments 0 and 1.</param>
+        /// <returns>String representation.</returns>
+        [UsedImplicitly]
+        public string ToString(AmplitudeRatioUnit unit, CultureInfo culture, string format, params object[] args)
+        {
+            string abbreviation = UnitSystem.GetCached(culture).GetDefaultAbbreviation(unit);
+            object[] finalArgs = new object[] {As(unit), abbreviation}
+                .Concat(args)
+                .ToArray();
+
+            return string.Format(culture, format, finalArgs);
+        }
+
+        /// <summary>
+        ///     Get default string representation of value and unit.
+        /// </summary>
+        /// <returns>String representation.</returns>
+        public override string ToString()
+        {
+            return ToString(AmplitudeRatioUnit.DecibelVolt);
+        }
+    }
+}

--- a/Src/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/Src/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -34,6 +34,25 @@ namespace UnitsNet
         private static readonly ReadOnlyCollection<UnitLocalization> DefaultLocalizations
             = new ReadOnlyCollection<UnitLocalization>(new List<UnitLocalization>
             {
+                new UnitLocalization(typeof (AmplitudeRatioUnit),
+                    new[]
+                    {
+                        new CulturesForEnumValue((int) AmplitudeRatioUnit.DecibelMicrovolt,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "dBµV"),
+                            }),
+                        new CulturesForEnumValue((int) AmplitudeRatioUnit.DecibelMillivolt,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "dBmV"),
+                            }),
+                        new CulturesForEnumValue((int) AmplitudeRatioUnit.DecibelVolt,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "dBV"),
+                            }),
+                    }),
                 new UnitLocalization(typeof (AngleUnit),
                     new[]
                     {

--- a/Tests/CustomCode/AmplitudeRatioTests.cs
+++ b/Tests/CustomCode/AmplitudeRatioTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+using System;
+using NUnit.Framework;
+
+namespace UnitsNet.Tests.CustomCode
+{
+    public class AmplitudeRatioTests : AmplitudeRatioTestsBase
+    {
+        protected override double DecibelMicrovoltsInOneDecibelVolt
+        {
+            get { return 121; }
+        }
+
+        protected override double DecibelMillivoltsInOneDecibelVolt
+        {
+            get { return 61; }
+        }
+
+        protected override double DecibelVoltsInOneDecibelVolt
+        {
+            get { return 1; }
+        }
+
+        protected override void AssertLogarithmicAddition()
+        {
+            AmplitudeRatio v = AmplitudeRatio.FromDecibelVolts(40);
+            Assert.AreEqual(46.0205999133, (v + v).DecibelVolts, DecibelVoltsTolerance);
+        }
+
+        protected override void AssertLogarithmicSubtraction()
+        {
+            AmplitudeRatio v = AmplitudeRatio.FromDecibelVolts(40);
+            Assert.AreEqual(46.6982292275, (AmplitudeRatio.FromDecibelVolts(50) - v).DecibelVolts, DecibelVoltsTolerance);
+        }
+
+        #region From Electric Potential Tests
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        public void InvalidVoltage_ExpectArgumentOutOfRangeException(double voltage)
+        {
+            var invalidVoltage = ElectricPotential.FromVolts(voltage);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AmplitudeRatio(invalidVoltage));
+        }
+
+        [TestCase(1, Result = 0)]
+        [TestCase(10, Result = 20)]
+        [TestCase(100, Result = 40)]
+        [TestCase(1000, Result = 60)]
+        public double ExpectVoltageConvertedToAmplitudeRatioCorrectly(double voltage)
+        {
+            // Amplitude ratio increases linearly by 20 dBV with power-of-10 increases of voltage.
+            var v = ElectricPotential.FromVolts(voltage);
+
+            return AmplitudeRatio.FromElectricPotential(v).DecibelVolts;
+        }
+
+        #endregion
+
+        #region To Electric Potential Tests
+
+        [TestCase(-40, Result = 0.01)]
+        [TestCase(-20, Result = 0.1)]
+        [TestCase(0,   Result = 1)]
+        [TestCase(20,  Result = 10)]
+        [TestCase(40,  Result = 100)]
+        public double ExpectAmplitudeRatioConvertedToVoltageCorrectly(double amplitudeRatio)
+        {
+            // Voltage increases by powers of 10 for every 20 dBV increase in amplitude ratio.
+            var ar = AmplitudeRatio.FromDecibelVolts(amplitudeRatio);
+
+            return AmplitudeRatio.ToElectricPotential(ar).Volts;
+        }
+
+        #endregion
+
+        #region To Power Ratio Tests
+
+        // http://www.maximintegrated.com/en/app-notes/index.mvp/id/808
+
+        [TestCase(8, Result = -38.99)]
+        [TestCase(20, Result = -26.99)]
+        [TestCase(40, Result = -6.99)]
+        [TestCase(60, Result = 13.01)]
+        public double AmplitudeRatioToPowerRatio_50OhmImpedance(double dBmV)
+        {
+            var ampRatio = AmplitudeRatio.FromDecibelMillivolts(dBmV);
+
+            return Math.Round(ampRatio.ToPowerRatio(ElectricResistance.FromOhms(50)).DecibelMilliwatts, 2);
+        }
+
+        [TestCase(8, Result = -40.75)]
+        [TestCase(20, Result = -28.75)]
+        [TestCase(40, Result = -8.75)]
+        [TestCase(60, Result = 11.25)]
+        public double AmplitudeRatioToPowerRatio_75OhmImpedance(double dBmV)
+        {
+            var ampRatio = AmplitudeRatio.FromDecibelMillivolts(dBmV);
+
+            return Math.Round(ampRatio.ToPowerRatio(ElectricResistance.FromOhms(75)).DecibelMilliwatts, 2);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/CustomCode/PowerRatioTests.cs
+++ b/Tests/CustomCode/PowerRatioTests.cs
@@ -80,5 +80,33 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         #endregion
+
+        #region To Amplitude Ratio Tests
+
+        // http://www.maximintegrated.com/en/app-notes/index.mvp/id/808
+
+        [TestCase(-36.99, Result = 10)]
+        [TestCase(-26.99, Result = 20)]
+        [TestCase(-16.99, Result = 30)]
+        [TestCase(-6.99, Result = 40)]
+        public double PowerRatioToAmplitudeRatio_50OhmImpedance(double dBmW)
+        {
+            var powerRatio = PowerRatio.FromDecibelMilliwatts(dBmW);
+
+            return Math.Round(powerRatio.ToAmplitudeRatio(ElectricResistance.FromOhms(50)).DecibelMillivolts, 2);
+        }
+
+        [TestCase(-38.75, Result = 10)]
+        [TestCase(-28.75, Result = 20)]
+        [TestCase(-18.75, Result = 30)]
+        [TestCase(-8.75, Result = 40)]
+        public double PowerRatioToAmplitudeRatio_75OhmImpedance(double dBmW)
+        {
+            var powerRatio = PowerRatio.FromDecibelMilliwatts(dBmW);
+
+            return Math.Round(powerRatio.ToAmplitudeRatio(ElectricResistance.FromOhms(75)).DecibelMillivolts, 2);
+        }
+
+        #endregion
     }
 }

--- a/Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
+++ b/Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
@@ -1,0 +1,183 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using UnitsNet.Units;
+
+// Disable build warning CS1718: Comparison made to same variable; did you mean to compare something else?
+#pragma warning disable 1718
+
+// ReSharper disable once CheckNamespace
+namespace UnitsNet.Tests
+{
+    /// <summary>
+    /// Test of AmplitudeRatio.
+    /// </summary>
+    [TestFixture]
+// ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class AmplitudeRatioTestsBase
+    {
+        protected abstract double DecibelMicrovoltsInOneDecibelVolt { get; }
+        protected abstract double DecibelMillivoltsInOneDecibelVolt { get; }
+        protected abstract double DecibelVoltsInOneDecibelVolt { get; }
+
+// ReSharper disable VirtualMemberNeverOverriden.Global
+        protected virtual double DecibelMicrovoltsTolerance { get { return 1e-5; } }
+        protected virtual double DecibelMillivoltsTolerance { get { return 1e-5; } }
+        protected virtual double DecibelVoltsTolerance { get { return 1e-5; } }
+// ReSharper restore VirtualMemberNeverOverriden.Global
+
+        [Test]
+        public void DecibelVoltToAmplitudeRatioUnits()
+        {
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.AreEqual(DecibelMicrovoltsInOneDecibelVolt, decibelvolt.DecibelMicrovolts, DecibelMicrovoltsTolerance);
+            Assert.AreEqual(DecibelMillivoltsInOneDecibelVolt, decibelvolt.DecibelMillivolts, DecibelMillivoltsTolerance);
+            Assert.AreEqual(DecibelVoltsInOneDecibelVolt, decibelvolt.DecibelVolts, DecibelVoltsTolerance);
+        }
+
+        [Test]
+        public void FromValueAndUnit()
+        {
+            Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelMicrovolt).DecibelMicrovolts, DecibelMicrovoltsTolerance);
+            Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelMillivolt).DecibelMillivolts, DecibelMillivoltsTolerance);
+            Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelVolt).DecibelVolts, DecibelVoltsTolerance);
+        }
+
+        [Test]
+        public void As()
+        {
+            var decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.AreEqual(DecibelMicrovoltsInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelMicrovolt), DecibelMicrovoltsTolerance);
+            Assert.AreEqual(DecibelMillivoltsInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelMillivolt), DecibelMillivoltsTolerance);
+            Assert.AreEqual(DecibelVoltsInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelVolt), DecibelVoltsTolerance);
+        }
+
+        [Test]
+        public void ConversionRoundTrip()
+        {
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.AreEqual(1, AmplitudeRatio.FromDecibelMicrovolts(decibelvolt.DecibelMicrovolts).DecibelVolts, DecibelMicrovoltsTolerance);
+            Assert.AreEqual(1, AmplitudeRatio.FromDecibelMillivolts(decibelvolt.DecibelMillivolts).DecibelVolts, DecibelMillivoltsTolerance);
+            Assert.AreEqual(1, AmplitudeRatio.FromDecibelVolts(decibelvolt.DecibelVolts).DecibelVolts, DecibelVoltsTolerance);
+        }
+
+        [Test]
+        public void LogarithmicArithmeticOperators()
+        {
+            AmplitudeRatio v = AmplitudeRatio.FromDecibelVolts(40);
+            Assert.AreEqual(-40, -v.DecibelVolts, DecibelVoltsTolerance);
+            AssertLogarithmicAddition();
+            AssertLogarithmicSubtraction();
+            Assert.AreEqual(50, (v*10).DecibelVolts, DecibelVoltsTolerance);
+            Assert.AreEqual(50, (10*v).DecibelVolts, DecibelVoltsTolerance);
+            Assert.AreEqual(35, (v/5).DecibelVolts, DecibelVoltsTolerance);
+            Assert.AreEqual(35, v/AmplitudeRatio.FromDecibelVolts(5), DecibelVoltsTolerance);
+        }
+        
+        protected abstract void AssertLogarithmicAddition();
+        
+        protected abstract void AssertLogarithmicSubtraction();
+
+        [Test]
+        public void ComparisonOperators()
+        {
+            AmplitudeRatio oneDecibelVolt = AmplitudeRatio.FromDecibelVolts(1);
+            AmplitudeRatio twoDecibelVolts = AmplitudeRatio.FromDecibelVolts(2);
+
+            Assert.True(oneDecibelVolt < twoDecibelVolts);
+            Assert.True(oneDecibelVolt <= twoDecibelVolts);
+            Assert.True(twoDecibelVolts > oneDecibelVolt);
+            Assert.True(twoDecibelVolts >= oneDecibelVolt);
+
+            Assert.False(oneDecibelVolt > twoDecibelVolts);
+            Assert.False(oneDecibelVolt >= twoDecibelVolts);
+            Assert.False(twoDecibelVolts < oneDecibelVolt);
+            Assert.False(twoDecibelVolts <= oneDecibelVolt);
+        }
+
+        [Test]
+        public void CompareToIsImplemented()
+        {
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.AreEqual(0, decibelvolt.CompareTo(decibelvolt));
+            Assert.Greater(decibelvolt.CompareTo(AmplitudeRatio.Zero), 0);
+            Assert.Less(AmplitudeRatio.Zero.CompareTo(decibelvolt), 0);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CompareToThrowsOnTypeMismatch()
+        {
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+// ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            decibelvolt.CompareTo(new object());
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void CompareToThrowsOnNull()
+        { 
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+// ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            decibelvolt.CompareTo(null);
+        }
+
+
+        [Test]
+        public void EqualityOperators()
+        {
+            AmplitudeRatio a = AmplitudeRatio.FromDecibelVolts(1);
+            AmplitudeRatio b = AmplitudeRatio.FromDecibelVolts(2);
+
+// ReSharper disable EqualExpressionComparison
+            Assert.True(a == a); 
+            Assert.True(a != b);
+
+            Assert.False(a == b);
+            Assert.False(a != a);
+// ReSharper restore EqualExpressionComparison
+        }
+
+        [Test]
+        public void EqualsIsImplemented()
+        {
+            AmplitudeRatio v = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.IsTrue(v.Equals(AmplitudeRatio.FromDecibelVolts(1)));
+            Assert.IsFalse(v.Equals(AmplitudeRatio.Zero));
+        }
+
+        [Test]
+        public void EqualsReturnsFalseOnTypeMismatch()
+        {
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.IsFalse(decibelvolt.Equals(new object()));
+        }
+
+        [Test]
+        public void EqualsReturnsFalseOnNull()
+        {
+            AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
+            Assert.IsFalse(decibelvolt.Equals(null));
+        }
+    }
+}


### PR DESCRIPTION
- [Amplitude ratio](http://en.wikipedia.org/wiki/Decibel#Voltage) is the strength of a signal expressed in decibels (dB) relative to one volt RMS.
- Amplitude ratios are commonly used in audio, RF, and telecommunications engineering.
- Added conversions between voltage and power ratios.
