### PR TITLE
Fix missing prefixes for localized abbreviations

### DIFF
--- a/UnitsNet/Scripts/GenerateUnits.ps1
+++ b/UnitsNet/Scripts/GenerateUnits.ps1
@@ -211,7 +211,7 @@ function Add-PrefixUnits {
                     Localization=$unit.Localization | % {
                         $abbrev = $prefixAbbreviation + $_.Abbreviations[0]
                         if ($_.AbbreviationsWithPrefixes) {
-                            $abbrev = $_.AbbreviationsWithPrefixes[$prefixIndex++]
+                            $abbrev = $_.AbbreviationsWithPrefixes[$prefixIndex]
                         }
 
                     New-Object PsObject -Property @{
@@ -222,6 +222,7 @@ function Add-PrefixUnits {
 
                 # Append prefix unit
                 $prefixUnits += $prefixUnit
+				$prefixIndex++;
             } # foreach prefixes
         } # foreach units
 


### PR DESCRIPTION
$prefixIndex variable shouldn't be incremented while enumerating by $unit.Localization because in that case for second and for all the next cultures abbreviation will be taken from the subsequent prefix index that is wrong.