### PR TITLE
Adding decimal, int and long overloads

### DIFF
--- a/UnitsNet.Tests/DecimalOverloadTests.cs
+++ b/UnitsNet.Tests/DecimalOverloadTests.cs
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 
 using Xunit;
+using UnitsNet.Extensions.NumberToAcceleration;
+using UnitsNet.Extensions.NumberToPower;
 
 namespace UnitsNet.Tests
 {
@@ -43,10 +45,35 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public static void CreatingQuantityWithDoubleBackingFieldFromNullableDecimalReturnsReturnsNullWhenGivenNull()
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableDecimalReturnsNullWhenGivenNull()
         {
             decimal? nullDecimal = null;
             Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(nullDecimal);
+            Assert.Null(acceleration);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromDecimalWithExtensionMethodReturnsCorrectValue()
+        {
+            decimal oneMeterPerSecondSquared = 1m;
+            Acceleration acceleration = oneMeterPerSecondSquared.MeterPerSecondSquared();
+            Assert.Equal(1.0, acceleration.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableDecimalWithExtensionMethodReturnsCorrectValue()
+        {
+            decimal? oneMeterPerSecondSquared = 1m;
+            Acceleration? acceleration = oneMeterPerSecondSquared.MeterPerSecondSquared();
+            Assert.NotNull(acceleration);
+            Assert.Equal(1.0, acceleration.Value.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableDecimalWithExtensionMethodReturnsNullWhenGivenNull()
+        {
+            decimal? nullDecimal = null;
+            Acceleration? acceleration = nullDecimal.MeterPerSecondSquared();
             Assert.Null(acceleration);
         }
 
@@ -68,10 +95,35 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public static void CreatingQuantityWithDecimalBackingFieldFromNullableDecimalReturnsReturnsNullWhenGivenNull()
+        public static void CreatingQuantityWithDecimalBackingFieldFromNullableDecimalReturnsNullWhenGivenNull()
         {
             decimal? nullDecimal = null;
             Power? power = Power.FromWatts(nullDecimal);
+            Assert.Null(power);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDecimalBackingFieldFromDecimalWithExtensionMethodReturnsCorrectValue()
+        {
+            decimal oneWatt = 1m;
+            Power power = oneWatt.Watts();
+            Assert.Equal(1.0, power.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDecimalBackingFieldFromNullableDecimalWithExtensionMethodReturnsCorrectValue()
+        {
+            decimal? oneWatt = 1m;
+            Power? power = oneWatt.Watts();
+            Assert.NotNull(power);
+            Assert.Equal(1.0, power.Value.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDecimalBackingFieldFromNullableDecimalWithExtensionMethodReturnsNullWhenGivenNull()
+        {
+            decimal? nullDecimal = null;
+            Power? power = nullDecimal.Watts();
             Assert.Null(power);
         }
     }

--- a/UnitsNet.Tests/DecimalOverloadTests.cs
+++ b/UnitsNet.Tests/DecimalOverloadTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright(c) 2007 Andreas Gullberg Larsen
+// https://github.com/angularsen/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Xunit;
+
+namespace UnitsNet.Tests
+{
+    public class DecimalOverloadTests
+    {
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromDecimalReturnsCorrectValue()
+        {
+            decimal oneMeterPerSecondSquared = 1m;
+            Acceleration acceleration = Acceleration.FromMeterPerSecondSquared(oneMeterPerSecondSquared);
+            Assert.Equal(1.0, acceleration.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableDecimalReturnsCorrectValue()
+        {
+            decimal? oneMeterPerSecondSquared = 1m;
+            Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(oneMeterPerSecondSquared);
+            Assert.NotNull(acceleration);
+            Assert.Equal(1.0, acceleration.Value.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableDecimalReturnsReturnsNullWhenGivenNull()
+        {
+            decimal? nullDecimal = null;
+            Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(nullDecimal);
+            Assert.Null(acceleration);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDecimalBackingFieldFromDecimalReturnsCorrectValue()
+        {
+            decimal oneWatt = 1m;
+            Power power = Power.FromWatts(oneWatt);
+            Assert.Equal(1.0, power.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDecimalBackingFieldFromNullableDecimalReturnsCorrectValue()
+        {
+            decimal? oneWatt = 1m;
+            Power? power = Power.FromWatts(oneWatt);
+            Assert.NotNull(power);
+            Assert.Equal(1.0, power.Value.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDecimalBackingFieldFromNullableDecimalReturnsReturnsNullWhenGivenNull()
+        {
+            decimal? nullDecimal = null;
+            Power? power = Power.FromWatts(nullDecimal);
+            Assert.Null(power);
+        }
+    }
+}

--- a/UnitsNet.Tests/IntOverloadTests.cs
+++ b/UnitsNet.Tests/IntOverloadTests.cs
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 
 using Xunit;
+using UnitsNet.Extensions.NumberToAcceleration;
+using UnitsNet.Extensions.NumberToPower;
 
 namespace UnitsNet.Tests
 {
@@ -43,10 +45,35 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public static void CreatingQuantityWithDoubleBackingFieldFromNullableIntReturnsReturnsNullWhenGivenNull()
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableIntReturnsNullWhenGivenNull()
         {
             int? nullInt = null;
             Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(nullInt);
+            Assert.Null(acceleration);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromIntWithExtensionMethodReturnsCorrectValue()
+        {
+            int oneMeterPerSecondSquared = 1;
+            Acceleration acceleration = oneMeterPerSecondSquared.MeterPerSecondSquared();
+            Assert.Equal(1.0, acceleration.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableIntWithExtensionMethodReturnsCorrectValue()
+        {
+            int? oneMeterPerSecondSquared = 1;
+            Acceleration? acceleration = oneMeterPerSecondSquared.MeterPerSecondSquared();
+            Assert.NotNull(acceleration);
+            Assert.Equal(1.0, acceleration.Value.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableIntWithExtensionMethodReturnsNullWhenGivenNull()
+        {
+            int? nullInt = null;
+            Acceleration? acceleration = nullInt.MeterPerSecondSquared();
             Assert.Null(acceleration);
         }
 
@@ -68,10 +95,35 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public static void CreatingQuantityWithIntBackingFieldFromNullableIntReturnsReturnsNullWhenGivenNull()
+        public static void CreatingQuantityWithIntBackingFieldFromNullableIntReturnsNullWhenGivenNull()
         {
             int? nullInt = null;
             Power? power = Power.FromWatts(nullInt);
+            Assert.Null(power);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithIntBackingFieldFromIntWithExtensionMethodReturnsCorrectValue()
+        {
+            int oneWatt = 1;
+            Power power = oneWatt.Watts();
+            Assert.Equal(1.0, power.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithIntBackingFieldFromNullableIntWithExtensionMethodReturnsCorrectValue()
+        {
+            int? oneWatt = 1;
+            Power? power = oneWatt.Watts();
+            Assert.NotNull(power);
+            Assert.Equal(1.0, power.Value.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithIntBackingFieldFromNullableIntWithExtensionMethodReturnsNullWhenGivenNull()
+        {
+            int? nullInt = null;
+            Power? power = nullInt.Watts();
             Assert.Null(power);
         }
     }

--- a/UnitsNet.Tests/IntOverloadTests.cs
+++ b/UnitsNet.Tests/IntOverloadTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright(c) 2007 Andreas Gullberg Larsen
+// https://github.com/angularsen/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Xunit;
+
+namespace UnitsNet.Tests
+{
+    public class IntOverloadTests
+    {
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromIntReturnsCorrectValue()
+        {
+            int oneMeterPerSecondSquared = 1;
+            Acceleration acceleration = Acceleration.FromMeterPerSecondSquared(oneMeterPerSecondSquared);
+            Assert.Equal(1.0, acceleration.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableIntReturnsCorrectValue()
+        {
+            int? oneMeterPerSecondSquared = 1;
+            Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(oneMeterPerSecondSquared);
+            Assert.NotNull(acceleration);
+            Assert.Equal(1.0, acceleration.Value.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableIntReturnsReturnsNullWhenGivenNull()
+        {
+            int? nullInt = null;
+            Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(nullInt);
+            Assert.Null(acceleration);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithIntBackingFieldFromIntReturnsCorrectValue()
+        {
+            int oneWatt = 1;
+            Power power = Power.FromWatts(oneWatt);
+            Assert.Equal(1.0, power.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithIntBackingFieldFromNullableIntReturnsCorrectValue()
+        {
+            int? oneWatt = 1;
+            Power? power = Power.FromWatts(oneWatt);
+            Assert.NotNull(power);
+            Assert.Equal(1.0, power.Value.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithIntBackingFieldFromNullableIntReturnsReturnsNullWhenGivenNull()
+        {
+            int? nullInt = null;
+            Power? power = Power.FromWatts(nullInt);
+            Assert.Null(power);
+        }
+    }
+}

--- a/UnitsNet.Tests/LongOverloadTests.cs
+++ b/UnitsNet.Tests/LongOverloadTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright(c) 2007 Andreas Gullberg Larsen
+// https://github.com/angularsen/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Xunit;
+
+namespace UnitsNet.Tests
+{
+    public class LongOverloadTests
+    {
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromLongReturnsCorrectValue()
+        {
+            long oneMeterPerSecondSquared = 1;
+            Acceleration acceleration = Acceleration.FromMeterPerSecondSquared(oneMeterPerSecondSquared);
+            Assert.Equal(1.0, acceleration.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableLongReturnsCorrectValue()
+        {
+            long? oneMeterPerSecondSquared = 1;
+            Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(oneMeterPerSecondSquared);
+            Assert.NotNull(acceleration);
+            Assert.Equal(1.0, acceleration.Value.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableLongReturnsReturnsNullWhenGivenNull()
+        {
+            long? nullLong = null;
+            Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(nullLong);
+            Assert.Null(acceleration);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithLongBackingFieldFromLongReturnsCorrectValue()
+        {
+            long oneWatt = 1;
+            Power power = Power.FromWatts(oneWatt);
+            Assert.Equal(1.0, power.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithLongBackingFieldFromNullableLongReturnsCorrectValue()
+        {
+            long? oneWatt = 1;
+            Power? power = Power.FromWatts(oneWatt);
+            Assert.NotNull(power);
+            Assert.Equal(1.0, power.Value.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithLongBackingFieldFromNullableLongReturnsReturnsNullWhenGivenNull()
+        {
+            long? nullLong = null;
+            Power? power = Power.FromWatts(nullLong);
+            Assert.Null(power);
+        }
+    }
+}

--- a/UnitsNet.Tests/LongOverloadTests.cs
+++ b/UnitsNet.Tests/LongOverloadTests.cs
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 
 using Xunit;
+using UnitsNet.Extensions.NumberToAcceleration;
+using UnitsNet.Extensions.NumberToPower;
 
 namespace UnitsNet.Tests
 {
@@ -43,10 +45,35 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public static void CreatingQuantityWithDoubleBackingFieldFromNullableLongReturnsReturnsNullWhenGivenNull()
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableLongReturnsNullWhenGivenNull()
         {
             long? nullLong = null;
             Acceleration? acceleration = Acceleration.FromMeterPerSecondSquared(nullLong);
+            Assert.Null(acceleration);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromLongWithExtensionMethodReturnsCorrectValue()
+        {
+            long oneMeterPerSecondSquared = 1;
+            Acceleration acceleration = oneMeterPerSecondSquared.MeterPerSecondSquared();
+            Assert.Equal(1.0, acceleration.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableLongWithExtensionMethodReturnsCorrectValue()
+        {
+            long? oneMeterPerSecondSquared = 1;
+            Acceleration? acceleration = oneMeterPerSecondSquared.MeterPerSecondSquared();
+            Assert.NotNull(acceleration);
+            Assert.Equal(1.0, acceleration.Value.MeterPerSecondSquared);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithDoubleBackingFieldFromNullableLongWithExtensionMethodReturnsNullWhenGivenNull()
+        {
+            long? nullLong = null;
+            Acceleration? acceleration = nullLong.MeterPerSecondSquared();
             Assert.Null(acceleration);
         }
 
@@ -68,10 +95,35 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public static void CreatingQuantityWithLongBackingFieldFromNullableLongReturnsReturnsNullWhenGivenNull()
+        public static void CreatingQuantityWithLongBackingFieldFromNullableLongReturnsNullWhenGivenNull()
         {
             long? nullLong = null;
             Power? power = Power.FromWatts(nullLong);
+            Assert.Null(power);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithLongBackingFieldFromLongWithExtensionMethodReturnsCorrectValue()
+        {
+            long oneWatt = 1;
+            Power power = oneWatt.Watts();
+            Assert.Equal(1.0, power.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithLongBackingFieldFromNullableLongWithExtensionMethodReturnsCorrectValue()
+        {
+            long? oneWatt = 1;
+            Power? power = oneWatt.Watts();
+            Assert.NotNull(power);
+            Assert.Equal(1.0, power.Value.Watts);
+        }
+
+        [Fact]
+        public static void CreatingQuantityWithLongBackingFieldFromNullableLongWithExtensionMethodReturnsNullWhenGivenNull()
+        {
+            long? nullLong = null;
+            Power? power = nullLong.Watts();
             Assert.Null(power);
         }
     }

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -197,6 +197,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from CentimeterPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromCentimeterPerSecondSquared(double centimeterpersecondsquared)
         {
             return new Acceleration((centimeterpersecondsquared) * 1e-2d);
@@ -232,6 +235,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from DecimeterPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromDecimeterPerSecondSquared(double decimeterpersecondsquared)
         {
             return new Acceleration((decimeterpersecondsquared) * 1e-1d);
@@ -267,6 +273,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KilometerPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromKilometerPerSecondSquared(double kilometerpersecondsquared)
         {
             return new Acceleration((kilometerpersecondsquared) * 1e3d);
@@ -302,6 +311,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MeterPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromMeterPerSecondSquared(double meterpersecondsquared)
         {
             return new Acceleration(meterpersecondsquared);
@@ -337,6 +349,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MicrometerPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromMicrometerPerSecondSquared(double micrometerpersecondsquared)
         {
             return new Acceleration((micrometerpersecondsquared) * 1e-6d);
@@ -372,6 +387,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MillimeterPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromMillimeterPerSecondSquared(double millimeterpersecondsquared)
         {
             return new Acceleration((millimeterpersecondsquared) * 1e-3d);
@@ -407,6 +425,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from NanometerPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Acceleration FromNanometerPerSecondSquared(double nanometerpersecondsquared)
         {
             return new Acceleration((nanometerpersecondsquared) * 1e-9d);

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _meterPerSecondSquared;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Acceleration() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Acceleration;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static AccelerationUnit BaseUnit
         {
             get { return AccelerationUnit.MeterPerSecondSquared; }
@@ -202,7 +202,7 @@ namespace UnitsNet
             return new Acceleration((centimeterpersecondsquared) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from CentimeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromCentimeterPerSecondSquared(int centimeterpersecondsquared)
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new Acceleration((centimeterpersecondsquared) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from CentimeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromCentimeterPerSecondSquared(long centimeterpersecondsquared)
@@ -218,14 +218,14 @@ namespace UnitsNet
             return new Acceleration((centimeterpersecondsquared) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from CentimeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromCentimeterPerSecondSquared(decimal centimeterpersecondsquared)
         {
-	        return new Acceleration((Convert.ToDouble(centimeterpersecondsquared)) * 1e-2d);
+            return new Acceleration((Convert.ToDouble(centimeterpersecondsquared)) * 1e-2d);
         }
 #endif
 
@@ -237,7 +237,7 @@ namespace UnitsNet
             return new Acceleration((decimeterpersecondsquared) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from DecimeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromDecimeterPerSecondSquared(int decimeterpersecondsquared)
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new Acceleration((decimeterpersecondsquared) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from DecimeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromDecimeterPerSecondSquared(long decimeterpersecondsquared)
@@ -253,14 +253,14 @@ namespace UnitsNet
             return new Acceleration((decimeterpersecondsquared) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from DecimeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromDecimeterPerSecondSquared(decimal decimeterpersecondsquared)
         {
-	        return new Acceleration((Convert.ToDouble(decimeterpersecondsquared)) * 1e-1d);
+            return new Acceleration((Convert.ToDouble(decimeterpersecondsquared)) * 1e-1d);
         }
 #endif
 
@@ -272,7 +272,7 @@ namespace UnitsNet
             return new Acceleration((kilometerpersecondsquared) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from KilometerPerSecondSquared.
         /// </summary>
         public static Acceleration FromKilometerPerSecondSquared(int kilometerpersecondsquared)
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new Acceleration((kilometerpersecondsquared) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from KilometerPerSecondSquared.
         /// </summary>
         public static Acceleration FromKilometerPerSecondSquared(long kilometerpersecondsquared)
@@ -288,14 +288,14 @@ namespace UnitsNet
             return new Acceleration((kilometerpersecondsquared) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from KilometerPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromKilometerPerSecondSquared(decimal kilometerpersecondsquared)
         {
-	        return new Acceleration((Convert.ToDouble(kilometerpersecondsquared)) * 1e3d);
+            return new Acceleration((Convert.ToDouble(kilometerpersecondsquared)) * 1e3d);
         }
 #endif
 
@@ -307,7 +307,7 @@ namespace UnitsNet
             return new Acceleration(meterpersecondsquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromMeterPerSecondSquared(int meterpersecondsquared)
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new Acceleration(meterpersecondsquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromMeterPerSecondSquared(long meterpersecondsquared)
@@ -323,14 +323,14 @@ namespace UnitsNet
             return new Acceleration(meterpersecondsquared);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromMeterPerSecondSquared(decimal meterpersecondsquared)
         {
-	        return new Acceleration(Convert.ToDouble(meterpersecondsquared));
+            return new Acceleration(Convert.ToDouble(meterpersecondsquared));
         }
 #endif
 
@@ -342,7 +342,7 @@ namespace UnitsNet
             return new Acceleration((micrometerpersecondsquared) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MicrometerPerSecondSquared.
         /// </summary>
         public static Acceleration FromMicrometerPerSecondSquared(int micrometerpersecondsquared)
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new Acceleration((micrometerpersecondsquared) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MicrometerPerSecondSquared.
         /// </summary>
         public static Acceleration FromMicrometerPerSecondSquared(long micrometerpersecondsquared)
@@ -358,14 +358,14 @@ namespace UnitsNet
             return new Acceleration((micrometerpersecondsquared) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MicrometerPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromMicrometerPerSecondSquared(decimal micrometerpersecondsquared)
         {
-	        return new Acceleration((Convert.ToDouble(micrometerpersecondsquared)) * 1e-6d);
+            return new Acceleration((Convert.ToDouble(micrometerpersecondsquared)) * 1e-6d);
         }
 #endif
 
@@ -377,7 +377,7 @@ namespace UnitsNet
             return new Acceleration((millimeterpersecondsquared) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MillimeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromMillimeterPerSecondSquared(int millimeterpersecondsquared)
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new Acceleration((millimeterpersecondsquared) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MillimeterPerSecondSquared.
         /// </summary>
         public static Acceleration FromMillimeterPerSecondSquared(long millimeterpersecondsquared)
@@ -393,14 +393,14 @@ namespace UnitsNet
             return new Acceleration((millimeterpersecondsquared) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from MillimeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromMillimeterPerSecondSquared(decimal millimeterpersecondsquared)
         {
-	        return new Acceleration((Convert.ToDouble(millimeterpersecondsquared)) * 1e-3d);
+            return new Acceleration((Convert.ToDouble(millimeterpersecondsquared)) * 1e-3d);
         }
 #endif
 
@@ -412,7 +412,7 @@ namespace UnitsNet
             return new Acceleration((nanometerpersecondsquared) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from NanometerPerSecondSquared.
         /// </summary>
         public static Acceleration FromNanometerPerSecondSquared(int nanometerpersecondsquared)
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new Acceleration((nanometerpersecondsquared) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from NanometerPerSecondSquared.
         /// </summary>
         public static Acceleration FromNanometerPerSecondSquared(long nanometerpersecondsquared)
@@ -428,14 +428,14 @@ namespace UnitsNet
             return new Acceleration((nanometerpersecondsquared) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Acceleration from NanometerPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration FromNanometerPerSecondSquared(decimal nanometerpersecondsquared)
         {
-	        return new Acceleration((Convert.ToDouble(nanometerpersecondsquared)) * 1e-9d);
+            return new Acceleration((Convert.ToDouble(nanometerpersecondsquared)) * 1e-9d);
         }
 #endif
 
@@ -456,7 +456,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromCentimeterPerSecondSquared(int? centimeterpersecondsquared)
@@ -471,7 +471,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromCentimeterPerSecondSquared(long? centimeterpersecondsquared)
@@ -486,7 +486,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from CentimeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromCentimeterPerSecondSquared(decimal? centimeterpersecondsquared)
@@ -516,7 +516,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromDecimeterPerSecondSquared(int? decimeterpersecondsquared)
@@ -531,7 +531,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromDecimeterPerSecondSquared(long? decimeterpersecondsquared)
@@ -546,7 +546,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from DecimeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromDecimeterPerSecondSquared(decimal? decimeterpersecondsquared)
@@ -576,7 +576,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromKilometerPerSecondSquared(int? kilometerpersecondsquared)
@@ -591,7 +591,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromKilometerPerSecondSquared(long? kilometerpersecondsquared)
@@ -606,7 +606,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from KilometerPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromKilometerPerSecondSquared(decimal? kilometerpersecondsquared)
@@ -636,7 +636,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMeterPerSecondSquared(int? meterpersecondsquared)
@@ -651,7 +651,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMeterPerSecondSquared(long? meterpersecondsquared)
@@ -666,7 +666,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from MeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromMeterPerSecondSquared(decimal? meterpersecondsquared)
@@ -696,7 +696,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMicrometerPerSecondSquared(int? micrometerpersecondsquared)
@@ -711,7 +711,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMicrometerPerSecondSquared(long? micrometerpersecondsquared)
@@ -726,7 +726,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from MicrometerPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromMicrometerPerSecondSquared(decimal? micrometerpersecondsquared)
@@ -756,7 +756,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMillimeterPerSecondSquared(int? millimeterpersecondsquared)
@@ -771,7 +771,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMillimeterPerSecondSquared(long? millimeterpersecondsquared)
@@ -786,7 +786,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from MillimeterPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromMillimeterPerSecondSquared(decimal? millimeterpersecondsquared)
@@ -816,7 +816,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromNanometerPerSecondSquared(int? nanometerpersecondsquared)
@@ -831,7 +831,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromNanometerPerSecondSquared(long? nanometerpersecondsquared)
@@ -846,7 +846,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Acceleration from NanometerPerSecondSquared of type decimal.
         /// </summary>
         public static Acceleration? FromNanometerPerSecondSquared(decimal? nanometerpersecondsquared)

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -202,6 +202,33 @@ namespace UnitsNet
             return new Acceleration((centimeterpersecondsquared) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Acceleration from CentimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromCentimeterPerSecondSquared(int centimeterpersecondsquared)
+        {
+            return new Acceleration((centimeterpersecondsquared) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from CentimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromCentimeterPerSecondSquared(long centimeterpersecondsquared)
+        {
+            return new Acceleration((centimeterpersecondsquared) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from CentimeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromCentimeterPerSecondSquared(decimal centimeterpersecondsquared)
+        {
+	        return new Acceleration((Convert.ToDouble(centimeterpersecondsquared)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Acceleration from DecimeterPerSecondSquared.
         /// </summary>
@@ -209,6 +236,33 @@ namespace UnitsNet
         {
             return new Acceleration((decimeterpersecondsquared) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Acceleration from DecimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromDecimeterPerSecondSquared(int decimeterpersecondsquared)
+        {
+            return new Acceleration((decimeterpersecondsquared) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from DecimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromDecimeterPerSecondSquared(long decimeterpersecondsquared)
+        {
+            return new Acceleration((decimeterpersecondsquared) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from DecimeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromDecimeterPerSecondSquared(decimal decimeterpersecondsquared)
+        {
+	        return new Acceleration((Convert.ToDouble(decimeterpersecondsquared)) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Acceleration from KilometerPerSecondSquared.
@@ -218,6 +272,33 @@ namespace UnitsNet
             return new Acceleration((kilometerpersecondsquared) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Acceleration from KilometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromKilometerPerSecondSquared(int kilometerpersecondsquared)
+        {
+            return new Acceleration((kilometerpersecondsquared) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from KilometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromKilometerPerSecondSquared(long kilometerpersecondsquared)
+        {
+            return new Acceleration((kilometerpersecondsquared) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from KilometerPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromKilometerPerSecondSquared(decimal kilometerpersecondsquared)
+        {
+	        return new Acceleration((Convert.ToDouble(kilometerpersecondsquared)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Acceleration from MeterPerSecondSquared.
         /// </summary>
@@ -225,6 +306,33 @@ namespace UnitsNet
         {
             return new Acceleration(meterpersecondsquared);
         }
+
+		/// <summary>
+        ///     Get Acceleration from MeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromMeterPerSecondSquared(int meterpersecondsquared)
+        {
+            return new Acceleration(meterpersecondsquared);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from MeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromMeterPerSecondSquared(long meterpersecondsquared)
+        {
+            return new Acceleration(meterpersecondsquared);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from MeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromMeterPerSecondSquared(decimal meterpersecondsquared)
+        {
+	        return new Acceleration(Convert.ToDouble(meterpersecondsquared));
+        }
+#endif
 
         /// <summary>
         ///     Get Acceleration from MicrometerPerSecondSquared.
@@ -234,6 +342,33 @@ namespace UnitsNet
             return new Acceleration((micrometerpersecondsquared) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Acceleration from MicrometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromMicrometerPerSecondSquared(int micrometerpersecondsquared)
+        {
+            return new Acceleration((micrometerpersecondsquared) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from MicrometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromMicrometerPerSecondSquared(long micrometerpersecondsquared)
+        {
+            return new Acceleration((micrometerpersecondsquared) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from MicrometerPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromMicrometerPerSecondSquared(decimal micrometerpersecondsquared)
+        {
+	        return new Acceleration((Convert.ToDouble(micrometerpersecondsquared)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Acceleration from MillimeterPerSecondSquared.
         /// </summary>
@@ -241,6 +376,33 @@ namespace UnitsNet
         {
             return new Acceleration((millimeterpersecondsquared) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Acceleration from MillimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromMillimeterPerSecondSquared(int millimeterpersecondsquared)
+        {
+            return new Acceleration((millimeterpersecondsquared) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from MillimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromMillimeterPerSecondSquared(long millimeterpersecondsquared)
+        {
+            return new Acceleration((millimeterpersecondsquared) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from MillimeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromMillimeterPerSecondSquared(decimal millimeterpersecondsquared)
+        {
+	        return new Acceleration((Convert.ToDouble(millimeterpersecondsquared)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Acceleration from NanometerPerSecondSquared.
@@ -250,12 +412,84 @@ namespace UnitsNet
             return new Acceleration((nanometerpersecondsquared) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Acceleration from NanometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromNanometerPerSecondSquared(int nanometerpersecondsquared)
+        {
+            return new Acceleration((nanometerpersecondsquared) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Acceleration from NanometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration FromNanometerPerSecondSquared(long nanometerpersecondsquared)
+        {
+            return new Acceleration((nanometerpersecondsquared) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Acceleration from NanometerPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration FromNanometerPerSecondSquared(decimal nanometerpersecondsquared)
+        {
+	        return new Acceleration((Convert.ToDouble(nanometerpersecondsquared)) * 1e-9d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
         /// </summary>
         public static Acceleration? FromCentimeterPerSecondSquared(double? centimeterpersecondsquared)
+        {
+            if (centimeterpersecondsquared.HasValue)
+            {
+                return FromCentimeterPerSecondSquared(centimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromCentimeterPerSecondSquared(int? centimeterpersecondsquared)
+        {
+            if (centimeterpersecondsquared.HasValue)
+            {
+                return FromCentimeterPerSecondSquared(centimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromCentimeterPerSecondSquared(long? centimeterpersecondsquared)
+        {
+            if (centimeterpersecondsquared.HasValue)
+            {
+                return FromCentimeterPerSecondSquared(centimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from CentimeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromCentimeterPerSecondSquared(decimal? centimeterpersecondsquared)
         {
             if (centimeterpersecondsquared.HasValue)
             {
@@ -282,10 +516,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromDecimeterPerSecondSquared(int? decimeterpersecondsquared)
+        {
+            if (decimeterpersecondsquared.HasValue)
+            {
+                return FromDecimeterPerSecondSquared(decimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromDecimeterPerSecondSquared(long? decimeterpersecondsquared)
+        {
+            if (decimeterpersecondsquared.HasValue)
+            {
+                return FromDecimeterPerSecondSquared(decimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from DecimeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromDecimeterPerSecondSquared(decimal? decimeterpersecondsquared)
+        {
+            if (decimeterpersecondsquared.HasValue)
+            {
+                return FromDecimeterPerSecondSquared(decimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromKilometerPerSecondSquared(double? kilometerpersecondsquared)
+        {
+            if (kilometerpersecondsquared.HasValue)
+            {
+                return FromKilometerPerSecondSquared(kilometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromKilometerPerSecondSquared(int? kilometerpersecondsquared)
+        {
+            if (kilometerpersecondsquared.HasValue)
+            {
+                return FromKilometerPerSecondSquared(kilometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromKilometerPerSecondSquared(long? kilometerpersecondsquared)
+        {
+            if (kilometerpersecondsquared.HasValue)
+            {
+                return FromKilometerPerSecondSquared(kilometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from KilometerPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromKilometerPerSecondSquared(decimal? kilometerpersecondsquared)
         {
             if (kilometerpersecondsquared.HasValue)
             {
@@ -312,10 +636,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromMeterPerSecondSquared(int? meterpersecondsquared)
+        {
+            if (meterpersecondsquared.HasValue)
+            {
+                return FromMeterPerSecondSquared(meterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromMeterPerSecondSquared(long? meterpersecondsquared)
+        {
+            if (meterpersecondsquared.HasValue)
+            {
+                return FromMeterPerSecondSquared(meterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from MeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromMeterPerSecondSquared(decimal? meterpersecondsquared)
+        {
+            if (meterpersecondsquared.HasValue)
+            {
+                return FromMeterPerSecondSquared(meterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromMicrometerPerSecondSquared(double? micrometerpersecondsquared)
+        {
+            if (micrometerpersecondsquared.HasValue)
+            {
+                return FromMicrometerPerSecondSquared(micrometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromMicrometerPerSecondSquared(int? micrometerpersecondsquared)
+        {
+            if (micrometerpersecondsquared.HasValue)
+            {
+                return FromMicrometerPerSecondSquared(micrometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromMicrometerPerSecondSquared(long? micrometerpersecondsquared)
+        {
+            if (micrometerpersecondsquared.HasValue)
+            {
+                return FromMicrometerPerSecondSquared(micrometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from MicrometerPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromMicrometerPerSecondSquared(decimal? micrometerpersecondsquared)
         {
             if (micrometerpersecondsquared.HasValue)
             {
@@ -342,10 +756,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromMillimeterPerSecondSquared(int? millimeterpersecondsquared)
+        {
+            if (millimeterpersecondsquared.HasValue)
+            {
+                return FromMillimeterPerSecondSquared(millimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromMillimeterPerSecondSquared(long? millimeterpersecondsquared)
+        {
+            if (millimeterpersecondsquared.HasValue)
+            {
+                return FromMillimeterPerSecondSquared(millimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from MillimeterPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromMillimeterPerSecondSquared(decimal? millimeterpersecondsquared)
+        {
+            if (millimeterpersecondsquared.HasValue)
+            {
+                return FromMillimeterPerSecondSquared(millimeterpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
         /// </summary>
         public static Acceleration? FromNanometerPerSecondSquared(double? nanometerpersecondsquared)
+        {
+            if (nanometerpersecondsquared.HasValue)
+            {
+                return FromNanometerPerSecondSquared(nanometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromNanometerPerSecondSquared(int? nanometerpersecondsquared)
+        {
+            if (nanometerpersecondsquared.HasValue)
+            {
+                return FromNanometerPerSecondSquared(nanometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
+        /// </summary>
+        public static Acceleration? FromNanometerPerSecondSquared(long? nanometerpersecondsquared)
+        {
+            if (nanometerpersecondsquared.HasValue)
+            {
+                return FromNanometerPerSecondSquared(nanometerpersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Acceleration from NanometerPerSecondSquared of type decimal.
+        /// </summary>
+        public static Acceleration? FromNanometerPerSecondSquared(decimal? nanometerpersecondsquared)
         {
             if (nanometerpersecondsquared.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -178,6 +178,33 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmicrovolts - 120);
         }
 
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelMicrovolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMicrovolts(int decibelmicrovolts)
+        {
+            return new AmplitudeRatio(decibelmicrovolts - 120);
+        }
+
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelMicrovolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMicrovolts(long decibelmicrovolts)
+        {
+            return new AmplitudeRatio(decibelmicrovolts - 120);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelMicrovolts of type decimal.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMicrovolts(decimal decibelmicrovolts)
+        {
+	        return new AmplitudeRatio(Convert.ToDouble(decibelmicrovolts) - 120);
+        }
+#endif
+
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
@@ -185,6 +212,33 @@ namespace UnitsNet
         {
             return new AmplitudeRatio(decibelmillivolts - 60);
         }
+
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelMillivolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMillivolts(int decibelmillivolts)
+        {
+            return new AmplitudeRatio(decibelmillivolts - 60);
+        }
+
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelMillivolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMillivolts(long decibelmillivolts)
+        {
+            return new AmplitudeRatio(decibelmillivolts - 60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelMillivolts of type decimal.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelMillivolts(decimal decibelmillivolts)
+        {
+	        return new AmplitudeRatio(Convert.ToDouble(decibelmillivolts) - 60);
+        }
+#endif
 
         /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
@@ -194,6 +248,33 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelsunloaded - 2.218487499);
         }
 
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelsUnloaded.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelsUnloaded(int decibelsunloaded)
+        {
+            return new AmplitudeRatio(decibelsunloaded - 2.218487499);
+        }
+
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelsUnloaded.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelsUnloaded(long decibelsunloaded)
+        {
+            return new AmplitudeRatio(decibelsunloaded - 2.218487499);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelsUnloaded of type decimal.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelsUnloaded(decimal decibelsunloaded)
+        {
+	        return new AmplitudeRatio(Convert.ToDouble(decibelsunloaded) - 2.218487499);
+        }
+#endif
+
         /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
@@ -202,12 +283,84 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelvolts);
         }
 
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelVolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelVolts(int decibelvolts)
+        {
+            return new AmplitudeRatio(decibelvolts);
+        }
+
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelVolts.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelVolts(long decibelvolts)
+        {
+            return new AmplitudeRatio(decibelvolts);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AmplitudeRatio from DecibelVolts of type decimal.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelVolts(decimal decibelvolts)
+        {
+	        return new AmplitudeRatio(Convert.ToDouble(decibelvolts));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMicrovolts(double? decibelmicrovolts)
+        {
+            if (decibelmicrovolts.HasValue)
+            {
+                return FromDecibelMicrovolts(decibelmicrovolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelMicrovolts(int? decibelmicrovolts)
+        {
+            if (decibelmicrovolts.HasValue)
+            {
+                return FromDecibelMicrovolts(decibelmicrovolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelMicrovolts(long? decibelmicrovolts)
+        {
+            if (decibelmicrovolts.HasValue)
+            {
+                return FromDecibelMicrovolts(decibelmicrovolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from DecibelMicrovolts of type decimal.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelMicrovolts(decimal? decibelmicrovolts)
         {
             if (decibelmicrovolts.HasValue)
             {
@@ -234,6 +387,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelMillivolts(int? decibelmillivolts)
+        {
+            if (decibelmillivolts.HasValue)
+            {
+                return FromDecibelMillivolts(decibelmillivolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelMillivolts(long? decibelmillivolts)
+        {
+            if (decibelmillivolts.HasValue)
+            {
+                return FromDecibelMillivolts(decibelmillivolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from DecibelMillivolts of type decimal.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelMillivolts(decimal? decibelmillivolts)
+        {
+            if (decibelmillivolts.HasValue)
+            {
+                return FromDecibelMillivolts(decibelmillivolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
         /// </summary>
@@ -249,10 +447,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelsUnloaded(int? decibelsunloaded)
+        {
+            if (decibelsunloaded.HasValue)
+            {
+                return FromDecibelsUnloaded(decibelsunloaded.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelsUnloaded(long? decibelsunloaded)
+        {
+            if (decibelsunloaded.HasValue)
+            {
+                return FromDecibelsUnloaded(decibelsunloaded.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from DecibelsUnloaded of type decimal.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelsUnloaded(decimal? decibelsunloaded)
+        {
+            if (decibelsunloaded.HasValue)
+            {
+                return FromDecibelsUnloaded(decibelsunloaded.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelVolts(double? decibelvolts)
+        {
+            if (decibelvolts.HasValue)
+            {
+                return FromDecibelVolts(decibelvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelVolts(int? decibelvolts)
+        {
+            if (decibelvolts.HasValue)
+            {
+                return FromDecibelVolts(decibelvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelVolts(long? decibelvolts)
+        {
+            if (decibelvolts.HasValue)
+            {
+                return FromDecibelVolts(decibelvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AmplitudeRatio from DecibelVolts of type decimal.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelVolts(decimal? decibelvolts)
         {
             if (decibelvolts.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -173,6 +173,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AmplitudeRatio FromDecibelMicrovolts(double decibelmicrovolts)
         {
             return new AmplitudeRatio(decibelmicrovolts - 120);
@@ -208,6 +211,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AmplitudeRatio FromDecibelMillivolts(double decibelmillivolts)
         {
             return new AmplitudeRatio(decibelmillivolts - 60);
@@ -243,6 +249,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AmplitudeRatio FromDecibelsUnloaded(double decibelsunloaded)
         {
             return new AmplitudeRatio(decibelsunloaded - 2.218487499);
@@ -278,6 +287,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AmplitudeRatio FromDecibelVolts(double decibelvolts)
         {
             return new AmplitudeRatio(decibelvolts);

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _decibelVolts;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public AmplitudeRatio() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.AmplitudeRatio;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static AmplitudeRatioUnit BaseUnit
         {
             get { return AmplitudeRatioUnit.DecibelVolt; }
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmicrovolts - 120);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts.
         /// </summary>
         public static AmplitudeRatio FromDecibelMicrovolts(int decibelmicrovolts)
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmicrovolts - 120);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts.
         /// </summary>
         public static AmplitudeRatio FromDecibelMicrovolts(long decibelmicrovolts)
@@ -194,14 +194,14 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmicrovolts - 120);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts of type decimal.
         /// </summary>
         public static AmplitudeRatio FromDecibelMicrovolts(decimal decibelmicrovolts)
         {
-	        return new AmplitudeRatio(Convert.ToDouble(decibelmicrovolts) - 120);
+            return new AmplitudeRatio(Convert.ToDouble(decibelmicrovolts) - 120);
         }
 #endif
 
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmillivolts - 60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
         public static AmplitudeRatio FromDecibelMillivolts(int decibelmillivolts)
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmillivolts - 60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
         public static AmplitudeRatio FromDecibelMillivolts(long decibelmillivolts)
@@ -229,14 +229,14 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelmillivolts - 60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts of type decimal.
         /// </summary>
         public static AmplitudeRatio FromDecibelMillivolts(decimal decibelmillivolts)
         {
-	        return new AmplitudeRatio(Convert.ToDouble(decibelmillivolts) - 60);
+            return new AmplitudeRatio(Convert.ToDouble(decibelmillivolts) - 60);
         }
 #endif
 
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelsunloaded - 2.218487499);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
         /// </summary>
         public static AmplitudeRatio FromDecibelsUnloaded(int decibelsunloaded)
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelsunloaded - 2.218487499);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
         /// </summary>
         public static AmplitudeRatio FromDecibelsUnloaded(long decibelsunloaded)
@@ -264,14 +264,14 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelsunloaded - 2.218487499);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded of type decimal.
         /// </summary>
         public static AmplitudeRatio FromDecibelsUnloaded(decimal decibelsunloaded)
         {
-	        return new AmplitudeRatio(Convert.ToDouble(decibelsunloaded) - 2.218487499);
+            return new AmplitudeRatio(Convert.ToDouble(decibelsunloaded) - 2.218487499);
         }
 #endif
 
@@ -283,7 +283,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelvolts);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
         public static AmplitudeRatio FromDecibelVolts(int decibelvolts)
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelvolts);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
         public static AmplitudeRatio FromDecibelVolts(long decibelvolts)
@@ -299,14 +299,14 @@ namespace UnitsNet
             return new AmplitudeRatio(decibelvolts);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts of type decimal.
         /// </summary>
         public static AmplitudeRatio FromDecibelVolts(decimal decibelvolts)
         {
-	        return new AmplitudeRatio(Convert.ToDouble(decibelvolts));
+            return new AmplitudeRatio(Convert.ToDouble(decibelvolts));
         }
 #endif
 
@@ -327,7 +327,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMicrovolts(int? decibelmicrovolts)
@@ -342,7 +342,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMicrovolts(long? decibelmicrovolts)
@@ -357,7 +357,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from DecibelMicrovolts of type decimal.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMicrovolts(decimal? decibelmicrovolts)
@@ -387,7 +387,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMillivolts(int? decibelmillivolts)
@@ -402,7 +402,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMillivolts(long? decibelmillivolts)
@@ -417,7 +417,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from DecibelMillivolts of type decimal.
         /// </summary>
         public static AmplitudeRatio? FromDecibelMillivolts(decimal? decibelmillivolts)
@@ -447,7 +447,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
         /// </summary>
         public static AmplitudeRatio? FromDecibelsUnloaded(int? decibelsunloaded)
@@ -462,7 +462,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
         /// </summary>
         public static AmplitudeRatio? FromDecibelsUnloaded(long? decibelsunloaded)
@@ -477,7 +477,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from DecibelsUnloaded of type decimal.
         /// </summary>
         public static AmplitudeRatio? FromDecibelsUnloaded(decimal? decibelsunloaded)
@@ -507,7 +507,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelVolts(int? decibelvolts)
@@ -522,7 +522,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelVolts(long? decibelvolts)
@@ -537,7 +537,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AmplitudeRatio from DecibelVolts of type decimal.
         /// </summary>
         public static AmplitudeRatio? FromDecibelVolts(decimal? decibelvolts)

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -250,6 +250,33 @@ namespace UnitsNet
             return new Angle(arcminutes/60);
         }
 
+		/// <summary>
+        ///     Get Angle from Arcminutes.
+        /// </summary>
+        public static Angle FromArcminutes(int arcminutes)
+        {
+            return new Angle(arcminutes/60);
+        }
+
+		/// <summary>
+        ///     Get Angle from Arcminutes.
+        /// </summary>
+        public static Angle FromArcminutes(long arcminutes)
+        {
+            return new Angle(arcminutes/60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Arcminutes of type decimal.
+        /// </summary>
+        public static Angle FromArcminutes(decimal arcminutes)
+        {
+	        return new Angle(Convert.ToDouble(arcminutes)/60);
+        }
+#endif
+
         /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
@@ -257,6 +284,33 @@ namespace UnitsNet
         {
             return new Angle(arcseconds/3600);
         }
+
+		/// <summary>
+        ///     Get Angle from Arcseconds.
+        /// </summary>
+        public static Angle FromArcseconds(int arcseconds)
+        {
+            return new Angle(arcseconds/3600);
+        }
+
+		/// <summary>
+        ///     Get Angle from Arcseconds.
+        /// </summary>
+        public static Angle FromArcseconds(long arcseconds)
+        {
+            return new Angle(arcseconds/3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Arcseconds of type decimal.
+        /// </summary>
+        public static Angle FromArcseconds(decimal arcseconds)
+        {
+	        return new Angle(Convert.ToDouble(arcseconds)/3600);
+        }
+#endif
 
         /// <summary>
         ///     Get Angle from Centiradians.
@@ -266,6 +320,33 @@ namespace UnitsNet
             return new Angle((centiradians*180/Math.PI) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Angle from Centiradians.
+        /// </summary>
+        public static Angle FromCentiradians(int centiradians)
+        {
+            return new Angle((centiradians*180/Math.PI) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Centiradians.
+        /// </summary>
+        public static Angle FromCentiradians(long centiradians)
+        {
+            return new Angle((centiradians*180/Math.PI) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Centiradians of type decimal.
+        /// </summary>
+        public static Angle FromCentiradians(decimal centiradians)
+        {
+	        return new Angle((Convert.ToDouble(centiradians)*180/Math.PI) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
@@ -273,6 +354,33 @@ namespace UnitsNet
         {
             return new Angle((deciradians*180/Math.PI) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Angle from Deciradians.
+        /// </summary>
+        public static Angle FromDeciradians(int deciradians)
+        {
+            return new Angle((deciradians*180/Math.PI) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Deciradians.
+        /// </summary>
+        public static Angle FromDeciradians(long deciradians)
+        {
+            return new Angle((deciradians*180/Math.PI) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Deciradians of type decimal.
+        /// </summary>
+        public static Angle FromDeciradians(decimal deciradians)
+        {
+	        return new Angle((Convert.ToDouble(deciradians)*180/Math.PI) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Angle from Degrees.
@@ -282,6 +390,33 @@ namespace UnitsNet
             return new Angle(degrees);
         }
 
+		/// <summary>
+        ///     Get Angle from Degrees.
+        /// </summary>
+        public static Angle FromDegrees(int degrees)
+        {
+            return new Angle(degrees);
+        }
+
+		/// <summary>
+        ///     Get Angle from Degrees.
+        /// </summary>
+        public static Angle FromDegrees(long degrees)
+        {
+            return new Angle(degrees);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Degrees of type decimal.
+        /// </summary>
+        public static Angle FromDegrees(decimal degrees)
+        {
+	        return new Angle(Convert.ToDouble(degrees));
+        }
+#endif
+
         /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
@@ -289,6 +424,33 @@ namespace UnitsNet
         {
             return new Angle(gradians*0.9);
         }
+
+		/// <summary>
+        ///     Get Angle from Gradians.
+        /// </summary>
+        public static Angle FromGradians(int gradians)
+        {
+            return new Angle(gradians*0.9);
+        }
+
+		/// <summary>
+        ///     Get Angle from Gradians.
+        /// </summary>
+        public static Angle FromGradians(long gradians)
+        {
+            return new Angle(gradians*0.9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Gradians of type decimal.
+        /// </summary>
+        public static Angle FromGradians(decimal gradians)
+        {
+	        return new Angle(Convert.ToDouble(gradians)*0.9);
+        }
+#endif
 
         /// <summary>
         ///     Get Angle from Microdegrees.
@@ -298,6 +460,33 @@ namespace UnitsNet
             return new Angle((microdegrees) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Angle from Microdegrees.
+        /// </summary>
+        public static Angle FromMicrodegrees(int microdegrees)
+        {
+            return new Angle((microdegrees) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Microdegrees.
+        /// </summary>
+        public static Angle FromMicrodegrees(long microdegrees)
+        {
+            return new Angle((microdegrees) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Microdegrees of type decimal.
+        /// </summary>
+        public static Angle FromMicrodegrees(decimal microdegrees)
+        {
+	        return new Angle((Convert.ToDouble(microdegrees)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
@@ -305,6 +494,33 @@ namespace UnitsNet
         {
             return new Angle((microradians*180/Math.PI) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get Angle from Microradians.
+        /// </summary>
+        public static Angle FromMicroradians(int microradians)
+        {
+            return new Angle((microradians*180/Math.PI) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Microradians.
+        /// </summary>
+        public static Angle FromMicroradians(long microradians)
+        {
+            return new Angle((microradians*180/Math.PI) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Microradians of type decimal.
+        /// </summary>
+        public static Angle FromMicroradians(decimal microradians)
+        {
+	        return new Angle((Convert.ToDouble(microradians)*180/Math.PI) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Angle from Millidegrees.
@@ -314,6 +530,33 @@ namespace UnitsNet
             return new Angle((millidegrees) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Angle from Millidegrees.
+        /// </summary>
+        public static Angle FromMillidegrees(int millidegrees)
+        {
+            return new Angle((millidegrees) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Millidegrees.
+        /// </summary>
+        public static Angle FromMillidegrees(long millidegrees)
+        {
+            return new Angle((millidegrees) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Millidegrees of type decimal.
+        /// </summary>
+        public static Angle FromMillidegrees(decimal millidegrees)
+        {
+	        return new Angle((Convert.ToDouble(millidegrees)) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
@@ -321,6 +564,33 @@ namespace UnitsNet
         {
             return new Angle((milliradians*180/Math.PI) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Angle from Milliradians.
+        /// </summary>
+        public static Angle FromMilliradians(int milliradians)
+        {
+            return new Angle((milliradians*180/Math.PI) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Milliradians.
+        /// </summary>
+        public static Angle FromMilliradians(long milliradians)
+        {
+            return new Angle((milliradians*180/Math.PI) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Milliradians of type decimal.
+        /// </summary>
+        public static Angle FromMilliradians(decimal milliradians)
+        {
+	        return new Angle((Convert.ToDouble(milliradians)*180/Math.PI) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Angle from Nanodegrees.
@@ -330,6 +600,33 @@ namespace UnitsNet
             return new Angle((nanodegrees) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Angle from Nanodegrees.
+        /// </summary>
+        public static Angle FromNanodegrees(int nanodegrees)
+        {
+            return new Angle((nanodegrees) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Nanodegrees.
+        /// </summary>
+        public static Angle FromNanodegrees(long nanodegrees)
+        {
+            return new Angle((nanodegrees) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Nanodegrees of type decimal.
+        /// </summary>
+        public static Angle FromNanodegrees(decimal nanodegrees)
+        {
+	        return new Angle((Convert.ToDouble(nanodegrees)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
@@ -337,6 +634,33 @@ namespace UnitsNet
         {
             return new Angle((nanoradians*180/Math.PI) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get Angle from Nanoradians.
+        /// </summary>
+        public static Angle FromNanoradians(int nanoradians)
+        {
+            return new Angle((nanoradians*180/Math.PI) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Angle from Nanoradians.
+        /// </summary>
+        public static Angle FromNanoradians(long nanoradians)
+        {
+            return new Angle((nanoradians*180/Math.PI) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Nanoradians of type decimal.
+        /// </summary>
+        public static Angle FromNanoradians(decimal nanoradians)
+        {
+	        return new Angle((Convert.ToDouble(nanoradians)*180/Math.PI) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get Angle from Radians.
@@ -346,12 +670,84 @@ namespace UnitsNet
             return new Angle(radians*180/Math.PI);
         }
 
+		/// <summary>
+        ///     Get Angle from Radians.
+        /// </summary>
+        public static Angle FromRadians(int radians)
+        {
+            return new Angle(radians*180/Math.PI);
+        }
+
+		/// <summary>
+        ///     Get Angle from Radians.
+        /// </summary>
+        public static Angle FromRadians(long radians)
+        {
+            return new Angle(radians*180/Math.PI);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Angle from Radians of type decimal.
+        /// </summary>
+        public static Angle FromRadians(decimal radians)
+        {
+	        return new Angle(Convert.ToDouble(radians)*180/Math.PI);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Angle from nullable Arcminutes.
         /// </summary>
         public static Angle? FromArcminutes(double? arcminutes)
+        {
+            if (arcminutes.HasValue)
+            {
+                return FromArcminutes(arcminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Arcminutes.
+        /// </summary>
+        public static Angle? FromArcminutes(int? arcminutes)
+        {
+            if (arcminutes.HasValue)
+            {
+                return FromArcminutes(arcminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Arcminutes.
+        /// </summary>
+        public static Angle? FromArcminutes(long? arcminutes)
+        {
+            if (arcminutes.HasValue)
+            {
+                return FromArcminutes(arcminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Arcminutes of type decimal.
+        /// </summary>
+        public static Angle? FromArcminutes(decimal? arcminutes)
         {
             if (arcminutes.HasValue)
             {
@@ -378,10 +774,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Angle from nullable Arcseconds.
+        /// </summary>
+        public static Angle? FromArcseconds(int? arcseconds)
+        {
+            if (arcseconds.HasValue)
+            {
+                return FromArcseconds(arcseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Arcseconds.
+        /// </summary>
+        public static Angle? FromArcseconds(long? arcseconds)
+        {
+            if (arcseconds.HasValue)
+            {
+                return FromArcseconds(arcseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Arcseconds of type decimal.
+        /// </summary>
+        public static Angle? FromArcseconds(decimal? arcseconds)
+        {
+            if (arcseconds.HasValue)
+            {
+                return FromArcseconds(arcseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Angle from nullable Centiradians.
         /// </summary>
         public static Angle? FromCentiradians(double? centiradians)
+        {
+            if (centiradians.HasValue)
+            {
+                return FromCentiradians(centiradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Centiradians.
+        /// </summary>
+        public static Angle? FromCentiradians(int? centiradians)
+        {
+            if (centiradians.HasValue)
+            {
+                return FromCentiradians(centiradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Centiradians.
+        /// </summary>
+        public static Angle? FromCentiradians(long? centiradians)
+        {
+            if (centiradians.HasValue)
+            {
+                return FromCentiradians(centiradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Centiradians of type decimal.
+        /// </summary>
+        public static Angle? FromCentiradians(decimal? centiradians)
         {
             if (centiradians.HasValue)
             {
@@ -408,10 +894,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Angle from nullable Deciradians.
+        /// </summary>
+        public static Angle? FromDeciradians(int? deciradians)
+        {
+            if (deciradians.HasValue)
+            {
+                return FromDeciradians(deciradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Deciradians.
+        /// </summary>
+        public static Angle? FromDeciradians(long? deciradians)
+        {
+            if (deciradians.HasValue)
+            {
+                return FromDeciradians(deciradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Deciradians of type decimal.
+        /// </summary>
+        public static Angle? FromDeciradians(decimal? deciradians)
+        {
+            if (deciradians.HasValue)
+            {
+                return FromDeciradians(deciradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Angle from nullable Degrees.
         /// </summary>
         public static Angle? FromDegrees(double? degrees)
+        {
+            if (degrees.HasValue)
+            {
+                return FromDegrees(degrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Degrees.
+        /// </summary>
+        public static Angle? FromDegrees(int? degrees)
+        {
+            if (degrees.HasValue)
+            {
+                return FromDegrees(degrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Degrees.
+        /// </summary>
+        public static Angle? FromDegrees(long? degrees)
+        {
+            if (degrees.HasValue)
+            {
+                return FromDegrees(degrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Degrees of type decimal.
+        /// </summary>
+        public static Angle? FromDegrees(decimal? degrees)
         {
             if (degrees.HasValue)
             {
@@ -438,10 +1014,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Angle from nullable Gradians.
+        /// </summary>
+        public static Angle? FromGradians(int? gradians)
+        {
+            if (gradians.HasValue)
+            {
+                return FromGradians(gradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Gradians.
+        /// </summary>
+        public static Angle? FromGradians(long? gradians)
+        {
+            if (gradians.HasValue)
+            {
+                return FromGradians(gradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Gradians of type decimal.
+        /// </summary>
+        public static Angle? FromGradians(decimal? gradians)
+        {
+            if (gradians.HasValue)
+            {
+                return FromGradians(gradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Angle from nullable Microdegrees.
         /// </summary>
         public static Angle? FromMicrodegrees(double? microdegrees)
+        {
+            if (microdegrees.HasValue)
+            {
+                return FromMicrodegrees(microdegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Microdegrees.
+        /// </summary>
+        public static Angle? FromMicrodegrees(int? microdegrees)
+        {
+            if (microdegrees.HasValue)
+            {
+                return FromMicrodegrees(microdegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Microdegrees.
+        /// </summary>
+        public static Angle? FromMicrodegrees(long? microdegrees)
+        {
+            if (microdegrees.HasValue)
+            {
+                return FromMicrodegrees(microdegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Microdegrees of type decimal.
+        /// </summary>
+        public static Angle? FromMicrodegrees(decimal? microdegrees)
         {
             if (microdegrees.HasValue)
             {
@@ -468,10 +1134,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Angle from nullable Microradians.
+        /// </summary>
+        public static Angle? FromMicroradians(int? microradians)
+        {
+            if (microradians.HasValue)
+            {
+                return FromMicroradians(microradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Microradians.
+        /// </summary>
+        public static Angle? FromMicroradians(long? microradians)
+        {
+            if (microradians.HasValue)
+            {
+                return FromMicroradians(microradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Microradians of type decimal.
+        /// </summary>
+        public static Angle? FromMicroradians(decimal? microradians)
+        {
+            if (microradians.HasValue)
+            {
+                return FromMicroradians(microradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Angle from nullable Millidegrees.
         /// </summary>
         public static Angle? FromMillidegrees(double? millidegrees)
+        {
+            if (millidegrees.HasValue)
+            {
+                return FromMillidegrees(millidegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Millidegrees.
+        /// </summary>
+        public static Angle? FromMillidegrees(int? millidegrees)
+        {
+            if (millidegrees.HasValue)
+            {
+                return FromMillidegrees(millidegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Millidegrees.
+        /// </summary>
+        public static Angle? FromMillidegrees(long? millidegrees)
+        {
+            if (millidegrees.HasValue)
+            {
+                return FromMillidegrees(millidegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Millidegrees of type decimal.
+        /// </summary>
+        public static Angle? FromMillidegrees(decimal? millidegrees)
         {
             if (millidegrees.HasValue)
             {
@@ -498,10 +1254,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Angle from nullable Milliradians.
+        /// </summary>
+        public static Angle? FromMilliradians(int? milliradians)
+        {
+            if (milliradians.HasValue)
+            {
+                return FromMilliradians(milliradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Milliradians.
+        /// </summary>
+        public static Angle? FromMilliradians(long? milliradians)
+        {
+            if (milliradians.HasValue)
+            {
+                return FromMilliradians(milliradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Milliradians of type decimal.
+        /// </summary>
+        public static Angle? FromMilliradians(decimal? milliradians)
+        {
+            if (milliradians.HasValue)
+            {
+                return FromMilliradians(milliradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Angle from nullable Nanodegrees.
         /// </summary>
         public static Angle? FromNanodegrees(double? nanodegrees)
+        {
+            if (nanodegrees.HasValue)
+            {
+                return FromNanodegrees(nanodegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Nanodegrees.
+        /// </summary>
+        public static Angle? FromNanodegrees(int? nanodegrees)
+        {
+            if (nanodegrees.HasValue)
+            {
+                return FromNanodegrees(nanodegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Nanodegrees.
+        /// </summary>
+        public static Angle? FromNanodegrees(long? nanodegrees)
+        {
+            if (nanodegrees.HasValue)
+            {
+                return FromNanodegrees(nanodegrees.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Nanodegrees of type decimal.
+        /// </summary>
+        public static Angle? FromNanodegrees(decimal? nanodegrees)
         {
             if (nanodegrees.HasValue)
             {
@@ -528,10 +1374,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Angle from nullable Nanoradians.
+        /// </summary>
+        public static Angle? FromNanoradians(int? nanoradians)
+        {
+            if (nanoradians.HasValue)
+            {
+                return FromNanoradians(nanoradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Nanoradians.
+        /// </summary>
+        public static Angle? FromNanoradians(long? nanoradians)
+        {
+            if (nanoradians.HasValue)
+            {
+                return FromNanoradians(nanoradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Nanoradians of type decimal.
+        /// </summary>
+        public static Angle? FromNanoradians(decimal? nanoradians)
+        {
+            if (nanoradians.HasValue)
+            {
+                return FromNanoradians(nanoradians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Angle from nullable Radians.
         /// </summary>
         public static Angle? FromRadians(double? radians)
+        {
+            if (radians.HasValue)
+            {
+                return FromRadians(radians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Radians.
+        /// </summary>
+        public static Angle? FromRadians(int? radians)
+        {
+            if (radians.HasValue)
+            {
+                return FromRadians(radians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from nullable Radians.
+        /// </summary>
+        public static Angle? FromRadians(long? radians)
+        {
+            if (radians.HasValue)
+            {
+                return FromRadians(radians.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Angle from Radians of type decimal.
+        /// </summary>
+        public static Angle? FromRadians(decimal? radians)
         {
             if (radians.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _degrees;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Angle() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Angle;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static AngleUnit BaseUnit
         {
             get { return AngleUnit.Degree; }
@@ -250,7 +250,7 @@ namespace UnitsNet
             return new Angle(arcminutes/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Arcminutes.
         /// </summary>
         public static Angle FromArcminutes(int arcminutes)
@@ -258,7 +258,7 @@ namespace UnitsNet
             return new Angle(arcminutes/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Arcminutes.
         /// </summary>
         public static Angle FromArcminutes(long arcminutes)
@@ -266,14 +266,14 @@ namespace UnitsNet
             return new Angle(arcminutes/60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Arcminutes of type decimal.
         /// </summary>
         public static Angle FromArcminutes(decimal arcminutes)
         {
-	        return new Angle(Convert.ToDouble(arcminutes)/60);
+            return new Angle(Convert.ToDouble(arcminutes)/60);
         }
 #endif
 
@@ -285,7 +285,7 @@ namespace UnitsNet
             return new Angle(arcseconds/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
         public static Angle FromArcseconds(int arcseconds)
@@ -293,7 +293,7 @@ namespace UnitsNet
             return new Angle(arcseconds/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
         public static Angle FromArcseconds(long arcseconds)
@@ -301,14 +301,14 @@ namespace UnitsNet
             return new Angle(arcseconds/3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Arcseconds of type decimal.
         /// </summary>
         public static Angle FromArcseconds(decimal arcseconds)
         {
-	        return new Angle(Convert.ToDouble(arcseconds)/3600);
+            return new Angle(Convert.ToDouble(arcseconds)/3600);
         }
 #endif
 
@@ -320,7 +320,7 @@ namespace UnitsNet
             return new Angle((centiradians*180/Math.PI) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Centiradians.
         /// </summary>
         public static Angle FromCentiradians(int centiradians)
@@ -328,7 +328,7 @@ namespace UnitsNet
             return new Angle((centiradians*180/Math.PI) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Centiradians.
         /// </summary>
         public static Angle FromCentiradians(long centiradians)
@@ -336,14 +336,14 @@ namespace UnitsNet
             return new Angle((centiradians*180/Math.PI) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Centiradians of type decimal.
         /// </summary>
         public static Angle FromCentiradians(decimal centiradians)
         {
-	        return new Angle((Convert.ToDouble(centiradians)*180/Math.PI) * 1e-2d);
+            return new Angle((Convert.ToDouble(centiradians)*180/Math.PI) * 1e-2d);
         }
 #endif
 
@@ -355,7 +355,7 @@ namespace UnitsNet
             return new Angle((deciradians*180/Math.PI) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
         public static Angle FromDeciradians(int deciradians)
@@ -363,7 +363,7 @@ namespace UnitsNet
             return new Angle((deciradians*180/Math.PI) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
         public static Angle FromDeciradians(long deciradians)
@@ -371,14 +371,14 @@ namespace UnitsNet
             return new Angle((deciradians*180/Math.PI) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Deciradians of type decimal.
         /// </summary>
         public static Angle FromDeciradians(decimal deciradians)
         {
-	        return new Angle((Convert.ToDouble(deciradians)*180/Math.PI) * 1e-1d);
+            return new Angle((Convert.ToDouble(deciradians)*180/Math.PI) * 1e-1d);
         }
 #endif
 
@@ -390,7 +390,7 @@ namespace UnitsNet
             return new Angle(degrees);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Degrees.
         /// </summary>
         public static Angle FromDegrees(int degrees)
@@ -398,7 +398,7 @@ namespace UnitsNet
             return new Angle(degrees);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Degrees.
         /// </summary>
         public static Angle FromDegrees(long degrees)
@@ -406,14 +406,14 @@ namespace UnitsNet
             return new Angle(degrees);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Degrees of type decimal.
         /// </summary>
         public static Angle FromDegrees(decimal degrees)
         {
-	        return new Angle(Convert.ToDouble(degrees));
+            return new Angle(Convert.ToDouble(degrees));
         }
 #endif
 
@@ -425,7 +425,7 @@ namespace UnitsNet
             return new Angle(gradians*0.9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
         public static Angle FromGradians(int gradians)
@@ -433,7 +433,7 @@ namespace UnitsNet
             return new Angle(gradians*0.9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
         public static Angle FromGradians(long gradians)
@@ -441,14 +441,14 @@ namespace UnitsNet
             return new Angle(gradians*0.9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Gradians of type decimal.
         /// </summary>
         public static Angle FromGradians(decimal gradians)
         {
-	        return new Angle(Convert.ToDouble(gradians)*0.9);
+            return new Angle(Convert.ToDouble(gradians)*0.9);
         }
 #endif
 
@@ -460,7 +460,7 @@ namespace UnitsNet
             return new Angle((microdegrees) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Microdegrees.
         /// </summary>
         public static Angle FromMicrodegrees(int microdegrees)
@@ -468,7 +468,7 @@ namespace UnitsNet
             return new Angle((microdegrees) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Microdegrees.
         /// </summary>
         public static Angle FromMicrodegrees(long microdegrees)
@@ -476,14 +476,14 @@ namespace UnitsNet
             return new Angle((microdegrees) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Microdegrees of type decimal.
         /// </summary>
         public static Angle FromMicrodegrees(decimal microdegrees)
         {
-	        return new Angle((Convert.ToDouble(microdegrees)) * 1e-6d);
+            return new Angle((Convert.ToDouble(microdegrees)) * 1e-6d);
         }
 #endif
 
@@ -495,7 +495,7 @@ namespace UnitsNet
             return new Angle((microradians*180/Math.PI) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
         public static Angle FromMicroradians(int microradians)
@@ -503,7 +503,7 @@ namespace UnitsNet
             return new Angle((microradians*180/Math.PI) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
         public static Angle FromMicroradians(long microradians)
@@ -511,14 +511,14 @@ namespace UnitsNet
             return new Angle((microradians*180/Math.PI) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Microradians of type decimal.
         /// </summary>
         public static Angle FromMicroradians(decimal microradians)
         {
-	        return new Angle((Convert.ToDouble(microradians)*180/Math.PI) * 1e-6d);
+            return new Angle((Convert.ToDouble(microradians)*180/Math.PI) * 1e-6d);
         }
 #endif
 
@@ -530,7 +530,7 @@ namespace UnitsNet
             return new Angle((millidegrees) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Millidegrees.
         /// </summary>
         public static Angle FromMillidegrees(int millidegrees)
@@ -538,7 +538,7 @@ namespace UnitsNet
             return new Angle((millidegrees) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Millidegrees.
         /// </summary>
         public static Angle FromMillidegrees(long millidegrees)
@@ -546,14 +546,14 @@ namespace UnitsNet
             return new Angle((millidegrees) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Millidegrees of type decimal.
         /// </summary>
         public static Angle FromMillidegrees(decimal millidegrees)
         {
-	        return new Angle((Convert.ToDouble(millidegrees)) * 1e-3d);
+            return new Angle((Convert.ToDouble(millidegrees)) * 1e-3d);
         }
 #endif
 
@@ -565,7 +565,7 @@ namespace UnitsNet
             return new Angle((milliradians*180/Math.PI) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
         public static Angle FromMilliradians(int milliradians)
@@ -573,7 +573,7 @@ namespace UnitsNet
             return new Angle((milliradians*180/Math.PI) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
         public static Angle FromMilliradians(long milliradians)
@@ -581,14 +581,14 @@ namespace UnitsNet
             return new Angle((milliradians*180/Math.PI) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Milliradians of type decimal.
         /// </summary>
         public static Angle FromMilliradians(decimal milliradians)
         {
-	        return new Angle((Convert.ToDouble(milliradians)*180/Math.PI) * 1e-3d);
+            return new Angle((Convert.ToDouble(milliradians)*180/Math.PI) * 1e-3d);
         }
 #endif
 
@@ -600,7 +600,7 @@ namespace UnitsNet
             return new Angle((nanodegrees) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Nanodegrees.
         /// </summary>
         public static Angle FromNanodegrees(int nanodegrees)
@@ -608,7 +608,7 @@ namespace UnitsNet
             return new Angle((nanodegrees) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Nanodegrees.
         /// </summary>
         public static Angle FromNanodegrees(long nanodegrees)
@@ -616,14 +616,14 @@ namespace UnitsNet
             return new Angle((nanodegrees) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Nanodegrees of type decimal.
         /// </summary>
         public static Angle FromNanodegrees(decimal nanodegrees)
         {
-	        return new Angle((Convert.ToDouble(nanodegrees)) * 1e-9d);
+            return new Angle((Convert.ToDouble(nanodegrees)) * 1e-9d);
         }
 #endif
 
@@ -635,7 +635,7 @@ namespace UnitsNet
             return new Angle((nanoradians*180/Math.PI) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
         public static Angle FromNanoradians(int nanoradians)
@@ -643,7 +643,7 @@ namespace UnitsNet
             return new Angle((nanoradians*180/Math.PI) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
         public static Angle FromNanoradians(long nanoradians)
@@ -651,14 +651,14 @@ namespace UnitsNet
             return new Angle((nanoradians*180/Math.PI) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Nanoradians of type decimal.
         /// </summary>
         public static Angle FromNanoradians(decimal nanoradians)
         {
-	        return new Angle((Convert.ToDouble(nanoradians)*180/Math.PI) * 1e-9d);
+            return new Angle((Convert.ToDouble(nanoradians)*180/Math.PI) * 1e-9d);
         }
 #endif
 
@@ -670,7 +670,7 @@ namespace UnitsNet
             return new Angle(radians*180/Math.PI);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Radians.
         /// </summary>
         public static Angle FromRadians(int radians)
@@ -678,7 +678,7 @@ namespace UnitsNet
             return new Angle(radians*180/Math.PI);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Radians.
         /// </summary>
         public static Angle FromRadians(long radians)
@@ -686,14 +686,14 @@ namespace UnitsNet
             return new Angle(radians*180/Math.PI);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Angle from Radians of type decimal.
         /// </summary>
         public static Angle FromRadians(decimal radians)
         {
-	        return new Angle(Convert.ToDouble(radians)*180/Math.PI);
+            return new Angle(Convert.ToDouble(radians)*180/Math.PI);
         }
 #endif
 
@@ -714,7 +714,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Arcminutes.
         /// </summary>
         public static Angle? FromArcminutes(int? arcminutes)
@@ -729,7 +729,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Arcminutes.
         /// </summary>
         public static Angle? FromArcminutes(long? arcminutes)
@@ -744,7 +744,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Arcminutes of type decimal.
         /// </summary>
         public static Angle? FromArcminutes(decimal? arcminutes)
@@ -774,7 +774,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Arcseconds.
         /// </summary>
         public static Angle? FromArcseconds(int? arcseconds)
@@ -789,7 +789,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Arcseconds.
         /// </summary>
         public static Angle? FromArcseconds(long? arcseconds)
@@ -804,7 +804,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Arcseconds of type decimal.
         /// </summary>
         public static Angle? FromArcseconds(decimal? arcseconds)
@@ -834,7 +834,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Centiradians.
         /// </summary>
         public static Angle? FromCentiradians(int? centiradians)
@@ -849,7 +849,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Centiradians.
         /// </summary>
         public static Angle? FromCentiradians(long? centiradians)
@@ -864,7 +864,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Centiradians of type decimal.
         /// </summary>
         public static Angle? FromCentiradians(decimal? centiradians)
@@ -894,7 +894,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Deciradians.
         /// </summary>
         public static Angle? FromDeciradians(int? deciradians)
@@ -909,7 +909,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Deciradians.
         /// </summary>
         public static Angle? FromDeciradians(long? deciradians)
@@ -924,7 +924,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Deciradians of type decimal.
         /// </summary>
         public static Angle? FromDeciradians(decimal? deciradians)
@@ -954,7 +954,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Degrees.
         /// </summary>
         public static Angle? FromDegrees(int? degrees)
@@ -969,7 +969,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Degrees.
         /// </summary>
         public static Angle? FromDegrees(long? degrees)
@@ -984,7 +984,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Degrees of type decimal.
         /// </summary>
         public static Angle? FromDegrees(decimal? degrees)
@@ -1014,7 +1014,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Gradians.
         /// </summary>
         public static Angle? FromGradians(int? gradians)
@@ -1029,7 +1029,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Gradians.
         /// </summary>
         public static Angle? FromGradians(long? gradians)
@@ -1044,7 +1044,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Gradians of type decimal.
         /// </summary>
         public static Angle? FromGradians(decimal? gradians)
@@ -1074,7 +1074,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Microdegrees.
         /// </summary>
         public static Angle? FromMicrodegrees(int? microdegrees)
@@ -1089,7 +1089,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Microdegrees.
         /// </summary>
         public static Angle? FromMicrodegrees(long? microdegrees)
@@ -1104,7 +1104,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Microdegrees of type decimal.
         /// </summary>
         public static Angle? FromMicrodegrees(decimal? microdegrees)
@@ -1134,7 +1134,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Microradians.
         /// </summary>
         public static Angle? FromMicroradians(int? microradians)
@@ -1149,7 +1149,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Microradians.
         /// </summary>
         public static Angle? FromMicroradians(long? microradians)
@@ -1164,7 +1164,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Microradians of type decimal.
         /// </summary>
         public static Angle? FromMicroradians(decimal? microradians)
@@ -1194,7 +1194,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Millidegrees.
         /// </summary>
         public static Angle? FromMillidegrees(int? millidegrees)
@@ -1209,7 +1209,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Millidegrees.
         /// </summary>
         public static Angle? FromMillidegrees(long? millidegrees)
@@ -1224,7 +1224,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Millidegrees of type decimal.
         /// </summary>
         public static Angle? FromMillidegrees(decimal? millidegrees)
@@ -1254,7 +1254,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Milliradians.
         /// </summary>
         public static Angle? FromMilliradians(int? milliradians)
@@ -1269,7 +1269,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Milliradians.
         /// </summary>
         public static Angle? FromMilliradians(long? milliradians)
@@ -1284,7 +1284,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Milliradians of type decimal.
         /// </summary>
         public static Angle? FromMilliradians(decimal? milliradians)
@@ -1314,7 +1314,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Nanodegrees.
         /// </summary>
         public static Angle? FromNanodegrees(int? nanodegrees)
@@ -1329,7 +1329,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Nanodegrees.
         /// </summary>
         public static Angle? FromNanodegrees(long? nanodegrees)
@@ -1344,7 +1344,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Nanodegrees of type decimal.
         /// </summary>
         public static Angle? FromNanodegrees(decimal? nanodegrees)
@@ -1374,7 +1374,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Nanoradians.
         /// </summary>
         public static Angle? FromNanoradians(int? nanoradians)
@@ -1389,7 +1389,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Nanoradians.
         /// </summary>
         public static Angle? FromNanoradians(long? nanoradians)
@@ -1404,7 +1404,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Nanoradians of type decimal.
         /// </summary>
         public static Angle? FromNanoradians(decimal? nanoradians)
@@ -1434,7 +1434,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Radians.
         /// </summary>
         public static Angle? FromRadians(int? radians)
@@ -1449,7 +1449,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from nullable Radians.
         /// </summary>
         public static Angle? FromRadians(long? radians)
@@ -1464,7 +1464,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Angle from Radians of type decimal.
         /// </summary>
         public static Angle? FromRadians(decimal? radians)

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -245,6 +245,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcminutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromArcminutes(double arcminutes)
         {
             return new Angle(arcminutes/60);
@@ -280,6 +283,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromArcseconds(double arcseconds)
         {
             return new Angle(arcseconds/3600);
@@ -315,6 +321,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Centiradians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromCentiradians(double centiradians)
         {
             return new Angle((centiradians*180/Math.PI) * 1e-2d);
@@ -350,6 +359,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromDeciradians(double deciradians)
         {
             return new Angle((deciradians*180/Math.PI) * 1e-1d);
@@ -385,6 +397,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Degrees.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromDegrees(double degrees)
         {
             return new Angle(degrees);
@@ -420,6 +435,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromGradians(double gradians)
         {
             return new Angle(gradians*0.9);
@@ -455,6 +473,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Microdegrees.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromMicrodegrees(double microdegrees)
         {
             return new Angle((microdegrees) * 1e-6d);
@@ -490,6 +511,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromMicroradians(double microradians)
         {
             return new Angle((microradians*180/Math.PI) * 1e-6d);
@@ -525,6 +549,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Millidegrees.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromMillidegrees(double millidegrees)
         {
             return new Angle((millidegrees) * 1e-3d);
@@ -560,6 +587,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromMilliradians(double milliradians)
         {
             return new Angle((milliradians*180/Math.PI) * 1e-3d);
@@ -595,6 +625,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Nanodegrees.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromNanodegrees(double nanodegrees)
         {
             return new Angle((nanodegrees) * 1e-9d);
@@ -630,6 +663,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromNanoradians(double nanoradians)
         {
             return new Angle((nanoradians*180/Math.PI) * 1e-9d);
@@ -665,6 +701,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Radians.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Angle FromRadians(double radians)
         {
             return new Angle(radians*180/Math.PI);

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _voltamperes;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ApparentPower() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ApparentPower;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ApparentPowerUnit BaseUnit
         {
             get { return ApparentPowerUnit.Voltampere; }
@@ -170,7 +170,7 @@ namespace UnitsNet
             return new ApparentPower((kilovoltamperes) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Kilovoltamperes.
         /// </summary>
         public static ApparentPower FromKilovoltamperes(int kilovoltamperes)
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new ApparentPower((kilovoltamperes) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Kilovoltamperes.
         /// </summary>
         public static ApparentPower FromKilovoltamperes(long kilovoltamperes)
@@ -186,14 +186,14 @@ namespace UnitsNet
             return new ApparentPower((kilovoltamperes) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Kilovoltamperes of type decimal.
         /// </summary>
         public static ApparentPower FromKilovoltamperes(decimal kilovoltamperes)
         {
-	        return new ApparentPower((Convert.ToDouble(kilovoltamperes)) * 1e3d);
+            return new ApparentPower((Convert.ToDouble(kilovoltamperes)) * 1e3d);
         }
 #endif
 
@@ -205,7 +205,7 @@ namespace UnitsNet
             return new ApparentPower((megavoltamperes) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
         public static ApparentPower FromMegavoltamperes(int megavoltamperes)
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new ApparentPower((megavoltamperes) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
         public static ApparentPower FromMegavoltamperes(long megavoltamperes)
@@ -221,14 +221,14 @@ namespace UnitsNet
             return new ApparentPower((megavoltamperes) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Megavoltamperes of type decimal.
         /// </summary>
         public static ApparentPower FromMegavoltamperes(decimal megavoltamperes)
         {
-	        return new ApparentPower((Convert.ToDouble(megavoltamperes)) * 1e6d);
+            return new ApparentPower((Convert.ToDouble(megavoltamperes)) * 1e6d);
         }
 #endif
 
@@ -240,7 +240,7 @@ namespace UnitsNet
             return new ApparentPower(voltamperes);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Voltamperes.
         /// </summary>
         public static ApparentPower FromVoltamperes(int voltamperes)
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new ApparentPower(voltamperes);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Voltamperes.
         /// </summary>
         public static ApparentPower FromVoltamperes(long voltamperes)
@@ -256,14 +256,14 @@ namespace UnitsNet
             return new ApparentPower(voltamperes);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ApparentPower from Voltamperes of type decimal.
         /// </summary>
         public static ApparentPower FromVoltamperes(decimal voltamperes)
         {
-	        return new ApparentPower(Convert.ToDouble(voltamperes));
+            return new ApparentPower(Convert.ToDouble(voltamperes));
         }
 #endif
 
@@ -284,7 +284,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from nullable Kilovoltamperes.
         /// </summary>
         public static ApparentPower? FromKilovoltamperes(int? kilovoltamperes)
@@ -299,7 +299,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from nullable Kilovoltamperes.
         /// </summary>
         public static ApparentPower? FromKilovoltamperes(long? kilovoltamperes)
@@ -314,7 +314,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from Kilovoltamperes of type decimal.
         /// </summary>
         public static ApparentPower? FromKilovoltamperes(decimal? kilovoltamperes)
@@ -344,7 +344,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from nullable Megavoltamperes.
         /// </summary>
         public static ApparentPower? FromMegavoltamperes(int? megavoltamperes)
@@ -359,7 +359,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from nullable Megavoltamperes.
         /// </summary>
         public static ApparentPower? FromMegavoltamperes(long? megavoltamperes)
@@ -374,7 +374,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from Megavoltamperes of type decimal.
         /// </summary>
         public static ApparentPower? FromMegavoltamperes(decimal? megavoltamperes)
@@ -404,7 +404,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from nullable Voltamperes.
         /// </summary>
         public static ApparentPower? FromVoltamperes(int? voltamperes)
@@ -419,7 +419,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from nullable Voltamperes.
         /// </summary>
         public static ApparentPower? FromVoltamperes(long? voltamperes)
@@ -434,7 +434,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ApparentPower from Voltamperes of type decimal.
         /// </summary>
         public static ApparentPower? FromVoltamperes(decimal? voltamperes)

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -170,6 +170,33 @@ namespace UnitsNet
             return new ApparentPower((kilovoltamperes) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ApparentPower from Kilovoltamperes.
+        /// </summary>
+        public static ApparentPower FromKilovoltamperes(int kilovoltamperes)
+        {
+            return new ApparentPower((kilovoltamperes) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ApparentPower from Kilovoltamperes.
+        /// </summary>
+        public static ApparentPower FromKilovoltamperes(long kilovoltamperes)
+        {
+            return new ApparentPower((kilovoltamperes) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ApparentPower from Kilovoltamperes of type decimal.
+        /// </summary>
+        public static ApparentPower FromKilovoltamperes(decimal kilovoltamperes)
+        {
+	        return new ApparentPower((Convert.ToDouble(kilovoltamperes)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
@@ -177,6 +204,33 @@ namespace UnitsNet
         {
             return new ApparentPower((megavoltamperes) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get ApparentPower from Megavoltamperes.
+        /// </summary>
+        public static ApparentPower FromMegavoltamperes(int megavoltamperes)
+        {
+            return new ApparentPower((megavoltamperes) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ApparentPower from Megavoltamperes.
+        /// </summary>
+        public static ApparentPower FromMegavoltamperes(long megavoltamperes)
+        {
+            return new ApparentPower((megavoltamperes) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ApparentPower from Megavoltamperes of type decimal.
+        /// </summary>
+        public static ApparentPower FromMegavoltamperes(decimal megavoltamperes)
+        {
+	        return new ApparentPower((Convert.ToDouble(megavoltamperes)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ApparentPower from Voltamperes.
@@ -186,12 +240,84 @@ namespace UnitsNet
             return new ApparentPower(voltamperes);
         }
 
+		/// <summary>
+        ///     Get ApparentPower from Voltamperes.
+        /// </summary>
+        public static ApparentPower FromVoltamperes(int voltamperes)
+        {
+            return new ApparentPower(voltamperes);
+        }
+
+		/// <summary>
+        ///     Get ApparentPower from Voltamperes.
+        /// </summary>
+        public static ApparentPower FromVoltamperes(long voltamperes)
+        {
+            return new ApparentPower(voltamperes);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ApparentPower from Voltamperes of type decimal.
+        /// </summary>
+        public static ApparentPower FromVoltamperes(decimal voltamperes)
+        {
+	        return new ApparentPower(Convert.ToDouble(voltamperes));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ApparentPower from nullable Kilovoltamperes.
         /// </summary>
         public static ApparentPower? FromKilovoltamperes(double? kilovoltamperes)
+        {
+            if (kilovoltamperes.HasValue)
+            {
+                return FromKilovoltamperes(kilovoltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from nullable Kilovoltamperes.
+        /// </summary>
+        public static ApparentPower? FromKilovoltamperes(int? kilovoltamperes)
+        {
+            if (kilovoltamperes.HasValue)
+            {
+                return FromKilovoltamperes(kilovoltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from nullable Kilovoltamperes.
+        /// </summary>
+        public static ApparentPower? FromKilovoltamperes(long? kilovoltamperes)
+        {
+            if (kilovoltamperes.HasValue)
+            {
+                return FromKilovoltamperes(kilovoltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from Kilovoltamperes of type decimal.
+        /// </summary>
+        public static ApparentPower? FromKilovoltamperes(decimal? kilovoltamperes)
         {
             if (kilovoltamperes.HasValue)
             {
@@ -218,10 +344,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ApparentPower from nullable Megavoltamperes.
+        /// </summary>
+        public static ApparentPower? FromMegavoltamperes(int? megavoltamperes)
+        {
+            if (megavoltamperes.HasValue)
+            {
+                return FromMegavoltamperes(megavoltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from nullable Megavoltamperes.
+        /// </summary>
+        public static ApparentPower? FromMegavoltamperes(long? megavoltamperes)
+        {
+            if (megavoltamperes.HasValue)
+            {
+                return FromMegavoltamperes(megavoltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from Megavoltamperes of type decimal.
+        /// </summary>
+        public static ApparentPower? FromMegavoltamperes(decimal? megavoltamperes)
+        {
+            if (megavoltamperes.HasValue)
+            {
+                return FromMegavoltamperes(megavoltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ApparentPower from nullable Voltamperes.
         /// </summary>
         public static ApparentPower? FromVoltamperes(double? voltamperes)
+        {
+            if (voltamperes.HasValue)
+            {
+                return FromVoltamperes(voltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from nullable Voltamperes.
+        /// </summary>
+        public static ApparentPower? FromVoltamperes(int? voltamperes)
+        {
+            if (voltamperes.HasValue)
+            {
+                return FromVoltamperes(voltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from nullable Voltamperes.
+        /// </summary>
+        public static ApparentPower? FromVoltamperes(long? voltamperes)
+        {
+            if (voltamperes.HasValue)
+            {
+                return FromVoltamperes(voltamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ApparentPower from Voltamperes of type decimal.
+        /// </summary>
+        public static ApparentPower? FromVoltamperes(decimal? voltamperes)
         {
             if (voltamperes.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -165,6 +165,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Kilovoltamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ApparentPower FromKilovoltamperes(double kilovoltamperes)
         {
             return new ApparentPower((kilovoltamperes) * 1e3d);
@@ -200,6 +203,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ApparentPower FromMegavoltamperes(double megavoltamperes)
         {
             return new ApparentPower((megavoltamperes) * 1e6d);
@@ -235,6 +241,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Voltamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ApparentPower FromVoltamperes(double voltamperes)
         {
             return new ApparentPower(voltamperes);

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -237,6 +237,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Acres.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromAcres(double acres)
         {
             return new Area(acres*4046.85642);
@@ -272,6 +275,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromHectares(double hectares)
         {
             return new Area(hectares*1e4);
@@ -307,6 +313,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareCentimeters(double squarecentimeters)
         {
             return new Area(squarecentimeters*1e-4);
@@ -342,6 +351,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareDecimeters(double squaredecimeters)
         {
             return new Area(squaredecimeters*1e-2);
@@ -377,6 +389,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareFeet(double squarefeet)
         {
             return new Area(squarefeet*0.092903);
@@ -412,6 +427,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareInches(double squareinches)
         {
             return new Area(squareinches*0.00064516);
@@ -447,6 +465,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareKilometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareKilometers(double squarekilometers)
         {
             return new Area(squarekilometers*1e6);
@@ -482,6 +503,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareMeters(double squaremeters)
         {
             return new Area(squaremeters);
@@ -517,6 +541,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMicrometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareMicrometers(double squaremicrometers)
         {
             return new Area(squaremicrometers*1e-12);
@@ -552,6 +579,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareMiles(double squaremiles)
         {
             return new Area(squaremiles*2.59e6);
@@ -587,6 +617,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareMillimeters(double squaremillimeters)
         {
             return new Area(squaremillimeters*1e-6);
@@ -622,6 +655,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Area FromSquareYards(double squareyards)
         {
             return new Area(squareyards*0.836127);

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -242,6 +242,33 @@ namespace UnitsNet
             return new Area(acres*4046.85642);
         }
 
+		/// <summary>
+        ///     Get Area from Acres.
+        /// </summary>
+        public static Area FromAcres(int acres)
+        {
+            return new Area(acres*4046.85642);
+        }
+
+		/// <summary>
+        ///     Get Area from Acres.
+        /// </summary>
+        public static Area FromAcres(long acres)
+        {
+            return new Area(acres*4046.85642);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from Acres of type decimal.
+        /// </summary>
+        public static Area FromAcres(decimal acres)
+        {
+	        return new Area(Convert.ToDouble(acres)*4046.85642);
+        }
+#endif
+
         /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
@@ -249,6 +276,33 @@ namespace UnitsNet
         {
             return new Area(hectares*1e4);
         }
+
+		/// <summary>
+        ///     Get Area from Hectares.
+        /// </summary>
+        public static Area FromHectares(int hectares)
+        {
+            return new Area(hectares*1e4);
+        }
+
+		/// <summary>
+        ///     Get Area from Hectares.
+        /// </summary>
+        public static Area FromHectares(long hectares)
+        {
+            return new Area(hectares*1e4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from Hectares of type decimal.
+        /// </summary>
+        public static Area FromHectares(decimal hectares)
+        {
+	        return new Area(Convert.ToDouble(hectares)*1e4);
+        }
+#endif
 
         /// <summary>
         ///     Get Area from SquareCentimeters.
@@ -258,6 +312,33 @@ namespace UnitsNet
             return new Area(squarecentimeters*1e-4);
         }
 
+		/// <summary>
+        ///     Get Area from SquareCentimeters.
+        /// </summary>
+        public static Area FromSquareCentimeters(int squarecentimeters)
+        {
+            return new Area(squarecentimeters*1e-4);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareCentimeters.
+        /// </summary>
+        public static Area FromSquareCentimeters(long squarecentimeters)
+        {
+            return new Area(squarecentimeters*1e-4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareCentimeters of type decimal.
+        /// </summary>
+        public static Area FromSquareCentimeters(decimal squarecentimeters)
+        {
+	        return new Area(Convert.ToDouble(squarecentimeters)*1e-4);
+        }
+#endif
+
         /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
@@ -265,6 +346,33 @@ namespace UnitsNet
         {
             return new Area(squaredecimeters*1e-2);
         }
+
+		/// <summary>
+        ///     Get Area from SquareDecimeters.
+        /// </summary>
+        public static Area FromSquareDecimeters(int squaredecimeters)
+        {
+            return new Area(squaredecimeters*1e-2);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareDecimeters.
+        /// </summary>
+        public static Area FromSquareDecimeters(long squaredecimeters)
+        {
+            return new Area(squaredecimeters*1e-2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareDecimeters of type decimal.
+        /// </summary>
+        public static Area FromSquareDecimeters(decimal squaredecimeters)
+        {
+	        return new Area(Convert.ToDouble(squaredecimeters)*1e-2);
+        }
+#endif
 
         /// <summary>
         ///     Get Area from SquareFeet.
@@ -274,6 +382,33 @@ namespace UnitsNet
             return new Area(squarefeet*0.092903);
         }
 
+		/// <summary>
+        ///     Get Area from SquareFeet.
+        /// </summary>
+        public static Area FromSquareFeet(int squarefeet)
+        {
+            return new Area(squarefeet*0.092903);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareFeet.
+        /// </summary>
+        public static Area FromSquareFeet(long squarefeet)
+        {
+            return new Area(squarefeet*0.092903);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareFeet of type decimal.
+        /// </summary>
+        public static Area FromSquareFeet(decimal squarefeet)
+        {
+	        return new Area(Convert.ToDouble(squarefeet)*0.092903);
+        }
+#endif
+
         /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
@@ -281,6 +416,33 @@ namespace UnitsNet
         {
             return new Area(squareinches*0.00064516);
         }
+
+		/// <summary>
+        ///     Get Area from SquareInches.
+        /// </summary>
+        public static Area FromSquareInches(int squareinches)
+        {
+            return new Area(squareinches*0.00064516);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareInches.
+        /// </summary>
+        public static Area FromSquareInches(long squareinches)
+        {
+            return new Area(squareinches*0.00064516);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareInches of type decimal.
+        /// </summary>
+        public static Area FromSquareInches(decimal squareinches)
+        {
+	        return new Area(Convert.ToDouble(squareinches)*0.00064516);
+        }
+#endif
 
         /// <summary>
         ///     Get Area from SquareKilometers.
@@ -290,6 +452,33 @@ namespace UnitsNet
             return new Area(squarekilometers*1e6);
         }
 
+		/// <summary>
+        ///     Get Area from SquareKilometers.
+        /// </summary>
+        public static Area FromSquareKilometers(int squarekilometers)
+        {
+            return new Area(squarekilometers*1e6);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareKilometers.
+        /// </summary>
+        public static Area FromSquareKilometers(long squarekilometers)
+        {
+            return new Area(squarekilometers*1e6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareKilometers of type decimal.
+        /// </summary>
+        public static Area FromSquareKilometers(decimal squarekilometers)
+        {
+	        return new Area(Convert.ToDouble(squarekilometers)*1e6);
+        }
+#endif
+
         /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
@@ -297,6 +486,33 @@ namespace UnitsNet
         {
             return new Area(squaremeters);
         }
+
+		/// <summary>
+        ///     Get Area from SquareMeters.
+        /// </summary>
+        public static Area FromSquareMeters(int squaremeters)
+        {
+            return new Area(squaremeters);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareMeters.
+        /// </summary>
+        public static Area FromSquareMeters(long squaremeters)
+        {
+            return new Area(squaremeters);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareMeters of type decimal.
+        /// </summary>
+        public static Area FromSquareMeters(decimal squaremeters)
+        {
+	        return new Area(Convert.ToDouble(squaremeters));
+        }
+#endif
 
         /// <summary>
         ///     Get Area from SquareMicrometers.
@@ -306,6 +522,33 @@ namespace UnitsNet
             return new Area(squaremicrometers*1e-12);
         }
 
+		/// <summary>
+        ///     Get Area from SquareMicrometers.
+        /// </summary>
+        public static Area FromSquareMicrometers(int squaremicrometers)
+        {
+            return new Area(squaremicrometers*1e-12);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareMicrometers.
+        /// </summary>
+        public static Area FromSquareMicrometers(long squaremicrometers)
+        {
+            return new Area(squaremicrometers*1e-12);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareMicrometers of type decimal.
+        /// </summary>
+        public static Area FromSquareMicrometers(decimal squaremicrometers)
+        {
+	        return new Area(Convert.ToDouble(squaremicrometers)*1e-12);
+        }
+#endif
+
         /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
@@ -313,6 +556,33 @@ namespace UnitsNet
         {
             return new Area(squaremiles*2.59e6);
         }
+
+		/// <summary>
+        ///     Get Area from SquareMiles.
+        /// </summary>
+        public static Area FromSquareMiles(int squaremiles)
+        {
+            return new Area(squaremiles*2.59e6);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareMiles.
+        /// </summary>
+        public static Area FromSquareMiles(long squaremiles)
+        {
+            return new Area(squaremiles*2.59e6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareMiles of type decimal.
+        /// </summary>
+        public static Area FromSquareMiles(decimal squaremiles)
+        {
+	        return new Area(Convert.ToDouble(squaremiles)*2.59e6);
+        }
+#endif
 
         /// <summary>
         ///     Get Area from SquareMillimeters.
@@ -322,6 +592,33 @@ namespace UnitsNet
             return new Area(squaremillimeters*1e-6);
         }
 
+		/// <summary>
+        ///     Get Area from SquareMillimeters.
+        /// </summary>
+        public static Area FromSquareMillimeters(int squaremillimeters)
+        {
+            return new Area(squaremillimeters*1e-6);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareMillimeters.
+        /// </summary>
+        public static Area FromSquareMillimeters(long squaremillimeters)
+        {
+            return new Area(squaremillimeters*1e-6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareMillimeters of type decimal.
+        /// </summary>
+        public static Area FromSquareMillimeters(decimal squaremillimeters)
+        {
+	        return new Area(Convert.ToDouble(squaremillimeters)*1e-6);
+        }
+#endif
+
         /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
@@ -330,12 +627,84 @@ namespace UnitsNet
             return new Area(squareyards*0.836127);
         }
 
+		/// <summary>
+        ///     Get Area from SquareYards.
+        /// </summary>
+        public static Area FromSquareYards(int squareyards)
+        {
+            return new Area(squareyards*0.836127);
+        }
+
+		/// <summary>
+        ///     Get Area from SquareYards.
+        /// </summary>
+        public static Area FromSquareYards(long squareyards)
+        {
+            return new Area(squareyards*0.836127);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Area from SquareYards of type decimal.
+        /// </summary>
+        public static Area FromSquareYards(decimal squareyards)
+        {
+	        return new Area(Convert.ToDouble(squareyards)*0.836127);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Area from nullable Acres.
         /// </summary>
         public static Area? FromAcres(double? acres)
+        {
+            if (acres.HasValue)
+            {
+                return FromAcres(acres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable Acres.
+        /// </summary>
+        public static Area? FromAcres(int? acres)
+        {
+            if (acres.HasValue)
+            {
+                return FromAcres(acres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable Acres.
+        /// </summary>
+        public static Area? FromAcres(long? acres)
+        {
+            if (acres.HasValue)
+            {
+                return FromAcres(acres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from Acres of type decimal.
+        /// </summary>
+        public static Area? FromAcres(decimal? acres)
         {
             if (acres.HasValue)
             {
@@ -362,10 +731,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Area from nullable Hectares.
+        /// </summary>
+        public static Area? FromHectares(int? hectares)
+        {
+            if (hectares.HasValue)
+            {
+                return FromHectares(hectares.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable Hectares.
+        /// </summary>
+        public static Area? FromHectares(long? hectares)
+        {
+            if (hectares.HasValue)
+            {
+                return FromHectares(hectares.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from Hectares of type decimal.
+        /// </summary>
+        public static Area? FromHectares(decimal? hectares)
+        {
+            if (hectares.HasValue)
+            {
+                return FromHectares(hectares.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Area from nullable SquareCentimeters.
         /// </summary>
         public static Area? FromSquareCentimeters(double? squarecentimeters)
+        {
+            if (squarecentimeters.HasValue)
+            {
+                return FromSquareCentimeters(squarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareCentimeters.
+        /// </summary>
+        public static Area? FromSquareCentimeters(int? squarecentimeters)
+        {
+            if (squarecentimeters.HasValue)
+            {
+                return FromSquareCentimeters(squarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareCentimeters.
+        /// </summary>
+        public static Area? FromSquareCentimeters(long? squarecentimeters)
+        {
+            if (squarecentimeters.HasValue)
+            {
+                return FromSquareCentimeters(squarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareCentimeters of type decimal.
+        /// </summary>
+        public static Area? FromSquareCentimeters(decimal? squarecentimeters)
         {
             if (squarecentimeters.HasValue)
             {
@@ -392,10 +851,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Area from nullable SquareDecimeters.
+        /// </summary>
+        public static Area? FromSquareDecimeters(int? squaredecimeters)
+        {
+            if (squaredecimeters.HasValue)
+            {
+                return FromSquareDecimeters(squaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareDecimeters.
+        /// </summary>
+        public static Area? FromSquareDecimeters(long? squaredecimeters)
+        {
+            if (squaredecimeters.HasValue)
+            {
+                return FromSquareDecimeters(squaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareDecimeters of type decimal.
+        /// </summary>
+        public static Area? FromSquareDecimeters(decimal? squaredecimeters)
+        {
+            if (squaredecimeters.HasValue)
+            {
+                return FromSquareDecimeters(squaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Area from nullable SquareFeet.
         /// </summary>
         public static Area? FromSquareFeet(double? squarefeet)
+        {
+            if (squarefeet.HasValue)
+            {
+                return FromSquareFeet(squarefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareFeet.
+        /// </summary>
+        public static Area? FromSquareFeet(int? squarefeet)
+        {
+            if (squarefeet.HasValue)
+            {
+                return FromSquareFeet(squarefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareFeet.
+        /// </summary>
+        public static Area? FromSquareFeet(long? squarefeet)
+        {
+            if (squarefeet.HasValue)
+            {
+                return FromSquareFeet(squarefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareFeet of type decimal.
+        /// </summary>
+        public static Area? FromSquareFeet(decimal? squarefeet)
         {
             if (squarefeet.HasValue)
             {
@@ -422,10 +971,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Area from nullable SquareInches.
+        /// </summary>
+        public static Area? FromSquareInches(int? squareinches)
+        {
+            if (squareinches.HasValue)
+            {
+                return FromSquareInches(squareinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareInches.
+        /// </summary>
+        public static Area? FromSquareInches(long? squareinches)
+        {
+            if (squareinches.HasValue)
+            {
+                return FromSquareInches(squareinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareInches of type decimal.
+        /// </summary>
+        public static Area? FromSquareInches(decimal? squareinches)
+        {
+            if (squareinches.HasValue)
+            {
+                return FromSquareInches(squareinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Area from nullable SquareKilometers.
         /// </summary>
         public static Area? FromSquareKilometers(double? squarekilometers)
+        {
+            if (squarekilometers.HasValue)
+            {
+                return FromSquareKilometers(squarekilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareKilometers.
+        /// </summary>
+        public static Area? FromSquareKilometers(int? squarekilometers)
+        {
+            if (squarekilometers.HasValue)
+            {
+                return FromSquareKilometers(squarekilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareKilometers.
+        /// </summary>
+        public static Area? FromSquareKilometers(long? squarekilometers)
+        {
+            if (squarekilometers.HasValue)
+            {
+                return FromSquareKilometers(squarekilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareKilometers of type decimal.
+        /// </summary>
+        public static Area? FromSquareKilometers(decimal? squarekilometers)
         {
             if (squarekilometers.HasValue)
             {
@@ -452,10 +1091,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMeters.
+        /// </summary>
+        public static Area? FromSquareMeters(int? squaremeters)
+        {
+            if (squaremeters.HasValue)
+            {
+                return FromSquareMeters(squaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMeters.
+        /// </summary>
+        public static Area? FromSquareMeters(long? squaremeters)
+        {
+            if (squaremeters.HasValue)
+            {
+                return FromSquareMeters(squaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareMeters of type decimal.
+        /// </summary>
+        public static Area? FromSquareMeters(decimal? squaremeters)
+        {
+            if (squaremeters.HasValue)
+            {
+                return FromSquareMeters(squaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Area from nullable SquareMicrometers.
         /// </summary>
         public static Area? FromSquareMicrometers(double? squaremicrometers)
+        {
+            if (squaremicrometers.HasValue)
+            {
+                return FromSquareMicrometers(squaremicrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMicrometers.
+        /// </summary>
+        public static Area? FromSquareMicrometers(int? squaremicrometers)
+        {
+            if (squaremicrometers.HasValue)
+            {
+                return FromSquareMicrometers(squaremicrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMicrometers.
+        /// </summary>
+        public static Area? FromSquareMicrometers(long? squaremicrometers)
+        {
+            if (squaremicrometers.HasValue)
+            {
+                return FromSquareMicrometers(squaremicrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareMicrometers of type decimal.
+        /// </summary>
+        public static Area? FromSquareMicrometers(decimal? squaremicrometers)
         {
             if (squaremicrometers.HasValue)
             {
@@ -482,6 +1211,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMiles.
+        /// </summary>
+        public static Area? FromSquareMiles(int? squaremiles)
+        {
+            if (squaremiles.HasValue)
+            {
+                return FromSquareMiles(squaremiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMiles.
+        /// </summary>
+        public static Area? FromSquareMiles(long? squaremiles)
+        {
+            if (squaremiles.HasValue)
+            {
+                return FromSquareMiles(squaremiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareMiles of type decimal.
+        /// </summary>
+        public static Area? FromSquareMiles(decimal? squaremiles)
+        {
+            if (squaremiles.HasValue)
+            {
+                return FromSquareMiles(squaremiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Area from nullable SquareMillimeters.
         /// </summary>
@@ -497,10 +1271,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMillimeters.
+        /// </summary>
+        public static Area? FromSquareMillimeters(int? squaremillimeters)
+        {
+            if (squaremillimeters.HasValue)
+            {
+                return FromSquareMillimeters(squaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareMillimeters.
+        /// </summary>
+        public static Area? FromSquareMillimeters(long? squaremillimeters)
+        {
+            if (squaremillimeters.HasValue)
+            {
+                return FromSquareMillimeters(squaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareMillimeters of type decimal.
+        /// </summary>
+        public static Area? FromSquareMillimeters(decimal? squaremillimeters)
+        {
+            if (squaremillimeters.HasValue)
+            {
+                return FromSquareMillimeters(squaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Area from nullable SquareYards.
         /// </summary>
         public static Area? FromSquareYards(double? squareyards)
+        {
+            if (squareyards.HasValue)
+            {
+                return FromSquareYards(squareyards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareYards.
+        /// </summary>
+        public static Area? FromSquareYards(int? squareyards)
+        {
+            if (squareyards.HasValue)
+            {
+                return FromSquareYards(squareyards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from nullable SquareYards.
+        /// </summary>
+        public static Area? FromSquareYards(long? squareyards)
+        {
+            if (squareyards.HasValue)
+            {
+                return FromSquareYards(squareyards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Area from SquareYards of type decimal.
+        /// </summary>
+        public static Area? FromSquareYards(decimal? squareyards)
         {
             if (squareyards.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _squareMeters;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Area() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Area;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static AreaUnit BaseUnit
         {
             get { return AreaUnit.SquareMeter; }
@@ -242,7 +242,7 @@ namespace UnitsNet
             return new Area(acres*4046.85642);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from Acres.
         /// </summary>
         public static Area FromAcres(int acres)
@@ -250,7 +250,7 @@ namespace UnitsNet
             return new Area(acres*4046.85642);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from Acres.
         /// </summary>
         public static Area FromAcres(long acres)
@@ -258,14 +258,14 @@ namespace UnitsNet
             return new Area(acres*4046.85642);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from Acres of type decimal.
         /// </summary>
         public static Area FromAcres(decimal acres)
         {
-	        return new Area(Convert.ToDouble(acres)*4046.85642);
+            return new Area(Convert.ToDouble(acres)*4046.85642);
         }
 #endif
 
@@ -277,7 +277,7 @@ namespace UnitsNet
             return new Area(hectares*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
         public static Area FromHectares(int hectares)
@@ -285,7 +285,7 @@ namespace UnitsNet
             return new Area(hectares*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
         public static Area FromHectares(long hectares)
@@ -293,14 +293,14 @@ namespace UnitsNet
             return new Area(hectares*1e4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from Hectares of type decimal.
         /// </summary>
         public static Area FromHectares(decimal hectares)
         {
-	        return new Area(Convert.ToDouble(hectares)*1e4);
+            return new Area(Convert.ToDouble(hectares)*1e4);
         }
 #endif
 
@@ -312,7 +312,7 @@ namespace UnitsNet
             return new Area(squarecentimeters*1e-4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareCentimeters.
         /// </summary>
         public static Area FromSquareCentimeters(int squarecentimeters)
@@ -320,7 +320,7 @@ namespace UnitsNet
             return new Area(squarecentimeters*1e-4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareCentimeters.
         /// </summary>
         public static Area FromSquareCentimeters(long squarecentimeters)
@@ -328,14 +328,14 @@ namespace UnitsNet
             return new Area(squarecentimeters*1e-4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareCentimeters of type decimal.
         /// </summary>
         public static Area FromSquareCentimeters(decimal squarecentimeters)
         {
-	        return new Area(Convert.ToDouble(squarecentimeters)*1e-4);
+            return new Area(Convert.ToDouble(squarecentimeters)*1e-4);
         }
 #endif
 
@@ -347,7 +347,7 @@ namespace UnitsNet
             return new Area(squaredecimeters*1e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
         public static Area FromSquareDecimeters(int squaredecimeters)
@@ -355,7 +355,7 @@ namespace UnitsNet
             return new Area(squaredecimeters*1e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
         public static Area FromSquareDecimeters(long squaredecimeters)
@@ -363,14 +363,14 @@ namespace UnitsNet
             return new Area(squaredecimeters*1e-2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareDecimeters of type decimal.
         /// </summary>
         public static Area FromSquareDecimeters(decimal squaredecimeters)
         {
-	        return new Area(Convert.ToDouble(squaredecimeters)*1e-2);
+            return new Area(Convert.ToDouble(squaredecimeters)*1e-2);
         }
 #endif
 
@@ -382,7 +382,7 @@ namespace UnitsNet
             return new Area(squarefeet*0.092903);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareFeet.
         /// </summary>
         public static Area FromSquareFeet(int squarefeet)
@@ -390,7 +390,7 @@ namespace UnitsNet
             return new Area(squarefeet*0.092903);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareFeet.
         /// </summary>
         public static Area FromSquareFeet(long squarefeet)
@@ -398,14 +398,14 @@ namespace UnitsNet
             return new Area(squarefeet*0.092903);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareFeet of type decimal.
         /// </summary>
         public static Area FromSquareFeet(decimal squarefeet)
         {
-	        return new Area(Convert.ToDouble(squarefeet)*0.092903);
+            return new Area(Convert.ToDouble(squarefeet)*0.092903);
         }
 #endif
 
@@ -417,7 +417,7 @@ namespace UnitsNet
             return new Area(squareinches*0.00064516);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
         public static Area FromSquareInches(int squareinches)
@@ -425,7 +425,7 @@ namespace UnitsNet
             return new Area(squareinches*0.00064516);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
         public static Area FromSquareInches(long squareinches)
@@ -433,14 +433,14 @@ namespace UnitsNet
             return new Area(squareinches*0.00064516);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareInches of type decimal.
         /// </summary>
         public static Area FromSquareInches(decimal squareinches)
         {
-	        return new Area(Convert.ToDouble(squareinches)*0.00064516);
+            return new Area(Convert.ToDouble(squareinches)*0.00064516);
         }
 #endif
 
@@ -452,7 +452,7 @@ namespace UnitsNet
             return new Area(squarekilometers*1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareKilometers.
         /// </summary>
         public static Area FromSquareKilometers(int squarekilometers)
@@ -460,7 +460,7 @@ namespace UnitsNet
             return new Area(squarekilometers*1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareKilometers.
         /// </summary>
         public static Area FromSquareKilometers(long squarekilometers)
@@ -468,14 +468,14 @@ namespace UnitsNet
             return new Area(squarekilometers*1e6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareKilometers of type decimal.
         /// </summary>
         public static Area FromSquareKilometers(decimal squarekilometers)
         {
-	        return new Area(Convert.ToDouble(squarekilometers)*1e6);
+            return new Area(Convert.ToDouble(squarekilometers)*1e6);
         }
 #endif
 
@@ -487,7 +487,7 @@ namespace UnitsNet
             return new Area(squaremeters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
         public static Area FromSquareMeters(int squaremeters)
@@ -495,7 +495,7 @@ namespace UnitsNet
             return new Area(squaremeters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
         public static Area FromSquareMeters(long squaremeters)
@@ -503,14 +503,14 @@ namespace UnitsNet
             return new Area(squaremeters);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMeters of type decimal.
         /// </summary>
         public static Area FromSquareMeters(decimal squaremeters)
         {
-	        return new Area(Convert.ToDouble(squaremeters));
+            return new Area(Convert.ToDouble(squaremeters));
         }
 #endif
 
@@ -522,7 +522,7 @@ namespace UnitsNet
             return new Area(squaremicrometers*1e-12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMicrometers.
         /// </summary>
         public static Area FromSquareMicrometers(int squaremicrometers)
@@ -530,7 +530,7 @@ namespace UnitsNet
             return new Area(squaremicrometers*1e-12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMicrometers.
         /// </summary>
         public static Area FromSquareMicrometers(long squaremicrometers)
@@ -538,14 +538,14 @@ namespace UnitsNet
             return new Area(squaremicrometers*1e-12);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMicrometers of type decimal.
         /// </summary>
         public static Area FromSquareMicrometers(decimal squaremicrometers)
         {
-	        return new Area(Convert.ToDouble(squaremicrometers)*1e-12);
+            return new Area(Convert.ToDouble(squaremicrometers)*1e-12);
         }
 #endif
 
@@ -557,7 +557,7 @@ namespace UnitsNet
             return new Area(squaremiles*2.59e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
         public static Area FromSquareMiles(int squaremiles)
@@ -565,7 +565,7 @@ namespace UnitsNet
             return new Area(squaremiles*2.59e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
         public static Area FromSquareMiles(long squaremiles)
@@ -573,14 +573,14 @@ namespace UnitsNet
             return new Area(squaremiles*2.59e6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMiles of type decimal.
         /// </summary>
         public static Area FromSquareMiles(decimal squaremiles)
         {
-	        return new Area(Convert.ToDouble(squaremiles)*2.59e6);
+            return new Area(Convert.ToDouble(squaremiles)*2.59e6);
         }
 #endif
 
@@ -592,7 +592,7 @@ namespace UnitsNet
             return new Area(squaremillimeters*1e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMillimeters.
         /// </summary>
         public static Area FromSquareMillimeters(int squaremillimeters)
@@ -600,7 +600,7 @@ namespace UnitsNet
             return new Area(squaremillimeters*1e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMillimeters.
         /// </summary>
         public static Area FromSquareMillimeters(long squaremillimeters)
@@ -608,14 +608,14 @@ namespace UnitsNet
             return new Area(squaremillimeters*1e-6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareMillimeters of type decimal.
         /// </summary>
         public static Area FromSquareMillimeters(decimal squaremillimeters)
         {
-	        return new Area(Convert.ToDouble(squaremillimeters)*1e-6);
+            return new Area(Convert.ToDouble(squaremillimeters)*1e-6);
         }
 #endif
 
@@ -627,7 +627,7 @@ namespace UnitsNet
             return new Area(squareyards*0.836127);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
         public static Area FromSquareYards(int squareyards)
@@ -635,7 +635,7 @@ namespace UnitsNet
             return new Area(squareyards*0.836127);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
         public static Area FromSquareYards(long squareyards)
@@ -643,14 +643,14 @@ namespace UnitsNet
             return new Area(squareyards*0.836127);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Area from SquareYards of type decimal.
         /// </summary>
         public static Area FromSquareYards(decimal squareyards)
         {
-	        return new Area(Convert.ToDouble(squareyards)*0.836127);
+            return new Area(Convert.ToDouble(squareyards)*0.836127);
         }
 #endif
 
@@ -671,7 +671,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable Acres.
         /// </summary>
         public static Area? FromAcres(int? acres)
@@ -686,7 +686,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable Acres.
         /// </summary>
         public static Area? FromAcres(long? acres)
@@ -701,7 +701,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from Acres of type decimal.
         /// </summary>
         public static Area? FromAcres(decimal? acres)
@@ -731,7 +731,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable Hectares.
         /// </summary>
         public static Area? FromHectares(int? hectares)
@@ -746,7 +746,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable Hectares.
         /// </summary>
         public static Area? FromHectares(long? hectares)
@@ -761,7 +761,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from Hectares of type decimal.
         /// </summary>
         public static Area? FromHectares(decimal? hectares)
@@ -791,7 +791,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareCentimeters.
         /// </summary>
         public static Area? FromSquareCentimeters(int? squarecentimeters)
@@ -806,7 +806,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareCentimeters.
         /// </summary>
         public static Area? FromSquareCentimeters(long? squarecentimeters)
@@ -821,7 +821,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareCentimeters of type decimal.
         /// </summary>
         public static Area? FromSquareCentimeters(decimal? squarecentimeters)
@@ -851,7 +851,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareDecimeters.
         /// </summary>
         public static Area? FromSquareDecimeters(int? squaredecimeters)
@@ -866,7 +866,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareDecimeters.
         /// </summary>
         public static Area? FromSquareDecimeters(long? squaredecimeters)
@@ -881,7 +881,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareDecimeters of type decimal.
         /// </summary>
         public static Area? FromSquareDecimeters(decimal? squaredecimeters)
@@ -911,7 +911,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareFeet.
         /// </summary>
         public static Area? FromSquareFeet(int? squarefeet)
@@ -926,7 +926,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareFeet.
         /// </summary>
         public static Area? FromSquareFeet(long? squarefeet)
@@ -941,7 +941,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareFeet of type decimal.
         /// </summary>
         public static Area? FromSquareFeet(decimal? squarefeet)
@@ -971,7 +971,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareInches.
         /// </summary>
         public static Area? FromSquareInches(int? squareinches)
@@ -986,7 +986,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareInches.
         /// </summary>
         public static Area? FromSquareInches(long? squareinches)
@@ -1001,7 +1001,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareInches of type decimal.
         /// </summary>
         public static Area? FromSquareInches(decimal? squareinches)
@@ -1031,7 +1031,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareKilometers.
         /// </summary>
         public static Area? FromSquareKilometers(int? squarekilometers)
@@ -1046,7 +1046,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareKilometers.
         /// </summary>
         public static Area? FromSquareKilometers(long? squarekilometers)
@@ -1061,7 +1061,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareKilometers of type decimal.
         /// </summary>
         public static Area? FromSquareKilometers(decimal? squarekilometers)
@@ -1091,7 +1091,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMeters.
         /// </summary>
         public static Area? FromSquareMeters(int? squaremeters)
@@ -1106,7 +1106,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMeters.
         /// </summary>
         public static Area? FromSquareMeters(long? squaremeters)
@@ -1121,7 +1121,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareMeters of type decimal.
         /// </summary>
         public static Area? FromSquareMeters(decimal? squaremeters)
@@ -1151,7 +1151,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMicrometers.
         /// </summary>
         public static Area? FromSquareMicrometers(int? squaremicrometers)
@@ -1166,7 +1166,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMicrometers.
         /// </summary>
         public static Area? FromSquareMicrometers(long? squaremicrometers)
@@ -1181,7 +1181,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareMicrometers of type decimal.
         /// </summary>
         public static Area? FromSquareMicrometers(decimal? squaremicrometers)
@@ -1211,7 +1211,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMiles.
         /// </summary>
         public static Area? FromSquareMiles(int? squaremiles)
@@ -1226,7 +1226,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMiles.
         /// </summary>
         public static Area? FromSquareMiles(long? squaremiles)
@@ -1241,7 +1241,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareMiles of type decimal.
         /// </summary>
         public static Area? FromSquareMiles(decimal? squaremiles)
@@ -1271,7 +1271,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMillimeters.
         /// </summary>
         public static Area? FromSquareMillimeters(int? squaremillimeters)
@@ -1286,7 +1286,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareMillimeters.
         /// </summary>
         public static Area? FromSquareMillimeters(long? squaremillimeters)
@@ -1301,7 +1301,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareMillimeters of type decimal.
         /// </summary>
         public static Area? FromSquareMillimeters(decimal? squaremillimeters)
@@ -1331,7 +1331,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareYards.
         /// </summary>
         public static Area? FromSquareYards(int? squareyards)
@@ -1346,7 +1346,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from nullable SquareYards.
         /// </summary>
         public static Area? FromSquareYards(long? squareyards)
@@ -1361,7 +1361,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Area from SquareYards of type decimal.
         /// </summary>
         public static Area? FromSquareYards(decimal? squareyards)

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _metersToTheFourth;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public AreaMomentOfInertia() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.AreaMomentOfInertia;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static AreaMomentOfInertiaUnit BaseUnit
         {
             get { return AreaMomentOfInertiaUnit.MeterToTheFourth; }
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(centimeterstothefourth/1e8);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromCentimetersToTheFourth(int centimeterstothefourth)
@@ -202,7 +202,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(centimeterstothefourth/1e8);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromCentimetersToTheFourth(long centimeterstothefourth)
@@ -210,14 +210,14 @@ namespace UnitsNet
             return new AreaMomentOfInertia(centimeterstothefourth/1e8);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia FromCentimetersToTheFourth(decimal centimeterstothefourth)
         {
-	        return new AreaMomentOfInertia(Convert.ToDouble(centimeterstothefourth)/1e8);
+            return new AreaMomentOfInertia(Convert.ToDouble(centimeterstothefourth)/1e8);
         }
 #endif
 
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(decimeterstothefourth/1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromDecimetersToTheFourth(int decimeterstothefourth)
@@ -237,7 +237,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(decimeterstothefourth/1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromDecimetersToTheFourth(long decimeterstothefourth)
@@ -245,14 +245,14 @@ namespace UnitsNet
             return new AreaMomentOfInertia(decimeterstothefourth/1e4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia FromDecimetersToTheFourth(decimal decimeterstothefourth)
         {
-	        return new AreaMomentOfInertia(Convert.ToDouble(decimeterstothefourth)/1e4);
+            return new AreaMomentOfInertia(Convert.ToDouble(decimeterstothefourth)/1e4);
         }
 #endif
 
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromFeetToTheFourth(int feettothefourth)
@@ -272,7 +272,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromFeetToTheFourth(long feettothefourth)
@@ -280,14 +280,14 @@ namespace UnitsNet
             return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia FromFeetToTheFourth(decimal feettothefourth)
         {
-	        return new AreaMomentOfInertia(Convert.ToDouble(feettothefourth)*Math.Pow(0.3048, 4));
+            return new AreaMomentOfInertia(Convert.ToDouble(feettothefourth)*Math.Pow(0.3048, 4));
         }
 #endif
 
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromInchesToTheFourth(int inchestothefourth)
@@ -307,7 +307,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromInchesToTheFourth(long inchestothefourth)
@@ -315,14 +315,14 @@ namespace UnitsNet
             return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia FromInchesToTheFourth(decimal inchestothefourth)
         {
-	        return new AreaMomentOfInertia(Convert.ToDouble(inchestothefourth)*Math.Pow(2.54e-2, 4));
+            return new AreaMomentOfInertia(Convert.ToDouble(inchestothefourth)*Math.Pow(2.54e-2, 4));
         }
 #endif
 
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(meterstothefourth);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromMetersToTheFourth(int meterstothefourth)
@@ -342,7 +342,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(meterstothefourth);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromMetersToTheFourth(long meterstothefourth)
@@ -350,14 +350,14 @@ namespace UnitsNet
             return new AreaMomentOfInertia(meterstothefourth);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia FromMetersToTheFourth(decimal meterstothefourth)
         {
-	        return new AreaMomentOfInertia(Convert.ToDouble(meterstothefourth));
+            return new AreaMomentOfInertia(Convert.ToDouble(meterstothefourth));
         }
 #endif
 
@@ -369,7 +369,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(millimeterstothefourth/1e12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromMillimetersToTheFourth(int millimeterstothefourth)
@@ -377,7 +377,7 @@ namespace UnitsNet
             return new AreaMomentOfInertia(millimeterstothefourth/1e12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia FromMillimetersToTheFourth(long millimeterstothefourth)
@@ -385,14 +385,14 @@ namespace UnitsNet
             return new AreaMomentOfInertia(millimeterstothefourth/1e12);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia FromMillimetersToTheFourth(decimal millimeterstothefourth)
         {
-	        return new AreaMomentOfInertia(Convert.ToDouble(millimeterstothefourth)/1e12);
+            return new AreaMomentOfInertia(Convert.ToDouble(millimeterstothefourth)/1e12);
         }
 #endif
 
@@ -413,7 +413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromCentimetersToTheFourth(int? centimeterstothefourth)
@@ -428,7 +428,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromCentimetersToTheFourth(long? centimeterstothefourth)
@@ -443,7 +443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from CentimetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia? FromCentimetersToTheFourth(decimal? centimeterstothefourth)
@@ -473,7 +473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromDecimetersToTheFourth(int? decimeterstothefourth)
@@ -488,7 +488,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromDecimetersToTheFourth(long? decimeterstothefourth)
@@ -503,7 +503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from DecimetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia? FromDecimetersToTheFourth(decimal? decimeterstothefourth)
@@ -533,7 +533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromFeetToTheFourth(int? feettothefourth)
@@ -548,7 +548,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromFeetToTheFourth(long? feettothefourth)
@@ -563,7 +563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from FeetToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia? FromFeetToTheFourth(decimal? feettothefourth)
@@ -593,7 +593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromInchesToTheFourth(int? inchestothefourth)
@@ -608,7 +608,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromInchesToTheFourth(long? inchestothefourth)
@@ -623,7 +623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from InchesToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia? FromInchesToTheFourth(decimal? inchestothefourth)
@@ -653,7 +653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromMetersToTheFourth(int? meterstothefourth)
@@ -668,7 +668,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromMetersToTheFourth(long? meterstothefourth)
@@ -683,7 +683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from MetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia? FromMetersToTheFourth(decimal? meterstothefourth)
@@ -713,7 +713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromMillimetersToTheFourth(int? millimeterstothefourth)
@@ -728,7 +728,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromMillimetersToTheFourth(long? millimeterstothefourth)
@@ -743,7 +743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable AreaMomentOfInertia from MillimetersToTheFourth of type decimal.
         /// </summary>
         public static AreaMomentOfInertia? FromMillimetersToTheFourth(decimal? millimeterstothefourth)

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -194,6 +194,33 @@ namespace UnitsNet
             return new AreaMomentOfInertia(centimeterstothefourth/1e8);
         }
 
+		/// <summary>
+        ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromCentimetersToTheFourth(int centimeterstothefourth)
+        {
+            return new AreaMomentOfInertia(centimeterstothefourth/1e8);
+        }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromCentimetersToTheFourth(long centimeterstothefourth)
+        {
+            return new AreaMomentOfInertia(centimeterstothefourth/1e8);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AreaMomentOfInertia from CentimetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia FromCentimetersToTheFourth(decimal centimeterstothefourth)
+        {
+	        return new AreaMomentOfInertia(Convert.ToDouble(centimeterstothefourth)/1e8);
+        }
+#endif
+
         /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
@@ -201,6 +228,33 @@ namespace UnitsNet
         {
             return new AreaMomentOfInertia(decimeterstothefourth/1e4);
         }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromDecimetersToTheFourth(int decimeterstothefourth)
+        {
+            return new AreaMomentOfInertia(decimeterstothefourth/1e4);
+        }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromDecimetersToTheFourth(long decimeterstothefourth)
+        {
+            return new AreaMomentOfInertia(decimeterstothefourth/1e4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AreaMomentOfInertia from DecimetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia FromDecimetersToTheFourth(decimal decimeterstothefourth)
+        {
+	        return new AreaMomentOfInertia(Convert.ToDouble(decimeterstothefourth)/1e4);
+        }
+#endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
@@ -210,6 +264,33 @@ namespace UnitsNet
             return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
         }
 
+		/// <summary>
+        ///     Get AreaMomentOfInertia from FeetToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromFeetToTheFourth(int feettothefourth)
+        {
+            return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
+        }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from FeetToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromFeetToTheFourth(long feettothefourth)
+        {
+            return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AreaMomentOfInertia from FeetToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia FromFeetToTheFourth(decimal feettothefourth)
+        {
+	        return new AreaMomentOfInertia(Convert.ToDouble(feettothefourth)*Math.Pow(0.3048, 4));
+        }
+#endif
+
         /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
@@ -217,6 +298,33 @@ namespace UnitsNet
         {
             return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
         }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from InchesToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromInchesToTheFourth(int inchestothefourth)
+        {
+            return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
+        }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from InchesToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromInchesToTheFourth(long inchestothefourth)
+        {
+            return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AreaMomentOfInertia from InchesToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia FromInchesToTheFourth(decimal inchestothefourth)
+        {
+	        return new AreaMomentOfInertia(Convert.ToDouble(inchestothefourth)*Math.Pow(2.54e-2, 4));
+        }
+#endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
@@ -226,6 +334,33 @@ namespace UnitsNet
             return new AreaMomentOfInertia(meterstothefourth);
         }
 
+		/// <summary>
+        ///     Get AreaMomentOfInertia from MetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromMetersToTheFourth(int meterstothefourth)
+        {
+            return new AreaMomentOfInertia(meterstothefourth);
+        }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from MetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromMetersToTheFourth(long meterstothefourth)
+        {
+            return new AreaMomentOfInertia(meterstothefourth);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AreaMomentOfInertia from MetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia FromMetersToTheFourth(decimal meterstothefourth)
+        {
+	        return new AreaMomentOfInertia(Convert.ToDouble(meterstothefourth));
+        }
+#endif
+
         /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
@@ -234,12 +369,84 @@ namespace UnitsNet
             return new AreaMomentOfInertia(millimeterstothefourth/1e12);
         }
 
+		/// <summary>
+        ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromMillimetersToTheFourth(int millimeterstothefourth)
+        {
+            return new AreaMomentOfInertia(millimeterstothefourth/1e12);
+        }
+
+		/// <summary>
+        ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia FromMillimetersToTheFourth(long millimeterstothefourth)
+        {
+            return new AreaMomentOfInertia(millimeterstothefourth/1e12);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get AreaMomentOfInertia from MillimetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia FromMillimetersToTheFourth(decimal millimeterstothefourth)
+        {
+	        return new AreaMomentOfInertia(Convert.ToDouble(millimeterstothefourth)/1e12);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromCentimetersToTheFourth(double? centimeterstothefourth)
+        {
+            if (centimeterstothefourth.HasValue)
+            {
+                return FromCentimetersToTheFourth(centimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromCentimetersToTheFourth(int? centimeterstothefourth)
+        {
+            if (centimeterstothefourth.HasValue)
+            {
+                return FromCentimetersToTheFourth(centimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromCentimetersToTheFourth(long? centimeterstothefourth)
+        {
+            if (centimeterstothefourth.HasValue)
+            {
+                return FromCentimetersToTheFourth(centimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from CentimetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia? FromCentimetersToTheFourth(decimal? centimeterstothefourth)
         {
             if (centimeterstothefourth.HasValue)
             {
@@ -266,10 +473,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromDecimetersToTheFourth(int? decimeterstothefourth)
+        {
+            if (decimeterstothefourth.HasValue)
+            {
+                return FromDecimetersToTheFourth(decimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromDecimetersToTheFourth(long? decimeterstothefourth)
+        {
+            if (decimeterstothefourth.HasValue)
+            {
+                return FromDecimetersToTheFourth(decimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from DecimetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia? FromDecimetersToTheFourth(decimal? decimeterstothefourth)
+        {
+            if (decimeterstothefourth.HasValue)
+            {
+                return FromDecimetersToTheFourth(decimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromFeetToTheFourth(double? feettothefourth)
+        {
+            if (feettothefourth.HasValue)
+            {
+                return FromFeetToTheFourth(feettothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromFeetToTheFourth(int? feettothefourth)
+        {
+            if (feettothefourth.HasValue)
+            {
+                return FromFeetToTheFourth(feettothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromFeetToTheFourth(long? feettothefourth)
+        {
+            if (feettothefourth.HasValue)
+            {
+                return FromFeetToTheFourth(feettothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from FeetToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia? FromFeetToTheFourth(decimal? feettothefourth)
         {
             if (feettothefourth.HasValue)
             {
@@ -296,6 +593,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromInchesToTheFourth(int? inchestothefourth)
+        {
+            if (inchestothefourth.HasValue)
+            {
+                return FromInchesToTheFourth(inchestothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromInchesToTheFourth(long? inchestothefourth)
+        {
+            if (inchestothefourth.HasValue)
+            {
+                return FromInchesToTheFourth(inchestothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from InchesToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia? FromInchesToTheFourth(decimal? inchestothefourth)
+        {
+            if (inchestothefourth.HasValue)
+            {
+                return FromInchesToTheFourth(inchestothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
         /// </summary>
@@ -311,10 +653,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromMetersToTheFourth(int? meterstothefourth)
+        {
+            if (meterstothefourth.HasValue)
+            {
+                return FromMetersToTheFourth(meterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromMetersToTheFourth(long? meterstothefourth)
+        {
+            if (meterstothefourth.HasValue)
+            {
+                return FromMetersToTheFourth(meterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from MetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia? FromMetersToTheFourth(decimal? meterstothefourth)
+        {
+            if (meterstothefourth.HasValue)
+            {
+                return FromMetersToTheFourth(meterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
         /// </summary>
         public static AreaMomentOfInertia? FromMillimetersToTheFourth(double? millimeterstothefourth)
+        {
+            if (millimeterstothefourth.HasValue)
+            {
+                return FromMillimetersToTheFourth(millimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromMillimetersToTheFourth(int? millimeterstothefourth)
+        {
+            if (millimeterstothefourth.HasValue)
+            {
+                return FromMillimetersToTheFourth(millimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
+        /// </summary>
+        public static AreaMomentOfInertia? FromMillimetersToTheFourth(long? millimeterstothefourth)
+        {
+            if (millimeterstothefourth.HasValue)
+            {
+                return FromMillimetersToTheFourth(millimeterstothefourth.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable AreaMomentOfInertia from MillimetersToTheFourth of type decimal.
+        /// </summary>
+        public static AreaMomentOfInertia? FromMillimetersToTheFourth(decimal? millimeterstothefourth)
         {
             if (millimeterstothefourth.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -189,6 +189,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AreaMomentOfInertia FromCentimetersToTheFourth(double centimeterstothefourth)
         {
             return new AreaMomentOfInertia(centimeterstothefourth/1e8);
@@ -224,6 +227,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AreaMomentOfInertia FromDecimetersToTheFourth(double decimeterstothefourth)
         {
             return new AreaMomentOfInertia(decimeterstothefourth/1e4);
@@ -259,6 +265,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AreaMomentOfInertia FromFeetToTheFourth(double feettothefourth)
         {
             return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
@@ -294,6 +303,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AreaMomentOfInertia FromInchesToTheFourth(double inchestothefourth)
         {
             return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
@@ -329,6 +341,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AreaMomentOfInertia FromMetersToTheFourth(double meterstothefourth)
         {
             return new AreaMomentOfInertia(meterstothefourth);
@@ -364,6 +379,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static AreaMomentOfInertia FromMillimetersToTheFourth(double millimeterstothefourth)
         {
             return new AreaMomentOfInertia(millimeterstothefourth/1e12);

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -170,6 +170,33 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
         }
 
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(int gramsperkilowatthour)
+        {
+            return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
+        }
+
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(long gramsperkilowatthour)
+        {
+            return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour of type decimal.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(decimal gramsperkilowatthour)
+        {
+	        return new BrakeSpecificFuelConsumption(Convert.ToDouble(gramsperkilowatthour)/3.6e9);
+        }
+#endif
+
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
@@ -177,6 +204,33 @@ namespace UnitsNet
         {
             return new BrakeSpecificFuelConsumption(kilogramsperjoule);
         }
+
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(int kilogramsperjoule)
+        {
+            return new BrakeSpecificFuelConsumption(kilogramsperjoule);
+        }
+
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(long kilogramsperjoule)
+        {
+            return new BrakeSpecificFuelConsumption(kilogramsperjoule);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule of type decimal.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(decimal kilogramsperjoule)
+        {
+	        return new BrakeSpecificFuelConsumption(Convert.ToDouble(kilogramsperjoule));
+        }
+#endif
 
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
@@ -186,12 +240,84 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
         }
 
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(int poundspermechanicalhorsepowerhour)
+        {
+            return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
+        }
+
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(long poundspermechanicalhorsepowerhour)
+        {
+            return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour of type decimal.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(decimal poundspermechanicalhorsepowerhour)
+        {
+	        return new BrakeSpecificFuelConsumption(Convert.ToDouble(poundspermechanicalhorsepowerhour)*1.689659410672e-7);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(double? gramsperkilowatthour)
+        {
+            if (gramsperkilowatthour.HasValue)
+            {
+                return FromGramsPerKiloWattHour(gramsperkilowatthour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(int? gramsperkilowatthour)
+        {
+            if (gramsperkilowatthour.HasValue)
+            {
+                return FromGramsPerKiloWattHour(gramsperkilowatthour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(long? gramsperkilowatthour)
+        {
+            if (gramsperkilowatthour.HasValue)
+            {
+                return FromGramsPerKiloWattHour(gramsperkilowatthour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from GramsPerKiloWattHour of type decimal.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(decimal? gramsperkilowatthour)
         {
             if (gramsperkilowatthour.HasValue)
             {
@@ -218,10 +344,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(int? kilogramsperjoule)
+        {
+            if (kilogramsperjoule.HasValue)
+            {
+                return FromKilogramsPerJoule(kilogramsperjoule.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(long? kilogramsperjoule)
+        {
+            if (kilogramsperjoule.HasValue)
+            {
+                return FromKilogramsPerJoule(kilogramsperjoule.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from KilogramsPerJoule of type decimal.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(decimal? kilogramsperjoule)
+        {
+            if (kilogramsperjoule.HasValue)
+            {
+                return FromKilogramsPerJoule(kilogramsperjoule.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(double? poundspermechanicalhorsepowerhour)
+        {
+            if (poundspermechanicalhorsepowerhour.HasValue)
+            {
+                return FromPoundsPerMechanicalHorsepowerHour(poundspermechanicalhorsepowerhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(int? poundspermechanicalhorsepowerhour)
+        {
+            if (poundspermechanicalhorsepowerhour.HasValue)
+            {
+                return FromPoundsPerMechanicalHorsepowerHour(poundspermechanicalhorsepowerhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(long? poundspermechanicalhorsepowerhour)
+        {
+            if (poundspermechanicalhorsepowerhour.HasValue)
+            {
+                return FromPoundsPerMechanicalHorsepowerHour(poundspermechanicalhorsepowerhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour of type decimal.
+        /// </summary>
+        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(decimal? poundspermechanicalhorsepowerhour)
         {
             if (poundspermechanicalhorsepowerhour.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _kilogramsPerJoule;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public BrakeSpecificFuelConsumption() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.BrakeSpecificFuelConsumption;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static BrakeSpecificFuelConsumptionUnit BaseUnit
         {
             get { return BrakeSpecificFuelConsumptionUnit.KilogramPerJoule; }
@@ -170,7 +170,7 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(int gramsperkilowatthour)
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(long gramsperkilowatthour)
@@ -186,14 +186,14 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour of type decimal.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(decimal gramsperkilowatthour)
         {
-	        return new BrakeSpecificFuelConsumption(Convert.ToDouble(gramsperkilowatthour)/3.6e9);
+            return new BrakeSpecificFuelConsumption(Convert.ToDouble(gramsperkilowatthour)/3.6e9);
         }
 #endif
 
@@ -205,7 +205,7 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(kilogramsperjoule);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(int kilogramsperjoule)
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(kilogramsperjoule);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(long kilogramsperjoule)
@@ -221,14 +221,14 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(kilogramsperjoule);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule of type decimal.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(decimal kilogramsperjoule)
         {
-	        return new BrakeSpecificFuelConsumption(Convert.ToDouble(kilogramsperjoule));
+            return new BrakeSpecificFuelConsumption(Convert.ToDouble(kilogramsperjoule));
         }
 #endif
 
@@ -240,7 +240,7 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(int poundspermechanicalhorsepowerhour)
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(long poundspermechanicalhorsepowerhour)
@@ -256,14 +256,14 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour of type decimal.
         /// </summary>
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(decimal poundspermechanicalhorsepowerhour)
         {
-	        return new BrakeSpecificFuelConsumption(Convert.ToDouble(poundspermechanicalhorsepowerhour)*1.689659410672e-7);
+            return new BrakeSpecificFuelConsumption(Convert.ToDouble(poundspermechanicalhorsepowerhour)*1.689659410672e-7);
         }
 #endif
 
@@ -284,7 +284,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(int? gramsperkilowatthour)
@@ -299,7 +299,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(long? gramsperkilowatthour)
@@ -314,7 +314,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from GramsPerKiloWattHour of type decimal.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(decimal? gramsperkilowatthour)
@@ -344,7 +344,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(int? kilogramsperjoule)
@@ -359,7 +359,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(long? kilogramsperjoule)
@@ -374,7 +374,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from KilogramsPerJoule of type decimal.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(decimal? kilogramsperjoule)
@@ -404,7 +404,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(int? poundspermechanicalhorsepowerhour)
@@ -419,7 +419,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(long? poundspermechanicalhorsepowerhour)
@@ -434,7 +434,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour of type decimal.
         /// </summary>
         public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(decimal? poundspermechanicalhorsepowerhour)

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -165,6 +165,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(double gramsperkilowatthour)
         {
             return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
@@ -200,6 +203,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(double kilogramsperjoule)
         {
             return new BrakeSpecificFuelConsumption(kilogramsperjoule);
@@ -235,6 +241,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(double poundspermechanicalhorsepowerhour)
         {
             return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _kilogramsPerCubicMeter;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Density() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Density;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static DensityUnit BaseUnit
         {
             get { return DensityUnit.KilogramPerCubicMeter; }
@@ -426,7 +426,7 @@ namespace UnitsNet
             return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerDeciLiter.
         /// </summary>
         public static Density FromCentigramsPerDeciLiter(int centigramsperdeciliter)
@@ -434,7 +434,7 @@ namespace UnitsNet
             return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerDeciLiter.
         /// </summary>
         public static Density FromCentigramsPerDeciLiter(long centigramsperdeciliter)
@@ -442,14 +442,14 @@ namespace UnitsNet
             return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromCentigramsPerDeciLiter(decimal centigramsperdeciliter)
         {
-	        return new Density((Convert.ToDouble(centigramsperdeciliter)/1e-1) * 1e-2d);
+            return new Density((Convert.ToDouble(centigramsperdeciliter)/1e-1) * 1e-2d);
         }
 #endif
 
@@ -461,7 +461,7 @@ namespace UnitsNet
             return new Density((centigramsperliter/1) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
         public static Density FromCentigramsPerLiter(int centigramsperliter)
@@ -469,7 +469,7 @@ namespace UnitsNet
             return new Density((centigramsperliter/1) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
         public static Density FromCentigramsPerLiter(long centigramsperliter)
@@ -477,14 +477,14 @@ namespace UnitsNet
             return new Density((centigramsperliter/1) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerLiter of type decimal.
         /// </summary>
         public static Density FromCentigramsPerLiter(decimal centigramsperliter)
         {
-	        return new Density((Convert.ToDouble(centigramsperliter)/1) * 1e-2d);
+            return new Density((Convert.ToDouble(centigramsperliter)/1) * 1e-2d);
         }
 #endif
 
@@ -496,7 +496,7 @@ namespace UnitsNet
             return new Density((centigramspermilliliter/1e-3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
         /// </summary>
         public static Density FromCentigramsPerMilliliter(int centigramspermilliliter)
@@ -504,7 +504,7 @@ namespace UnitsNet
             return new Density((centigramspermilliliter/1e-3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
         /// </summary>
         public static Density FromCentigramsPerMilliliter(long centigramspermilliliter)
@@ -512,14 +512,14 @@ namespace UnitsNet
             return new Density((centigramspermilliliter/1e-3) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from CentigramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromCentigramsPerMilliliter(decimal centigramspermilliliter)
         {
-	        return new Density((Convert.ToDouble(centigramspermilliliter)/1e-3) * 1e-2d);
+            return new Density((Convert.ToDouble(centigramspermilliliter)/1e-3) * 1e-2d);
         }
 #endif
 
@@ -531,7 +531,7 @@ namespace UnitsNet
             return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
         public static Density FromDecigramsPerDeciLiter(int decigramsperdeciliter)
@@ -539,7 +539,7 @@ namespace UnitsNet
             return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
         public static Density FromDecigramsPerDeciLiter(long decigramsperdeciliter)
@@ -547,14 +547,14 @@ namespace UnitsNet
             return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromDecigramsPerDeciLiter(decimal decigramsperdeciliter)
         {
-	        return new Density((Convert.ToDouble(decigramsperdeciliter)/1e-1) * 1e-1d);
+            return new Density((Convert.ToDouble(decigramsperdeciliter)/1e-1) * 1e-1d);
         }
 #endif
 
@@ -566,7 +566,7 @@ namespace UnitsNet
             return new Density((decigramsperliter/1) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerLiter.
         /// </summary>
         public static Density FromDecigramsPerLiter(int decigramsperliter)
@@ -574,7 +574,7 @@ namespace UnitsNet
             return new Density((decigramsperliter/1) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerLiter.
         /// </summary>
         public static Density FromDecigramsPerLiter(long decigramsperliter)
@@ -582,14 +582,14 @@ namespace UnitsNet
             return new Density((decigramsperliter/1) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerLiter of type decimal.
         /// </summary>
         public static Density FromDecigramsPerLiter(decimal decigramsperliter)
         {
-	        return new Density((Convert.ToDouble(decigramsperliter)/1) * 1e-1d);
+            return new Density((Convert.ToDouble(decigramsperliter)/1) * 1e-1d);
         }
 #endif
 
@@ -601,7 +601,7 @@ namespace UnitsNet
             return new Density((decigramspermilliliter/1e-3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
         public static Density FromDecigramsPerMilliliter(int decigramspermilliliter)
@@ -609,7 +609,7 @@ namespace UnitsNet
             return new Density((decigramspermilliliter/1e-3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
         public static Density FromDecigramsPerMilliliter(long decigramspermilliliter)
@@ -617,14 +617,14 @@ namespace UnitsNet
             return new Density((decigramspermilliliter/1e-3) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from DecigramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromDecigramsPerMilliliter(decimal decigramspermilliliter)
         {
-	        return new Density((Convert.ToDouble(decigramspermilliliter)/1e-3) * 1e-1d);
+            return new Density((Convert.ToDouble(decigramspermilliliter)/1e-3) * 1e-1d);
         }
 #endif
 
@@ -636,7 +636,7 @@ namespace UnitsNet
             return new Density(gramspercubiccentimeter/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
         /// </summary>
         public static Density FromGramsPerCubicCentimeter(int gramspercubiccentimeter)
@@ -644,7 +644,7 @@ namespace UnitsNet
             return new Density(gramspercubiccentimeter/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
         /// </summary>
         public static Density FromGramsPerCubicCentimeter(long gramspercubiccentimeter)
@@ -652,14 +652,14 @@ namespace UnitsNet
             return new Density(gramspercubiccentimeter/1e-3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicCentimeter of type decimal.
         /// </summary>
         public static Density FromGramsPerCubicCentimeter(decimal gramspercubiccentimeter)
         {
-	        return new Density(Convert.ToDouble(gramspercubiccentimeter)/1e-3);
+            return new Density(Convert.ToDouble(gramspercubiccentimeter)/1e-3);
         }
 #endif
 
@@ -671,7 +671,7 @@ namespace UnitsNet
             return new Density(gramspercubicmeter/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
         public static Density FromGramsPerCubicMeter(int gramspercubicmeter)
@@ -679,7 +679,7 @@ namespace UnitsNet
             return new Density(gramspercubicmeter/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
         public static Density FromGramsPerCubicMeter(long gramspercubicmeter)
@@ -687,14 +687,14 @@ namespace UnitsNet
             return new Density(gramspercubicmeter/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicMeter of type decimal.
         /// </summary>
         public static Density FromGramsPerCubicMeter(decimal gramspercubicmeter)
         {
-	        return new Density(Convert.ToDouble(gramspercubicmeter)/1e3);
+            return new Density(Convert.ToDouble(gramspercubicmeter)/1e3);
         }
 #endif
 
@@ -706,7 +706,7 @@ namespace UnitsNet
             return new Density(gramspercubicmillimeter/1e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
         /// </summary>
         public static Density FromGramsPerCubicMillimeter(int gramspercubicmillimeter)
@@ -714,7 +714,7 @@ namespace UnitsNet
             return new Density(gramspercubicmillimeter/1e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
         /// </summary>
         public static Density FromGramsPerCubicMillimeter(long gramspercubicmillimeter)
@@ -722,14 +722,14 @@ namespace UnitsNet
             return new Density(gramspercubicmillimeter/1e-6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerCubicMillimeter of type decimal.
         /// </summary>
         public static Density FromGramsPerCubicMillimeter(decimal gramspercubicmillimeter)
         {
-	        return new Density(Convert.ToDouble(gramspercubicmillimeter)/1e-6);
+            return new Density(Convert.ToDouble(gramspercubicmillimeter)/1e-6);
         }
 #endif
 
@@ -741,7 +741,7 @@ namespace UnitsNet
             return new Density(gramsperdeciliter/1e-1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
         public static Density FromGramsPerDeciLiter(int gramsperdeciliter)
@@ -749,7 +749,7 @@ namespace UnitsNet
             return new Density(gramsperdeciliter/1e-1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
         public static Density FromGramsPerDeciLiter(long gramsperdeciliter)
@@ -757,14 +757,14 @@ namespace UnitsNet
             return new Density(gramsperdeciliter/1e-1);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromGramsPerDeciLiter(decimal gramsperdeciliter)
         {
-	        return new Density(Convert.ToDouble(gramsperdeciliter)/1e-1);
+            return new Density(Convert.ToDouble(gramsperdeciliter)/1e-1);
         }
 #endif
 
@@ -776,7 +776,7 @@ namespace UnitsNet
             return new Density(gramsperliter/1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerLiter.
         /// </summary>
         public static Density FromGramsPerLiter(int gramsperliter)
@@ -784,7 +784,7 @@ namespace UnitsNet
             return new Density(gramsperliter/1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerLiter.
         /// </summary>
         public static Density FromGramsPerLiter(long gramsperliter)
@@ -792,14 +792,14 @@ namespace UnitsNet
             return new Density(gramsperliter/1);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerLiter of type decimal.
         /// </summary>
         public static Density FromGramsPerLiter(decimal gramsperliter)
         {
-	        return new Density(Convert.ToDouble(gramsperliter)/1);
+            return new Density(Convert.ToDouble(gramsperliter)/1);
         }
 #endif
 
@@ -811,7 +811,7 @@ namespace UnitsNet
             return new Density(gramspermilliliter/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
         public static Density FromGramsPerMilliliter(int gramspermilliliter)
@@ -819,7 +819,7 @@ namespace UnitsNet
             return new Density(gramspermilliliter/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
         public static Density FromGramsPerMilliliter(long gramspermilliliter)
@@ -827,14 +827,14 @@ namespace UnitsNet
             return new Density(gramspermilliliter/1e-3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from GramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromGramsPerMilliliter(decimal gramspermilliliter)
         {
-	        return new Density(Convert.ToDouble(gramspermilliliter)/1e-3);
+            return new Density(Convert.ToDouble(gramspermilliliter)/1e-3);
         }
 #endif
 
@@ -846,7 +846,7 @@ namespace UnitsNet
             return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
         /// </summary>
         public static Density FromKilogramsPerCubicCentimeter(int kilogramspercubiccentimeter)
@@ -854,7 +854,7 @@ namespace UnitsNet
             return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
         /// </summary>
         public static Density FromKilogramsPerCubicCentimeter(long kilogramspercubiccentimeter)
@@ -862,14 +862,14 @@ namespace UnitsNet
             return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter of type decimal.
         /// </summary>
         public static Density FromKilogramsPerCubicCentimeter(decimal kilogramspercubiccentimeter)
         {
-	        return new Density((Convert.ToDouble(kilogramspercubiccentimeter)/1e-3) * 1e3d);
+            return new Density((Convert.ToDouble(kilogramspercubiccentimeter)/1e-3) * 1e3d);
         }
 #endif
 
@@ -881,7 +881,7 @@ namespace UnitsNet
             return new Density((kilogramspercubicmeter/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
         public static Density FromKilogramsPerCubicMeter(int kilogramspercubicmeter)
@@ -889,7 +889,7 @@ namespace UnitsNet
             return new Density((kilogramspercubicmeter/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
         public static Density FromKilogramsPerCubicMeter(long kilogramspercubicmeter)
@@ -897,14 +897,14 @@ namespace UnitsNet
             return new Density((kilogramspercubicmeter/1e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicMeter of type decimal.
         /// </summary>
         public static Density FromKilogramsPerCubicMeter(decimal kilogramspercubicmeter)
         {
-	        return new Density((Convert.ToDouble(kilogramspercubicmeter)/1e3) * 1e3d);
+            return new Density((Convert.ToDouble(kilogramspercubicmeter)/1e3) * 1e3d);
         }
 #endif
 
@@ -916,7 +916,7 @@ namespace UnitsNet
             return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
         /// </summary>
         public static Density FromKilogramsPerCubicMillimeter(int kilogramspercubicmillimeter)
@@ -924,7 +924,7 @@ namespace UnitsNet
             return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
         /// </summary>
         public static Density FromKilogramsPerCubicMillimeter(long kilogramspercubicmillimeter)
@@ -932,14 +932,14 @@ namespace UnitsNet
             return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter of type decimal.
         /// </summary>
         public static Density FromKilogramsPerCubicMillimeter(decimal kilogramspercubicmillimeter)
         {
-	        return new Density((Convert.ToDouble(kilogramspercubicmillimeter)/1e-6) * 1e3d);
+            return new Density((Convert.ToDouble(kilogramspercubicmillimeter)/1e-6) * 1e3d);
         }
 #endif
 
@@ -951,7 +951,7 @@ namespace UnitsNet
             return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
         public static Density FromKilopoundsPerCubicFoot(int kilopoundspercubicfoot)
@@ -959,7 +959,7 @@ namespace UnitsNet
             return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
         public static Density FromKilopoundsPerCubicFoot(long kilopoundspercubicfoot)
@@ -967,14 +967,14 @@ namespace UnitsNet
             return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot of type decimal.
         /// </summary>
         public static Density FromKilopoundsPerCubicFoot(decimal kilopoundspercubicfoot)
         {
-	        return new Density((Convert.ToDouble(kilopoundspercubicfoot)/0.062427961) * 1e3d);
+            return new Density((Convert.ToDouble(kilopoundspercubicfoot)/0.062427961) * 1e3d);
         }
 #endif
 
@@ -986,7 +986,7 @@ namespace UnitsNet
             return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
         /// </summary>
         public static Density FromKilopoundsPerCubicInch(int kilopoundspercubicinch)
@@ -994,7 +994,7 @@ namespace UnitsNet
             return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
         /// </summary>
         public static Density FromKilopoundsPerCubicInch(long kilopoundspercubicinch)
@@ -1002,14 +1002,14 @@ namespace UnitsNet
             return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from KilopoundsPerCubicInch of type decimal.
         /// </summary>
         public static Density FromKilopoundsPerCubicInch(decimal kilopoundspercubicinch)
         {
-	        return new Density((Convert.ToDouble(kilopoundspercubicinch)/3.6127298147753e-5) * 1e3d);
+            return new Density((Convert.ToDouble(kilopoundspercubicinch)/3.6127298147753e-5) * 1e3d);
         }
 #endif
 
@@ -1021,7 +1021,7 @@ namespace UnitsNet
             return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
         public static Density FromMicrogramsPerDeciLiter(int microgramsperdeciliter)
@@ -1029,7 +1029,7 @@ namespace UnitsNet
             return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
         public static Density FromMicrogramsPerDeciLiter(long microgramsperdeciliter)
@@ -1037,14 +1037,14 @@ namespace UnitsNet
             return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromMicrogramsPerDeciLiter(decimal microgramsperdeciliter)
         {
-	        return new Density((Convert.ToDouble(microgramsperdeciliter)/1e-1) * 1e-6d);
+            return new Density((Convert.ToDouble(microgramsperdeciliter)/1e-1) * 1e-6d);
         }
 #endif
 
@@ -1056,7 +1056,7 @@ namespace UnitsNet
             return new Density((microgramsperliter/1) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerLiter.
         /// </summary>
         public static Density FromMicrogramsPerLiter(int microgramsperliter)
@@ -1064,7 +1064,7 @@ namespace UnitsNet
             return new Density((microgramsperliter/1) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerLiter.
         /// </summary>
         public static Density FromMicrogramsPerLiter(long microgramsperliter)
@@ -1072,14 +1072,14 @@ namespace UnitsNet
             return new Density((microgramsperliter/1) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerLiter of type decimal.
         /// </summary>
         public static Density FromMicrogramsPerLiter(decimal microgramsperliter)
         {
-	        return new Density((Convert.ToDouble(microgramsperliter)/1) * 1e-6d);
+            return new Density((Convert.ToDouble(microgramsperliter)/1) * 1e-6d);
         }
 #endif
 
@@ -1091,7 +1091,7 @@ namespace UnitsNet
             return new Density((microgramspermilliliter/1e-3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
         public static Density FromMicrogramsPerMilliliter(int microgramspermilliliter)
@@ -1099,7 +1099,7 @@ namespace UnitsNet
             return new Density((microgramspermilliliter/1e-3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
         public static Density FromMicrogramsPerMilliliter(long microgramspermilliliter)
@@ -1107,14 +1107,14 @@ namespace UnitsNet
             return new Density((microgramspermilliliter/1e-3) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from MicrogramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromMicrogramsPerMilliliter(decimal microgramspermilliliter)
         {
-	        return new Density((Convert.ToDouble(microgramspermilliliter)/1e-3) * 1e-6d);
+            return new Density((Convert.ToDouble(microgramspermilliliter)/1e-3) * 1e-6d);
         }
 #endif
 
@@ -1126,7 +1126,7 @@ namespace UnitsNet
             return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
         /// </summary>
         public static Density FromMilligramsPerDeciLiter(int milligramsperdeciliter)
@@ -1134,7 +1134,7 @@ namespace UnitsNet
             return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
         /// </summary>
         public static Density FromMilligramsPerDeciLiter(long milligramsperdeciliter)
@@ -1142,14 +1142,14 @@ namespace UnitsNet
             return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromMilligramsPerDeciLiter(decimal milligramsperdeciliter)
         {
-	        return new Density((Convert.ToDouble(milligramsperdeciliter)/1e-1) * 1e-3d);
+            return new Density((Convert.ToDouble(milligramsperdeciliter)/1e-1) * 1e-3d);
         }
 #endif
 
@@ -1161,7 +1161,7 @@ namespace UnitsNet
             return new Density((milligramsperliter/1) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
         public static Density FromMilligramsPerLiter(int milligramsperliter)
@@ -1169,7 +1169,7 @@ namespace UnitsNet
             return new Density((milligramsperliter/1) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
         public static Density FromMilligramsPerLiter(long milligramsperliter)
@@ -1177,14 +1177,14 @@ namespace UnitsNet
             return new Density((milligramsperliter/1) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerLiter of type decimal.
         /// </summary>
         public static Density FromMilligramsPerLiter(decimal milligramsperliter)
         {
-	        return new Density((Convert.ToDouble(milligramsperliter)/1) * 1e-3d);
+            return new Density((Convert.ToDouble(milligramsperliter)/1) * 1e-3d);
         }
 #endif
 
@@ -1196,7 +1196,7 @@ namespace UnitsNet
             return new Density((milligramspermilliliter/1e-3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
         /// </summary>
         public static Density FromMilligramsPerMilliliter(int milligramspermilliliter)
@@ -1204,7 +1204,7 @@ namespace UnitsNet
             return new Density((milligramspermilliliter/1e-3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
         /// </summary>
         public static Density FromMilligramsPerMilliliter(long milligramspermilliliter)
@@ -1212,14 +1212,14 @@ namespace UnitsNet
             return new Density((milligramspermilliliter/1e-3) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from MilligramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromMilligramsPerMilliliter(decimal milligramspermilliliter)
         {
-	        return new Density((Convert.ToDouble(milligramspermilliliter)/1e-3) * 1e-3d);
+            return new Density((Convert.ToDouble(milligramspermilliliter)/1e-3) * 1e-3d);
         }
 #endif
 
@@ -1231,7 +1231,7 @@ namespace UnitsNet
             return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
         public static Density FromNanogramsPerDeciLiter(int nanogramsperdeciliter)
@@ -1239,7 +1239,7 @@ namespace UnitsNet
             return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
         public static Density FromNanogramsPerDeciLiter(long nanogramsperdeciliter)
@@ -1247,14 +1247,14 @@ namespace UnitsNet
             return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromNanogramsPerDeciLiter(decimal nanogramsperdeciliter)
         {
-	        return new Density((Convert.ToDouble(nanogramsperdeciliter)/1e-1) * 1e-9d);
+            return new Density((Convert.ToDouble(nanogramsperdeciliter)/1e-1) * 1e-9d);
         }
 #endif
 
@@ -1266,7 +1266,7 @@ namespace UnitsNet
             return new Density((nanogramsperliter/1) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerLiter.
         /// </summary>
         public static Density FromNanogramsPerLiter(int nanogramsperliter)
@@ -1274,7 +1274,7 @@ namespace UnitsNet
             return new Density((nanogramsperliter/1) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerLiter.
         /// </summary>
         public static Density FromNanogramsPerLiter(long nanogramsperliter)
@@ -1282,14 +1282,14 @@ namespace UnitsNet
             return new Density((nanogramsperliter/1) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerLiter of type decimal.
         /// </summary>
         public static Density FromNanogramsPerLiter(decimal nanogramsperliter)
         {
-	        return new Density((Convert.ToDouble(nanogramsperliter)/1) * 1e-9d);
+            return new Density((Convert.ToDouble(nanogramsperliter)/1) * 1e-9d);
         }
 #endif
 
@@ -1301,7 +1301,7 @@ namespace UnitsNet
             return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
         public static Density FromNanogramsPerMilliliter(int nanogramspermilliliter)
@@ -1309,7 +1309,7 @@ namespace UnitsNet
             return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
         public static Density FromNanogramsPerMilliliter(long nanogramspermilliliter)
@@ -1317,14 +1317,14 @@ namespace UnitsNet
             return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from NanogramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromNanogramsPerMilliliter(decimal nanogramspermilliliter)
         {
-	        return new Density((Convert.ToDouble(nanogramspermilliliter)/1e-3) * 1e-9d);
+            return new Density((Convert.ToDouble(nanogramspermilliliter)/1e-3) * 1e-9d);
         }
 #endif
 
@@ -1336,7 +1336,7 @@ namespace UnitsNet
             return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
         /// </summary>
         public static Density FromPicogramsPerDeciLiter(int picogramsperdeciliter)
@@ -1344,7 +1344,7 @@ namespace UnitsNet
             return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
         /// </summary>
         public static Density FromPicogramsPerDeciLiter(long picogramsperdeciliter)
@@ -1352,14 +1352,14 @@ namespace UnitsNet
             return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density FromPicogramsPerDeciLiter(decimal picogramsperdeciliter)
         {
-	        return new Density((Convert.ToDouble(picogramsperdeciliter)/1e-1) * 1e-12d);
+            return new Density((Convert.ToDouble(picogramsperdeciliter)/1e-1) * 1e-12d);
         }
 #endif
 
@@ -1371,7 +1371,7 @@ namespace UnitsNet
             return new Density((picogramsperliter/1) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
         public static Density FromPicogramsPerLiter(int picogramsperliter)
@@ -1379,7 +1379,7 @@ namespace UnitsNet
             return new Density((picogramsperliter/1) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
         public static Density FromPicogramsPerLiter(long picogramsperliter)
@@ -1387,14 +1387,14 @@ namespace UnitsNet
             return new Density((picogramsperliter/1) * 1e-12d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerLiter of type decimal.
         /// </summary>
         public static Density FromPicogramsPerLiter(decimal picogramsperliter)
         {
-	        return new Density((Convert.ToDouble(picogramsperliter)/1) * 1e-12d);
+            return new Density((Convert.ToDouble(picogramsperliter)/1) * 1e-12d);
         }
 #endif
 
@@ -1406,7 +1406,7 @@ namespace UnitsNet
             return new Density((picogramspermilliliter/1e-3) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
         /// </summary>
         public static Density FromPicogramsPerMilliliter(int picogramspermilliliter)
@@ -1414,7 +1414,7 @@ namespace UnitsNet
             return new Density((picogramspermilliliter/1e-3) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
         /// </summary>
         public static Density FromPicogramsPerMilliliter(long picogramspermilliliter)
@@ -1422,14 +1422,14 @@ namespace UnitsNet
             return new Density((picogramspermilliliter/1e-3) * 1e-12d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from PicogramsPerMilliliter of type decimal.
         /// </summary>
         public static Density FromPicogramsPerMilliliter(decimal picogramspermilliliter)
         {
-	        return new Density((Convert.ToDouble(picogramspermilliliter)/1e-3) * 1e-12d);
+            return new Density((Convert.ToDouble(picogramspermilliliter)/1e-3) * 1e-12d);
         }
 #endif
 
@@ -1441,7 +1441,7 @@ namespace UnitsNet
             return new Density(poundspercubicfoot/0.062427961);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
         public static Density FromPoundsPerCubicFoot(int poundspercubicfoot)
@@ -1449,7 +1449,7 @@ namespace UnitsNet
             return new Density(poundspercubicfoot/0.062427961);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
         public static Density FromPoundsPerCubicFoot(long poundspercubicfoot)
@@ -1457,14 +1457,14 @@ namespace UnitsNet
             return new Density(poundspercubicfoot/0.062427961);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from PoundsPerCubicFoot of type decimal.
         /// </summary>
         public static Density FromPoundsPerCubicFoot(decimal poundspercubicfoot)
         {
-	        return new Density(Convert.ToDouble(poundspercubicfoot)/0.062427961);
+            return new Density(Convert.ToDouble(poundspercubicfoot)/0.062427961);
         }
 #endif
 
@@ -1476,7 +1476,7 @@ namespace UnitsNet
             return new Density(poundspercubicinch/3.6127298147753e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PoundsPerCubicInch.
         /// </summary>
         public static Density FromPoundsPerCubicInch(int poundspercubicinch)
@@ -1484,7 +1484,7 @@ namespace UnitsNet
             return new Density(poundspercubicinch/3.6127298147753e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from PoundsPerCubicInch.
         /// </summary>
         public static Density FromPoundsPerCubicInch(long poundspercubicinch)
@@ -1492,14 +1492,14 @@ namespace UnitsNet
             return new Density(poundspercubicinch/3.6127298147753e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from PoundsPerCubicInch of type decimal.
         /// </summary>
         public static Density FromPoundsPerCubicInch(decimal poundspercubicinch)
         {
-	        return new Density(Convert.ToDouble(poundspercubicinch)/3.6127298147753e-5);
+            return new Density(Convert.ToDouble(poundspercubicinch)/3.6127298147753e-5);
         }
 #endif
 
@@ -1511,7 +1511,7 @@ namespace UnitsNet
             return new Density(slugspercubicfoot*515.378818);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
         public static Density FromSlugsPerCubicFoot(int slugspercubicfoot)
@@ -1519,7 +1519,7 @@ namespace UnitsNet
             return new Density(slugspercubicfoot*515.378818);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
         public static Density FromSlugsPerCubicFoot(long slugspercubicfoot)
@@ -1527,14 +1527,14 @@ namespace UnitsNet
             return new Density(slugspercubicfoot*515.378818);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from SlugsPerCubicFoot of type decimal.
         /// </summary>
         public static Density FromSlugsPerCubicFoot(decimal slugspercubicfoot)
         {
-	        return new Density(Convert.ToDouble(slugspercubicfoot)*515.378818);
+            return new Density(Convert.ToDouble(slugspercubicfoot)*515.378818);
         }
 #endif
 
@@ -1546,7 +1546,7 @@ namespace UnitsNet
             return new Density(tonnespercubiccentimeter/1e-9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
         /// </summary>
         public static Density FromTonnesPerCubicCentimeter(int tonnespercubiccentimeter)
@@ -1554,7 +1554,7 @@ namespace UnitsNet
             return new Density(tonnespercubiccentimeter/1e-9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
         /// </summary>
         public static Density FromTonnesPerCubicCentimeter(long tonnespercubiccentimeter)
@@ -1562,14 +1562,14 @@ namespace UnitsNet
             return new Density(tonnespercubiccentimeter/1e-9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter of type decimal.
         /// </summary>
         public static Density FromTonnesPerCubicCentimeter(decimal tonnespercubiccentimeter)
         {
-	        return new Density(Convert.ToDouble(tonnespercubiccentimeter)/1e-9);
+            return new Density(Convert.ToDouble(tonnespercubiccentimeter)/1e-9);
         }
 #endif
 
@@ -1581,7 +1581,7 @@ namespace UnitsNet
             return new Density(tonnespercubicmeter/0.001);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
         public static Density FromTonnesPerCubicMeter(int tonnespercubicmeter)
@@ -1589,7 +1589,7 @@ namespace UnitsNet
             return new Density(tonnespercubicmeter/0.001);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
         public static Density FromTonnesPerCubicMeter(long tonnespercubicmeter)
@@ -1597,14 +1597,14 @@ namespace UnitsNet
             return new Density(tonnespercubicmeter/0.001);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicMeter of type decimal.
         /// </summary>
         public static Density FromTonnesPerCubicMeter(decimal tonnespercubicmeter)
         {
-	        return new Density(Convert.ToDouble(tonnespercubicmeter)/0.001);
+            return new Density(Convert.ToDouble(tonnespercubicmeter)/0.001);
         }
 #endif
 
@@ -1616,7 +1616,7 @@ namespace UnitsNet
             return new Density(tonnespercubicmillimeter/1e-12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
         /// </summary>
         public static Density FromTonnesPerCubicMillimeter(int tonnespercubicmillimeter)
@@ -1624,7 +1624,7 @@ namespace UnitsNet
             return new Density(tonnespercubicmillimeter/1e-12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
         /// </summary>
         public static Density FromTonnesPerCubicMillimeter(long tonnespercubicmillimeter)
@@ -1632,14 +1632,14 @@ namespace UnitsNet
             return new Density(tonnespercubicmillimeter/1e-12);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter of type decimal.
         /// </summary>
         public static Density FromTonnesPerCubicMillimeter(decimal tonnespercubicmillimeter)
         {
-	        return new Density(Convert.ToDouble(tonnespercubicmillimeter)/1e-12);
+            return new Density(Convert.ToDouble(tonnespercubicmillimeter)/1e-12);
         }
 #endif
 
@@ -1660,7 +1660,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable CentigramsPerDeciLiter.
         /// </summary>
         public static Density? FromCentigramsPerDeciLiter(int? centigramsperdeciliter)
@@ -1675,7 +1675,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable CentigramsPerDeciLiter.
         /// </summary>
         public static Density? FromCentigramsPerDeciLiter(long? centigramsperdeciliter)
@@ -1690,7 +1690,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from CentigramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromCentigramsPerDeciLiter(decimal? centigramsperdeciliter)
@@ -1720,7 +1720,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable CentigramsPerLiter.
         /// </summary>
         public static Density? FromCentigramsPerLiter(int? centigramsperliter)
@@ -1735,7 +1735,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable CentigramsPerLiter.
         /// </summary>
         public static Density? FromCentigramsPerLiter(long? centigramsperliter)
@@ -1750,7 +1750,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from CentigramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromCentigramsPerLiter(decimal? centigramsperliter)
@@ -1780,7 +1780,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable CentigramsPerMilliliter.
         /// </summary>
         public static Density? FromCentigramsPerMilliliter(int? centigramspermilliliter)
@@ -1795,7 +1795,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable CentigramsPerMilliliter.
         /// </summary>
         public static Density? FromCentigramsPerMilliliter(long? centigramspermilliliter)
@@ -1810,7 +1810,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from CentigramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromCentigramsPerMilliliter(decimal? centigramspermilliliter)
@@ -1840,7 +1840,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable DecigramsPerDeciLiter.
         /// </summary>
         public static Density? FromDecigramsPerDeciLiter(int? decigramsperdeciliter)
@@ -1855,7 +1855,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable DecigramsPerDeciLiter.
         /// </summary>
         public static Density? FromDecigramsPerDeciLiter(long? decigramsperdeciliter)
@@ -1870,7 +1870,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from DecigramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromDecigramsPerDeciLiter(decimal? decigramsperdeciliter)
@@ -1900,7 +1900,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable DecigramsPerLiter.
         /// </summary>
         public static Density? FromDecigramsPerLiter(int? decigramsperliter)
@@ -1915,7 +1915,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable DecigramsPerLiter.
         /// </summary>
         public static Density? FromDecigramsPerLiter(long? decigramsperliter)
@@ -1930,7 +1930,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from DecigramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromDecigramsPerLiter(decimal? decigramsperliter)
@@ -1960,7 +1960,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable DecigramsPerMilliliter.
         /// </summary>
         public static Density? FromDecigramsPerMilliliter(int? decigramspermilliliter)
@@ -1975,7 +1975,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable DecigramsPerMilliliter.
         /// </summary>
         public static Density? FromDecigramsPerMilliliter(long? decigramspermilliliter)
@@ -1990,7 +1990,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from DecigramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromDecigramsPerMilliliter(decimal? decigramspermilliliter)
@@ -2020,7 +2020,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicCentimeter.
         /// </summary>
         public static Density? FromGramsPerCubicCentimeter(int? gramspercubiccentimeter)
@@ -2035,7 +2035,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicCentimeter.
         /// </summary>
         public static Density? FromGramsPerCubicCentimeter(long? gramspercubiccentimeter)
@@ -2050,7 +2050,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from GramsPerCubicCentimeter of type decimal.
         /// </summary>
         public static Density? FromGramsPerCubicCentimeter(decimal? gramspercubiccentimeter)
@@ -2080,7 +2080,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMeter.
         /// </summary>
         public static Density? FromGramsPerCubicMeter(int? gramspercubicmeter)
@@ -2095,7 +2095,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMeter.
         /// </summary>
         public static Density? FromGramsPerCubicMeter(long? gramspercubicmeter)
@@ -2110,7 +2110,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from GramsPerCubicMeter of type decimal.
         /// </summary>
         public static Density? FromGramsPerCubicMeter(decimal? gramspercubicmeter)
@@ -2140,7 +2140,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMillimeter.
         /// </summary>
         public static Density? FromGramsPerCubicMillimeter(int? gramspercubicmillimeter)
@@ -2155,7 +2155,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMillimeter.
         /// </summary>
         public static Density? FromGramsPerCubicMillimeter(long? gramspercubicmillimeter)
@@ -2170,7 +2170,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from GramsPerCubicMillimeter of type decimal.
         /// </summary>
         public static Density? FromGramsPerCubicMillimeter(decimal? gramspercubicmillimeter)
@@ -2200,7 +2200,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerDeciLiter.
         /// </summary>
         public static Density? FromGramsPerDeciLiter(int? gramsperdeciliter)
@@ -2215,7 +2215,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerDeciLiter.
         /// </summary>
         public static Density? FromGramsPerDeciLiter(long? gramsperdeciliter)
@@ -2230,7 +2230,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from GramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromGramsPerDeciLiter(decimal? gramsperdeciliter)
@@ -2260,7 +2260,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerLiter.
         /// </summary>
         public static Density? FromGramsPerLiter(int? gramsperliter)
@@ -2275,7 +2275,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerLiter.
         /// </summary>
         public static Density? FromGramsPerLiter(long? gramsperliter)
@@ -2290,7 +2290,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from GramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromGramsPerLiter(decimal? gramsperliter)
@@ -2320,7 +2320,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerMilliliter.
         /// </summary>
         public static Density? FromGramsPerMilliliter(int? gramspermilliliter)
@@ -2335,7 +2335,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable GramsPerMilliliter.
         /// </summary>
         public static Density? FromGramsPerMilliliter(long? gramspermilliliter)
@@ -2350,7 +2350,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from GramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromGramsPerMilliliter(decimal? gramspermilliliter)
@@ -2380,7 +2380,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicCentimeter(int? kilogramspercubiccentimeter)
@@ -2395,7 +2395,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicCentimeter(long? kilogramspercubiccentimeter)
@@ -2410,7 +2410,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from KilogramsPerCubicCentimeter of type decimal.
         /// </summary>
         public static Density? FromKilogramsPerCubicCentimeter(decimal? kilogramspercubiccentimeter)
@@ -2440,7 +2440,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicMeter(int? kilogramspercubicmeter)
@@ -2455,7 +2455,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicMeter(long? kilogramspercubicmeter)
@@ -2470,7 +2470,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from KilogramsPerCubicMeter of type decimal.
         /// </summary>
         public static Density? FromKilogramsPerCubicMeter(decimal? kilogramspercubicmeter)
@@ -2500,7 +2500,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicMillimeter(int? kilogramspercubicmillimeter)
@@ -2515,7 +2515,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicMillimeter(long? kilogramspercubicmillimeter)
@@ -2530,7 +2530,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from KilogramsPerCubicMillimeter of type decimal.
         /// </summary>
         public static Density? FromKilogramsPerCubicMillimeter(decimal? kilogramspercubicmillimeter)
@@ -2560,7 +2560,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
         /// </summary>
         public static Density? FromKilopoundsPerCubicFoot(int? kilopoundspercubicfoot)
@@ -2575,7 +2575,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
         /// </summary>
         public static Density? FromKilopoundsPerCubicFoot(long? kilopoundspercubicfoot)
@@ -2590,7 +2590,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from KilopoundsPerCubicFoot of type decimal.
         /// </summary>
         public static Density? FromKilopoundsPerCubicFoot(decimal? kilopoundspercubicfoot)
@@ -2620,7 +2620,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicInch.
         /// </summary>
         public static Density? FromKilopoundsPerCubicInch(int? kilopoundspercubicinch)
@@ -2635,7 +2635,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicInch.
         /// </summary>
         public static Density? FromKilopoundsPerCubicInch(long? kilopoundspercubicinch)
@@ -2650,7 +2650,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from KilopoundsPerCubicInch of type decimal.
         /// </summary>
         public static Density? FromKilopoundsPerCubicInch(decimal? kilopoundspercubicinch)
@@ -2680,7 +2680,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
         /// </summary>
         public static Density? FromMicrogramsPerDeciLiter(int? microgramsperdeciliter)
@@ -2695,7 +2695,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
         /// </summary>
         public static Density? FromMicrogramsPerDeciLiter(long? microgramsperdeciliter)
@@ -2710,7 +2710,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from MicrogramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromMicrogramsPerDeciLiter(decimal? microgramsperdeciliter)
@@ -2740,7 +2740,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerLiter.
         /// </summary>
         public static Density? FromMicrogramsPerLiter(int? microgramsperliter)
@@ -2755,7 +2755,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerLiter.
         /// </summary>
         public static Density? FromMicrogramsPerLiter(long? microgramsperliter)
@@ -2770,7 +2770,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from MicrogramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromMicrogramsPerLiter(decimal? microgramsperliter)
@@ -2800,7 +2800,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerMilliliter.
         /// </summary>
         public static Density? FromMicrogramsPerMilliliter(int? microgramspermilliliter)
@@ -2815,7 +2815,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerMilliliter.
         /// </summary>
         public static Density? FromMicrogramsPerMilliliter(long? microgramspermilliliter)
@@ -2830,7 +2830,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from MicrogramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromMicrogramsPerMilliliter(decimal? microgramspermilliliter)
@@ -2860,7 +2860,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MilligramsPerDeciLiter.
         /// </summary>
         public static Density? FromMilligramsPerDeciLiter(int? milligramsperdeciliter)
@@ -2875,7 +2875,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MilligramsPerDeciLiter.
         /// </summary>
         public static Density? FromMilligramsPerDeciLiter(long? milligramsperdeciliter)
@@ -2890,7 +2890,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from MilligramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromMilligramsPerDeciLiter(decimal? milligramsperdeciliter)
@@ -2920,7 +2920,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MilligramsPerLiter.
         /// </summary>
         public static Density? FromMilligramsPerLiter(int? milligramsperliter)
@@ -2935,7 +2935,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MilligramsPerLiter.
         /// </summary>
         public static Density? FromMilligramsPerLiter(long? milligramsperliter)
@@ -2950,7 +2950,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from MilligramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromMilligramsPerLiter(decimal? milligramsperliter)
@@ -2980,7 +2980,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MilligramsPerMilliliter.
         /// </summary>
         public static Density? FromMilligramsPerMilliliter(int? milligramspermilliliter)
@@ -2995,7 +2995,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable MilligramsPerMilliliter.
         /// </summary>
         public static Density? FromMilligramsPerMilliliter(long? milligramspermilliliter)
@@ -3010,7 +3010,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from MilligramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromMilligramsPerMilliliter(decimal? milligramspermilliliter)
@@ -3040,7 +3040,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable NanogramsPerDeciLiter.
         /// </summary>
         public static Density? FromNanogramsPerDeciLiter(int? nanogramsperdeciliter)
@@ -3055,7 +3055,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable NanogramsPerDeciLiter.
         /// </summary>
         public static Density? FromNanogramsPerDeciLiter(long? nanogramsperdeciliter)
@@ -3070,7 +3070,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from NanogramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromNanogramsPerDeciLiter(decimal? nanogramsperdeciliter)
@@ -3100,7 +3100,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable NanogramsPerLiter.
         /// </summary>
         public static Density? FromNanogramsPerLiter(int? nanogramsperliter)
@@ -3115,7 +3115,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable NanogramsPerLiter.
         /// </summary>
         public static Density? FromNanogramsPerLiter(long? nanogramsperliter)
@@ -3130,7 +3130,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from NanogramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromNanogramsPerLiter(decimal? nanogramsperliter)
@@ -3160,7 +3160,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable NanogramsPerMilliliter.
         /// </summary>
         public static Density? FromNanogramsPerMilliliter(int? nanogramspermilliliter)
@@ -3175,7 +3175,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable NanogramsPerMilliliter.
         /// </summary>
         public static Density? FromNanogramsPerMilliliter(long? nanogramspermilliliter)
@@ -3190,7 +3190,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from NanogramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromNanogramsPerMilliliter(decimal? nanogramspermilliliter)
@@ -3220,7 +3220,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PicogramsPerDeciLiter.
         /// </summary>
         public static Density? FromPicogramsPerDeciLiter(int? picogramsperdeciliter)
@@ -3235,7 +3235,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PicogramsPerDeciLiter.
         /// </summary>
         public static Density? FromPicogramsPerDeciLiter(long? picogramsperdeciliter)
@@ -3250,7 +3250,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from PicogramsPerDeciLiter of type decimal.
         /// </summary>
         public static Density? FromPicogramsPerDeciLiter(decimal? picogramsperdeciliter)
@@ -3280,7 +3280,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PicogramsPerLiter.
         /// </summary>
         public static Density? FromPicogramsPerLiter(int? picogramsperliter)
@@ -3295,7 +3295,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PicogramsPerLiter.
         /// </summary>
         public static Density? FromPicogramsPerLiter(long? picogramsperliter)
@@ -3310,7 +3310,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from PicogramsPerLiter of type decimal.
         /// </summary>
         public static Density? FromPicogramsPerLiter(decimal? picogramsperliter)
@@ -3340,7 +3340,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PicogramsPerMilliliter.
         /// </summary>
         public static Density? FromPicogramsPerMilliliter(int? picogramspermilliliter)
@@ -3355,7 +3355,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PicogramsPerMilliliter.
         /// </summary>
         public static Density? FromPicogramsPerMilliliter(long? picogramspermilliliter)
@@ -3370,7 +3370,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from PicogramsPerMilliliter of type decimal.
         /// </summary>
         public static Density? FromPicogramsPerMilliliter(decimal? picogramspermilliliter)
@@ -3400,7 +3400,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicFoot.
         /// </summary>
         public static Density? FromPoundsPerCubicFoot(int? poundspercubicfoot)
@@ -3415,7 +3415,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicFoot.
         /// </summary>
         public static Density? FromPoundsPerCubicFoot(long? poundspercubicfoot)
@@ -3430,7 +3430,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from PoundsPerCubicFoot of type decimal.
         /// </summary>
         public static Density? FromPoundsPerCubicFoot(decimal? poundspercubicfoot)
@@ -3460,7 +3460,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicInch.
         /// </summary>
         public static Density? FromPoundsPerCubicInch(int? poundspercubicinch)
@@ -3475,7 +3475,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicInch.
         /// </summary>
         public static Density? FromPoundsPerCubicInch(long? poundspercubicinch)
@@ -3490,7 +3490,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from PoundsPerCubicInch of type decimal.
         /// </summary>
         public static Density? FromPoundsPerCubicInch(decimal? poundspercubicinch)
@@ -3520,7 +3520,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable SlugsPerCubicFoot.
         /// </summary>
         public static Density? FromSlugsPerCubicFoot(int? slugspercubicfoot)
@@ -3535,7 +3535,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable SlugsPerCubicFoot.
         /// </summary>
         public static Density? FromSlugsPerCubicFoot(long? slugspercubicfoot)
@@ -3550,7 +3550,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from SlugsPerCubicFoot of type decimal.
         /// </summary>
         public static Density? FromSlugsPerCubicFoot(decimal? slugspercubicfoot)
@@ -3580,7 +3580,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
         /// </summary>
         public static Density? FromTonnesPerCubicCentimeter(int? tonnespercubiccentimeter)
@@ -3595,7 +3595,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
         /// </summary>
         public static Density? FromTonnesPerCubicCentimeter(long? tonnespercubiccentimeter)
@@ -3610,7 +3610,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from TonnesPerCubicCentimeter of type decimal.
         /// </summary>
         public static Density? FromTonnesPerCubicCentimeter(decimal? tonnespercubiccentimeter)
@@ -3640,7 +3640,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMeter.
         /// </summary>
         public static Density? FromTonnesPerCubicMeter(int? tonnespercubicmeter)
@@ -3655,7 +3655,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMeter.
         /// </summary>
         public static Density? FromTonnesPerCubicMeter(long? tonnespercubicmeter)
@@ -3670,7 +3670,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from TonnesPerCubicMeter of type decimal.
         /// </summary>
         public static Density? FromTonnesPerCubicMeter(decimal? tonnespercubicmeter)
@@ -3700,7 +3700,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
         /// </summary>
         public static Density? FromTonnesPerCubicMillimeter(int? tonnespercubicmillimeter)
@@ -3715,7 +3715,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
         /// </summary>
         public static Density? FromTonnesPerCubicMillimeter(long? tonnespercubicmillimeter)
@@ -3730,7 +3730,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Density from TonnesPerCubicMillimeter of type decimal.
         /// </summary>
         public static Density? FromTonnesPerCubicMillimeter(decimal? tonnespercubicmillimeter)

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -421,6 +421,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromCentigramsPerDeciLiter(double centigramsperdeciliter)
         {
             return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
@@ -456,6 +459,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromCentigramsPerLiter(double centigramsperliter)
         {
             return new Density((centigramsperliter/1) * 1e-2d);
@@ -491,6 +497,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromCentigramsPerMilliliter(double centigramspermilliliter)
         {
             return new Density((centigramspermilliliter/1e-3) * 1e-2d);
@@ -526,6 +535,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromDecigramsPerDeciLiter(double decigramsperdeciliter)
         {
             return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
@@ -561,6 +573,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromDecigramsPerLiter(double decigramsperliter)
         {
             return new Density((decigramsperliter/1) * 1e-1d);
@@ -596,6 +611,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromDecigramsPerMilliliter(double decigramspermilliliter)
         {
             return new Density((decigramspermilliliter/1e-3) * 1e-1d);
@@ -631,6 +649,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromGramsPerCubicCentimeter(double gramspercubiccentimeter)
         {
             return new Density(gramspercubiccentimeter/1e-3);
@@ -666,6 +687,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromGramsPerCubicMeter(double gramspercubicmeter)
         {
             return new Density(gramspercubicmeter/1e3);
@@ -701,6 +725,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromGramsPerCubicMillimeter(double gramspercubicmillimeter)
         {
             return new Density(gramspercubicmillimeter/1e-6);
@@ -736,6 +763,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromGramsPerDeciLiter(double gramsperdeciliter)
         {
             return new Density(gramsperdeciliter/1e-1);
@@ -771,6 +801,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromGramsPerLiter(double gramsperliter)
         {
             return new Density(gramsperliter/1);
@@ -806,6 +839,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromGramsPerMilliliter(double gramspermilliliter)
         {
             return new Density(gramspermilliliter/1e-3);
@@ -841,6 +877,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromKilogramsPerCubicCentimeter(double kilogramspercubiccentimeter)
         {
             return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
@@ -876,6 +915,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromKilogramsPerCubicMeter(double kilogramspercubicmeter)
         {
             return new Density((kilogramspercubicmeter/1e3) * 1e3d);
@@ -911,6 +953,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromKilogramsPerCubicMillimeter(double kilogramspercubicmillimeter)
         {
             return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
@@ -946,6 +991,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromKilopoundsPerCubicFoot(double kilopoundspercubicfoot)
         {
             return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
@@ -981,6 +1029,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromKilopoundsPerCubicInch(double kilopoundspercubicinch)
         {
             return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
@@ -1016,6 +1067,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromMicrogramsPerDeciLiter(double microgramsperdeciliter)
         {
             return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
@@ -1051,6 +1105,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromMicrogramsPerLiter(double microgramsperliter)
         {
             return new Density((microgramsperliter/1) * 1e-6d);
@@ -1086,6 +1143,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromMicrogramsPerMilliliter(double microgramspermilliliter)
         {
             return new Density((microgramspermilliliter/1e-3) * 1e-6d);
@@ -1121,6 +1181,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromMilligramsPerDeciLiter(double milligramsperdeciliter)
         {
             return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
@@ -1156,6 +1219,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromMilligramsPerLiter(double milligramsperliter)
         {
             return new Density((milligramsperliter/1) * 1e-3d);
@@ -1191,6 +1257,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromMilligramsPerMilliliter(double milligramspermilliliter)
         {
             return new Density((milligramspermilliliter/1e-3) * 1e-3d);
@@ -1226,6 +1295,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromNanogramsPerDeciLiter(double nanogramsperdeciliter)
         {
             return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
@@ -1261,6 +1333,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromNanogramsPerLiter(double nanogramsperliter)
         {
             return new Density((nanogramsperliter/1) * 1e-9d);
@@ -1296,6 +1371,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromNanogramsPerMilliliter(double nanogramspermilliliter)
         {
             return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
@@ -1331,6 +1409,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromPicogramsPerDeciLiter(double picogramsperdeciliter)
         {
             return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
@@ -1366,6 +1447,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromPicogramsPerLiter(double picogramsperliter)
         {
             return new Density((picogramsperliter/1) * 1e-12d);
@@ -1401,6 +1485,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromPicogramsPerMilliliter(double picogramspermilliliter)
         {
             return new Density((picogramspermilliliter/1e-3) * 1e-12d);
@@ -1436,6 +1523,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromPoundsPerCubicFoot(double poundspercubicfoot)
         {
             return new Density(poundspercubicfoot/0.062427961);
@@ -1471,6 +1561,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerCubicInch.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromPoundsPerCubicInch(double poundspercubicinch)
         {
             return new Density(poundspercubicinch/3.6127298147753e-5);
@@ -1506,6 +1599,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromSlugsPerCubicFoot(double slugspercubicfoot)
         {
             return new Density(slugspercubicfoot*515.378818);
@@ -1541,6 +1637,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromTonnesPerCubicCentimeter(double tonnespercubiccentimeter)
         {
             return new Density(tonnespercubiccentimeter/1e-9);
@@ -1576,6 +1675,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromTonnesPerCubicMeter(double tonnespercubicmeter)
         {
             return new Density(tonnespercubicmeter/0.001);
@@ -1611,6 +1713,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Density FromTonnesPerCubicMillimeter(double tonnespercubicmillimeter)
         {
             return new Density(tonnespercubicmillimeter/1e-12);

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -426,6 +426,33 @@ namespace UnitsNet
             return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Density from CentigramsPerDeciLiter.
+        /// </summary>
+        public static Density FromCentigramsPerDeciLiter(int centigramsperdeciliter)
+        {
+            return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Density from CentigramsPerDeciLiter.
+        /// </summary>
+        public static Density FromCentigramsPerDeciLiter(long centigramsperdeciliter)
+        {
+            return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from CentigramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromCentigramsPerDeciLiter(decimal centigramsperdeciliter)
+        {
+	        return new Density((Convert.ToDouble(centigramsperdeciliter)/1e-1) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
@@ -433,6 +460,33 @@ namespace UnitsNet
         {
             return new Density((centigramsperliter/1) * 1e-2d);
         }
+
+		/// <summary>
+        ///     Get Density from CentigramsPerLiter.
+        /// </summary>
+        public static Density FromCentigramsPerLiter(int centigramsperliter)
+        {
+            return new Density((centigramsperliter/1) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Density from CentigramsPerLiter.
+        /// </summary>
+        public static Density FromCentigramsPerLiter(long centigramsperliter)
+        {
+            return new Density((centigramsperliter/1) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from CentigramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromCentigramsPerLiter(decimal centigramsperliter)
+        {
+	        return new Density((Convert.ToDouble(centigramsperliter)/1) * 1e-2d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
@@ -442,6 +496,33 @@ namespace UnitsNet
             return new Density((centigramspermilliliter/1e-3) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Density from CentigramsPerMilliliter.
+        /// </summary>
+        public static Density FromCentigramsPerMilliliter(int centigramspermilliliter)
+        {
+            return new Density((centigramspermilliliter/1e-3) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Density from CentigramsPerMilliliter.
+        /// </summary>
+        public static Density FromCentigramsPerMilliliter(long centigramspermilliliter)
+        {
+            return new Density((centigramspermilliliter/1e-3) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from CentigramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromCentigramsPerMilliliter(decimal centigramspermilliliter)
+        {
+	        return new Density((Convert.ToDouble(centigramspermilliliter)/1e-3) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
@@ -449,6 +530,33 @@ namespace UnitsNet
         {
             return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Density from DecigramsPerDeciLiter.
+        /// </summary>
+        public static Density FromDecigramsPerDeciLiter(int decigramsperdeciliter)
+        {
+            return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Density from DecigramsPerDeciLiter.
+        /// </summary>
+        public static Density FromDecigramsPerDeciLiter(long decigramsperdeciliter)
+        {
+            return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from DecigramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromDecigramsPerDeciLiter(decimal decigramsperdeciliter)
+        {
+	        return new Density((Convert.ToDouble(decigramsperdeciliter)/1e-1) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from DecigramsPerLiter.
@@ -458,6 +566,33 @@ namespace UnitsNet
             return new Density((decigramsperliter/1) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get Density from DecigramsPerLiter.
+        /// </summary>
+        public static Density FromDecigramsPerLiter(int decigramsperliter)
+        {
+            return new Density((decigramsperliter/1) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Density from DecigramsPerLiter.
+        /// </summary>
+        public static Density FromDecigramsPerLiter(long decigramsperliter)
+        {
+            return new Density((decigramsperliter/1) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from DecigramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromDecigramsPerLiter(decimal decigramsperliter)
+        {
+	        return new Density((Convert.ToDouble(decigramsperliter)/1) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
@@ -465,6 +600,33 @@ namespace UnitsNet
         {
             return new Density((decigramspermilliliter/1e-3) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Density from DecigramsPerMilliliter.
+        /// </summary>
+        public static Density FromDecigramsPerMilliliter(int decigramspermilliliter)
+        {
+            return new Density((decigramspermilliliter/1e-3) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Density from DecigramsPerMilliliter.
+        /// </summary>
+        public static Density FromDecigramsPerMilliliter(long decigramspermilliliter)
+        {
+            return new Density((decigramspermilliliter/1e-3) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from DecigramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromDecigramsPerMilliliter(decimal decigramspermilliliter)
+        {
+	        return new Density((Convert.ToDouble(decigramspermilliliter)/1e-3) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
@@ -474,6 +636,33 @@ namespace UnitsNet
             return new Density(gramspercubiccentimeter/1e-3);
         }
 
+		/// <summary>
+        ///     Get Density from GramsPerCubicCentimeter.
+        /// </summary>
+        public static Density FromGramsPerCubicCentimeter(int gramspercubiccentimeter)
+        {
+            return new Density(gramspercubiccentimeter/1e-3);
+        }
+
+		/// <summary>
+        ///     Get Density from GramsPerCubicCentimeter.
+        /// </summary>
+        public static Density FromGramsPerCubicCentimeter(long gramspercubiccentimeter)
+        {
+            return new Density(gramspercubiccentimeter/1e-3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from GramsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static Density FromGramsPerCubicCentimeter(decimal gramspercubiccentimeter)
+        {
+	        return new Density(Convert.ToDouble(gramspercubiccentimeter)/1e-3);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
@@ -481,6 +670,33 @@ namespace UnitsNet
         {
             return new Density(gramspercubicmeter/1e3);
         }
+
+		/// <summary>
+        ///     Get Density from GramsPerCubicMeter.
+        /// </summary>
+        public static Density FromGramsPerCubicMeter(int gramspercubicmeter)
+        {
+            return new Density(gramspercubicmeter/1e3);
+        }
+
+		/// <summary>
+        ///     Get Density from GramsPerCubicMeter.
+        /// </summary>
+        public static Density FromGramsPerCubicMeter(long gramspercubicmeter)
+        {
+            return new Density(gramspercubicmeter/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from GramsPerCubicMeter of type decimal.
+        /// </summary>
+        public static Density FromGramsPerCubicMeter(decimal gramspercubicmeter)
+        {
+	        return new Density(Convert.ToDouble(gramspercubicmeter)/1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
@@ -490,6 +706,33 @@ namespace UnitsNet
             return new Density(gramspercubicmillimeter/1e-6);
         }
 
+		/// <summary>
+        ///     Get Density from GramsPerCubicMillimeter.
+        /// </summary>
+        public static Density FromGramsPerCubicMillimeter(int gramspercubicmillimeter)
+        {
+            return new Density(gramspercubicmillimeter/1e-6);
+        }
+
+		/// <summary>
+        ///     Get Density from GramsPerCubicMillimeter.
+        /// </summary>
+        public static Density FromGramsPerCubicMillimeter(long gramspercubicmillimeter)
+        {
+            return new Density(gramspercubicmillimeter/1e-6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from GramsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static Density FromGramsPerCubicMillimeter(decimal gramspercubicmillimeter)
+        {
+	        return new Density(Convert.ToDouble(gramspercubicmillimeter)/1e-6);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
@@ -497,6 +740,33 @@ namespace UnitsNet
         {
             return new Density(gramsperdeciliter/1e-1);
         }
+
+		/// <summary>
+        ///     Get Density from GramsPerDeciLiter.
+        /// </summary>
+        public static Density FromGramsPerDeciLiter(int gramsperdeciliter)
+        {
+            return new Density(gramsperdeciliter/1e-1);
+        }
+
+		/// <summary>
+        ///     Get Density from GramsPerDeciLiter.
+        /// </summary>
+        public static Density FromGramsPerDeciLiter(long gramsperdeciliter)
+        {
+            return new Density(gramsperdeciliter/1e-1);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from GramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromGramsPerDeciLiter(decimal gramsperdeciliter)
+        {
+	        return new Density(Convert.ToDouble(gramsperdeciliter)/1e-1);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from GramsPerLiter.
@@ -506,6 +776,33 @@ namespace UnitsNet
             return new Density(gramsperliter/1);
         }
 
+		/// <summary>
+        ///     Get Density from GramsPerLiter.
+        /// </summary>
+        public static Density FromGramsPerLiter(int gramsperliter)
+        {
+            return new Density(gramsperliter/1);
+        }
+
+		/// <summary>
+        ///     Get Density from GramsPerLiter.
+        /// </summary>
+        public static Density FromGramsPerLiter(long gramsperliter)
+        {
+            return new Density(gramsperliter/1);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from GramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromGramsPerLiter(decimal gramsperliter)
+        {
+	        return new Density(Convert.ToDouble(gramsperliter)/1);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
@@ -513,6 +810,33 @@ namespace UnitsNet
         {
             return new Density(gramspermilliliter/1e-3);
         }
+
+		/// <summary>
+        ///     Get Density from GramsPerMilliliter.
+        /// </summary>
+        public static Density FromGramsPerMilliliter(int gramspermilliliter)
+        {
+            return new Density(gramspermilliliter/1e-3);
+        }
+
+		/// <summary>
+        ///     Get Density from GramsPerMilliliter.
+        /// </summary>
+        public static Density FromGramsPerMilliliter(long gramspermilliliter)
+        {
+            return new Density(gramspermilliliter/1e-3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from GramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromGramsPerMilliliter(decimal gramspermilliliter)
+        {
+	        return new Density(Convert.ToDouble(gramspermilliliter)/1e-3);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
@@ -522,6 +846,33 @@ namespace UnitsNet
             return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicCentimeter.
+        /// </summary>
+        public static Density FromKilogramsPerCubicCentimeter(int kilogramspercubiccentimeter)
+        {
+            return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicCentimeter.
+        /// </summary>
+        public static Density FromKilogramsPerCubicCentimeter(long kilogramspercubiccentimeter)
+        {
+            return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static Density FromKilogramsPerCubicCentimeter(decimal kilogramspercubiccentimeter)
+        {
+	        return new Density((Convert.ToDouble(kilogramspercubiccentimeter)/1e-3) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
@@ -529,6 +880,33 @@ namespace UnitsNet
         {
             return new Density((kilogramspercubicmeter/1e3) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicMeter.
+        /// </summary>
+        public static Density FromKilogramsPerCubicMeter(int kilogramspercubicmeter)
+        {
+            return new Density((kilogramspercubicmeter/1e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicMeter.
+        /// </summary>
+        public static Density FromKilogramsPerCubicMeter(long kilogramspercubicmeter)
+        {
+            return new Density((kilogramspercubicmeter/1e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicMeter of type decimal.
+        /// </summary>
+        public static Density FromKilogramsPerCubicMeter(decimal kilogramspercubicmeter)
+        {
+	        return new Density((Convert.ToDouble(kilogramspercubicmeter)/1e3) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
@@ -538,6 +916,33 @@ namespace UnitsNet
             return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicMillimeter.
+        /// </summary>
+        public static Density FromKilogramsPerCubicMillimeter(int kilogramspercubicmillimeter)
+        {
+            return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicMillimeter.
+        /// </summary>
+        public static Density FromKilogramsPerCubicMillimeter(long kilogramspercubicmillimeter)
+        {
+            return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from KilogramsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static Density FromKilogramsPerCubicMillimeter(decimal kilogramspercubicmillimeter)
+        {
+	        return new Density((Convert.ToDouble(kilogramspercubicmillimeter)/1e-6) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
@@ -545,6 +950,33 @@ namespace UnitsNet
         {
             return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Density from KilopoundsPerCubicFoot.
+        /// </summary>
+        public static Density FromKilopoundsPerCubicFoot(int kilopoundspercubicfoot)
+        {
+            return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Density from KilopoundsPerCubicFoot.
+        /// </summary>
+        public static Density FromKilopoundsPerCubicFoot(long kilopoundspercubicfoot)
+        {
+            return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from KilopoundsPerCubicFoot of type decimal.
+        /// </summary>
+        public static Density FromKilopoundsPerCubicFoot(decimal kilopoundspercubicfoot)
+        {
+	        return new Density((Convert.ToDouble(kilopoundspercubicfoot)/0.062427961) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
@@ -554,6 +986,33 @@ namespace UnitsNet
             return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Density from KilopoundsPerCubicInch.
+        /// </summary>
+        public static Density FromKilopoundsPerCubicInch(int kilopoundspercubicinch)
+        {
+            return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Density from KilopoundsPerCubicInch.
+        /// </summary>
+        public static Density FromKilopoundsPerCubicInch(long kilopoundspercubicinch)
+        {
+            return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from KilopoundsPerCubicInch of type decimal.
+        /// </summary>
+        public static Density FromKilopoundsPerCubicInch(decimal kilopoundspercubicinch)
+        {
+	        return new Density((Convert.ToDouble(kilopoundspercubicinch)/3.6127298147753e-5) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
@@ -561,6 +1020,33 @@ namespace UnitsNet
         {
             return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get Density from MicrogramsPerDeciLiter.
+        /// </summary>
+        public static Density FromMicrogramsPerDeciLiter(int microgramsperdeciliter)
+        {
+            return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Density from MicrogramsPerDeciLiter.
+        /// </summary>
+        public static Density FromMicrogramsPerDeciLiter(long microgramsperdeciliter)
+        {
+            return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from MicrogramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromMicrogramsPerDeciLiter(decimal microgramsperdeciliter)
+        {
+	        return new Density((Convert.ToDouble(microgramsperdeciliter)/1e-1) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from MicrogramsPerLiter.
@@ -570,6 +1056,33 @@ namespace UnitsNet
             return new Density((microgramsperliter/1) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Density from MicrogramsPerLiter.
+        /// </summary>
+        public static Density FromMicrogramsPerLiter(int microgramsperliter)
+        {
+            return new Density((microgramsperliter/1) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Density from MicrogramsPerLiter.
+        /// </summary>
+        public static Density FromMicrogramsPerLiter(long microgramsperliter)
+        {
+            return new Density((microgramsperliter/1) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from MicrogramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromMicrogramsPerLiter(decimal microgramsperliter)
+        {
+	        return new Density((Convert.ToDouble(microgramsperliter)/1) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
@@ -577,6 +1090,33 @@ namespace UnitsNet
         {
             return new Density((microgramspermilliliter/1e-3) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get Density from MicrogramsPerMilliliter.
+        /// </summary>
+        public static Density FromMicrogramsPerMilliliter(int microgramspermilliliter)
+        {
+            return new Density((microgramspermilliliter/1e-3) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Density from MicrogramsPerMilliliter.
+        /// </summary>
+        public static Density FromMicrogramsPerMilliliter(long microgramspermilliliter)
+        {
+            return new Density((microgramspermilliliter/1e-3) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from MicrogramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromMicrogramsPerMilliliter(decimal microgramspermilliliter)
+        {
+	        return new Density((Convert.ToDouble(microgramspermilliliter)/1e-3) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
@@ -586,6 +1126,33 @@ namespace UnitsNet
             return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Density from MilligramsPerDeciLiter.
+        /// </summary>
+        public static Density FromMilligramsPerDeciLiter(int milligramsperdeciliter)
+        {
+            return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Density from MilligramsPerDeciLiter.
+        /// </summary>
+        public static Density FromMilligramsPerDeciLiter(long milligramsperdeciliter)
+        {
+            return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from MilligramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromMilligramsPerDeciLiter(decimal milligramsperdeciliter)
+        {
+	        return new Density((Convert.ToDouble(milligramsperdeciliter)/1e-1) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
@@ -593,6 +1160,33 @@ namespace UnitsNet
         {
             return new Density((milligramsperliter/1) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Density from MilligramsPerLiter.
+        /// </summary>
+        public static Density FromMilligramsPerLiter(int milligramsperliter)
+        {
+            return new Density((milligramsperliter/1) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Density from MilligramsPerLiter.
+        /// </summary>
+        public static Density FromMilligramsPerLiter(long milligramsperliter)
+        {
+            return new Density((milligramsperliter/1) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from MilligramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromMilligramsPerLiter(decimal milligramsperliter)
+        {
+	        return new Density((Convert.ToDouble(milligramsperliter)/1) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
@@ -602,6 +1196,33 @@ namespace UnitsNet
             return new Density((milligramspermilliliter/1e-3) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Density from MilligramsPerMilliliter.
+        /// </summary>
+        public static Density FromMilligramsPerMilliliter(int milligramspermilliliter)
+        {
+            return new Density((milligramspermilliliter/1e-3) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Density from MilligramsPerMilliliter.
+        /// </summary>
+        public static Density FromMilligramsPerMilliliter(long milligramspermilliliter)
+        {
+            return new Density((milligramspermilliliter/1e-3) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from MilligramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromMilligramsPerMilliliter(decimal milligramspermilliliter)
+        {
+	        return new Density((Convert.ToDouble(milligramspermilliliter)/1e-3) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
@@ -609,6 +1230,33 @@ namespace UnitsNet
         {
             return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get Density from NanogramsPerDeciLiter.
+        /// </summary>
+        public static Density FromNanogramsPerDeciLiter(int nanogramsperdeciliter)
+        {
+            return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Density from NanogramsPerDeciLiter.
+        /// </summary>
+        public static Density FromNanogramsPerDeciLiter(long nanogramsperdeciliter)
+        {
+            return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from NanogramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromNanogramsPerDeciLiter(decimal nanogramsperdeciliter)
+        {
+	        return new Density((Convert.ToDouble(nanogramsperdeciliter)/1e-1) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from NanogramsPerLiter.
@@ -618,6 +1266,33 @@ namespace UnitsNet
             return new Density((nanogramsperliter/1) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Density from NanogramsPerLiter.
+        /// </summary>
+        public static Density FromNanogramsPerLiter(int nanogramsperliter)
+        {
+            return new Density((nanogramsperliter/1) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Density from NanogramsPerLiter.
+        /// </summary>
+        public static Density FromNanogramsPerLiter(long nanogramsperliter)
+        {
+            return new Density((nanogramsperliter/1) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from NanogramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromNanogramsPerLiter(decimal nanogramsperliter)
+        {
+	        return new Density((Convert.ToDouble(nanogramsperliter)/1) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
@@ -625,6 +1300,33 @@ namespace UnitsNet
         {
             return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get Density from NanogramsPerMilliliter.
+        /// </summary>
+        public static Density FromNanogramsPerMilliliter(int nanogramspermilliliter)
+        {
+            return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Density from NanogramsPerMilliliter.
+        /// </summary>
+        public static Density FromNanogramsPerMilliliter(long nanogramspermilliliter)
+        {
+            return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from NanogramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromNanogramsPerMilliliter(decimal nanogramspermilliliter)
+        {
+	        return new Density((Convert.ToDouble(nanogramspermilliliter)/1e-3) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
@@ -634,6 +1336,33 @@ namespace UnitsNet
             return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
         }
 
+		/// <summary>
+        ///     Get Density from PicogramsPerDeciLiter.
+        /// </summary>
+        public static Density FromPicogramsPerDeciLiter(int picogramsperdeciliter)
+        {
+            return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
+        }
+
+		/// <summary>
+        ///     Get Density from PicogramsPerDeciLiter.
+        /// </summary>
+        public static Density FromPicogramsPerDeciLiter(long picogramsperdeciliter)
+        {
+            return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from PicogramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density FromPicogramsPerDeciLiter(decimal picogramsperdeciliter)
+        {
+	        return new Density((Convert.ToDouble(picogramsperdeciliter)/1e-1) * 1e-12d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
@@ -641,6 +1370,33 @@ namespace UnitsNet
         {
             return new Density((picogramsperliter/1) * 1e-12d);
         }
+
+		/// <summary>
+        ///     Get Density from PicogramsPerLiter.
+        /// </summary>
+        public static Density FromPicogramsPerLiter(int picogramsperliter)
+        {
+            return new Density((picogramsperliter/1) * 1e-12d);
+        }
+
+		/// <summary>
+        ///     Get Density from PicogramsPerLiter.
+        /// </summary>
+        public static Density FromPicogramsPerLiter(long picogramsperliter)
+        {
+            return new Density((picogramsperliter/1) * 1e-12d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from PicogramsPerLiter of type decimal.
+        /// </summary>
+        public static Density FromPicogramsPerLiter(decimal picogramsperliter)
+        {
+	        return new Density((Convert.ToDouble(picogramsperliter)/1) * 1e-12d);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
@@ -650,6 +1406,33 @@ namespace UnitsNet
             return new Density((picogramspermilliliter/1e-3) * 1e-12d);
         }
 
+		/// <summary>
+        ///     Get Density from PicogramsPerMilliliter.
+        /// </summary>
+        public static Density FromPicogramsPerMilliliter(int picogramspermilliliter)
+        {
+            return new Density((picogramspermilliliter/1e-3) * 1e-12d);
+        }
+
+		/// <summary>
+        ///     Get Density from PicogramsPerMilliliter.
+        /// </summary>
+        public static Density FromPicogramsPerMilliliter(long picogramspermilliliter)
+        {
+            return new Density((picogramspermilliliter/1e-3) * 1e-12d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from PicogramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density FromPicogramsPerMilliliter(decimal picogramspermilliliter)
+        {
+	        return new Density((Convert.ToDouble(picogramspermilliliter)/1e-3) * 1e-12d);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
@@ -657,6 +1440,33 @@ namespace UnitsNet
         {
             return new Density(poundspercubicfoot/0.062427961);
         }
+
+		/// <summary>
+        ///     Get Density from PoundsPerCubicFoot.
+        /// </summary>
+        public static Density FromPoundsPerCubicFoot(int poundspercubicfoot)
+        {
+            return new Density(poundspercubicfoot/0.062427961);
+        }
+
+		/// <summary>
+        ///     Get Density from PoundsPerCubicFoot.
+        /// </summary>
+        public static Density FromPoundsPerCubicFoot(long poundspercubicfoot)
+        {
+            return new Density(poundspercubicfoot/0.062427961);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from PoundsPerCubicFoot of type decimal.
+        /// </summary>
+        public static Density FromPoundsPerCubicFoot(decimal poundspercubicfoot)
+        {
+	        return new Density(Convert.ToDouble(poundspercubicfoot)/0.062427961);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from PoundsPerCubicInch.
@@ -666,6 +1476,33 @@ namespace UnitsNet
             return new Density(poundspercubicinch/3.6127298147753e-5);
         }
 
+		/// <summary>
+        ///     Get Density from PoundsPerCubicInch.
+        /// </summary>
+        public static Density FromPoundsPerCubicInch(int poundspercubicinch)
+        {
+            return new Density(poundspercubicinch/3.6127298147753e-5);
+        }
+
+		/// <summary>
+        ///     Get Density from PoundsPerCubicInch.
+        /// </summary>
+        public static Density FromPoundsPerCubicInch(long poundspercubicinch)
+        {
+            return new Density(poundspercubicinch/3.6127298147753e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from PoundsPerCubicInch of type decimal.
+        /// </summary>
+        public static Density FromPoundsPerCubicInch(decimal poundspercubicinch)
+        {
+	        return new Density(Convert.ToDouble(poundspercubicinch)/3.6127298147753e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
@@ -673,6 +1510,33 @@ namespace UnitsNet
         {
             return new Density(slugspercubicfoot*515.378818);
         }
+
+		/// <summary>
+        ///     Get Density from SlugsPerCubicFoot.
+        /// </summary>
+        public static Density FromSlugsPerCubicFoot(int slugspercubicfoot)
+        {
+            return new Density(slugspercubicfoot*515.378818);
+        }
+
+		/// <summary>
+        ///     Get Density from SlugsPerCubicFoot.
+        /// </summary>
+        public static Density FromSlugsPerCubicFoot(long slugspercubicfoot)
+        {
+            return new Density(slugspercubicfoot*515.378818);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from SlugsPerCubicFoot of type decimal.
+        /// </summary>
+        public static Density FromSlugsPerCubicFoot(decimal slugspercubicfoot)
+        {
+	        return new Density(Convert.ToDouble(slugspercubicfoot)*515.378818);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
@@ -682,6 +1546,33 @@ namespace UnitsNet
             return new Density(tonnespercubiccentimeter/1e-9);
         }
 
+		/// <summary>
+        ///     Get Density from TonnesPerCubicCentimeter.
+        /// </summary>
+        public static Density FromTonnesPerCubicCentimeter(int tonnespercubiccentimeter)
+        {
+            return new Density(tonnespercubiccentimeter/1e-9);
+        }
+
+		/// <summary>
+        ///     Get Density from TonnesPerCubicCentimeter.
+        /// </summary>
+        public static Density FromTonnesPerCubicCentimeter(long tonnespercubiccentimeter)
+        {
+            return new Density(tonnespercubiccentimeter/1e-9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from TonnesPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static Density FromTonnesPerCubicCentimeter(decimal tonnespercubiccentimeter)
+        {
+	        return new Density(Convert.ToDouble(tonnespercubiccentimeter)/1e-9);
+        }
+#endif
+
         /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
@@ -689,6 +1580,33 @@ namespace UnitsNet
         {
             return new Density(tonnespercubicmeter/0.001);
         }
+
+		/// <summary>
+        ///     Get Density from TonnesPerCubicMeter.
+        /// </summary>
+        public static Density FromTonnesPerCubicMeter(int tonnespercubicmeter)
+        {
+            return new Density(tonnespercubicmeter/0.001);
+        }
+
+		/// <summary>
+        ///     Get Density from TonnesPerCubicMeter.
+        /// </summary>
+        public static Density FromTonnesPerCubicMeter(long tonnespercubicmeter)
+        {
+            return new Density(tonnespercubicmeter/0.001);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from TonnesPerCubicMeter of type decimal.
+        /// </summary>
+        public static Density FromTonnesPerCubicMeter(decimal tonnespercubicmeter)
+        {
+	        return new Density(Convert.ToDouble(tonnespercubicmeter)/0.001);
+        }
+#endif
 
         /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
@@ -698,12 +1616,84 @@ namespace UnitsNet
             return new Density(tonnespercubicmillimeter/1e-12);
         }
 
+		/// <summary>
+        ///     Get Density from TonnesPerCubicMillimeter.
+        /// </summary>
+        public static Density FromTonnesPerCubicMillimeter(int tonnespercubicmillimeter)
+        {
+            return new Density(tonnespercubicmillimeter/1e-12);
+        }
+
+		/// <summary>
+        ///     Get Density from TonnesPerCubicMillimeter.
+        /// </summary>
+        public static Density FromTonnesPerCubicMillimeter(long tonnespercubicmillimeter)
+        {
+            return new Density(tonnespercubicmillimeter/1e-12);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Density from TonnesPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static Density FromTonnesPerCubicMillimeter(decimal tonnespercubicmillimeter)
+        {
+	        return new Density(Convert.ToDouble(tonnespercubicmillimeter)/1e-12);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Density from nullable CentigramsPerDeciLiter.
         /// </summary>
         public static Density? FromCentigramsPerDeciLiter(double? centigramsperdeciliter)
+        {
+            if (centigramsperdeciliter.HasValue)
+            {
+                return FromCentigramsPerDeciLiter(centigramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable CentigramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromCentigramsPerDeciLiter(int? centigramsperdeciliter)
+        {
+            if (centigramsperdeciliter.HasValue)
+            {
+                return FromCentigramsPerDeciLiter(centigramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable CentigramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromCentigramsPerDeciLiter(long? centigramsperdeciliter)
+        {
+            if (centigramsperdeciliter.HasValue)
+            {
+                return FromCentigramsPerDeciLiter(centigramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from CentigramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromCentigramsPerDeciLiter(decimal? centigramsperdeciliter)
         {
             if (centigramsperdeciliter.HasValue)
             {
@@ -730,10 +1720,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable CentigramsPerLiter.
+        /// </summary>
+        public static Density? FromCentigramsPerLiter(int? centigramsperliter)
+        {
+            if (centigramsperliter.HasValue)
+            {
+                return FromCentigramsPerLiter(centigramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable CentigramsPerLiter.
+        /// </summary>
+        public static Density? FromCentigramsPerLiter(long? centigramsperliter)
+        {
+            if (centigramsperliter.HasValue)
+            {
+                return FromCentigramsPerLiter(centigramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from CentigramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromCentigramsPerLiter(decimal? centigramsperliter)
+        {
+            if (centigramsperliter.HasValue)
+            {
+                return FromCentigramsPerLiter(centigramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable CentigramsPerMilliliter.
         /// </summary>
         public static Density? FromCentigramsPerMilliliter(double? centigramspermilliliter)
+        {
+            if (centigramspermilliliter.HasValue)
+            {
+                return FromCentigramsPerMilliliter(centigramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable CentigramsPerMilliliter.
+        /// </summary>
+        public static Density? FromCentigramsPerMilliliter(int? centigramspermilliliter)
+        {
+            if (centigramspermilliliter.HasValue)
+            {
+                return FromCentigramsPerMilliliter(centigramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable CentigramsPerMilliliter.
+        /// </summary>
+        public static Density? FromCentigramsPerMilliliter(long? centigramspermilliliter)
+        {
+            if (centigramspermilliliter.HasValue)
+            {
+                return FromCentigramsPerMilliliter(centigramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from CentigramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromCentigramsPerMilliliter(decimal? centigramspermilliliter)
         {
             if (centigramspermilliliter.HasValue)
             {
@@ -760,10 +1840,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable DecigramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromDecigramsPerDeciLiter(int? decigramsperdeciliter)
+        {
+            if (decigramsperdeciliter.HasValue)
+            {
+                return FromDecigramsPerDeciLiter(decigramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable DecigramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromDecigramsPerDeciLiter(long? decigramsperdeciliter)
+        {
+            if (decigramsperdeciliter.HasValue)
+            {
+                return FromDecigramsPerDeciLiter(decigramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from DecigramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromDecigramsPerDeciLiter(decimal? decigramsperdeciliter)
+        {
+            if (decigramsperdeciliter.HasValue)
+            {
+                return FromDecigramsPerDeciLiter(decigramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable DecigramsPerLiter.
         /// </summary>
         public static Density? FromDecigramsPerLiter(double? decigramsperliter)
+        {
+            if (decigramsperliter.HasValue)
+            {
+                return FromDecigramsPerLiter(decigramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable DecigramsPerLiter.
+        /// </summary>
+        public static Density? FromDecigramsPerLiter(int? decigramsperliter)
+        {
+            if (decigramsperliter.HasValue)
+            {
+                return FromDecigramsPerLiter(decigramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable DecigramsPerLiter.
+        /// </summary>
+        public static Density? FromDecigramsPerLiter(long? decigramsperliter)
+        {
+            if (decigramsperliter.HasValue)
+            {
+                return FromDecigramsPerLiter(decigramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from DecigramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromDecigramsPerLiter(decimal? decigramsperliter)
         {
             if (decigramsperliter.HasValue)
             {
@@ -790,10 +1960,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable DecigramsPerMilliliter.
+        /// </summary>
+        public static Density? FromDecigramsPerMilliliter(int? decigramspermilliliter)
+        {
+            if (decigramspermilliliter.HasValue)
+            {
+                return FromDecigramsPerMilliliter(decigramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable DecigramsPerMilliliter.
+        /// </summary>
+        public static Density? FromDecigramsPerMilliliter(long? decigramspermilliliter)
+        {
+            if (decigramspermilliliter.HasValue)
+            {
+                return FromDecigramsPerMilliliter(decigramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from DecigramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromDecigramsPerMilliliter(decimal? decigramspermilliliter)
+        {
+            if (decigramspermilliliter.HasValue)
+            {
+                return FromDecigramsPerMilliliter(decigramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicCentimeter.
         /// </summary>
         public static Density? FromGramsPerCubicCentimeter(double? gramspercubiccentimeter)
+        {
+            if (gramspercubiccentimeter.HasValue)
+            {
+                return FromGramsPerCubicCentimeter(gramspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerCubicCentimeter.
+        /// </summary>
+        public static Density? FromGramsPerCubicCentimeter(int? gramspercubiccentimeter)
+        {
+            if (gramspercubiccentimeter.HasValue)
+            {
+                return FromGramsPerCubicCentimeter(gramspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerCubicCentimeter.
+        /// </summary>
+        public static Density? FromGramsPerCubicCentimeter(long? gramspercubiccentimeter)
+        {
+            if (gramspercubiccentimeter.HasValue)
+            {
+                return FromGramsPerCubicCentimeter(gramspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from GramsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static Density? FromGramsPerCubicCentimeter(decimal? gramspercubiccentimeter)
         {
             if (gramspercubiccentimeter.HasValue)
             {
@@ -820,10 +2080,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerCubicMeter.
+        /// </summary>
+        public static Density? FromGramsPerCubicMeter(int? gramspercubicmeter)
+        {
+            if (gramspercubicmeter.HasValue)
+            {
+                return FromGramsPerCubicMeter(gramspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerCubicMeter.
+        /// </summary>
+        public static Density? FromGramsPerCubicMeter(long? gramspercubicmeter)
+        {
+            if (gramspercubicmeter.HasValue)
+            {
+                return FromGramsPerCubicMeter(gramspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from GramsPerCubicMeter of type decimal.
+        /// </summary>
+        public static Density? FromGramsPerCubicMeter(decimal? gramspercubicmeter)
+        {
+            if (gramspercubicmeter.HasValue)
+            {
+                return FromGramsPerCubicMeter(gramspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMillimeter.
         /// </summary>
         public static Density? FromGramsPerCubicMillimeter(double? gramspercubicmillimeter)
+        {
+            if (gramspercubicmillimeter.HasValue)
+            {
+                return FromGramsPerCubicMillimeter(gramspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerCubicMillimeter.
+        /// </summary>
+        public static Density? FromGramsPerCubicMillimeter(int? gramspercubicmillimeter)
+        {
+            if (gramspercubicmillimeter.HasValue)
+            {
+                return FromGramsPerCubicMillimeter(gramspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerCubicMillimeter.
+        /// </summary>
+        public static Density? FromGramsPerCubicMillimeter(long? gramspercubicmillimeter)
+        {
+            if (gramspercubicmillimeter.HasValue)
+            {
+                return FromGramsPerCubicMillimeter(gramspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from GramsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static Density? FromGramsPerCubicMillimeter(decimal? gramspercubicmillimeter)
         {
             if (gramspercubicmillimeter.HasValue)
             {
@@ -850,10 +2200,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromGramsPerDeciLiter(int? gramsperdeciliter)
+        {
+            if (gramsperdeciliter.HasValue)
+            {
+                return FromGramsPerDeciLiter(gramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromGramsPerDeciLiter(long? gramsperdeciliter)
+        {
+            if (gramsperdeciliter.HasValue)
+            {
+                return FromGramsPerDeciLiter(gramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from GramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromGramsPerDeciLiter(decimal? gramsperdeciliter)
+        {
+            if (gramsperdeciliter.HasValue)
+            {
+                return FromGramsPerDeciLiter(gramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable GramsPerLiter.
         /// </summary>
         public static Density? FromGramsPerLiter(double? gramsperliter)
+        {
+            if (gramsperliter.HasValue)
+            {
+                return FromGramsPerLiter(gramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerLiter.
+        /// </summary>
+        public static Density? FromGramsPerLiter(int? gramsperliter)
+        {
+            if (gramsperliter.HasValue)
+            {
+                return FromGramsPerLiter(gramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerLiter.
+        /// </summary>
+        public static Density? FromGramsPerLiter(long? gramsperliter)
+        {
+            if (gramsperliter.HasValue)
+            {
+                return FromGramsPerLiter(gramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from GramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromGramsPerLiter(decimal? gramsperliter)
         {
             if (gramsperliter.HasValue)
             {
@@ -880,10 +2320,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerMilliliter.
+        /// </summary>
+        public static Density? FromGramsPerMilliliter(int? gramspermilliliter)
+        {
+            if (gramspermilliliter.HasValue)
+            {
+                return FromGramsPerMilliliter(gramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable GramsPerMilliliter.
+        /// </summary>
+        public static Density? FromGramsPerMilliliter(long? gramspermilliliter)
+        {
+            if (gramspermilliliter.HasValue)
+            {
+                return FromGramsPerMilliliter(gramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from GramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromGramsPerMilliliter(decimal? gramspermilliliter)
+        {
+            if (gramspermilliliter.HasValue)
+            {
+                return FromGramsPerMilliliter(gramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicCentimeter(double? kilogramspercubiccentimeter)
+        {
+            if (kilogramspercubiccentimeter.HasValue)
+            {
+                return FromKilogramsPerCubicCentimeter(kilogramspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicCentimeter(int? kilogramspercubiccentimeter)
+        {
+            if (kilogramspercubiccentimeter.HasValue)
+            {
+                return FromKilogramsPerCubicCentimeter(kilogramspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicCentimeter(long? kilogramspercubiccentimeter)
+        {
+            if (kilogramspercubiccentimeter.HasValue)
+            {
+                return FromKilogramsPerCubicCentimeter(kilogramspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from KilogramsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicCentimeter(decimal? kilogramspercubiccentimeter)
         {
             if (kilogramspercubiccentimeter.HasValue)
             {
@@ -910,10 +2440,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable KilogramsPerCubicMeter.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicMeter(int? kilogramspercubicmeter)
+        {
+            if (kilogramspercubicmeter.HasValue)
+            {
+                return FromKilogramsPerCubicMeter(kilogramspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilogramsPerCubicMeter.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicMeter(long? kilogramspercubicmeter)
+        {
+            if (kilogramspercubicmeter.HasValue)
+            {
+                return FromKilogramsPerCubicMeter(kilogramspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from KilogramsPerCubicMeter of type decimal.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicMeter(decimal? kilogramspercubicmeter)
+        {
+            if (kilogramspercubicmeter.HasValue)
+            {
+                return FromKilogramsPerCubicMeter(kilogramspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
         /// </summary>
         public static Density? FromKilogramsPerCubicMillimeter(double? kilogramspercubicmillimeter)
+        {
+            if (kilogramspercubicmillimeter.HasValue)
+            {
+                return FromKilogramsPerCubicMillimeter(kilogramspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicMillimeter(int? kilogramspercubicmillimeter)
+        {
+            if (kilogramspercubicmillimeter.HasValue)
+            {
+                return FromKilogramsPerCubicMillimeter(kilogramspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicMillimeter(long? kilogramspercubicmillimeter)
+        {
+            if (kilogramspercubicmillimeter.HasValue)
+            {
+                return FromKilogramsPerCubicMillimeter(kilogramspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from KilogramsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static Density? FromKilogramsPerCubicMillimeter(decimal? kilogramspercubicmillimeter)
         {
             if (kilogramspercubicmillimeter.HasValue)
             {
@@ -940,10 +2560,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
+        /// </summary>
+        public static Density? FromKilopoundsPerCubicFoot(int? kilopoundspercubicfoot)
+        {
+            if (kilopoundspercubicfoot.HasValue)
+            {
+                return FromKilopoundsPerCubicFoot(kilopoundspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
+        /// </summary>
+        public static Density? FromKilopoundsPerCubicFoot(long? kilopoundspercubicfoot)
+        {
+            if (kilopoundspercubicfoot.HasValue)
+            {
+                return FromKilopoundsPerCubicFoot(kilopoundspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from KilopoundsPerCubicFoot of type decimal.
+        /// </summary>
+        public static Density? FromKilopoundsPerCubicFoot(decimal? kilopoundspercubicfoot)
+        {
+            if (kilopoundspercubicfoot.HasValue)
+            {
+                return FromKilopoundsPerCubicFoot(kilopoundspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicInch.
         /// </summary>
         public static Density? FromKilopoundsPerCubicInch(double? kilopoundspercubicinch)
+        {
+            if (kilopoundspercubicinch.HasValue)
+            {
+                return FromKilopoundsPerCubicInch(kilopoundspercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilopoundsPerCubicInch.
+        /// </summary>
+        public static Density? FromKilopoundsPerCubicInch(int? kilopoundspercubicinch)
+        {
+            if (kilopoundspercubicinch.HasValue)
+            {
+                return FromKilopoundsPerCubicInch(kilopoundspercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable KilopoundsPerCubicInch.
+        /// </summary>
+        public static Density? FromKilopoundsPerCubicInch(long? kilopoundspercubicinch)
+        {
+            if (kilopoundspercubicinch.HasValue)
+            {
+                return FromKilopoundsPerCubicInch(kilopoundspercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from KilopoundsPerCubicInch of type decimal.
+        /// </summary>
+        public static Density? FromKilopoundsPerCubicInch(decimal? kilopoundspercubicinch)
         {
             if (kilopoundspercubicinch.HasValue)
             {
@@ -970,10 +2680,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromMicrogramsPerDeciLiter(int? microgramsperdeciliter)
+        {
+            if (microgramsperdeciliter.HasValue)
+            {
+                return FromMicrogramsPerDeciLiter(microgramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromMicrogramsPerDeciLiter(long? microgramsperdeciliter)
+        {
+            if (microgramsperdeciliter.HasValue)
+            {
+                return FromMicrogramsPerDeciLiter(microgramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from MicrogramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromMicrogramsPerDeciLiter(decimal? microgramsperdeciliter)
+        {
+            if (microgramsperdeciliter.HasValue)
+            {
+                return FromMicrogramsPerDeciLiter(microgramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerLiter.
         /// </summary>
         public static Density? FromMicrogramsPerLiter(double? microgramsperliter)
+        {
+            if (microgramsperliter.HasValue)
+            {
+                return FromMicrogramsPerLiter(microgramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MicrogramsPerLiter.
+        /// </summary>
+        public static Density? FromMicrogramsPerLiter(int? microgramsperliter)
+        {
+            if (microgramsperliter.HasValue)
+            {
+                return FromMicrogramsPerLiter(microgramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MicrogramsPerLiter.
+        /// </summary>
+        public static Density? FromMicrogramsPerLiter(long? microgramsperliter)
+        {
+            if (microgramsperliter.HasValue)
+            {
+                return FromMicrogramsPerLiter(microgramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from MicrogramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromMicrogramsPerLiter(decimal? microgramsperliter)
         {
             if (microgramsperliter.HasValue)
             {
@@ -1000,10 +2800,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable MicrogramsPerMilliliter.
+        /// </summary>
+        public static Density? FromMicrogramsPerMilliliter(int? microgramspermilliliter)
+        {
+            if (microgramspermilliliter.HasValue)
+            {
+                return FromMicrogramsPerMilliliter(microgramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MicrogramsPerMilliliter.
+        /// </summary>
+        public static Density? FromMicrogramsPerMilliliter(long? microgramspermilliliter)
+        {
+            if (microgramspermilliliter.HasValue)
+            {
+                return FromMicrogramsPerMilliliter(microgramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from MicrogramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromMicrogramsPerMilliliter(decimal? microgramspermilliliter)
+        {
+            if (microgramspermilliliter.HasValue)
+            {
+                return FromMicrogramsPerMilliliter(microgramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable MilligramsPerDeciLiter.
         /// </summary>
         public static Density? FromMilligramsPerDeciLiter(double? milligramsperdeciliter)
+        {
+            if (milligramsperdeciliter.HasValue)
+            {
+                return FromMilligramsPerDeciLiter(milligramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MilligramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromMilligramsPerDeciLiter(int? milligramsperdeciliter)
+        {
+            if (milligramsperdeciliter.HasValue)
+            {
+                return FromMilligramsPerDeciLiter(milligramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MilligramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromMilligramsPerDeciLiter(long? milligramsperdeciliter)
+        {
+            if (milligramsperdeciliter.HasValue)
+            {
+                return FromMilligramsPerDeciLiter(milligramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from MilligramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromMilligramsPerDeciLiter(decimal? milligramsperdeciliter)
         {
             if (milligramsperdeciliter.HasValue)
             {
@@ -1030,10 +2920,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable MilligramsPerLiter.
+        /// </summary>
+        public static Density? FromMilligramsPerLiter(int? milligramsperliter)
+        {
+            if (milligramsperliter.HasValue)
+            {
+                return FromMilligramsPerLiter(milligramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MilligramsPerLiter.
+        /// </summary>
+        public static Density? FromMilligramsPerLiter(long? milligramsperliter)
+        {
+            if (milligramsperliter.HasValue)
+            {
+                return FromMilligramsPerLiter(milligramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from MilligramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromMilligramsPerLiter(decimal? milligramsperliter)
+        {
+            if (milligramsperliter.HasValue)
+            {
+                return FromMilligramsPerLiter(milligramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable MilligramsPerMilliliter.
         /// </summary>
         public static Density? FromMilligramsPerMilliliter(double? milligramspermilliliter)
+        {
+            if (milligramspermilliliter.HasValue)
+            {
+                return FromMilligramsPerMilliliter(milligramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MilligramsPerMilliliter.
+        /// </summary>
+        public static Density? FromMilligramsPerMilliliter(int? milligramspermilliliter)
+        {
+            if (milligramspermilliliter.HasValue)
+            {
+                return FromMilligramsPerMilliliter(milligramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable MilligramsPerMilliliter.
+        /// </summary>
+        public static Density? FromMilligramsPerMilliliter(long? milligramspermilliliter)
+        {
+            if (milligramspermilliliter.HasValue)
+            {
+                return FromMilligramsPerMilliliter(milligramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from MilligramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromMilligramsPerMilliliter(decimal? milligramspermilliliter)
         {
             if (milligramspermilliliter.HasValue)
             {
@@ -1060,10 +3040,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable NanogramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromNanogramsPerDeciLiter(int? nanogramsperdeciliter)
+        {
+            if (nanogramsperdeciliter.HasValue)
+            {
+                return FromNanogramsPerDeciLiter(nanogramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable NanogramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromNanogramsPerDeciLiter(long? nanogramsperdeciliter)
+        {
+            if (nanogramsperdeciliter.HasValue)
+            {
+                return FromNanogramsPerDeciLiter(nanogramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from NanogramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromNanogramsPerDeciLiter(decimal? nanogramsperdeciliter)
+        {
+            if (nanogramsperdeciliter.HasValue)
+            {
+                return FromNanogramsPerDeciLiter(nanogramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable NanogramsPerLiter.
         /// </summary>
         public static Density? FromNanogramsPerLiter(double? nanogramsperliter)
+        {
+            if (nanogramsperliter.HasValue)
+            {
+                return FromNanogramsPerLiter(nanogramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable NanogramsPerLiter.
+        /// </summary>
+        public static Density? FromNanogramsPerLiter(int? nanogramsperliter)
+        {
+            if (nanogramsperliter.HasValue)
+            {
+                return FromNanogramsPerLiter(nanogramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable NanogramsPerLiter.
+        /// </summary>
+        public static Density? FromNanogramsPerLiter(long? nanogramsperliter)
+        {
+            if (nanogramsperliter.HasValue)
+            {
+                return FromNanogramsPerLiter(nanogramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from NanogramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromNanogramsPerLiter(decimal? nanogramsperliter)
         {
             if (nanogramsperliter.HasValue)
             {
@@ -1090,10 +3160,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable NanogramsPerMilliliter.
+        /// </summary>
+        public static Density? FromNanogramsPerMilliliter(int? nanogramspermilliliter)
+        {
+            if (nanogramspermilliliter.HasValue)
+            {
+                return FromNanogramsPerMilliliter(nanogramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable NanogramsPerMilliliter.
+        /// </summary>
+        public static Density? FromNanogramsPerMilliliter(long? nanogramspermilliliter)
+        {
+            if (nanogramspermilliliter.HasValue)
+            {
+                return FromNanogramsPerMilliliter(nanogramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from NanogramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromNanogramsPerMilliliter(decimal? nanogramspermilliliter)
+        {
+            if (nanogramspermilliliter.HasValue)
+            {
+                return FromNanogramsPerMilliliter(nanogramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable PicogramsPerDeciLiter.
         /// </summary>
         public static Density? FromPicogramsPerDeciLiter(double? picogramsperdeciliter)
+        {
+            if (picogramsperdeciliter.HasValue)
+            {
+                return FromPicogramsPerDeciLiter(picogramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PicogramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromPicogramsPerDeciLiter(int? picogramsperdeciliter)
+        {
+            if (picogramsperdeciliter.HasValue)
+            {
+                return FromPicogramsPerDeciLiter(picogramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PicogramsPerDeciLiter.
+        /// </summary>
+        public static Density? FromPicogramsPerDeciLiter(long? picogramsperdeciliter)
+        {
+            if (picogramsperdeciliter.HasValue)
+            {
+                return FromPicogramsPerDeciLiter(picogramsperdeciliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from PicogramsPerDeciLiter of type decimal.
+        /// </summary>
+        public static Density? FromPicogramsPerDeciLiter(decimal? picogramsperdeciliter)
         {
             if (picogramsperdeciliter.HasValue)
             {
@@ -1120,10 +3280,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable PicogramsPerLiter.
+        /// </summary>
+        public static Density? FromPicogramsPerLiter(int? picogramsperliter)
+        {
+            if (picogramsperliter.HasValue)
+            {
+                return FromPicogramsPerLiter(picogramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PicogramsPerLiter.
+        /// </summary>
+        public static Density? FromPicogramsPerLiter(long? picogramsperliter)
+        {
+            if (picogramsperliter.HasValue)
+            {
+                return FromPicogramsPerLiter(picogramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from PicogramsPerLiter of type decimal.
+        /// </summary>
+        public static Density? FromPicogramsPerLiter(decimal? picogramsperliter)
+        {
+            if (picogramsperliter.HasValue)
+            {
+                return FromPicogramsPerLiter(picogramsperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable PicogramsPerMilliliter.
         /// </summary>
         public static Density? FromPicogramsPerMilliliter(double? picogramspermilliliter)
+        {
+            if (picogramspermilliliter.HasValue)
+            {
+                return FromPicogramsPerMilliliter(picogramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PicogramsPerMilliliter.
+        /// </summary>
+        public static Density? FromPicogramsPerMilliliter(int? picogramspermilliliter)
+        {
+            if (picogramspermilliliter.HasValue)
+            {
+                return FromPicogramsPerMilliliter(picogramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PicogramsPerMilliliter.
+        /// </summary>
+        public static Density? FromPicogramsPerMilliliter(long? picogramspermilliliter)
+        {
+            if (picogramspermilliliter.HasValue)
+            {
+                return FromPicogramsPerMilliliter(picogramspermilliliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from PicogramsPerMilliliter of type decimal.
+        /// </summary>
+        public static Density? FromPicogramsPerMilliliter(decimal? picogramspermilliliter)
         {
             if (picogramspermilliliter.HasValue)
             {
@@ -1150,10 +3400,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable PoundsPerCubicFoot.
+        /// </summary>
+        public static Density? FromPoundsPerCubicFoot(int? poundspercubicfoot)
+        {
+            if (poundspercubicfoot.HasValue)
+            {
+                return FromPoundsPerCubicFoot(poundspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PoundsPerCubicFoot.
+        /// </summary>
+        public static Density? FromPoundsPerCubicFoot(long? poundspercubicfoot)
+        {
+            if (poundspercubicfoot.HasValue)
+            {
+                return FromPoundsPerCubicFoot(poundspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from PoundsPerCubicFoot of type decimal.
+        /// </summary>
+        public static Density? FromPoundsPerCubicFoot(decimal? poundspercubicfoot)
+        {
+            if (poundspercubicfoot.HasValue)
+            {
+                return FromPoundsPerCubicFoot(poundspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicInch.
         /// </summary>
         public static Density? FromPoundsPerCubicInch(double? poundspercubicinch)
+        {
+            if (poundspercubicinch.HasValue)
+            {
+                return FromPoundsPerCubicInch(poundspercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PoundsPerCubicInch.
+        /// </summary>
+        public static Density? FromPoundsPerCubicInch(int? poundspercubicinch)
+        {
+            if (poundspercubicinch.HasValue)
+            {
+                return FromPoundsPerCubicInch(poundspercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable PoundsPerCubicInch.
+        /// </summary>
+        public static Density? FromPoundsPerCubicInch(long? poundspercubicinch)
+        {
+            if (poundspercubicinch.HasValue)
+            {
+                return FromPoundsPerCubicInch(poundspercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from PoundsPerCubicInch of type decimal.
+        /// </summary>
+        public static Density? FromPoundsPerCubicInch(decimal? poundspercubicinch)
         {
             if (poundspercubicinch.HasValue)
             {
@@ -1180,10 +3520,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable SlugsPerCubicFoot.
+        /// </summary>
+        public static Density? FromSlugsPerCubicFoot(int? slugspercubicfoot)
+        {
+            if (slugspercubicfoot.HasValue)
+            {
+                return FromSlugsPerCubicFoot(slugspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable SlugsPerCubicFoot.
+        /// </summary>
+        public static Density? FromSlugsPerCubicFoot(long? slugspercubicfoot)
+        {
+            if (slugspercubicfoot.HasValue)
+            {
+                return FromSlugsPerCubicFoot(slugspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from SlugsPerCubicFoot of type decimal.
+        /// </summary>
+        public static Density? FromSlugsPerCubicFoot(decimal? slugspercubicfoot)
+        {
+            if (slugspercubicfoot.HasValue)
+            {
+                return FromSlugsPerCubicFoot(slugspercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
         /// </summary>
         public static Density? FromTonnesPerCubicCentimeter(double? tonnespercubiccentimeter)
+        {
+            if (tonnespercubiccentimeter.HasValue)
+            {
+                return FromTonnesPerCubicCentimeter(tonnespercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
+        /// </summary>
+        public static Density? FromTonnesPerCubicCentimeter(int? tonnespercubiccentimeter)
+        {
+            if (tonnespercubiccentimeter.HasValue)
+            {
+                return FromTonnesPerCubicCentimeter(tonnespercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
+        /// </summary>
+        public static Density? FromTonnesPerCubicCentimeter(long? tonnespercubiccentimeter)
+        {
+            if (tonnespercubiccentimeter.HasValue)
+            {
+                return FromTonnesPerCubicCentimeter(tonnespercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from TonnesPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static Density? FromTonnesPerCubicCentimeter(decimal? tonnespercubiccentimeter)
         {
             if (tonnespercubiccentimeter.HasValue)
             {
@@ -1210,10 +3640,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Density from nullable TonnesPerCubicMeter.
+        /// </summary>
+        public static Density? FromTonnesPerCubicMeter(int? tonnespercubicmeter)
+        {
+            if (tonnespercubicmeter.HasValue)
+            {
+                return FromTonnesPerCubicMeter(tonnespercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable TonnesPerCubicMeter.
+        /// </summary>
+        public static Density? FromTonnesPerCubicMeter(long? tonnespercubicmeter)
+        {
+            if (tonnespercubicmeter.HasValue)
+            {
+                return FromTonnesPerCubicMeter(tonnespercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from TonnesPerCubicMeter of type decimal.
+        /// </summary>
+        public static Density? FromTonnesPerCubicMeter(decimal? tonnespercubicmeter)
+        {
+            if (tonnespercubicmeter.HasValue)
+            {
+                return FromTonnesPerCubicMeter(tonnespercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
         /// </summary>
         public static Density? FromTonnesPerCubicMillimeter(double? tonnespercubicmillimeter)
+        {
+            if (tonnespercubicmillimeter.HasValue)
+            {
+                return FromTonnesPerCubicMillimeter(tonnespercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
+        /// </summary>
+        public static Density? FromTonnesPerCubicMillimeter(int? tonnespercubicmillimeter)
+        {
+            if (tonnespercubicmillimeter.HasValue)
+            {
+                return FromTonnesPerCubicMillimeter(tonnespercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
+        /// </summary>
+        public static Density? FromTonnesPerCubicMillimeter(long? tonnespercubicmillimeter)
+        {
+            if (tonnespercubicmillimeter.HasValue)
+            {
+                return FromTonnesPerCubicMillimeter(tonnespercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Density from TonnesPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static Density? FromTonnesPerCubicMillimeter(decimal? tonnespercubicmillimeter)
         {
             if (tonnespercubicmillimeter.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _seconds;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Duration() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Duration;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static DurationUnit BaseUnit
         {
             get { return DurationUnit.Second; }
@@ -226,7 +226,7 @@ namespace UnitsNet
             return new Duration(days*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Days.
         /// </summary>
         public static Duration FromDays(int days)
@@ -234,7 +234,7 @@ namespace UnitsNet
             return new Duration(days*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Days.
         /// </summary>
         public static Duration FromDays(long days)
@@ -242,14 +242,14 @@ namespace UnitsNet
             return new Duration(days*24*3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Days of type decimal.
         /// </summary>
         public static Duration FromDays(decimal days)
         {
-	        return new Duration(Convert.ToDouble(days)*24*3600);
+            return new Duration(Convert.ToDouble(days)*24*3600);
         }
 #endif
 
@@ -261,7 +261,7 @@ namespace UnitsNet
             return new Duration(hours*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
         public static Duration FromHours(int hours)
@@ -269,7 +269,7 @@ namespace UnitsNet
             return new Duration(hours*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
         public static Duration FromHours(long hours)
@@ -277,14 +277,14 @@ namespace UnitsNet
             return new Duration(hours*3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Hours of type decimal.
         /// </summary>
         public static Duration FromHours(decimal hours)
         {
-	        return new Duration(Convert.ToDouble(hours)*3600);
+            return new Duration(Convert.ToDouble(hours)*3600);
         }
 #endif
 
@@ -296,7 +296,7 @@ namespace UnitsNet
             return new Duration(microseconds/1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Microseconds.
         /// </summary>
         public static Duration FromMicroseconds(int microseconds)
@@ -304,7 +304,7 @@ namespace UnitsNet
             return new Duration(microseconds/1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Microseconds.
         /// </summary>
         public static Duration FromMicroseconds(long microseconds)
@@ -312,14 +312,14 @@ namespace UnitsNet
             return new Duration(microseconds/1e6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Microseconds of type decimal.
         /// </summary>
         public static Duration FromMicroseconds(decimal microseconds)
         {
-	        return new Duration(Convert.ToDouble(microseconds)/1e6);
+            return new Duration(Convert.ToDouble(microseconds)/1e6);
         }
 #endif
 
@@ -331,7 +331,7 @@ namespace UnitsNet
             return new Duration(milliseconds/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
         public static Duration FromMilliseconds(int milliseconds)
@@ -339,7 +339,7 @@ namespace UnitsNet
             return new Duration(milliseconds/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
         public static Duration FromMilliseconds(long milliseconds)
@@ -347,14 +347,14 @@ namespace UnitsNet
             return new Duration(milliseconds/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Milliseconds of type decimal.
         /// </summary>
         public static Duration FromMilliseconds(decimal milliseconds)
         {
-	        return new Duration(Convert.ToDouble(milliseconds)/1e3);
+            return new Duration(Convert.ToDouble(milliseconds)/1e3);
         }
 #endif
 
@@ -366,7 +366,7 @@ namespace UnitsNet
             return new Duration(minutes*60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Minutes.
         /// </summary>
         public static Duration FromMinutes(int minutes)
@@ -374,7 +374,7 @@ namespace UnitsNet
             return new Duration(minutes*60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Minutes.
         /// </summary>
         public static Duration FromMinutes(long minutes)
@@ -382,14 +382,14 @@ namespace UnitsNet
             return new Duration(minutes*60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Minutes of type decimal.
         /// </summary>
         public static Duration FromMinutes(decimal minutes)
         {
-	        return new Duration(Convert.ToDouble(minutes)*60);
+            return new Duration(Convert.ToDouble(minutes)*60);
         }
 #endif
 
@@ -401,7 +401,7 @@ namespace UnitsNet
             return new Duration(months*30*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Months.
         /// </summary>
         public static Duration FromMonths(int months)
@@ -409,7 +409,7 @@ namespace UnitsNet
             return new Duration(months*30*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Months.
         /// </summary>
         public static Duration FromMonths(long months)
@@ -417,14 +417,14 @@ namespace UnitsNet
             return new Duration(months*30*24*3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Months of type decimal.
         /// </summary>
         public static Duration FromMonths(decimal months)
         {
-	        return new Duration(Convert.ToDouble(months)*30*24*3600);
+            return new Duration(Convert.ToDouble(months)*30*24*3600);
         }
 #endif
 
@@ -436,7 +436,7 @@ namespace UnitsNet
             return new Duration(nanoseconds/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Nanoseconds.
         /// </summary>
         public static Duration FromNanoseconds(int nanoseconds)
@@ -444,7 +444,7 @@ namespace UnitsNet
             return new Duration(nanoseconds/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Nanoseconds.
         /// </summary>
         public static Duration FromNanoseconds(long nanoseconds)
@@ -452,14 +452,14 @@ namespace UnitsNet
             return new Duration(nanoseconds/1e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Nanoseconds of type decimal.
         /// </summary>
         public static Duration FromNanoseconds(decimal nanoseconds)
         {
-	        return new Duration(Convert.ToDouble(nanoseconds)/1e9);
+            return new Duration(Convert.ToDouble(nanoseconds)/1e9);
         }
 #endif
 
@@ -471,7 +471,7 @@ namespace UnitsNet
             return new Duration(seconds);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
         public static Duration FromSeconds(int seconds)
@@ -479,7 +479,7 @@ namespace UnitsNet
             return new Duration(seconds);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
         public static Duration FromSeconds(long seconds)
@@ -487,14 +487,14 @@ namespace UnitsNet
             return new Duration(seconds);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Seconds of type decimal.
         /// </summary>
         public static Duration FromSeconds(decimal seconds)
         {
-	        return new Duration(Convert.ToDouble(seconds));
+            return new Duration(Convert.ToDouble(seconds));
         }
 #endif
 
@@ -506,7 +506,7 @@ namespace UnitsNet
             return new Duration(weeks*7*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Weeks.
         /// </summary>
         public static Duration FromWeeks(int weeks)
@@ -514,7 +514,7 @@ namespace UnitsNet
             return new Duration(weeks*7*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Weeks.
         /// </summary>
         public static Duration FromWeeks(long weeks)
@@ -522,14 +522,14 @@ namespace UnitsNet
             return new Duration(weeks*7*24*3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Weeks of type decimal.
         /// </summary>
         public static Duration FromWeeks(decimal weeks)
         {
-	        return new Duration(Convert.ToDouble(weeks)*7*24*3600);
+            return new Duration(Convert.ToDouble(weeks)*7*24*3600);
         }
 #endif
 
@@ -541,7 +541,7 @@ namespace UnitsNet
             return new Duration(years*365*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Years.
         /// </summary>
         public static Duration FromYears(int years)
@@ -549,7 +549,7 @@ namespace UnitsNet
             return new Duration(years*365*24*3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Years.
         /// </summary>
         public static Duration FromYears(long years)
@@ -557,14 +557,14 @@ namespace UnitsNet
             return new Duration(years*365*24*3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Duration from Years of type decimal.
         /// </summary>
         public static Duration FromYears(decimal years)
         {
-	        return new Duration(Convert.ToDouble(years)*365*24*3600);
+            return new Duration(Convert.ToDouble(years)*365*24*3600);
         }
 #endif
 
@@ -585,7 +585,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Days.
         /// </summary>
         public static Duration? FromDays(int? days)
@@ -600,7 +600,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Days.
         /// </summary>
         public static Duration? FromDays(long? days)
@@ -615,7 +615,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Days of type decimal.
         /// </summary>
         public static Duration? FromDays(decimal? days)
@@ -645,7 +645,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Hours.
         /// </summary>
         public static Duration? FromHours(int? hours)
@@ -660,7 +660,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Hours.
         /// </summary>
         public static Duration? FromHours(long? hours)
@@ -675,7 +675,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Hours of type decimal.
         /// </summary>
         public static Duration? FromHours(decimal? hours)
@@ -705,7 +705,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Microseconds.
         /// </summary>
         public static Duration? FromMicroseconds(int? microseconds)
@@ -720,7 +720,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Microseconds.
         /// </summary>
         public static Duration? FromMicroseconds(long? microseconds)
@@ -735,7 +735,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Microseconds of type decimal.
         /// </summary>
         public static Duration? FromMicroseconds(decimal? microseconds)
@@ -765,7 +765,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Milliseconds.
         /// </summary>
         public static Duration? FromMilliseconds(int? milliseconds)
@@ -780,7 +780,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Milliseconds.
         /// </summary>
         public static Duration? FromMilliseconds(long? milliseconds)
@@ -795,7 +795,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Milliseconds of type decimal.
         /// </summary>
         public static Duration? FromMilliseconds(decimal? milliseconds)
@@ -825,7 +825,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Minutes.
         /// </summary>
         public static Duration? FromMinutes(int? minutes)
@@ -840,7 +840,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Minutes.
         /// </summary>
         public static Duration? FromMinutes(long? minutes)
@@ -855,7 +855,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Minutes of type decimal.
         /// </summary>
         public static Duration? FromMinutes(decimal? minutes)
@@ -885,7 +885,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Months.
         /// </summary>
         public static Duration? FromMonths(int? months)
@@ -900,7 +900,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Months.
         /// </summary>
         public static Duration? FromMonths(long? months)
@@ -915,7 +915,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Months of type decimal.
         /// </summary>
         public static Duration? FromMonths(decimal? months)
@@ -945,7 +945,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Nanoseconds.
         /// </summary>
         public static Duration? FromNanoseconds(int? nanoseconds)
@@ -960,7 +960,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Nanoseconds.
         /// </summary>
         public static Duration? FromNanoseconds(long? nanoseconds)
@@ -975,7 +975,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Nanoseconds of type decimal.
         /// </summary>
         public static Duration? FromNanoseconds(decimal? nanoseconds)
@@ -1005,7 +1005,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Seconds.
         /// </summary>
         public static Duration? FromSeconds(int? seconds)
@@ -1020,7 +1020,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Seconds.
         /// </summary>
         public static Duration? FromSeconds(long? seconds)
@@ -1035,7 +1035,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Seconds of type decimal.
         /// </summary>
         public static Duration? FromSeconds(decimal? seconds)
@@ -1065,7 +1065,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Weeks.
         /// </summary>
         public static Duration? FromWeeks(int? weeks)
@@ -1080,7 +1080,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Weeks.
         /// </summary>
         public static Duration? FromWeeks(long? weeks)
@@ -1095,7 +1095,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Weeks of type decimal.
         /// </summary>
         public static Duration? FromWeeks(decimal? weeks)
@@ -1125,7 +1125,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Years.
         /// </summary>
         public static Duration? FromYears(int? years)
@@ -1140,7 +1140,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from nullable Years.
         /// </summary>
         public static Duration? FromYears(long? years)
@@ -1155,7 +1155,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Duration from Years of type decimal.
         /// </summary>
         public static Duration? FromYears(decimal? years)

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -226,6 +226,33 @@ namespace UnitsNet
             return new Duration(days*24*3600);
         }
 
+		/// <summary>
+        ///     Get Duration from Days.
+        /// </summary>
+        public static Duration FromDays(int days)
+        {
+            return new Duration(days*24*3600);
+        }
+
+		/// <summary>
+        ///     Get Duration from Days.
+        /// </summary>
+        public static Duration FromDays(long days)
+        {
+            return new Duration(days*24*3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Days of type decimal.
+        /// </summary>
+        public static Duration FromDays(decimal days)
+        {
+	        return new Duration(Convert.ToDouble(days)*24*3600);
+        }
+#endif
+
         /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
@@ -233,6 +260,33 @@ namespace UnitsNet
         {
             return new Duration(hours*3600);
         }
+
+		/// <summary>
+        ///     Get Duration from Hours.
+        /// </summary>
+        public static Duration FromHours(int hours)
+        {
+            return new Duration(hours*3600);
+        }
+
+		/// <summary>
+        ///     Get Duration from Hours.
+        /// </summary>
+        public static Duration FromHours(long hours)
+        {
+            return new Duration(hours*3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Hours of type decimal.
+        /// </summary>
+        public static Duration FromHours(decimal hours)
+        {
+	        return new Duration(Convert.ToDouble(hours)*3600);
+        }
+#endif
 
         /// <summary>
         ///     Get Duration from Microseconds.
@@ -242,6 +296,33 @@ namespace UnitsNet
             return new Duration(microseconds/1e6);
         }
 
+		/// <summary>
+        ///     Get Duration from Microseconds.
+        /// </summary>
+        public static Duration FromMicroseconds(int microseconds)
+        {
+            return new Duration(microseconds/1e6);
+        }
+
+		/// <summary>
+        ///     Get Duration from Microseconds.
+        /// </summary>
+        public static Duration FromMicroseconds(long microseconds)
+        {
+            return new Duration(microseconds/1e6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Microseconds of type decimal.
+        /// </summary>
+        public static Duration FromMicroseconds(decimal microseconds)
+        {
+	        return new Duration(Convert.ToDouble(microseconds)/1e6);
+        }
+#endif
+
         /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
@@ -249,6 +330,33 @@ namespace UnitsNet
         {
             return new Duration(milliseconds/1e3);
         }
+
+		/// <summary>
+        ///     Get Duration from Milliseconds.
+        /// </summary>
+        public static Duration FromMilliseconds(int milliseconds)
+        {
+            return new Duration(milliseconds/1e3);
+        }
+
+		/// <summary>
+        ///     Get Duration from Milliseconds.
+        /// </summary>
+        public static Duration FromMilliseconds(long milliseconds)
+        {
+            return new Duration(milliseconds/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Milliseconds of type decimal.
+        /// </summary>
+        public static Duration FromMilliseconds(decimal milliseconds)
+        {
+	        return new Duration(Convert.ToDouble(milliseconds)/1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Duration from Minutes.
@@ -258,6 +366,33 @@ namespace UnitsNet
             return new Duration(minutes*60);
         }
 
+		/// <summary>
+        ///     Get Duration from Minutes.
+        /// </summary>
+        public static Duration FromMinutes(int minutes)
+        {
+            return new Duration(minutes*60);
+        }
+
+		/// <summary>
+        ///     Get Duration from Minutes.
+        /// </summary>
+        public static Duration FromMinutes(long minutes)
+        {
+            return new Duration(minutes*60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Minutes of type decimal.
+        /// </summary>
+        public static Duration FromMinutes(decimal minutes)
+        {
+	        return new Duration(Convert.ToDouble(minutes)*60);
+        }
+#endif
+
         /// <summary>
         ///     Get Duration from Months.
         /// </summary>
@@ -265,6 +400,33 @@ namespace UnitsNet
         {
             return new Duration(months*30*24*3600);
         }
+
+		/// <summary>
+        ///     Get Duration from Months.
+        /// </summary>
+        public static Duration FromMonths(int months)
+        {
+            return new Duration(months*30*24*3600);
+        }
+
+		/// <summary>
+        ///     Get Duration from Months.
+        /// </summary>
+        public static Duration FromMonths(long months)
+        {
+            return new Duration(months*30*24*3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Months of type decimal.
+        /// </summary>
+        public static Duration FromMonths(decimal months)
+        {
+	        return new Duration(Convert.ToDouble(months)*30*24*3600);
+        }
+#endif
 
         /// <summary>
         ///     Get Duration from Nanoseconds.
@@ -274,6 +436,33 @@ namespace UnitsNet
             return new Duration(nanoseconds/1e9);
         }
 
+		/// <summary>
+        ///     Get Duration from Nanoseconds.
+        /// </summary>
+        public static Duration FromNanoseconds(int nanoseconds)
+        {
+            return new Duration(nanoseconds/1e9);
+        }
+
+		/// <summary>
+        ///     Get Duration from Nanoseconds.
+        /// </summary>
+        public static Duration FromNanoseconds(long nanoseconds)
+        {
+            return new Duration(nanoseconds/1e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Nanoseconds of type decimal.
+        /// </summary>
+        public static Duration FromNanoseconds(decimal nanoseconds)
+        {
+	        return new Duration(Convert.ToDouble(nanoseconds)/1e9);
+        }
+#endif
+
         /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
@@ -281,6 +470,33 @@ namespace UnitsNet
         {
             return new Duration(seconds);
         }
+
+		/// <summary>
+        ///     Get Duration from Seconds.
+        /// </summary>
+        public static Duration FromSeconds(int seconds)
+        {
+            return new Duration(seconds);
+        }
+
+		/// <summary>
+        ///     Get Duration from Seconds.
+        /// </summary>
+        public static Duration FromSeconds(long seconds)
+        {
+            return new Duration(seconds);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Seconds of type decimal.
+        /// </summary>
+        public static Duration FromSeconds(decimal seconds)
+        {
+	        return new Duration(Convert.ToDouble(seconds));
+        }
+#endif
 
         /// <summary>
         ///     Get Duration from Weeks.
@@ -290,6 +506,33 @@ namespace UnitsNet
             return new Duration(weeks*7*24*3600);
         }
 
+		/// <summary>
+        ///     Get Duration from Weeks.
+        /// </summary>
+        public static Duration FromWeeks(int weeks)
+        {
+            return new Duration(weeks*7*24*3600);
+        }
+
+		/// <summary>
+        ///     Get Duration from Weeks.
+        /// </summary>
+        public static Duration FromWeeks(long weeks)
+        {
+            return new Duration(weeks*7*24*3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Weeks of type decimal.
+        /// </summary>
+        public static Duration FromWeeks(decimal weeks)
+        {
+	        return new Duration(Convert.ToDouble(weeks)*7*24*3600);
+        }
+#endif
+
         /// <summary>
         ///     Get Duration from Years.
         /// </summary>
@@ -298,12 +541,84 @@ namespace UnitsNet
             return new Duration(years*365*24*3600);
         }
 
+		/// <summary>
+        ///     Get Duration from Years.
+        /// </summary>
+        public static Duration FromYears(int years)
+        {
+            return new Duration(years*365*24*3600);
+        }
+
+		/// <summary>
+        ///     Get Duration from Years.
+        /// </summary>
+        public static Duration FromYears(long years)
+        {
+            return new Duration(years*365*24*3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Duration from Years of type decimal.
+        /// </summary>
+        public static Duration FromYears(decimal years)
+        {
+	        return new Duration(Convert.ToDouble(years)*365*24*3600);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Duration from nullable Days.
         /// </summary>
         public static Duration? FromDays(double? days)
+        {
+            if (days.HasValue)
+            {
+                return FromDays(days.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Days.
+        /// </summary>
+        public static Duration? FromDays(int? days)
+        {
+            if (days.HasValue)
+            {
+                return FromDays(days.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Days.
+        /// </summary>
+        public static Duration? FromDays(long? days)
+        {
+            if (days.HasValue)
+            {
+                return FromDays(days.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Days of type decimal.
+        /// </summary>
+        public static Duration? FromDays(decimal? days)
         {
             if (days.HasValue)
             {
@@ -330,10 +645,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Duration from nullable Hours.
+        /// </summary>
+        public static Duration? FromHours(int? hours)
+        {
+            if (hours.HasValue)
+            {
+                return FromHours(hours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Hours.
+        /// </summary>
+        public static Duration? FromHours(long? hours)
+        {
+            if (hours.HasValue)
+            {
+                return FromHours(hours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Hours of type decimal.
+        /// </summary>
+        public static Duration? FromHours(decimal? hours)
+        {
+            if (hours.HasValue)
+            {
+                return FromHours(hours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Duration from nullable Microseconds.
         /// </summary>
         public static Duration? FromMicroseconds(double? microseconds)
+        {
+            if (microseconds.HasValue)
+            {
+                return FromMicroseconds(microseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Microseconds.
+        /// </summary>
+        public static Duration? FromMicroseconds(int? microseconds)
+        {
+            if (microseconds.HasValue)
+            {
+                return FromMicroseconds(microseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Microseconds.
+        /// </summary>
+        public static Duration? FromMicroseconds(long? microseconds)
+        {
+            if (microseconds.HasValue)
+            {
+                return FromMicroseconds(microseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Microseconds of type decimal.
+        /// </summary>
+        public static Duration? FromMicroseconds(decimal? microseconds)
         {
             if (microseconds.HasValue)
             {
@@ -360,10 +765,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Duration from nullable Milliseconds.
+        /// </summary>
+        public static Duration? FromMilliseconds(int? milliseconds)
+        {
+            if (milliseconds.HasValue)
+            {
+                return FromMilliseconds(milliseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Milliseconds.
+        /// </summary>
+        public static Duration? FromMilliseconds(long? milliseconds)
+        {
+            if (milliseconds.HasValue)
+            {
+                return FromMilliseconds(milliseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Milliseconds of type decimal.
+        /// </summary>
+        public static Duration? FromMilliseconds(decimal? milliseconds)
+        {
+            if (milliseconds.HasValue)
+            {
+                return FromMilliseconds(milliseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Duration from nullable Minutes.
         /// </summary>
         public static Duration? FromMinutes(double? minutes)
+        {
+            if (minutes.HasValue)
+            {
+                return FromMinutes(minutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Minutes.
+        /// </summary>
+        public static Duration? FromMinutes(int? minutes)
+        {
+            if (minutes.HasValue)
+            {
+                return FromMinutes(minutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Minutes.
+        /// </summary>
+        public static Duration? FromMinutes(long? minutes)
+        {
+            if (minutes.HasValue)
+            {
+                return FromMinutes(minutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Minutes of type decimal.
+        /// </summary>
+        public static Duration? FromMinutes(decimal? minutes)
         {
             if (minutes.HasValue)
             {
@@ -390,10 +885,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Duration from nullable Months.
+        /// </summary>
+        public static Duration? FromMonths(int? months)
+        {
+            if (months.HasValue)
+            {
+                return FromMonths(months.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Months.
+        /// </summary>
+        public static Duration? FromMonths(long? months)
+        {
+            if (months.HasValue)
+            {
+                return FromMonths(months.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Months of type decimal.
+        /// </summary>
+        public static Duration? FromMonths(decimal? months)
+        {
+            if (months.HasValue)
+            {
+                return FromMonths(months.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Duration from nullable Nanoseconds.
         /// </summary>
         public static Duration? FromNanoseconds(double? nanoseconds)
+        {
+            if (nanoseconds.HasValue)
+            {
+                return FromNanoseconds(nanoseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Nanoseconds.
+        /// </summary>
+        public static Duration? FromNanoseconds(int? nanoseconds)
+        {
+            if (nanoseconds.HasValue)
+            {
+                return FromNanoseconds(nanoseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Nanoseconds.
+        /// </summary>
+        public static Duration? FromNanoseconds(long? nanoseconds)
+        {
+            if (nanoseconds.HasValue)
+            {
+                return FromNanoseconds(nanoseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Nanoseconds of type decimal.
+        /// </summary>
+        public static Duration? FromNanoseconds(decimal? nanoseconds)
         {
             if (nanoseconds.HasValue)
             {
@@ -420,6 +1005,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Duration from nullable Seconds.
+        /// </summary>
+        public static Duration? FromSeconds(int? seconds)
+        {
+            if (seconds.HasValue)
+            {
+                return FromSeconds(seconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Seconds.
+        /// </summary>
+        public static Duration? FromSeconds(long? seconds)
+        {
+            if (seconds.HasValue)
+            {
+                return FromSeconds(seconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Seconds of type decimal.
+        /// </summary>
+        public static Duration? FromSeconds(decimal? seconds)
+        {
+            if (seconds.HasValue)
+            {
+                return FromSeconds(seconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Duration from nullable Weeks.
         /// </summary>
@@ -435,10 +1065,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Duration from nullable Weeks.
+        /// </summary>
+        public static Duration? FromWeeks(int? weeks)
+        {
+            if (weeks.HasValue)
+            {
+                return FromWeeks(weeks.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Weeks.
+        /// </summary>
+        public static Duration? FromWeeks(long? weeks)
+        {
+            if (weeks.HasValue)
+            {
+                return FromWeeks(weeks.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Weeks of type decimal.
+        /// </summary>
+        public static Duration? FromWeeks(decimal? weeks)
+        {
+            if (weeks.HasValue)
+            {
+                return FromWeeks(weeks.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Duration from nullable Years.
         /// </summary>
         public static Duration? FromYears(double? years)
+        {
+            if (years.HasValue)
+            {
+                return FromYears(years.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Years.
+        /// </summary>
+        public static Duration? FromYears(int? years)
+        {
+            if (years.HasValue)
+            {
+                return FromYears(years.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from nullable Years.
+        /// </summary>
+        public static Duration? FromYears(long? years)
+        {
+            if (years.HasValue)
+            {
+                return FromYears(years.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Duration from Years of type decimal.
+        /// </summary>
+        public static Duration? FromYears(decimal? years)
         {
             if (years.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -221,6 +221,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Days.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromDays(double days)
         {
             return new Duration(days*24*3600);
@@ -256,6 +259,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromHours(double hours)
         {
             return new Duration(hours*3600);
@@ -291,6 +297,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Microseconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromMicroseconds(double microseconds)
         {
             return new Duration(microseconds/1e6);
@@ -326,6 +335,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromMilliseconds(double milliseconds)
         {
             return new Duration(milliseconds/1e3);
@@ -361,6 +373,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Minutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromMinutes(double minutes)
         {
             return new Duration(minutes*60);
@@ -396,6 +411,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Months.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromMonths(double months)
         {
             return new Duration(months*30*24*3600);
@@ -431,6 +449,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Nanoseconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromNanoseconds(double nanoseconds)
         {
             return new Duration(nanoseconds/1e9);
@@ -466,6 +487,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromSeconds(double seconds)
         {
             return new Duration(seconds);
@@ -501,6 +525,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Weeks.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromWeeks(double weeks)
         {
             return new Duration(weeks*7*24*3600);
@@ -536,6 +563,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Years.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Duration FromYears(double years)
         {
             return new Duration(years*365*24*3600);

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -186,6 +186,33 @@ namespace UnitsNet
             return new DynamicViscosity((centipoise/10) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get DynamicViscosity from Centipoise.
+        /// </summary>
+        public static DynamicViscosity FromCentipoise(int centipoise)
+        {
+            return new DynamicViscosity((centipoise/10) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get DynamicViscosity from Centipoise.
+        /// </summary>
+        public static DynamicViscosity FromCentipoise(long centipoise)
+        {
+            return new DynamicViscosity((centipoise/10) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get DynamicViscosity from Centipoise of type decimal.
+        /// </summary>
+        public static DynamicViscosity FromCentipoise(decimal centipoise)
+        {
+	        return new DynamicViscosity((Convert.ToDouble(centipoise)/10) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
@@ -193,6 +220,33 @@ namespace UnitsNet
         {
             return new DynamicViscosity((millipascalseconds) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get DynamicViscosity from MillipascalSeconds.
+        /// </summary>
+        public static DynamicViscosity FromMillipascalSeconds(int millipascalseconds)
+        {
+            return new DynamicViscosity((millipascalseconds) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get DynamicViscosity from MillipascalSeconds.
+        /// </summary>
+        public static DynamicViscosity FromMillipascalSeconds(long millipascalseconds)
+        {
+            return new DynamicViscosity((millipascalseconds) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get DynamicViscosity from MillipascalSeconds of type decimal.
+        /// </summary>
+        public static DynamicViscosity FromMillipascalSeconds(decimal millipascalseconds)
+        {
+	        return new DynamicViscosity((Convert.ToDouble(millipascalseconds)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
@@ -202,6 +256,33 @@ namespace UnitsNet
             return new DynamicViscosity(newtonsecondspermetersquared);
         }
 
+		/// <summary>
+        ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
+        /// </summary>
+        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(int newtonsecondspermetersquared)
+        {
+            return new DynamicViscosity(newtonsecondspermetersquared);
+        }
+
+		/// <summary>
+        ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
+        /// </summary>
+        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(long newtonsecondspermetersquared)
+        {
+            return new DynamicViscosity(newtonsecondspermetersquared);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared of type decimal.
+        /// </summary>
+        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(decimal newtonsecondspermetersquared)
+        {
+	        return new DynamicViscosity(Convert.ToDouble(newtonsecondspermetersquared));
+        }
+#endif
+
         /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
@@ -209,6 +290,33 @@ namespace UnitsNet
         {
             return new DynamicViscosity(pascalseconds);
         }
+
+		/// <summary>
+        ///     Get DynamicViscosity from PascalSeconds.
+        /// </summary>
+        public static DynamicViscosity FromPascalSeconds(int pascalseconds)
+        {
+            return new DynamicViscosity(pascalseconds);
+        }
+
+		/// <summary>
+        ///     Get DynamicViscosity from PascalSeconds.
+        /// </summary>
+        public static DynamicViscosity FromPascalSeconds(long pascalseconds)
+        {
+            return new DynamicViscosity(pascalseconds);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get DynamicViscosity from PascalSeconds of type decimal.
+        /// </summary>
+        public static DynamicViscosity FromPascalSeconds(decimal pascalseconds)
+        {
+	        return new DynamicViscosity(Convert.ToDouble(pascalseconds));
+        }
+#endif
 
         /// <summary>
         ///     Get DynamicViscosity from Poise.
@@ -218,12 +326,84 @@ namespace UnitsNet
             return new DynamicViscosity(poise/10);
         }
 
+		/// <summary>
+        ///     Get DynamicViscosity from Poise.
+        /// </summary>
+        public static DynamicViscosity FromPoise(int poise)
+        {
+            return new DynamicViscosity(poise/10);
+        }
+
+		/// <summary>
+        ///     Get DynamicViscosity from Poise.
+        /// </summary>
+        public static DynamicViscosity FromPoise(long poise)
+        {
+            return new DynamicViscosity(poise/10);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get DynamicViscosity from Poise of type decimal.
+        /// </summary>
+        public static DynamicViscosity FromPoise(decimal poise)
+        {
+	        return new DynamicViscosity(Convert.ToDouble(poise)/10);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable Centipoise.
         /// </summary>
         public static DynamicViscosity? FromCentipoise(double? centipoise)
+        {
+            if (centipoise.HasValue)
+            {
+                return FromCentipoise(centipoise.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable Centipoise.
+        /// </summary>
+        public static DynamicViscosity? FromCentipoise(int? centipoise)
+        {
+            if (centipoise.HasValue)
+            {
+                return FromCentipoise(centipoise.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable Centipoise.
+        /// </summary>
+        public static DynamicViscosity? FromCentipoise(long? centipoise)
+        {
+            if (centipoise.HasValue)
+            {
+                return FromCentipoise(centipoise.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from Centipoise of type decimal.
+        /// </summary>
+        public static DynamicViscosity? FromCentipoise(decimal? centipoise)
         {
             if (centipoise.HasValue)
             {
@@ -250,10 +430,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
+        /// </summary>
+        public static DynamicViscosity? FromMillipascalSeconds(int? millipascalseconds)
+        {
+            if (millipascalseconds.HasValue)
+            {
+                return FromMillipascalSeconds(millipascalseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
+        /// </summary>
+        public static DynamicViscosity? FromMillipascalSeconds(long? millipascalseconds)
+        {
+            if (millipascalseconds.HasValue)
+            {
+                return FromMillipascalSeconds(millipascalseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from MillipascalSeconds of type decimal.
+        /// </summary>
+        public static DynamicViscosity? FromMillipascalSeconds(decimal? millipascalseconds)
+        {
+            if (millipascalseconds.HasValue)
+            {
+                return FromMillipascalSeconds(millipascalseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
         /// </summary>
         public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(double? newtonsecondspermetersquared)
+        {
+            if (newtonsecondspermetersquared.HasValue)
+            {
+                return FromNewtonSecondsPerMeterSquared(newtonsecondspermetersquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
+        /// </summary>
+        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(int? newtonsecondspermetersquared)
+        {
+            if (newtonsecondspermetersquared.HasValue)
+            {
+                return FromNewtonSecondsPerMeterSquared(newtonsecondspermetersquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
+        /// </summary>
+        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(long? newtonsecondspermetersquared)
+        {
+            if (newtonsecondspermetersquared.HasValue)
+            {
+                return FromNewtonSecondsPerMeterSquared(newtonsecondspermetersquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from NewtonSecondsPerMeterSquared of type decimal.
+        /// </summary>
+        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(decimal? newtonsecondspermetersquared)
         {
             if (newtonsecondspermetersquared.HasValue)
             {
@@ -280,10 +550,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable PascalSeconds.
+        /// </summary>
+        public static DynamicViscosity? FromPascalSeconds(int? pascalseconds)
+        {
+            if (pascalseconds.HasValue)
+            {
+                return FromPascalSeconds(pascalseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable PascalSeconds.
+        /// </summary>
+        public static DynamicViscosity? FromPascalSeconds(long? pascalseconds)
+        {
+            if (pascalseconds.HasValue)
+            {
+                return FromPascalSeconds(pascalseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from PascalSeconds of type decimal.
+        /// </summary>
+        public static DynamicViscosity? FromPascalSeconds(decimal? pascalseconds)
+        {
+            if (pascalseconds.HasValue)
+            {
+                return FromPascalSeconds(pascalseconds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable Poise.
         /// </summary>
         public static DynamicViscosity? FromPoise(double? poise)
+        {
+            if (poise.HasValue)
+            {
+                return FromPoise(poise.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable Poise.
+        /// </summary>
+        public static DynamicViscosity? FromPoise(int? poise)
+        {
+            if (poise.HasValue)
+            {
+                return FromPoise(poise.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from nullable Poise.
+        /// </summary>
+        public static DynamicViscosity? FromPoise(long? poise)
+        {
+            if (poise.HasValue)
+            {
+                return FromPoise(poise.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable DynamicViscosity from Poise of type decimal.
+        /// </summary>
+        public static DynamicViscosity? FromPoise(decimal? poise)
         {
             if (poise.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _newtonSecondsPerMeterSquared;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public DynamicViscosity() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.DynamicViscosity;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static DynamicViscosityUnit BaseUnit
         {
             get { return DynamicViscosityUnit.NewtonSecondPerMeterSquared; }
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new DynamicViscosity((centipoise/10) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from Centipoise.
         /// </summary>
         public static DynamicViscosity FromCentipoise(int centipoise)
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new DynamicViscosity((centipoise/10) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from Centipoise.
         /// </summary>
         public static DynamicViscosity FromCentipoise(long centipoise)
@@ -202,14 +202,14 @@ namespace UnitsNet
             return new DynamicViscosity((centipoise/10) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from Centipoise of type decimal.
         /// </summary>
         public static DynamicViscosity FromCentipoise(decimal centipoise)
         {
-	        return new DynamicViscosity((Convert.ToDouble(centipoise)/10) * 1e-2d);
+            return new DynamicViscosity((Convert.ToDouble(centipoise)/10) * 1e-2d);
         }
 #endif
 
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new DynamicViscosity((millipascalseconds) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
         public static DynamicViscosity FromMillipascalSeconds(int millipascalseconds)
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new DynamicViscosity((millipascalseconds) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
         public static DynamicViscosity FromMillipascalSeconds(long millipascalseconds)
@@ -237,14 +237,14 @@ namespace UnitsNet
             return new DynamicViscosity((millipascalseconds) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds of type decimal.
         /// </summary>
         public static DynamicViscosity FromMillipascalSeconds(decimal millipascalseconds)
         {
-	        return new DynamicViscosity((Convert.ToDouble(millipascalseconds)) * 1e-3d);
+            return new DynamicViscosity((Convert.ToDouble(millipascalseconds)) * 1e-3d);
         }
 #endif
 
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new DynamicViscosity(newtonsecondspermetersquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
         /// </summary>
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(int newtonsecondspermetersquared)
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new DynamicViscosity(newtonsecondspermetersquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
         /// </summary>
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(long newtonsecondspermetersquared)
@@ -272,14 +272,14 @@ namespace UnitsNet
             return new DynamicViscosity(newtonsecondspermetersquared);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared of type decimal.
         /// </summary>
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(decimal newtonsecondspermetersquared)
         {
-	        return new DynamicViscosity(Convert.ToDouble(newtonsecondspermetersquared));
+            return new DynamicViscosity(Convert.ToDouble(newtonsecondspermetersquared));
         }
 #endif
 
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new DynamicViscosity(pascalseconds);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
         public static DynamicViscosity FromPascalSeconds(int pascalseconds)
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new DynamicViscosity(pascalseconds);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
         public static DynamicViscosity FromPascalSeconds(long pascalseconds)
@@ -307,14 +307,14 @@ namespace UnitsNet
             return new DynamicViscosity(pascalseconds);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from PascalSeconds of type decimal.
         /// </summary>
         public static DynamicViscosity FromPascalSeconds(decimal pascalseconds)
         {
-	        return new DynamicViscosity(Convert.ToDouble(pascalseconds));
+            return new DynamicViscosity(Convert.ToDouble(pascalseconds));
         }
 #endif
 
@@ -326,7 +326,7 @@ namespace UnitsNet
             return new DynamicViscosity(poise/10);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from Poise.
         /// </summary>
         public static DynamicViscosity FromPoise(int poise)
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new DynamicViscosity(poise/10);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from Poise.
         /// </summary>
         public static DynamicViscosity FromPoise(long poise)
@@ -342,14 +342,14 @@ namespace UnitsNet
             return new DynamicViscosity(poise/10);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get DynamicViscosity from Poise of type decimal.
         /// </summary>
         public static DynamicViscosity FromPoise(decimal poise)
         {
-	        return new DynamicViscosity(Convert.ToDouble(poise)/10);
+            return new DynamicViscosity(Convert.ToDouble(poise)/10);
         }
 #endif
 
@@ -370,7 +370,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable Centipoise.
         /// </summary>
         public static DynamicViscosity? FromCentipoise(int? centipoise)
@@ -385,7 +385,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable Centipoise.
         /// </summary>
         public static DynamicViscosity? FromCentipoise(long? centipoise)
@@ -400,7 +400,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from Centipoise of type decimal.
         /// </summary>
         public static DynamicViscosity? FromCentipoise(decimal? centipoise)
@@ -430,7 +430,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
         /// </summary>
         public static DynamicViscosity? FromMillipascalSeconds(int? millipascalseconds)
@@ -445,7 +445,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
         /// </summary>
         public static DynamicViscosity? FromMillipascalSeconds(long? millipascalseconds)
@@ -460,7 +460,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from MillipascalSeconds of type decimal.
         /// </summary>
         public static DynamicViscosity? FromMillipascalSeconds(decimal? millipascalseconds)
@@ -490,7 +490,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
         /// </summary>
         public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(int? newtonsecondspermetersquared)
@@ -505,7 +505,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
         /// </summary>
         public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(long? newtonsecondspermetersquared)
@@ -520,7 +520,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from NewtonSecondsPerMeterSquared of type decimal.
         /// </summary>
         public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(decimal? newtonsecondspermetersquared)
@@ -550,7 +550,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable PascalSeconds.
         /// </summary>
         public static DynamicViscosity? FromPascalSeconds(int? pascalseconds)
@@ -565,7 +565,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable PascalSeconds.
         /// </summary>
         public static DynamicViscosity? FromPascalSeconds(long? pascalseconds)
@@ -580,7 +580,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from PascalSeconds of type decimal.
         /// </summary>
         public static DynamicViscosity? FromPascalSeconds(decimal? pascalseconds)
@@ -610,7 +610,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable Poise.
         /// </summary>
         public static DynamicViscosity? FromPoise(int? poise)
@@ -625,7 +625,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from nullable Poise.
         /// </summary>
         public static DynamicViscosity? FromPoise(long? poise)
@@ -640,7 +640,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable DynamicViscosity from Poise of type decimal.
         /// </summary>
         public static DynamicViscosity? FromPoise(decimal? poise)

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -181,6 +181,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Centipoise.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static DynamicViscosity FromCentipoise(double centipoise)
         {
             return new DynamicViscosity((centipoise/10) * 1e-2d);
@@ -216,6 +219,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static DynamicViscosity FromMillipascalSeconds(double millipascalseconds)
         {
             return new DynamicViscosity((millipascalseconds) * 1e-3d);
@@ -251,6 +257,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(double newtonsecondspermetersquared)
         {
             return new DynamicViscosity(newtonsecondspermetersquared);
@@ -286,6 +295,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static DynamicViscosity FromPascalSeconds(double pascalseconds)
         {
             return new DynamicViscosity(pascalseconds);
@@ -321,6 +333,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Poise.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static DynamicViscosity FromPoise(double poise)
         {
             return new DynamicViscosity(poise/10);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _siemens;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ElectricAdmittance() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ElectricAdmittance;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ElectricAdmittanceUnit BaseUnit
         {
             get { return ElectricAdmittanceUnit.Siemens; }
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new ElectricAdmittance((microsiemens) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Microsiemens.
         /// </summary>
         public static ElectricAdmittance FromMicrosiemens(int microsiemens)
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new ElectricAdmittance((microsiemens) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Microsiemens.
         /// </summary>
         public static ElectricAdmittance FromMicrosiemens(long microsiemens)
@@ -194,14 +194,14 @@ namespace UnitsNet
             return new ElectricAdmittance((microsiemens) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Microsiemens of type decimal.
         /// </summary>
         public static ElectricAdmittance FromMicrosiemens(decimal microsiemens)
         {
-	        return new ElectricAdmittance((Convert.ToDouble(microsiemens)) * 1e-6d);
+            return new ElectricAdmittance((Convert.ToDouble(microsiemens)) * 1e-6d);
         }
 #endif
 
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new ElectricAdmittance((millisiemens) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
         public static ElectricAdmittance FromMillisiemens(int millisiemens)
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new ElectricAdmittance((millisiemens) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
         public static ElectricAdmittance FromMillisiemens(long millisiemens)
@@ -229,14 +229,14 @@ namespace UnitsNet
             return new ElectricAdmittance((millisiemens) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Millisiemens of type decimal.
         /// </summary>
         public static ElectricAdmittance FromMillisiemens(decimal millisiemens)
         {
-	        return new ElectricAdmittance((Convert.ToDouble(millisiemens)) * 1e-3d);
+            return new ElectricAdmittance((Convert.ToDouble(millisiemens)) * 1e-3d);
         }
 #endif
 
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new ElectricAdmittance((nanosiemens) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
         /// </summary>
         public static ElectricAdmittance FromNanosiemens(int nanosiemens)
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new ElectricAdmittance((nanosiemens) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
         /// </summary>
         public static ElectricAdmittance FromNanosiemens(long nanosiemens)
@@ -264,14 +264,14 @@ namespace UnitsNet
             return new ElectricAdmittance((nanosiemens) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens of type decimal.
         /// </summary>
         public static ElectricAdmittance FromNanosiemens(decimal nanosiemens)
         {
-	        return new ElectricAdmittance((Convert.ToDouble(nanosiemens)) * 1e-9d);
+            return new ElectricAdmittance((Convert.ToDouble(nanosiemens)) * 1e-9d);
         }
 #endif
 
@@ -283,7 +283,7 @@ namespace UnitsNet
             return new ElectricAdmittance(siemens);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
         public static ElectricAdmittance FromSiemens(int siemens)
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new ElectricAdmittance(siemens);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
         public static ElectricAdmittance FromSiemens(long siemens)
@@ -299,14 +299,14 @@ namespace UnitsNet
             return new ElectricAdmittance(siemens);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricAdmittance from Siemens of type decimal.
         /// </summary>
         public static ElectricAdmittance FromSiemens(decimal siemens)
         {
-	        return new ElectricAdmittance(Convert.ToDouble(siemens));
+            return new ElectricAdmittance(Convert.ToDouble(siemens));
         }
 #endif
 
@@ -327,7 +327,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Microsiemens.
         /// </summary>
         public static ElectricAdmittance? FromMicrosiemens(int? microsiemens)
@@ -342,7 +342,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Microsiemens.
         /// </summary>
         public static ElectricAdmittance? FromMicrosiemens(long? microsiemens)
@@ -357,7 +357,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from Microsiemens of type decimal.
         /// </summary>
         public static ElectricAdmittance? FromMicrosiemens(decimal? microsiemens)
@@ -387,7 +387,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Millisiemens.
         /// </summary>
         public static ElectricAdmittance? FromMillisiemens(int? millisiemens)
@@ -402,7 +402,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Millisiemens.
         /// </summary>
         public static ElectricAdmittance? FromMillisiemens(long? millisiemens)
@@ -417,7 +417,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from Millisiemens of type decimal.
         /// </summary>
         public static ElectricAdmittance? FromMillisiemens(decimal? millisiemens)
@@ -447,7 +447,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
         /// </summary>
         public static ElectricAdmittance? FromNanosiemens(int? nanosiemens)
@@ -462,7 +462,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
         /// </summary>
         public static ElectricAdmittance? FromNanosiemens(long? nanosiemens)
@@ -477,7 +477,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from Nanosiemens of type decimal.
         /// </summary>
         public static ElectricAdmittance? FromNanosiemens(decimal? nanosiemens)
@@ -507,7 +507,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Siemens.
         /// </summary>
         public static ElectricAdmittance? FromSiemens(int? siemens)
@@ -522,7 +522,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Siemens.
         /// </summary>
         public static ElectricAdmittance? FromSiemens(long? siemens)
@@ -537,7 +537,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricAdmittance from Siemens of type decimal.
         /// </summary>
         public static ElectricAdmittance? FromSiemens(decimal? siemens)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -178,6 +178,33 @@ namespace UnitsNet
             return new ElectricAdmittance((microsiemens) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get ElectricAdmittance from Microsiemens.
+        /// </summary>
+        public static ElectricAdmittance FromMicrosiemens(int microsiemens)
+        {
+            return new ElectricAdmittance((microsiemens) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricAdmittance from Microsiemens.
+        /// </summary>
+        public static ElectricAdmittance FromMicrosiemens(long microsiemens)
+        {
+            return new ElectricAdmittance((microsiemens) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricAdmittance from Microsiemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance FromMicrosiemens(decimal microsiemens)
+        {
+	        return new ElectricAdmittance((Convert.ToDouble(microsiemens)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
@@ -185,6 +212,33 @@ namespace UnitsNet
         {
             return new ElectricAdmittance((millisiemens) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get ElectricAdmittance from Millisiemens.
+        /// </summary>
+        public static ElectricAdmittance FromMillisiemens(int millisiemens)
+        {
+            return new ElectricAdmittance((millisiemens) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricAdmittance from Millisiemens.
+        /// </summary>
+        public static ElectricAdmittance FromMillisiemens(long millisiemens)
+        {
+            return new ElectricAdmittance((millisiemens) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricAdmittance from Millisiemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance FromMillisiemens(decimal millisiemens)
+        {
+	        return new ElectricAdmittance((Convert.ToDouble(millisiemens)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
@@ -194,6 +248,33 @@ namespace UnitsNet
             return new ElectricAdmittance((nanosiemens) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get ElectricAdmittance from Nanosiemens.
+        /// </summary>
+        public static ElectricAdmittance FromNanosiemens(int nanosiemens)
+        {
+            return new ElectricAdmittance((nanosiemens) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get ElectricAdmittance from Nanosiemens.
+        /// </summary>
+        public static ElectricAdmittance FromNanosiemens(long nanosiemens)
+        {
+            return new ElectricAdmittance((nanosiemens) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricAdmittance from Nanosiemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance FromNanosiemens(decimal nanosiemens)
+        {
+	        return new ElectricAdmittance((Convert.ToDouble(nanosiemens)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
@@ -202,12 +283,84 @@ namespace UnitsNet
             return new ElectricAdmittance(siemens);
         }
 
+		/// <summary>
+        ///     Get ElectricAdmittance from Siemens.
+        /// </summary>
+        public static ElectricAdmittance FromSiemens(int siemens)
+        {
+            return new ElectricAdmittance(siemens);
+        }
+
+		/// <summary>
+        ///     Get ElectricAdmittance from Siemens.
+        /// </summary>
+        public static ElectricAdmittance FromSiemens(long siemens)
+        {
+            return new ElectricAdmittance(siemens);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricAdmittance from Siemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance FromSiemens(decimal siemens)
+        {
+	        return new ElectricAdmittance(Convert.ToDouble(siemens));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Microsiemens.
         /// </summary>
         public static ElectricAdmittance? FromMicrosiemens(double? microsiemens)
+        {
+            if (microsiemens.HasValue)
+            {
+                return FromMicrosiemens(microsiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Microsiemens.
+        /// </summary>
+        public static ElectricAdmittance? FromMicrosiemens(int? microsiemens)
+        {
+            if (microsiemens.HasValue)
+            {
+                return FromMicrosiemens(microsiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Microsiemens.
+        /// </summary>
+        public static ElectricAdmittance? FromMicrosiemens(long? microsiemens)
+        {
+            if (microsiemens.HasValue)
+            {
+                return FromMicrosiemens(microsiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from Microsiemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance? FromMicrosiemens(decimal? microsiemens)
         {
             if (microsiemens.HasValue)
             {
@@ -234,6 +387,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Millisiemens.
+        /// </summary>
+        public static ElectricAdmittance? FromMillisiemens(int? millisiemens)
+        {
+            if (millisiemens.HasValue)
+            {
+                return FromMillisiemens(millisiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Millisiemens.
+        /// </summary>
+        public static ElectricAdmittance? FromMillisiemens(long? millisiemens)
+        {
+            if (millisiemens.HasValue)
+            {
+                return FromMillisiemens(millisiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from Millisiemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance? FromMillisiemens(decimal? millisiemens)
+        {
+            if (millisiemens.HasValue)
+            {
+                return FromMillisiemens(millisiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
         /// </summary>
@@ -249,10 +447,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
+        /// </summary>
+        public static ElectricAdmittance? FromNanosiemens(int? nanosiemens)
+        {
+            if (nanosiemens.HasValue)
+            {
+                return FromNanosiemens(nanosiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
+        /// </summary>
+        public static ElectricAdmittance? FromNanosiemens(long? nanosiemens)
+        {
+            if (nanosiemens.HasValue)
+            {
+                return FromNanosiemens(nanosiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from Nanosiemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance? FromNanosiemens(decimal? nanosiemens)
+        {
+            if (nanosiemens.HasValue)
+            {
+                return FromNanosiemens(nanosiemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Siemens.
         /// </summary>
         public static ElectricAdmittance? FromSiemens(double? siemens)
+        {
+            if (siemens.HasValue)
+            {
+                return FromSiemens(siemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Siemens.
+        /// </summary>
+        public static ElectricAdmittance? FromSiemens(int? siemens)
+        {
+            if (siemens.HasValue)
+            {
+                return FromSiemens(siemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from nullable Siemens.
+        /// </summary>
+        public static ElectricAdmittance? FromSiemens(long? siemens)
+        {
+            if (siemens.HasValue)
+            {
+                return FromSiemens(siemens.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricAdmittance from Siemens of type decimal.
+        /// </summary>
+        public static ElectricAdmittance? FromSiemens(decimal? siemens)
         {
             if (siemens.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -173,6 +173,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Microsiemens.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricAdmittance FromMicrosiemens(double microsiemens)
         {
             return new ElectricAdmittance((microsiemens) * 1e-6d);
@@ -208,6 +211,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricAdmittance FromMillisiemens(double millisiemens)
         {
             return new ElectricAdmittance((millisiemens) * 1e-3d);
@@ -243,6 +249,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricAdmittance FromNanosiemens(double nanosiemens)
         {
             return new ElectricAdmittance((nanosiemens) * 1e-9d);
@@ -278,6 +287,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricAdmittance FromSiemens(double siemens)
         {
             return new ElectricAdmittance(siemens);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _amperes;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ElectricCurrent() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ElectricCurrent;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ElectricCurrentUnit BaseUnit
         {
             get { return ElectricCurrentUnit.Ampere; }
@@ -202,7 +202,7 @@ namespace UnitsNet
             return new ElectricCurrent(amperes);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Amperes.
         /// </summary>
         public static ElectricCurrent FromAmperes(int amperes)
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new ElectricCurrent(amperes);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Amperes.
         /// </summary>
         public static ElectricCurrent FromAmperes(long amperes)
@@ -218,14 +218,14 @@ namespace UnitsNet
             return new ElectricCurrent(amperes);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Amperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromAmperes(decimal amperes)
         {
-	        return new ElectricCurrent(Convert.ToDouble(amperes));
+            return new ElectricCurrent(Convert.ToDouble(amperes));
         }
 #endif
 
@@ -237,7 +237,7 @@ namespace UnitsNet
             return new ElectricCurrent((kiloamperes) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
         public static ElectricCurrent FromKiloamperes(int kiloamperes)
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new ElectricCurrent((kiloamperes) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
         public static ElectricCurrent FromKiloamperes(long kiloamperes)
@@ -253,14 +253,14 @@ namespace UnitsNet
             return new ElectricCurrent((kiloamperes) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Kiloamperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromKiloamperes(decimal kiloamperes)
         {
-	        return new ElectricCurrent((Convert.ToDouble(kiloamperes)) * 1e3d);
+            return new ElectricCurrent((Convert.ToDouble(kiloamperes)) * 1e3d);
         }
 #endif
 
@@ -272,7 +272,7 @@ namespace UnitsNet
             return new ElectricCurrent((megaamperes) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
         /// </summary>
         public static ElectricCurrent FromMegaamperes(int megaamperes)
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new ElectricCurrent((megaamperes) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
         /// </summary>
         public static ElectricCurrent FromMegaamperes(long megaamperes)
@@ -288,14 +288,14 @@ namespace UnitsNet
             return new ElectricCurrent((megaamperes) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Megaamperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromMegaamperes(decimal megaamperes)
         {
-	        return new ElectricCurrent((Convert.ToDouble(megaamperes)) * 1e6d);
+            return new ElectricCurrent((Convert.ToDouble(megaamperes)) * 1e6d);
         }
 #endif
 
@@ -307,7 +307,7 @@ namespace UnitsNet
             return new ElectricCurrent((microamperes) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
         public static ElectricCurrent FromMicroamperes(int microamperes)
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new ElectricCurrent((microamperes) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
         public static ElectricCurrent FromMicroamperes(long microamperes)
@@ -323,14 +323,14 @@ namespace UnitsNet
             return new ElectricCurrent((microamperes) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Microamperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromMicroamperes(decimal microamperes)
         {
-	        return new ElectricCurrent((Convert.ToDouble(microamperes)) * 1e-6d);
+            return new ElectricCurrent((Convert.ToDouble(microamperes)) * 1e-6d);
         }
 #endif
 
@@ -342,7 +342,7 @@ namespace UnitsNet
             return new ElectricCurrent((milliamperes) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
         /// </summary>
         public static ElectricCurrent FromMilliamperes(int milliamperes)
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new ElectricCurrent((milliamperes) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
         /// </summary>
         public static ElectricCurrent FromMilliamperes(long milliamperes)
@@ -358,14 +358,14 @@ namespace UnitsNet
             return new ElectricCurrent((milliamperes) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Milliamperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromMilliamperes(decimal milliamperes)
         {
-	        return new ElectricCurrent((Convert.ToDouble(milliamperes)) * 1e-3d);
+            return new ElectricCurrent((Convert.ToDouble(milliamperes)) * 1e-3d);
         }
 #endif
 
@@ -377,7 +377,7 @@ namespace UnitsNet
             return new ElectricCurrent((nanoamperes) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
         public static ElectricCurrent FromNanoamperes(int nanoamperes)
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new ElectricCurrent((nanoamperes) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
         public static ElectricCurrent FromNanoamperes(long nanoamperes)
@@ -393,14 +393,14 @@ namespace UnitsNet
             return new ElectricCurrent((nanoamperes) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Nanoamperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromNanoamperes(decimal nanoamperes)
         {
-	        return new ElectricCurrent((Convert.ToDouble(nanoamperes)) * 1e-9d);
+            return new ElectricCurrent((Convert.ToDouble(nanoamperes)) * 1e-9d);
         }
 #endif
 
@@ -412,7 +412,7 @@ namespace UnitsNet
             return new ElectricCurrent((picoamperes) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
         /// </summary>
         public static ElectricCurrent FromPicoamperes(int picoamperes)
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new ElectricCurrent((picoamperes) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
         /// </summary>
         public static ElectricCurrent FromPicoamperes(long picoamperes)
@@ -428,14 +428,14 @@ namespace UnitsNet
             return new ElectricCurrent((picoamperes) * 1e-12d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricCurrent from Picoamperes of type decimal.
         /// </summary>
         public static ElectricCurrent FromPicoamperes(decimal picoamperes)
         {
-	        return new ElectricCurrent((Convert.ToDouble(picoamperes)) * 1e-12d);
+            return new ElectricCurrent((Convert.ToDouble(picoamperes)) * 1e-12d);
         }
 #endif
 
@@ -456,7 +456,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Amperes.
         /// </summary>
         public static ElectricCurrent? FromAmperes(int? amperes)
@@ -471,7 +471,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Amperes.
         /// </summary>
         public static ElectricCurrent? FromAmperes(long? amperes)
@@ -486,7 +486,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Amperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromAmperes(decimal? amperes)
@@ -516,7 +516,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Kiloamperes.
         /// </summary>
         public static ElectricCurrent? FromKiloamperes(int? kiloamperes)
@@ -531,7 +531,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Kiloamperes.
         /// </summary>
         public static ElectricCurrent? FromKiloamperes(long? kiloamperes)
@@ -546,7 +546,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Kiloamperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromKiloamperes(decimal? kiloamperes)
@@ -576,7 +576,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Megaamperes.
         /// </summary>
         public static ElectricCurrent? FromMegaamperes(int? megaamperes)
@@ -591,7 +591,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Megaamperes.
         /// </summary>
         public static ElectricCurrent? FromMegaamperes(long? megaamperes)
@@ -606,7 +606,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Megaamperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromMegaamperes(decimal? megaamperes)
@@ -636,7 +636,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Microamperes.
         /// </summary>
         public static ElectricCurrent? FromMicroamperes(int? microamperes)
@@ -651,7 +651,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Microamperes.
         /// </summary>
         public static ElectricCurrent? FromMicroamperes(long? microamperes)
@@ -666,7 +666,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Microamperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromMicroamperes(decimal? microamperes)
@@ -696,7 +696,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Milliamperes.
         /// </summary>
         public static ElectricCurrent? FromMilliamperes(int? milliamperes)
@@ -711,7 +711,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Milliamperes.
         /// </summary>
         public static ElectricCurrent? FromMilliamperes(long? milliamperes)
@@ -726,7 +726,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Milliamperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromMilliamperes(decimal? milliamperes)
@@ -756,7 +756,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Nanoamperes.
         /// </summary>
         public static ElectricCurrent? FromNanoamperes(int? nanoamperes)
@@ -771,7 +771,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Nanoamperes.
         /// </summary>
         public static ElectricCurrent? FromNanoamperes(long? nanoamperes)
@@ -786,7 +786,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Nanoamperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromNanoamperes(decimal? nanoamperes)
@@ -816,7 +816,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Picoamperes.
         /// </summary>
         public static ElectricCurrent? FromPicoamperes(int? picoamperes)
@@ -831,7 +831,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from nullable Picoamperes.
         /// </summary>
         public static ElectricCurrent? FromPicoamperes(long? picoamperes)
@@ -846,7 +846,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricCurrent from Picoamperes of type decimal.
         /// </summary>
         public static ElectricCurrent? FromPicoamperes(decimal? picoamperes)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -202,6 +202,33 @@ namespace UnitsNet
             return new ElectricCurrent(amperes);
         }
 
+		/// <summary>
+        ///     Get ElectricCurrent from Amperes.
+        /// </summary>
+        public static ElectricCurrent FromAmperes(int amperes)
+        {
+            return new ElectricCurrent(amperes);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Amperes.
+        /// </summary>
+        public static ElectricCurrent FromAmperes(long amperes)
+        {
+            return new ElectricCurrent(amperes);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Amperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromAmperes(decimal amperes)
+        {
+	        return new ElectricCurrent(Convert.ToDouble(amperes));
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
@@ -209,6 +236,33 @@ namespace UnitsNet
         {
             return new ElectricCurrent((kiloamperes) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Kiloamperes.
+        /// </summary>
+        public static ElectricCurrent FromKiloamperes(int kiloamperes)
+        {
+            return new ElectricCurrent((kiloamperes) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Kiloamperes.
+        /// </summary>
+        public static ElectricCurrent FromKiloamperes(long kiloamperes)
+        {
+            return new ElectricCurrent((kiloamperes) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Kiloamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromKiloamperes(decimal kiloamperes)
+        {
+	        return new ElectricCurrent((Convert.ToDouble(kiloamperes)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
@@ -218,6 +272,33 @@ namespace UnitsNet
             return new ElectricCurrent((megaamperes) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get ElectricCurrent from Megaamperes.
+        /// </summary>
+        public static ElectricCurrent FromMegaamperes(int megaamperes)
+        {
+            return new ElectricCurrent((megaamperes) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Megaamperes.
+        /// </summary>
+        public static ElectricCurrent FromMegaamperes(long megaamperes)
+        {
+            return new ElectricCurrent((megaamperes) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Megaamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromMegaamperes(decimal megaamperes)
+        {
+	        return new ElectricCurrent((Convert.ToDouble(megaamperes)) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
@@ -225,6 +306,33 @@ namespace UnitsNet
         {
             return new ElectricCurrent((microamperes) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Microamperes.
+        /// </summary>
+        public static ElectricCurrent FromMicroamperes(int microamperes)
+        {
+            return new ElectricCurrent((microamperes) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Microamperes.
+        /// </summary>
+        public static ElectricCurrent FromMicroamperes(long microamperes)
+        {
+            return new ElectricCurrent((microamperes) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Microamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromMicroamperes(decimal microamperes)
+        {
+	        return new ElectricCurrent((Convert.ToDouble(microamperes)) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
@@ -234,6 +342,33 @@ namespace UnitsNet
             return new ElectricCurrent((milliamperes) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get ElectricCurrent from Milliamperes.
+        /// </summary>
+        public static ElectricCurrent FromMilliamperes(int milliamperes)
+        {
+            return new ElectricCurrent((milliamperes) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Milliamperes.
+        /// </summary>
+        public static ElectricCurrent FromMilliamperes(long milliamperes)
+        {
+            return new ElectricCurrent((milliamperes) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Milliamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromMilliamperes(decimal milliamperes)
+        {
+	        return new ElectricCurrent((Convert.ToDouble(milliamperes)) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
@@ -241,6 +376,33 @@ namespace UnitsNet
         {
             return new ElectricCurrent((nanoamperes) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Nanoamperes.
+        /// </summary>
+        public static ElectricCurrent FromNanoamperes(int nanoamperes)
+        {
+            return new ElectricCurrent((nanoamperes) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Nanoamperes.
+        /// </summary>
+        public static ElectricCurrent FromNanoamperes(long nanoamperes)
+        {
+            return new ElectricCurrent((nanoamperes) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Nanoamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromNanoamperes(decimal nanoamperes)
+        {
+	        return new ElectricCurrent((Convert.ToDouble(nanoamperes)) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
@@ -250,12 +412,84 @@ namespace UnitsNet
             return new ElectricCurrent((picoamperes) * 1e-12d);
         }
 
+		/// <summary>
+        ///     Get ElectricCurrent from Picoamperes.
+        /// </summary>
+        public static ElectricCurrent FromPicoamperes(int picoamperes)
+        {
+            return new ElectricCurrent((picoamperes) * 1e-12d);
+        }
+
+		/// <summary>
+        ///     Get ElectricCurrent from Picoamperes.
+        /// </summary>
+        public static ElectricCurrent FromPicoamperes(long picoamperes)
+        {
+            return new ElectricCurrent((picoamperes) * 1e-12d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricCurrent from Picoamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent FromPicoamperes(decimal picoamperes)
+        {
+	        return new ElectricCurrent((Convert.ToDouble(picoamperes)) * 1e-12d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Amperes.
         /// </summary>
         public static ElectricCurrent? FromAmperes(double? amperes)
+        {
+            if (amperes.HasValue)
+            {
+                return FromAmperes(amperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Amperes.
+        /// </summary>
+        public static ElectricCurrent? FromAmperes(int? amperes)
+        {
+            if (amperes.HasValue)
+            {
+                return FromAmperes(amperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Amperes.
+        /// </summary>
+        public static ElectricCurrent? FromAmperes(long? amperes)
+        {
+            if (amperes.HasValue)
+            {
+                return FromAmperes(amperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Amperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromAmperes(decimal? amperes)
         {
             if (amperes.HasValue)
             {
@@ -282,10 +516,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Kiloamperes.
+        /// </summary>
+        public static ElectricCurrent? FromKiloamperes(int? kiloamperes)
+        {
+            if (kiloamperes.HasValue)
+            {
+                return FromKiloamperes(kiloamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Kiloamperes.
+        /// </summary>
+        public static ElectricCurrent? FromKiloamperes(long? kiloamperes)
+        {
+            if (kiloamperes.HasValue)
+            {
+                return FromKiloamperes(kiloamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Kiloamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromKiloamperes(decimal? kiloamperes)
+        {
+            if (kiloamperes.HasValue)
+            {
+                return FromKiloamperes(kiloamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Megaamperes.
         /// </summary>
         public static ElectricCurrent? FromMegaamperes(double? megaamperes)
+        {
+            if (megaamperes.HasValue)
+            {
+                return FromMegaamperes(megaamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Megaamperes.
+        /// </summary>
+        public static ElectricCurrent? FromMegaamperes(int? megaamperes)
+        {
+            if (megaamperes.HasValue)
+            {
+                return FromMegaamperes(megaamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Megaamperes.
+        /// </summary>
+        public static ElectricCurrent? FromMegaamperes(long? megaamperes)
+        {
+            if (megaamperes.HasValue)
+            {
+                return FromMegaamperes(megaamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Megaamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromMegaamperes(decimal? megaamperes)
         {
             if (megaamperes.HasValue)
             {
@@ -312,10 +636,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Microamperes.
+        /// </summary>
+        public static ElectricCurrent? FromMicroamperes(int? microamperes)
+        {
+            if (microamperes.HasValue)
+            {
+                return FromMicroamperes(microamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Microamperes.
+        /// </summary>
+        public static ElectricCurrent? FromMicroamperes(long? microamperes)
+        {
+            if (microamperes.HasValue)
+            {
+                return FromMicroamperes(microamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Microamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromMicroamperes(decimal? microamperes)
+        {
+            if (microamperes.HasValue)
+            {
+                return FromMicroamperes(microamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Milliamperes.
         /// </summary>
         public static ElectricCurrent? FromMilliamperes(double? milliamperes)
+        {
+            if (milliamperes.HasValue)
+            {
+                return FromMilliamperes(milliamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Milliamperes.
+        /// </summary>
+        public static ElectricCurrent? FromMilliamperes(int? milliamperes)
+        {
+            if (milliamperes.HasValue)
+            {
+                return FromMilliamperes(milliamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Milliamperes.
+        /// </summary>
+        public static ElectricCurrent? FromMilliamperes(long? milliamperes)
+        {
+            if (milliamperes.HasValue)
+            {
+                return FromMilliamperes(milliamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Milliamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromMilliamperes(decimal? milliamperes)
         {
             if (milliamperes.HasValue)
             {
@@ -342,10 +756,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Nanoamperes.
+        /// </summary>
+        public static ElectricCurrent? FromNanoamperes(int? nanoamperes)
+        {
+            if (nanoamperes.HasValue)
+            {
+                return FromNanoamperes(nanoamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Nanoamperes.
+        /// </summary>
+        public static ElectricCurrent? FromNanoamperes(long? nanoamperes)
+        {
+            if (nanoamperes.HasValue)
+            {
+                return FromNanoamperes(nanoamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Nanoamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromNanoamperes(decimal? nanoamperes)
+        {
+            if (nanoamperes.HasValue)
+            {
+                return FromNanoamperes(nanoamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Picoamperes.
         /// </summary>
         public static ElectricCurrent? FromPicoamperes(double? picoamperes)
+        {
+            if (picoamperes.HasValue)
+            {
+                return FromPicoamperes(picoamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Picoamperes.
+        /// </summary>
+        public static ElectricCurrent? FromPicoamperes(int? picoamperes)
+        {
+            if (picoamperes.HasValue)
+            {
+                return FromPicoamperes(picoamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from nullable Picoamperes.
+        /// </summary>
+        public static ElectricCurrent? FromPicoamperes(long? picoamperes)
+        {
+            if (picoamperes.HasValue)
+            {
+                return FromPicoamperes(picoamperes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricCurrent from Picoamperes of type decimal.
+        /// </summary>
+        public static ElectricCurrent? FromPicoamperes(decimal? picoamperes)
         {
             if (picoamperes.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -197,6 +197,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Amperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromAmperes(double amperes)
         {
             return new ElectricCurrent(amperes);
@@ -232,6 +235,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromKiloamperes(double kiloamperes)
         {
             return new ElectricCurrent((kiloamperes) * 1e3d);
@@ -267,6 +273,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromMegaamperes(double megaamperes)
         {
             return new ElectricCurrent((megaamperes) * 1e6d);
@@ -302,6 +311,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromMicroamperes(double microamperes)
         {
             return new ElectricCurrent((microamperes) * 1e-6d);
@@ -337,6 +349,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromMilliamperes(double milliamperes)
         {
             return new ElectricCurrent((milliamperes) * 1e-3d);
@@ -372,6 +387,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromNanoamperes(double nanoamperes)
         {
             return new ElectricCurrent((nanoamperes) * 1e-9d);
@@ -407,6 +425,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricCurrent FromPicoamperes(double picoamperes)
         {
             return new ElectricCurrent((picoamperes) * 1e-12d);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -186,6 +186,33 @@ namespace UnitsNet
             return new ElectricPotential((kilovolts) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ElectricPotential from Kilovolts.
+        /// </summary>
+        public static ElectricPotential FromKilovolts(int kilovolts)
+        {
+            return new ElectricPotential((kilovolts) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotential from Kilovolts.
+        /// </summary>
+        public static ElectricPotential FromKilovolts(long kilovolts)
+        {
+            return new ElectricPotential((kilovolts) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotential from Kilovolts of type decimal.
+        /// </summary>
+        public static ElectricPotential FromKilovolts(decimal kilovolts)
+        {
+	        return new ElectricPotential((Convert.ToDouble(kilovolts)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
@@ -193,6 +220,33 @@ namespace UnitsNet
         {
             return new ElectricPotential((megavolts) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get ElectricPotential from Megavolts.
+        /// </summary>
+        public static ElectricPotential FromMegavolts(int megavolts)
+        {
+            return new ElectricPotential((megavolts) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotential from Megavolts.
+        /// </summary>
+        public static ElectricPotential FromMegavolts(long megavolts)
+        {
+            return new ElectricPotential((megavolts) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotential from Megavolts of type decimal.
+        /// </summary>
+        public static ElectricPotential FromMegavolts(decimal megavolts)
+        {
+	        return new ElectricPotential((Convert.ToDouble(megavolts)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricPotential from Microvolts.
@@ -202,6 +256,33 @@ namespace UnitsNet
             return new ElectricPotential((microvolts) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get ElectricPotential from Microvolts.
+        /// </summary>
+        public static ElectricPotential FromMicrovolts(int microvolts)
+        {
+            return new ElectricPotential((microvolts) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotential from Microvolts.
+        /// </summary>
+        public static ElectricPotential FromMicrovolts(long microvolts)
+        {
+            return new ElectricPotential((microvolts) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotential from Microvolts of type decimal.
+        /// </summary>
+        public static ElectricPotential FromMicrovolts(decimal microvolts)
+        {
+	        return new ElectricPotential((Convert.ToDouble(microvolts)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
@@ -209,6 +290,33 @@ namespace UnitsNet
         {
             return new ElectricPotential((millivolts) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get ElectricPotential from Millivolts.
+        /// </summary>
+        public static ElectricPotential FromMillivolts(int millivolts)
+        {
+            return new ElectricPotential((millivolts) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotential from Millivolts.
+        /// </summary>
+        public static ElectricPotential FromMillivolts(long millivolts)
+        {
+            return new ElectricPotential((millivolts) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotential from Millivolts of type decimal.
+        /// </summary>
+        public static ElectricPotential FromMillivolts(decimal millivolts)
+        {
+	        return new ElectricPotential((Convert.ToDouble(millivolts)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricPotential from Volts.
@@ -218,12 +326,84 @@ namespace UnitsNet
             return new ElectricPotential(volts);
         }
 
+		/// <summary>
+        ///     Get ElectricPotential from Volts.
+        /// </summary>
+        public static ElectricPotential FromVolts(int volts)
+        {
+            return new ElectricPotential(volts);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotential from Volts.
+        /// </summary>
+        public static ElectricPotential FromVolts(long volts)
+        {
+            return new ElectricPotential(volts);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotential from Volts of type decimal.
+        /// </summary>
+        public static ElectricPotential FromVolts(decimal volts)
+        {
+	        return new ElectricPotential(Convert.ToDouble(volts));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Kilovolts.
         /// </summary>
         public static ElectricPotential? FromKilovolts(double? kilovolts)
+        {
+            if (kilovolts.HasValue)
+            {
+                return FromKilovolts(kilovolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Kilovolts.
+        /// </summary>
+        public static ElectricPotential? FromKilovolts(int? kilovolts)
+        {
+            if (kilovolts.HasValue)
+            {
+                return FromKilovolts(kilovolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Kilovolts.
+        /// </summary>
+        public static ElectricPotential? FromKilovolts(long? kilovolts)
+        {
+            if (kilovolts.HasValue)
+            {
+                return FromKilovolts(kilovolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from Kilovolts of type decimal.
+        /// </summary>
+        public static ElectricPotential? FromKilovolts(decimal? kilovolts)
         {
             if (kilovolts.HasValue)
             {
@@ -250,10 +430,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Megavolts.
+        /// </summary>
+        public static ElectricPotential? FromMegavolts(int? megavolts)
+        {
+            if (megavolts.HasValue)
+            {
+                return FromMegavolts(megavolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Megavolts.
+        /// </summary>
+        public static ElectricPotential? FromMegavolts(long? megavolts)
+        {
+            if (megavolts.HasValue)
+            {
+                return FromMegavolts(megavolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from Megavolts of type decimal.
+        /// </summary>
+        public static ElectricPotential? FromMegavolts(decimal? megavolts)
+        {
+            if (megavolts.HasValue)
+            {
+                return FromMegavolts(megavolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Microvolts.
         /// </summary>
         public static ElectricPotential? FromMicrovolts(double? microvolts)
+        {
+            if (microvolts.HasValue)
+            {
+                return FromMicrovolts(microvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Microvolts.
+        /// </summary>
+        public static ElectricPotential? FromMicrovolts(int? microvolts)
+        {
+            if (microvolts.HasValue)
+            {
+                return FromMicrovolts(microvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Microvolts.
+        /// </summary>
+        public static ElectricPotential? FromMicrovolts(long? microvolts)
+        {
+            if (microvolts.HasValue)
+            {
+                return FromMicrovolts(microvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from Microvolts of type decimal.
+        /// </summary>
+        public static ElectricPotential? FromMicrovolts(decimal? microvolts)
         {
             if (microvolts.HasValue)
             {
@@ -280,10 +550,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Millivolts.
+        /// </summary>
+        public static ElectricPotential? FromMillivolts(int? millivolts)
+        {
+            if (millivolts.HasValue)
+            {
+                return FromMillivolts(millivolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Millivolts.
+        /// </summary>
+        public static ElectricPotential? FromMillivolts(long? millivolts)
+        {
+            if (millivolts.HasValue)
+            {
+                return FromMillivolts(millivolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from Millivolts of type decimal.
+        /// </summary>
+        public static ElectricPotential? FromMillivolts(decimal? millivolts)
+        {
+            if (millivolts.HasValue)
+            {
+                return FromMillivolts(millivolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Volts.
         /// </summary>
         public static ElectricPotential? FromVolts(double? volts)
+        {
+            if (volts.HasValue)
+            {
+                return FromVolts(volts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Volts.
+        /// </summary>
+        public static ElectricPotential? FromVolts(int? volts)
+        {
+            if (volts.HasValue)
+            {
+                return FromVolts(volts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from nullable Volts.
+        /// </summary>
+        public static ElectricPotential? FromVolts(long? volts)
+        {
+            if (volts.HasValue)
+            {
+                return FromVolts(volts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotential from Volts of type decimal.
+        /// </summary>
+        public static ElectricPotential? FromVolts(decimal? volts)
         {
             if (volts.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _volts;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ElectricPotential() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ElectricPotential;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ElectricPotentialUnit BaseUnit
         {
             get { return ElectricPotentialUnit.Volt; }
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new ElectricPotential((kilovolts) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Kilovolts.
         /// </summary>
         public static ElectricPotential FromKilovolts(int kilovolts)
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new ElectricPotential((kilovolts) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Kilovolts.
         /// </summary>
         public static ElectricPotential FromKilovolts(long kilovolts)
@@ -202,14 +202,14 @@ namespace UnitsNet
             return new ElectricPotential((kilovolts) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Kilovolts of type decimal.
         /// </summary>
         public static ElectricPotential FromKilovolts(decimal kilovolts)
         {
-	        return new ElectricPotential((Convert.ToDouble(kilovolts)) * 1e3d);
+            return new ElectricPotential((Convert.ToDouble(kilovolts)) * 1e3d);
         }
 #endif
 
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new ElectricPotential((megavolts) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
         public static ElectricPotential FromMegavolts(int megavolts)
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new ElectricPotential((megavolts) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
         public static ElectricPotential FromMegavolts(long megavolts)
@@ -237,14 +237,14 @@ namespace UnitsNet
             return new ElectricPotential((megavolts) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Megavolts of type decimal.
         /// </summary>
         public static ElectricPotential FromMegavolts(decimal megavolts)
         {
-	        return new ElectricPotential((Convert.ToDouble(megavolts)) * 1e6d);
+            return new ElectricPotential((Convert.ToDouble(megavolts)) * 1e6d);
         }
 #endif
 
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new ElectricPotential((microvolts) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
         public static ElectricPotential FromMicrovolts(int microvolts)
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new ElectricPotential((microvolts) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
         public static ElectricPotential FromMicrovolts(long microvolts)
@@ -272,14 +272,14 @@ namespace UnitsNet
             return new ElectricPotential((microvolts) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Microvolts of type decimal.
         /// </summary>
         public static ElectricPotential FromMicrovolts(decimal microvolts)
         {
-	        return new ElectricPotential((Convert.ToDouble(microvolts)) * 1e-6d);
+            return new ElectricPotential((Convert.ToDouble(microvolts)) * 1e-6d);
         }
 #endif
 
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new ElectricPotential((millivolts) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
         public static ElectricPotential FromMillivolts(int millivolts)
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new ElectricPotential((millivolts) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
         public static ElectricPotential FromMillivolts(long millivolts)
@@ -307,14 +307,14 @@ namespace UnitsNet
             return new ElectricPotential((millivolts) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Millivolts of type decimal.
         /// </summary>
         public static ElectricPotential FromMillivolts(decimal millivolts)
         {
-	        return new ElectricPotential((Convert.ToDouble(millivolts)) * 1e-3d);
+            return new ElectricPotential((Convert.ToDouble(millivolts)) * 1e-3d);
         }
 #endif
 
@@ -326,7 +326,7 @@ namespace UnitsNet
             return new ElectricPotential(volts);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Volts.
         /// </summary>
         public static ElectricPotential FromVolts(int volts)
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new ElectricPotential(volts);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Volts.
         /// </summary>
         public static ElectricPotential FromVolts(long volts)
@@ -342,14 +342,14 @@ namespace UnitsNet
             return new ElectricPotential(volts);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotential from Volts of type decimal.
         /// </summary>
         public static ElectricPotential FromVolts(decimal volts)
         {
-	        return new ElectricPotential(Convert.ToDouble(volts));
+            return new ElectricPotential(Convert.ToDouble(volts));
         }
 #endif
 
@@ -370,7 +370,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Kilovolts.
         /// </summary>
         public static ElectricPotential? FromKilovolts(int? kilovolts)
@@ -385,7 +385,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Kilovolts.
         /// </summary>
         public static ElectricPotential? FromKilovolts(long? kilovolts)
@@ -400,7 +400,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from Kilovolts of type decimal.
         /// </summary>
         public static ElectricPotential? FromKilovolts(decimal? kilovolts)
@@ -430,7 +430,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Megavolts.
         /// </summary>
         public static ElectricPotential? FromMegavolts(int? megavolts)
@@ -445,7 +445,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Megavolts.
         /// </summary>
         public static ElectricPotential? FromMegavolts(long? megavolts)
@@ -460,7 +460,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from Megavolts of type decimal.
         /// </summary>
         public static ElectricPotential? FromMegavolts(decimal? megavolts)
@@ -490,7 +490,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Microvolts.
         /// </summary>
         public static ElectricPotential? FromMicrovolts(int? microvolts)
@@ -505,7 +505,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Microvolts.
         /// </summary>
         public static ElectricPotential? FromMicrovolts(long? microvolts)
@@ -520,7 +520,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from Microvolts of type decimal.
         /// </summary>
         public static ElectricPotential? FromMicrovolts(decimal? microvolts)
@@ -550,7 +550,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Millivolts.
         /// </summary>
         public static ElectricPotential? FromMillivolts(int? millivolts)
@@ -565,7 +565,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Millivolts.
         /// </summary>
         public static ElectricPotential? FromMillivolts(long? millivolts)
@@ -580,7 +580,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from Millivolts of type decimal.
         /// </summary>
         public static ElectricPotential? FromMillivolts(decimal? millivolts)
@@ -610,7 +610,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Volts.
         /// </summary>
         public static ElectricPotential? FromVolts(int? volts)
@@ -625,7 +625,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from nullable Volts.
         /// </summary>
         public static ElectricPotential? FromVolts(long? volts)
@@ -640,7 +640,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotential from Volts of type decimal.
         /// </summary>
         public static ElectricPotential? FromVolts(decimal? volts)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -181,6 +181,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Kilovolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotential FromKilovolts(double kilovolts)
         {
             return new ElectricPotential((kilovolts) * 1e3d);
@@ -216,6 +219,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotential FromMegavolts(double megavolts)
         {
             return new ElectricPotential((megavolts) * 1e6d);
@@ -251,6 +257,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotential FromMicrovolts(double microvolts)
         {
             return new ElectricPotential((microvolts) * 1e-6d);
@@ -286,6 +295,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotential FromMillivolts(double millivolts)
         {
             return new ElectricPotential((millivolts) * 1e-3d);
@@ -321,6 +333,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Volts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotential FromVolts(double volts)
         {
             return new ElectricPotential(volts);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -186,6 +186,33 @@ namespace UnitsNet
             return new ElectricPotentialAc((kilovoltsac) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ElectricPotentialAc from KilovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromKilovoltsAc(int kilovoltsac)
+        {
+            return new ElectricPotentialAc((kilovoltsac) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from KilovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromKilovoltsAc(long kilovoltsac)
+        {
+            return new ElectricPotentialAc((kilovoltsac) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialAc from KilovoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc FromKilovoltsAc(decimal kilovoltsac)
+        {
+	        return new ElectricPotentialAc((Convert.ToDouble(kilovoltsac)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
@@ -193,6 +220,33 @@ namespace UnitsNet
         {
             return new ElectricPotentialAc((megavoltsac) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from MegavoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromMegavoltsAc(int megavoltsac)
+        {
+            return new ElectricPotentialAc((megavoltsac) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from MegavoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromMegavoltsAc(long megavoltsac)
+        {
+            return new ElectricPotentialAc((megavoltsac) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialAc from MegavoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc FromMegavoltsAc(decimal megavoltsac)
+        {
+	        return new ElectricPotentialAc((Convert.ToDouble(megavoltsac)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
@@ -202,6 +256,33 @@ namespace UnitsNet
             return new ElectricPotentialAc((microvoltsac) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get ElectricPotentialAc from MicrovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromMicrovoltsAc(int microvoltsac)
+        {
+            return new ElectricPotentialAc((microvoltsac) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from MicrovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromMicrovoltsAc(long microvoltsac)
+        {
+            return new ElectricPotentialAc((microvoltsac) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialAc from MicrovoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc FromMicrovoltsAc(decimal microvoltsac)
+        {
+	        return new ElectricPotentialAc((Convert.ToDouble(microvoltsac)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
@@ -209,6 +290,33 @@ namespace UnitsNet
         {
             return new ElectricPotentialAc((millivoltsac) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from MillivoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromMillivoltsAc(int millivoltsac)
+        {
+            return new ElectricPotentialAc((millivoltsac) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from MillivoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromMillivoltsAc(long millivoltsac)
+        {
+            return new ElectricPotentialAc((millivoltsac) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialAc from MillivoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc FromMillivoltsAc(decimal millivoltsac)
+        {
+	        return new ElectricPotentialAc((Convert.ToDouble(millivoltsac)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
@@ -218,12 +326,84 @@ namespace UnitsNet
             return new ElectricPotentialAc(voltsac);
         }
 
+		/// <summary>
+        ///     Get ElectricPotentialAc from VoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromVoltsAc(int voltsac)
+        {
+            return new ElectricPotentialAc(voltsac);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialAc from VoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc FromVoltsAc(long voltsac)
+        {
+            return new ElectricPotentialAc(voltsac);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialAc from VoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc FromVoltsAc(decimal voltsac)
+        {
+	        return new ElectricPotentialAc(Convert.ToDouble(voltsac));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromKilovoltsAc(double? kilovoltsac)
+        {
+            if (kilovoltsac.HasValue)
+            {
+                return FromKilovoltsAc(kilovoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromKilovoltsAc(int? kilovoltsac)
+        {
+            if (kilovoltsac.HasValue)
+            {
+                return FromKilovoltsAc(kilovoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromKilovoltsAc(long? kilovoltsac)
+        {
+            if (kilovoltsac.HasValue)
+            {
+                return FromKilovoltsAc(kilovoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from KilovoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc? FromKilovoltsAc(decimal? kilovoltsac)
         {
             if (kilovoltsac.HasValue)
             {
@@ -250,10 +430,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromMegavoltsAc(int? megavoltsac)
+        {
+            if (megavoltsac.HasValue)
+            {
+                return FromMegavoltsAc(megavoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromMegavoltsAc(long? megavoltsac)
+        {
+            if (megavoltsac.HasValue)
+            {
+                return FromMegavoltsAc(megavoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from MegavoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc? FromMegavoltsAc(decimal? megavoltsac)
+        {
+            if (megavoltsac.HasValue)
+            {
+                return FromMegavoltsAc(megavoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMicrovoltsAc(double? microvoltsac)
+        {
+            if (microvoltsac.HasValue)
+            {
+                return FromMicrovoltsAc(microvoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromMicrovoltsAc(int? microvoltsac)
+        {
+            if (microvoltsac.HasValue)
+            {
+                return FromMicrovoltsAc(microvoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromMicrovoltsAc(long? microvoltsac)
+        {
+            if (microvoltsac.HasValue)
+            {
+                return FromMicrovoltsAc(microvoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from MicrovoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc? FromMicrovoltsAc(decimal? microvoltsac)
         {
             if (microvoltsac.HasValue)
             {
@@ -280,10 +550,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromMillivoltsAc(int? millivoltsac)
+        {
+            if (millivoltsac.HasValue)
+            {
+                return FromMillivoltsAc(millivoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromMillivoltsAc(long? millivoltsac)
+        {
+            if (millivoltsac.HasValue)
+            {
+                return FromMillivoltsAc(millivoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from MillivoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc? FromMillivoltsAc(decimal? millivoltsac)
+        {
+            if (millivoltsac.HasValue)
+            {
+                return FromMillivoltsAc(millivoltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromVoltsAc(double? voltsac)
+        {
+            if (voltsac.HasValue)
+            {
+                return FromVoltsAc(voltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromVoltsAc(int? voltsac)
+        {
+            if (voltsac.HasValue)
+            {
+                return FromVoltsAc(voltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
+        /// </summary>
+        public static ElectricPotentialAc? FromVoltsAc(long? voltsac)
+        {
+            if (voltsac.HasValue)
+            {
+                return FromVoltsAc(voltsac.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialAc from VoltsAc of type decimal.
+        /// </summary>
+        public static ElectricPotentialAc? FromVoltsAc(decimal? voltsac)
         {
             if (voltsac.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _voltsAc;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ElectricPotentialAc() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ElectricPotentialAc;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ElectricPotentialAcUnit BaseUnit
         {
             get { return ElectricPotentialAcUnit.VoltAc; }
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((kilovoltsac) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromKilovoltsAc(int kilovoltsac)
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((kilovoltsac) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromKilovoltsAc(long kilovoltsac)
@@ -202,14 +202,14 @@ namespace UnitsNet
             return new ElectricPotentialAc((kilovoltsac) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc FromKilovoltsAc(decimal kilovoltsac)
         {
-	        return new ElectricPotentialAc((Convert.ToDouble(kilovoltsac)) * 1e3d);
+            return new ElectricPotentialAc((Convert.ToDouble(kilovoltsac)) * 1e3d);
         }
 #endif
 
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((megavoltsac) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromMegavoltsAc(int megavoltsac)
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((megavoltsac) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromMegavoltsAc(long megavoltsac)
@@ -237,14 +237,14 @@ namespace UnitsNet
             return new ElectricPotentialAc((megavoltsac) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc FromMegavoltsAc(decimal megavoltsac)
         {
-	        return new ElectricPotentialAc((Convert.ToDouble(megavoltsac)) * 1e6d);
+            return new ElectricPotentialAc((Convert.ToDouble(megavoltsac)) * 1e6d);
         }
 #endif
 
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((microvoltsac) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromMicrovoltsAc(int microvoltsac)
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((microvoltsac) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromMicrovoltsAc(long microvoltsac)
@@ -272,14 +272,14 @@ namespace UnitsNet
             return new ElectricPotentialAc((microvoltsac) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc FromMicrovoltsAc(decimal microvoltsac)
         {
-	        return new ElectricPotentialAc((Convert.ToDouble(microvoltsac)) * 1e-6d);
+            return new ElectricPotentialAc((Convert.ToDouble(microvoltsac)) * 1e-6d);
         }
 #endif
 
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((millivoltsac) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromMillivoltsAc(int millivoltsac)
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new ElectricPotentialAc((millivoltsac) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromMillivoltsAc(long millivoltsac)
@@ -307,14 +307,14 @@ namespace UnitsNet
             return new ElectricPotentialAc((millivoltsac) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc FromMillivoltsAc(decimal millivoltsac)
         {
-	        return new ElectricPotentialAc((Convert.ToDouble(millivoltsac)) * 1e-3d);
+            return new ElectricPotentialAc((Convert.ToDouble(millivoltsac)) * 1e-3d);
         }
 #endif
 
@@ -326,7 +326,7 @@ namespace UnitsNet
             return new ElectricPotentialAc(voltsac);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromVoltsAc(int voltsac)
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new ElectricPotentialAc(voltsac);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
         /// </summary>
         public static ElectricPotentialAc FromVoltsAc(long voltsac)
@@ -342,14 +342,14 @@ namespace UnitsNet
             return new ElectricPotentialAc(voltsac);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc FromVoltsAc(decimal voltsac)
         {
-	        return new ElectricPotentialAc(Convert.ToDouble(voltsac));
+            return new ElectricPotentialAc(Convert.ToDouble(voltsac));
         }
 #endif
 
@@ -370,7 +370,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromKilovoltsAc(int? kilovoltsac)
@@ -385,7 +385,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromKilovoltsAc(long? kilovoltsac)
@@ -400,7 +400,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from KilovoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc? FromKilovoltsAc(decimal? kilovoltsac)
@@ -430,7 +430,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMegavoltsAc(int? megavoltsac)
@@ -445,7 +445,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMegavoltsAc(long? megavoltsac)
@@ -460,7 +460,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from MegavoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc? FromMegavoltsAc(decimal? megavoltsac)
@@ -490,7 +490,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMicrovoltsAc(int? microvoltsac)
@@ -505,7 +505,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMicrovoltsAc(long? microvoltsac)
@@ -520,7 +520,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from MicrovoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc? FromMicrovoltsAc(decimal? microvoltsac)
@@ -550,7 +550,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMillivoltsAc(int? millivoltsac)
@@ -565,7 +565,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromMillivoltsAc(long? millivoltsac)
@@ -580,7 +580,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from MillivoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc? FromMillivoltsAc(decimal? millivoltsac)
@@ -610,7 +610,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromVoltsAc(int? voltsac)
@@ -625,7 +625,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
         /// </summary>
         public static ElectricPotentialAc? FromVoltsAc(long? voltsac)
@@ -640,7 +640,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialAc from VoltsAc of type decimal.
         /// </summary>
         public static ElectricPotentialAc? FromVoltsAc(decimal? voltsac)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -181,6 +181,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialAc FromKilovoltsAc(double kilovoltsac)
         {
             return new ElectricPotentialAc((kilovoltsac) * 1e3d);
@@ -216,6 +219,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialAc FromMegavoltsAc(double megavoltsac)
         {
             return new ElectricPotentialAc((megavoltsac) * 1e6d);
@@ -251,6 +257,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialAc FromMicrovoltsAc(double microvoltsac)
         {
             return new ElectricPotentialAc((microvoltsac) * 1e-6d);
@@ -286,6 +295,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialAc FromMillivoltsAc(double millivoltsac)
         {
             return new ElectricPotentialAc((millivoltsac) * 1e-3d);
@@ -321,6 +333,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialAc FromVoltsAc(double voltsac)
         {
             return new ElectricPotentialAc(voltsac);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -186,6 +186,33 @@ namespace UnitsNet
             return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ElectricPotentialDc from KilovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromKilovoltsDc(int kilovoltsdc)
+        {
+            return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from KilovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromKilovoltsDc(long kilovoltsdc)
+        {
+            return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialDc from KilovoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc FromKilovoltsDc(decimal kilovoltsdc)
+        {
+	        return new ElectricPotentialDc((Convert.ToDouble(kilovoltsdc)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
@@ -193,6 +220,33 @@ namespace UnitsNet
         {
             return new ElectricPotentialDc((megavoltsdc) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from MegavoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromMegavoltsDc(int megavoltsdc)
+        {
+            return new ElectricPotentialDc((megavoltsdc) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from MegavoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromMegavoltsDc(long megavoltsdc)
+        {
+            return new ElectricPotentialDc((megavoltsdc) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialDc from MegavoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc FromMegavoltsDc(decimal megavoltsdc)
+        {
+	        return new ElectricPotentialDc((Convert.ToDouble(megavoltsdc)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
@@ -202,6 +256,33 @@ namespace UnitsNet
             return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get ElectricPotentialDc from MicrovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromMicrovoltsDc(int microvoltsdc)
+        {
+            return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from MicrovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromMicrovoltsDc(long microvoltsdc)
+        {
+            return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialDc from MicrovoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc FromMicrovoltsDc(decimal microvoltsdc)
+        {
+	        return new ElectricPotentialDc((Convert.ToDouble(microvoltsdc)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
@@ -209,6 +290,33 @@ namespace UnitsNet
         {
             return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from MillivoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromMillivoltsDc(int millivoltsdc)
+        {
+            return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from MillivoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromMillivoltsDc(long millivoltsdc)
+        {
+            return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialDc from MillivoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc FromMillivoltsDc(decimal millivoltsdc)
+        {
+	        return new ElectricPotentialDc((Convert.ToDouble(millivoltsdc)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
@@ -218,12 +326,84 @@ namespace UnitsNet
             return new ElectricPotentialDc(voltsdc);
         }
 
+		/// <summary>
+        ///     Get ElectricPotentialDc from VoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromVoltsDc(int voltsdc)
+        {
+            return new ElectricPotentialDc(voltsdc);
+        }
+
+		/// <summary>
+        ///     Get ElectricPotentialDc from VoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc FromVoltsDc(long voltsdc)
+        {
+            return new ElectricPotentialDc(voltsdc);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricPotentialDc from VoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc FromVoltsDc(decimal voltsdc)
+        {
+	        return new ElectricPotentialDc(Convert.ToDouble(voltsdc));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromKilovoltsDc(double? kilovoltsdc)
+        {
+            if (kilovoltsdc.HasValue)
+            {
+                return FromKilovoltsDc(kilovoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromKilovoltsDc(int? kilovoltsdc)
+        {
+            if (kilovoltsdc.HasValue)
+            {
+                return FromKilovoltsDc(kilovoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromKilovoltsDc(long? kilovoltsdc)
+        {
+            if (kilovoltsdc.HasValue)
+            {
+                return FromKilovoltsDc(kilovoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from KilovoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc? FromKilovoltsDc(decimal? kilovoltsdc)
         {
             if (kilovoltsdc.HasValue)
             {
@@ -250,10 +430,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromMegavoltsDc(int? megavoltsdc)
+        {
+            if (megavoltsdc.HasValue)
+            {
+                return FromMegavoltsDc(megavoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromMegavoltsDc(long? megavoltsdc)
+        {
+            if (megavoltsdc.HasValue)
+            {
+                return FromMegavoltsDc(megavoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from MegavoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc? FromMegavoltsDc(decimal? megavoltsdc)
+        {
+            if (megavoltsdc.HasValue)
+            {
+                return FromMegavoltsDc(megavoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMicrovoltsDc(double? microvoltsdc)
+        {
+            if (microvoltsdc.HasValue)
+            {
+                return FromMicrovoltsDc(microvoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromMicrovoltsDc(int? microvoltsdc)
+        {
+            if (microvoltsdc.HasValue)
+            {
+                return FromMicrovoltsDc(microvoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromMicrovoltsDc(long? microvoltsdc)
+        {
+            if (microvoltsdc.HasValue)
+            {
+                return FromMicrovoltsDc(microvoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from MicrovoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc? FromMicrovoltsDc(decimal? microvoltsdc)
         {
             if (microvoltsdc.HasValue)
             {
@@ -280,10 +550,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromMillivoltsDc(int? millivoltsdc)
+        {
+            if (millivoltsdc.HasValue)
+            {
+                return FromMillivoltsDc(millivoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromMillivoltsDc(long? millivoltsdc)
+        {
+            if (millivoltsdc.HasValue)
+            {
+                return FromMillivoltsDc(millivoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from MillivoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc? FromMillivoltsDc(decimal? millivoltsdc)
+        {
+            if (millivoltsdc.HasValue)
+            {
+                return FromMillivoltsDc(millivoltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromVoltsDc(double? voltsdc)
+        {
+            if (voltsdc.HasValue)
+            {
+                return FromVoltsDc(voltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromVoltsDc(int? voltsdc)
+        {
+            if (voltsdc.HasValue)
+            {
+                return FromVoltsDc(voltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
+        /// </summary>
+        public static ElectricPotentialDc? FromVoltsDc(long? voltsdc)
+        {
+            if (voltsdc.HasValue)
+            {
+                return FromVoltsDc(voltsdc.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricPotentialDc from VoltsDc of type decimal.
+        /// </summary>
+        public static ElectricPotentialDc? FromVoltsDc(decimal? voltsdc)
         {
             if (voltsdc.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -181,6 +181,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialDc FromKilovoltsDc(double kilovoltsdc)
         {
             return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
@@ -216,6 +219,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialDc FromMegavoltsDc(double megavoltsdc)
         {
             return new ElectricPotentialDc((megavoltsdc) * 1e6d);
@@ -251,6 +257,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialDc FromMicrovoltsDc(double microvoltsdc)
         {
             return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
@@ -286,6 +295,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialDc FromMillivoltsDc(double millivoltsdc)
         {
             return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
@@ -321,6 +333,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricPotentialDc FromVoltsDc(double voltsdc)
         {
             return new ElectricPotentialDc(voltsdc);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _voltsDc;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ElectricPotentialDc() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ElectricPotentialDc;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ElectricPotentialDcUnit BaseUnit
         {
             get { return ElectricPotentialDcUnit.VoltDc; }
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromKilovoltsDc(int kilovoltsdc)
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromKilovoltsDc(long kilovoltsdc)
@@ -202,14 +202,14 @@ namespace UnitsNet
             return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc FromKilovoltsDc(decimal kilovoltsdc)
         {
-	        return new ElectricPotentialDc((Convert.ToDouble(kilovoltsdc)) * 1e3d);
+            return new ElectricPotentialDc((Convert.ToDouble(kilovoltsdc)) * 1e3d);
         }
 #endif
 
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((megavoltsdc) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromMegavoltsDc(int megavoltsdc)
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((megavoltsdc) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromMegavoltsDc(long megavoltsdc)
@@ -237,14 +237,14 @@ namespace UnitsNet
             return new ElectricPotentialDc((megavoltsdc) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc FromMegavoltsDc(decimal megavoltsdc)
         {
-	        return new ElectricPotentialDc((Convert.ToDouble(megavoltsdc)) * 1e6d);
+            return new ElectricPotentialDc((Convert.ToDouble(megavoltsdc)) * 1e6d);
         }
 #endif
 
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromMicrovoltsDc(int microvoltsdc)
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromMicrovoltsDc(long microvoltsdc)
@@ -272,14 +272,14 @@ namespace UnitsNet
             return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc FromMicrovoltsDc(decimal microvoltsdc)
         {
-	        return new ElectricPotentialDc((Convert.ToDouble(microvoltsdc)) * 1e-6d);
+            return new ElectricPotentialDc((Convert.ToDouble(microvoltsdc)) * 1e-6d);
         }
 #endif
 
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromMillivoltsDc(int millivoltsdc)
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromMillivoltsDc(long millivoltsdc)
@@ -307,14 +307,14 @@ namespace UnitsNet
             return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc FromMillivoltsDc(decimal millivoltsdc)
         {
-	        return new ElectricPotentialDc((Convert.ToDouble(millivoltsdc)) * 1e-3d);
+            return new ElectricPotentialDc((Convert.ToDouble(millivoltsdc)) * 1e-3d);
         }
 #endif
 
@@ -326,7 +326,7 @@ namespace UnitsNet
             return new ElectricPotentialDc(voltsdc);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromVoltsDc(int voltsdc)
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new ElectricPotentialDc(voltsdc);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
         /// </summary>
         public static ElectricPotentialDc FromVoltsDc(long voltsdc)
@@ -342,14 +342,14 @@ namespace UnitsNet
             return new ElectricPotentialDc(voltsdc);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc FromVoltsDc(decimal voltsdc)
         {
-	        return new ElectricPotentialDc(Convert.ToDouble(voltsdc));
+            return new ElectricPotentialDc(Convert.ToDouble(voltsdc));
         }
 #endif
 
@@ -370,7 +370,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromKilovoltsDc(int? kilovoltsdc)
@@ -385,7 +385,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromKilovoltsDc(long? kilovoltsdc)
@@ -400,7 +400,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from KilovoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc? FromKilovoltsDc(decimal? kilovoltsdc)
@@ -430,7 +430,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMegavoltsDc(int? megavoltsdc)
@@ -445,7 +445,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMegavoltsDc(long? megavoltsdc)
@@ -460,7 +460,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from MegavoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc? FromMegavoltsDc(decimal? megavoltsdc)
@@ -490,7 +490,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMicrovoltsDc(int? microvoltsdc)
@@ -505,7 +505,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMicrovoltsDc(long? microvoltsdc)
@@ -520,7 +520,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from MicrovoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc? FromMicrovoltsDc(decimal? microvoltsdc)
@@ -550,7 +550,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMillivoltsDc(int? millivoltsdc)
@@ -565,7 +565,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromMillivoltsDc(long? millivoltsdc)
@@ -580,7 +580,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from MillivoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc? FromMillivoltsDc(decimal? millivoltsdc)
@@ -610,7 +610,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromVoltsDc(int? voltsdc)
@@ -625,7 +625,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
         /// </summary>
         public static ElectricPotentialDc? FromVoltsDc(long? voltsdc)
@@ -640,7 +640,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricPotentialDc from VoltsDc of type decimal.
         /// </summary>
         public static ElectricPotentialDc? FromVoltsDc(decimal? voltsdc)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -178,6 +178,33 @@ namespace UnitsNet
             return new ElectricResistance((kiloohms) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ElectricResistance from Kiloohms.
+        /// </summary>
+        public static ElectricResistance FromKiloohms(int kiloohms)
+        {
+            return new ElectricResistance((kiloohms) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricResistance from Kiloohms.
+        /// </summary>
+        public static ElectricResistance FromKiloohms(long kiloohms)
+        {
+            return new ElectricResistance((kiloohms) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricResistance from Kiloohms of type decimal.
+        /// </summary>
+        public static ElectricResistance FromKiloohms(decimal kiloohms)
+        {
+	        return new ElectricResistance((Convert.ToDouble(kiloohms)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
@@ -185,6 +212,33 @@ namespace UnitsNet
         {
             return new ElectricResistance((megaohms) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get ElectricResistance from Megaohms.
+        /// </summary>
+        public static ElectricResistance FromMegaohms(int megaohms)
+        {
+            return new ElectricResistance((megaohms) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ElectricResistance from Megaohms.
+        /// </summary>
+        public static ElectricResistance FromMegaohms(long megaohms)
+        {
+            return new ElectricResistance((megaohms) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricResistance from Megaohms of type decimal.
+        /// </summary>
+        public static ElectricResistance FromMegaohms(decimal megaohms)
+        {
+	        return new ElectricResistance((Convert.ToDouble(megaohms)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ElectricResistance from Milliohms.
@@ -194,6 +248,33 @@ namespace UnitsNet
             return new ElectricResistance((milliohms) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get ElectricResistance from Milliohms.
+        /// </summary>
+        public static ElectricResistance FromMilliohms(int milliohms)
+        {
+            return new ElectricResistance((milliohms) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ElectricResistance from Milliohms.
+        /// </summary>
+        public static ElectricResistance FromMilliohms(long milliohms)
+        {
+            return new ElectricResistance((milliohms) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricResistance from Milliohms of type decimal.
+        /// </summary>
+        public static ElectricResistance FromMilliohms(decimal milliohms)
+        {
+	        return new ElectricResistance((Convert.ToDouble(milliohms)) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
@@ -202,12 +283,84 @@ namespace UnitsNet
             return new ElectricResistance(ohms);
         }
 
+		/// <summary>
+        ///     Get ElectricResistance from Ohms.
+        /// </summary>
+        public static ElectricResistance FromOhms(int ohms)
+        {
+            return new ElectricResistance(ohms);
+        }
+
+		/// <summary>
+        ///     Get ElectricResistance from Ohms.
+        /// </summary>
+        public static ElectricResistance FromOhms(long ohms)
+        {
+            return new ElectricResistance(ohms);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ElectricResistance from Ohms of type decimal.
+        /// </summary>
+        public static ElectricResistance FromOhms(decimal ohms)
+        {
+	        return new ElectricResistance(Convert.ToDouble(ohms));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Kiloohms.
         /// </summary>
         public static ElectricResistance? FromKiloohms(double? kiloohms)
+        {
+            if (kiloohms.HasValue)
+            {
+                return FromKiloohms(kiloohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Kiloohms.
+        /// </summary>
+        public static ElectricResistance? FromKiloohms(int? kiloohms)
+        {
+            if (kiloohms.HasValue)
+            {
+                return FromKiloohms(kiloohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Kiloohms.
+        /// </summary>
+        public static ElectricResistance? FromKiloohms(long? kiloohms)
+        {
+            if (kiloohms.HasValue)
+            {
+                return FromKiloohms(kiloohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from Kiloohms of type decimal.
+        /// </summary>
+        public static ElectricResistance? FromKiloohms(decimal? kiloohms)
         {
             if (kiloohms.HasValue)
             {
@@ -234,6 +387,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Megaohms.
+        /// </summary>
+        public static ElectricResistance? FromMegaohms(int? megaohms)
+        {
+            if (megaohms.HasValue)
+            {
+                return FromMegaohms(megaohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Megaohms.
+        /// </summary>
+        public static ElectricResistance? FromMegaohms(long? megaohms)
+        {
+            if (megaohms.HasValue)
+            {
+                return FromMegaohms(megaohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from Megaohms of type decimal.
+        /// </summary>
+        public static ElectricResistance? FromMegaohms(decimal? megaohms)
+        {
+            if (megaohms.HasValue)
+            {
+                return FromMegaohms(megaohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Milliohms.
         /// </summary>
@@ -249,10 +447,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Milliohms.
+        /// </summary>
+        public static ElectricResistance? FromMilliohms(int? milliohms)
+        {
+            if (milliohms.HasValue)
+            {
+                return FromMilliohms(milliohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Milliohms.
+        /// </summary>
+        public static ElectricResistance? FromMilliohms(long? milliohms)
+        {
+            if (milliohms.HasValue)
+            {
+                return FromMilliohms(milliohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from Milliohms of type decimal.
+        /// </summary>
+        public static ElectricResistance? FromMilliohms(decimal? milliohms)
+        {
+            if (milliohms.HasValue)
+            {
+                return FromMilliohms(milliohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Ohms.
         /// </summary>
         public static ElectricResistance? FromOhms(double? ohms)
+        {
+            if (ohms.HasValue)
+            {
+                return FromOhms(ohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Ohms.
+        /// </summary>
+        public static ElectricResistance? FromOhms(int? ohms)
+        {
+            if (ohms.HasValue)
+            {
+                return FromOhms(ohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from nullable Ohms.
+        /// </summary>
+        public static ElectricResistance? FromOhms(long? ohms)
+        {
+            if (ohms.HasValue)
+            {
+                return FromOhms(ohms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ElectricResistance from Ohms of type decimal.
+        /// </summary>
+        public static ElectricResistance? FromOhms(decimal? ohms)
         {
             if (ohms.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -173,6 +173,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Kiloohms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricResistance FromKiloohms(double kiloohms)
         {
             return new ElectricResistance((kiloohms) * 1e3d);
@@ -208,6 +211,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricResistance FromMegaohms(double megaohms)
         {
             return new ElectricResistance((megaohms) * 1e6d);
@@ -243,6 +249,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Milliohms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricResistance FromMilliohms(double milliohms)
         {
             return new ElectricResistance((milliohms) * 1e-3d);
@@ -278,6 +287,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ElectricResistance FromOhms(double ohms)
         {
             return new ElectricResistance(ohms);

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _ohms;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ElectricResistance() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ElectricResistance;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ElectricResistanceUnit BaseUnit
         {
             get { return ElectricResistanceUnit.Ohm; }
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new ElectricResistance((kiloohms) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Kiloohms.
         /// </summary>
         public static ElectricResistance FromKiloohms(int kiloohms)
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new ElectricResistance((kiloohms) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Kiloohms.
         /// </summary>
         public static ElectricResistance FromKiloohms(long kiloohms)
@@ -194,14 +194,14 @@ namespace UnitsNet
             return new ElectricResistance((kiloohms) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Kiloohms of type decimal.
         /// </summary>
         public static ElectricResistance FromKiloohms(decimal kiloohms)
         {
-	        return new ElectricResistance((Convert.ToDouble(kiloohms)) * 1e3d);
+            return new ElectricResistance((Convert.ToDouble(kiloohms)) * 1e3d);
         }
 #endif
 
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new ElectricResistance((megaohms) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
         public static ElectricResistance FromMegaohms(int megaohms)
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new ElectricResistance((megaohms) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
         public static ElectricResistance FromMegaohms(long megaohms)
@@ -229,14 +229,14 @@ namespace UnitsNet
             return new ElectricResistance((megaohms) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Megaohms of type decimal.
         /// </summary>
         public static ElectricResistance FromMegaohms(decimal megaohms)
         {
-	        return new ElectricResistance((Convert.ToDouble(megaohms)) * 1e6d);
+            return new ElectricResistance((Convert.ToDouble(megaohms)) * 1e6d);
         }
 #endif
 
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new ElectricResistance((milliohms) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Milliohms.
         /// </summary>
         public static ElectricResistance FromMilliohms(int milliohms)
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new ElectricResistance((milliohms) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Milliohms.
         /// </summary>
         public static ElectricResistance FromMilliohms(long milliohms)
@@ -264,14 +264,14 @@ namespace UnitsNet
             return new ElectricResistance((milliohms) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Milliohms of type decimal.
         /// </summary>
         public static ElectricResistance FromMilliohms(decimal milliohms)
         {
-	        return new ElectricResistance((Convert.ToDouble(milliohms)) * 1e-3d);
+            return new ElectricResistance((Convert.ToDouble(milliohms)) * 1e-3d);
         }
 #endif
 
@@ -283,7 +283,7 @@ namespace UnitsNet
             return new ElectricResistance(ohms);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
         public static ElectricResistance FromOhms(int ohms)
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new ElectricResistance(ohms);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
         public static ElectricResistance FromOhms(long ohms)
@@ -299,14 +299,14 @@ namespace UnitsNet
             return new ElectricResistance(ohms);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ElectricResistance from Ohms of type decimal.
         /// </summary>
         public static ElectricResistance FromOhms(decimal ohms)
         {
-	        return new ElectricResistance(Convert.ToDouble(ohms));
+            return new ElectricResistance(Convert.ToDouble(ohms));
         }
 #endif
 
@@ -327,7 +327,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Kiloohms.
         /// </summary>
         public static ElectricResistance? FromKiloohms(int? kiloohms)
@@ -342,7 +342,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Kiloohms.
         /// </summary>
         public static ElectricResistance? FromKiloohms(long? kiloohms)
@@ -357,7 +357,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from Kiloohms of type decimal.
         /// </summary>
         public static ElectricResistance? FromKiloohms(decimal? kiloohms)
@@ -387,7 +387,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Megaohms.
         /// </summary>
         public static ElectricResistance? FromMegaohms(int? megaohms)
@@ -402,7 +402,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Megaohms.
         /// </summary>
         public static ElectricResistance? FromMegaohms(long? megaohms)
@@ -417,7 +417,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from Megaohms of type decimal.
         /// </summary>
         public static ElectricResistance? FromMegaohms(decimal? megaohms)
@@ -447,7 +447,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Milliohms.
         /// </summary>
         public static ElectricResistance? FromMilliohms(int? milliohms)
@@ -462,7 +462,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Milliohms.
         /// </summary>
         public static ElectricResistance? FromMilliohms(long? milliohms)
@@ -477,7 +477,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from Milliohms of type decimal.
         /// </summary>
         public static ElectricResistance? FromMilliohms(decimal? milliohms)
@@ -507,7 +507,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Ohms.
         /// </summary>
         public static ElectricResistance? FromOhms(int? ohms)
@@ -522,7 +522,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from nullable Ohms.
         /// </summary>
         public static ElectricResistance? FromOhms(long? ohms)
@@ -537,7 +537,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ElectricResistance from Ohms of type decimal.
         /// </summary>
         public static ElectricResistance? FromOhms(decimal? ohms)

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -317,6 +317,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from BritishThermalUnits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromBritishThermalUnits(double britishthermalunits)
         {
             return new Energy(britishthermalunits*1055.05585262);
@@ -352,6 +355,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromCalories(double calories)
         {
             return new Energy(calories*4.184);
@@ -387,6 +393,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsEc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromDecathermsEc(double decathermsec)
         {
             return new Energy((decathermsec*105505585.262) * 1e1d);
@@ -422,6 +431,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromDecathermsImperial(double decathermsimperial)
         {
             return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
@@ -457,6 +469,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsUs.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromDecathermsUs(double decathermsus)
         {
             return new Energy((decathermsus*1.054804e+8) * 1e1d);
@@ -492,6 +507,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromElectronVolts(double electronvolts)
         {
             return new Energy(electronvolts*1.602176565e-19);
@@ -527,6 +545,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Ergs.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromErgs(double ergs)
         {
             return new Energy(ergs*1e-7);
@@ -562,6 +583,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromFootPounds(double footpounds)
         {
             return new Energy(footpounds*1.355817948);
@@ -597,6 +621,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromGigabritishThermalUnits(double gigabritishthermalunits)
         {
             return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
@@ -632,6 +659,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromGigawattHours(double gigawatthours)
         {
             return new Energy((gigawatthours*3600d) * 1e9d);
@@ -667,6 +697,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Joules.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromJoules(double joules)
         {
             return new Energy(joules);
@@ -702,6 +735,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromKilobritishThermalUnits(double kilobritishthermalunits)
         {
             return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
@@ -737,6 +773,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Kilocalories.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromKilocalories(double kilocalories)
         {
             return new Energy((kilocalories*4.184) * 1e3d);
@@ -772,6 +811,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromKilojoules(double kilojoules)
         {
             return new Energy((kilojoules) * 1e3d);
@@ -807,6 +849,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from KilowattHours.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromKilowattHours(double kilowatthours)
         {
             return new Energy((kilowatthours*3600d) * 1e3d);
@@ -842,6 +887,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromMegabritishThermalUnits(double megabritishthermalunits)
         {
             return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
@@ -877,6 +925,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Megajoules.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromMegajoules(double megajoules)
         {
             return new Energy((megajoules) * 1e6d);
@@ -912,6 +963,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromMegawattHours(double megawatthours)
         {
             return new Energy((megawatthours*3600d) * 1e6d);
@@ -947,6 +1001,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsEc.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromThermsEc(double thermsec)
         {
             return new Energy(thermsec*105505585.262);
@@ -982,6 +1039,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromThermsImperial(double thermsimperial)
         {
             return new Energy(thermsimperial*1.05505585257348e+14);
@@ -1017,6 +1077,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsUs.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromThermsUs(double thermsus)
         {
             return new Energy(thermsus*1.054804e+8);
@@ -1052,6 +1115,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Energy FromWattHours(double watthours)
         {
             return new Energy(watthours*3600d);

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -322,6 +322,33 @@ namespace UnitsNet
             return new Energy(britishthermalunits*1055.05585262);
         }
 
+		/// <summary>
+        ///     Get Energy from BritishThermalUnits.
+        /// </summary>
+        public static Energy FromBritishThermalUnits(int britishthermalunits)
+        {
+            return new Energy(britishthermalunits*1055.05585262);
+        }
+
+		/// <summary>
+        ///     Get Energy from BritishThermalUnits.
+        /// </summary>
+        public static Energy FromBritishThermalUnits(long britishthermalunits)
+        {
+            return new Energy(britishthermalunits*1055.05585262);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from BritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy FromBritishThermalUnits(decimal britishthermalunits)
+        {
+	        return new Energy(Convert.ToDouble(britishthermalunits)*1055.05585262);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
@@ -329,6 +356,33 @@ namespace UnitsNet
         {
             return new Energy(calories*4.184);
         }
+
+		/// <summary>
+        ///     Get Energy from Calories.
+        /// </summary>
+        public static Energy FromCalories(int calories)
+        {
+            return new Energy(calories*4.184);
+        }
+
+		/// <summary>
+        ///     Get Energy from Calories.
+        /// </summary>
+        public static Energy FromCalories(long calories)
+        {
+            return new Energy(calories*4.184);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from Calories of type decimal.
+        /// </summary>
+        public static Energy FromCalories(decimal calories)
+        {
+	        return new Energy(Convert.ToDouble(calories)*4.184);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from DecathermsEc.
@@ -338,6 +392,33 @@ namespace UnitsNet
             return new Energy((decathermsec*105505585.262) * 1e1d);
         }
 
+		/// <summary>
+        ///     Get Energy from DecathermsEc.
+        /// </summary>
+        public static Energy FromDecathermsEc(int decathermsec)
+        {
+            return new Energy((decathermsec*105505585.262) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get Energy from DecathermsEc.
+        /// </summary>
+        public static Energy FromDecathermsEc(long decathermsec)
+        {
+            return new Energy((decathermsec*105505585.262) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from DecathermsEc of type decimal.
+        /// </summary>
+        public static Energy FromDecathermsEc(decimal decathermsec)
+        {
+	        return new Energy((Convert.ToDouble(decathermsec)*105505585.262) * 1e1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
@@ -345,6 +426,33 @@ namespace UnitsNet
         {
             return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
         }
+
+		/// <summary>
+        ///     Get Energy from DecathermsImperial.
+        /// </summary>
+        public static Energy FromDecathermsImperial(int decathermsimperial)
+        {
+            return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get Energy from DecathermsImperial.
+        /// </summary>
+        public static Energy FromDecathermsImperial(long decathermsimperial)
+        {
+            return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from DecathermsImperial of type decimal.
+        /// </summary>
+        public static Energy FromDecathermsImperial(decimal decathermsimperial)
+        {
+	        return new Energy((Convert.ToDouble(decathermsimperial)*1.05505585257348e+14) * 1e1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from DecathermsUs.
@@ -354,6 +462,33 @@ namespace UnitsNet
             return new Energy((decathermsus*1.054804e+8) * 1e1d);
         }
 
+		/// <summary>
+        ///     Get Energy from DecathermsUs.
+        /// </summary>
+        public static Energy FromDecathermsUs(int decathermsus)
+        {
+            return new Energy((decathermsus*1.054804e+8) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get Energy from DecathermsUs.
+        /// </summary>
+        public static Energy FromDecathermsUs(long decathermsus)
+        {
+            return new Energy((decathermsus*1.054804e+8) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from DecathermsUs of type decimal.
+        /// </summary>
+        public static Energy FromDecathermsUs(decimal decathermsus)
+        {
+	        return new Energy((Convert.ToDouble(decathermsus)*1.054804e+8) * 1e1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
@@ -361,6 +496,33 @@ namespace UnitsNet
         {
             return new Energy(electronvolts*1.602176565e-19);
         }
+
+		/// <summary>
+        ///     Get Energy from ElectronVolts.
+        /// </summary>
+        public static Energy FromElectronVolts(int electronvolts)
+        {
+            return new Energy(electronvolts*1.602176565e-19);
+        }
+
+		/// <summary>
+        ///     Get Energy from ElectronVolts.
+        /// </summary>
+        public static Energy FromElectronVolts(long electronvolts)
+        {
+            return new Energy(electronvolts*1.602176565e-19);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from ElectronVolts of type decimal.
+        /// </summary>
+        public static Energy FromElectronVolts(decimal electronvolts)
+        {
+	        return new Energy(Convert.ToDouble(electronvolts)*1.602176565e-19);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from Ergs.
@@ -370,6 +532,33 @@ namespace UnitsNet
             return new Energy(ergs*1e-7);
         }
 
+		/// <summary>
+        ///     Get Energy from Ergs.
+        /// </summary>
+        public static Energy FromErgs(int ergs)
+        {
+            return new Energy(ergs*1e-7);
+        }
+
+		/// <summary>
+        ///     Get Energy from Ergs.
+        /// </summary>
+        public static Energy FromErgs(long ergs)
+        {
+            return new Energy(ergs*1e-7);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from Ergs of type decimal.
+        /// </summary>
+        public static Energy FromErgs(decimal ergs)
+        {
+	        return new Energy(Convert.ToDouble(ergs)*1e-7);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
@@ -377,6 +566,33 @@ namespace UnitsNet
         {
             return new Energy(footpounds*1.355817948);
         }
+
+		/// <summary>
+        ///     Get Energy from FootPounds.
+        /// </summary>
+        public static Energy FromFootPounds(int footpounds)
+        {
+            return new Energy(footpounds*1.355817948);
+        }
+
+		/// <summary>
+        ///     Get Energy from FootPounds.
+        /// </summary>
+        public static Energy FromFootPounds(long footpounds)
+        {
+            return new Energy(footpounds*1.355817948);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from FootPounds of type decimal.
+        /// </summary>
+        public static Energy FromFootPounds(decimal footpounds)
+        {
+	        return new Energy(Convert.ToDouble(footpounds)*1.355817948);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
@@ -386,6 +602,33 @@ namespace UnitsNet
             return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
         }
 
+		/// <summary>
+        ///     Get Energy from GigabritishThermalUnits.
+        /// </summary>
+        public static Energy FromGigabritishThermalUnits(int gigabritishthermalunits)
+        {
+            return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
+        }
+
+		/// <summary>
+        ///     Get Energy from GigabritishThermalUnits.
+        /// </summary>
+        public static Energy FromGigabritishThermalUnits(long gigabritishthermalunits)
+        {
+            return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from GigabritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy FromGigabritishThermalUnits(decimal gigabritishthermalunits)
+        {
+	        return new Energy((Convert.ToDouble(gigabritishthermalunits)*1055.05585262) * 1e9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
@@ -393,6 +636,33 @@ namespace UnitsNet
         {
             return new Energy((gigawatthours*3600d) * 1e9d);
         }
+
+		/// <summary>
+        ///     Get Energy from GigawattHours.
+        /// </summary>
+        public static Energy FromGigawattHours(int gigawatthours)
+        {
+            return new Energy((gigawatthours*3600d) * 1e9d);
+        }
+
+		/// <summary>
+        ///     Get Energy from GigawattHours.
+        /// </summary>
+        public static Energy FromGigawattHours(long gigawatthours)
+        {
+            return new Energy((gigawatthours*3600d) * 1e9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from GigawattHours of type decimal.
+        /// </summary>
+        public static Energy FromGigawattHours(decimal gigawatthours)
+        {
+	        return new Energy((Convert.ToDouble(gigawatthours)*3600d) * 1e9d);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from Joules.
@@ -402,6 +672,33 @@ namespace UnitsNet
             return new Energy(joules);
         }
 
+		/// <summary>
+        ///     Get Energy from Joules.
+        /// </summary>
+        public static Energy FromJoules(int joules)
+        {
+            return new Energy(joules);
+        }
+
+		/// <summary>
+        ///     Get Energy from Joules.
+        /// </summary>
+        public static Energy FromJoules(long joules)
+        {
+            return new Energy(joules);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from Joules of type decimal.
+        /// </summary>
+        public static Energy FromJoules(decimal joules)
+        {
+	        return new Energy(Convert.ToDouble(joules));
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
@@ -409,6 +706,33 @@ namespace UnitsNet
         {
             return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Energy from KilobritishThermalUnits.
+        /// </summary>
+        public static Energy FromKilobritishThermalUnits(int kilobritishthermalunits)
+        {
+            return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Energy from KilobritishThermalUnits.
+        /// </summary>
+        public static Energy FromKilobritishThermalUnits(long kilobritishthermalunits)
+        {
+            return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from KilobritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy FromKilobritishThermalUnits(decimal kilobritishthermalunits)
+        {
+	        return new Energy((Convert.ToDouble(kilobritishthermalunits)*1055.05585262) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from Kilocalories.
@@ -418,6 +742,33 @@ namespace UnitsNet
             return new Energy((kilocalories*4.184) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Energy from Kilocalories.
+        /// </summary>
+        public static Energy FromKilocalories(int kilocalories)
+        {
+            return new Energy((kilocalories*4.184) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Energy from Kilocalories.
+        /// </summary>
+        public static Energy FromKilocalories(long kilocalories)
+        {
+            return new Energy((kilocalories*4.184) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from Kilocalories of type decimal.
+        /// </summary>
+        public static Energy FromKilocalories(decimal kilocalories)
+        {
+	        return new Energy((Convert.ToDouble(kilocalories)*4.184) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
@@ -425,6 +776,33 @@ namespace UnitsNet
         {
             return new Energy((kilojoules) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Energy from Kilojoules.
+        /// </summary>
+        public static Energy FromKilojoules(int kilojoules)
+        {
+            return new Energy((kilojoules) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Energy from Kilojoules.
+        /// </summary>
+        public static Energy FromKilojoules(long kilojoules)
+        {
+            return new Energy((kilojoules) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from Kilojoules of type decimal.
+        /// </summary>
+        public static Energy FromKilojoules(decimal kilojoules)
+        {
+	        return new Energy((Convert.ToDouble(kilojoules)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from KilowattHours.
@@ -434,6 +812,33 @@ namespace UnitsNet
             return new Energy((kilowatthours*3600d) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Energy from KilowattHours.
+        /// </summary>
+        public static Energy FromKilowattHours(int kilowatthours)
+        {
+            return new Energy((kilowatthours*3600d) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Energy from KilowattHours.
+        /// </summary>
+        public static Energy FromKilowattHours(long kilowatthours)
+        {
+            return new Energy((kilowatthours*3600d) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from KilowattHours of type decimal.
+        /// </summary>
+        public static Energy FromKilowattHours(decimal kilowatthours)
+        {
+	        return new Energy((Convert.ToDouble(kilowatthours)*3600d) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
@@ -441,6 +846,33 @@ namespace UnitsNet
         {
             return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get Energy from MegabritishThermalUnits.
+        /// </summary>
+        public static Energy FromMegabritishThermalUnits(int megabritishthermalunits)
+        {
+            return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Energy from MegabritishThermalUnits.
+        /// </summary>
+        public static Energy FromMegabritishThermalUnits(long megabritishthermalunits)
+        {
+            return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from MegabritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy FromMegabritishThermalUnits(decimal megabritishthermalunits)
+        {
+	        return new Energy((Convert.ToDouble(megabritishthermalunits)*1055.05585262) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from Megajoules.
@@ -450,6 +882,33 @@ namespace UnitsNet
             return new Energy((megajoules) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get Energy from Megajoules.
+        /// </summary>
+        public static Energy FromMegajoules(int megajoules)
+        {
+            return new Energy((megajoules) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Energy from Megajoules.
+        /// </summary>
+        public static Energy FromMegajoules(long megajoules)
+        {
+            return new Energy((megajoules) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from Megajoules of type decimal.
+        /// </summary>
+        public static Energy FromMegajoules(decimal megajoules)
+        {
+	        return new Energy((Convert.ToDouble(megajoules)) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
@@ -457,6 +916,33 @@ namespace UnitsNet
         {
             return new Energy((megawatthours*3600d) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get Energy from MegawattHours.
+        /// </summary>
+        public static Energy FromMegawattHours(int megawatthours)
+        {
+            return new Energy((megawatthours*3600d) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Energy from MegawattHours.
+        /// </summary>
+        public static Energy FromMegawattHours(long megawatthours)
+        {
+            return new Energy((megawatthours*3600d) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from MegawattHours of type decimal.
+        /// </summary>
+        public static Energy FromMegawattHours(decimal megawatthours)
+        {
+	        return new Energy((Convert.ToDouble(megawatthours)*3600d) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from ThermsEc.
@@ -466,6 +952,33 @@ namespace UnitsNet
             return new Energy(thermsec*105505585.262);
         }
 
+		/// <summary>
+        ///     Get Energy from ThermsEc.
+        /// </summary>
+        public static Energy FromThermsEc(int thermsec)
+        {
+            return new Energy(thermsec*105505585.262);
+        }
+
+		/// <summary>
+        ///     Get Energy from ThermsEc.
+        /// </summary>
+        public static Energy FromThermsEc(long thermsec)
+        {
+            return new Energy(thermsec*105505585.262);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from ThermsEc of type decimal.
+        /// </summary>
+        public static Energy FromThermsEc(decimal thermsec)
+        {
+	        return new Energy(Convert.ToDouble(thermsec)*105505585.262);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
@@ -473,6 +986,33 @@ namespace UnitsNet
         {
             return new Energy(thermsimperial*1.05505585257348e+14);
         }
+
+		/// <summary>
+        ///     Get Energy from ThermsImperial.
+        /// </summary>
+        public static Energy FromThermsImperial(int thermsimperial)
+        {
+            return new Energy(thermsimperial*1.05505585257348e+14);
+        }
+
+		/// <summary>
+        ///     Get Energy from ThermsImperial.
+        /// </summary>
+        public static Energy FromThermsImperial(long thermsimperial)
+        {
+            return new Energy(thermsimperial*1.05505585257348e+14);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from ThermsImperial of type decimal.
+        /// </summary>
+        public static Energy FromThermsImperial(decimal thermsimperial)
+        {
+	        return new Energy(Convert.ToDouble(thermsimperial)*1.05505585257348e+14);
+        }
+#endif
 
         /// <summary>
         ///     Get Energy from ThermsUs.
@@ -482,6 +1022,33 @@ namespace UnitsNet
             return new Energy(thermsus*1.054804e+8);
         }
 
+		/// <summary>
+        ///     Get Energy from ThermsUs.
+        /// </summary>
+        public static Energy FromThermsUs(int thermsus)
+        {
+            return new Energy(thermsus*1.054804e+8);
+        }
+
+		/// <summary>
+        ///     Get Energy from ThermsUs.
+        /// </summary>
+        public static Energy FromThermsUs(long thermsus)
+        {
+            return new Energy(thermsus*1.054804e+8);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from ThermsUs of type decimal.
+        /// </summary>
+        public static Energy FromThermsUs(decimal thermsus)
+        {
+	        return new Energy(Convert.ToDouble(thermsus)*1.054804e+8);
+        }
+#endif
+
         /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
@@ -490,12 +1057,84 @@ namespace UnitsNet
             return new Energy(watthours*3600d);
         }
 
+		/// <summary>
+        ///     Get Energy from WattHours.
+        /// </summary>
+        public static Energy FromWattHours(int watthours)
+        {
+            return new Energy(watthours*3600d);
+        }
+
+		/// <summary>
+        ///     Get Energy from WattHours.
+        /// </summary>
+        public static Energy FromWattHours(long watthours)
+        {
+            return new Energy(watthours*3600d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Energy from WattHours of type decimal.
+        /// </summary>
+        public static Energy FromWattHours(decimal watthours)
+        {
+	        return new Energy(Convert.ToDouble(watthours)*3600d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Energy from nullable BritishThermalUnits.
         /// </summary>
         public static Energy? FromBritishThermalUnits(double? britishthermalunits)
+        {
+            if (britishthermalunits.HasValue)
+            {
+                return FromBritishThermalUnits(britishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable BritishThermalUnits.
+        /// </summary>
+        public static Energy? FromBritishThermalUnits(int? britishthermalunits)
+        {
+            if (britishthermalunits.HasValue)
+            {
+                return FromBritishThermalUnits(britishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable BritishThermalUnits.
+        /// </summary>
+        public static Energy? FromBritishThermalUnits(long? britishthermalunits)
+        {
+            if (britishthermalunits.HasValue)
+            {
+                return FromBritishThermalUnits(britishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from BritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy? FromBritishThermalUnits(decimal? britishthermalunits)
         {
             if (britishthermalunits.HasValue)
             {
@@ -522,10 +1161,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable Calories.
+        /// </summary>
+        public static Energy? FromCalories(int? calories)
+        {
+            if (calories.HasValue)
+            {
+                return FromCalories(calories.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Calories.
+        /// </summary>
+        public static Energy? FromCalories(long? calories)
+        {
+            if (calories.HasValue)
+            {
+                return FromCalories(calories.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from Calories of type decimal.
+        /// </summary>
+        public static Energy? FromCalories(decimal? calories)
+        {
+            if (calories.HasValue)
+            {
+                return FromCalories(calories.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable DecathermsEc.
         /// </summary>
         public static Energy? FromDecathermsEc(double? decathermsec)
+        {
+            if (decathermsec.HasValue)
+            {
+                return FromDecathermsEc(decathermsec.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable DecathermsEc.
+        /// </summary>
+        public static Energy? FromDecathermsEc(int? decathermsec)
+        {
+            if (decathermsec.HasValue)
+            {
+                return FromDecathermsEc(decathermsec.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable DecathermsEc.
+        /// </summary>
+        public static Energy? FromDecathermsEc(long? decathermsec)
+        {
+            if (decathermsec.HasValue)
+            {
+                return FromDecathermsEc(decathermsec.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from DecathermsEc of type decimal.
+        /// </summary>
+        public static Energy? FromDecathermsEc(decimal? decathermsec)
         {
             if (decathermsec.HasValue)
             {
@@ -552,10 +1281,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable DecathermsImperial.
+        /// </summary>
+        public static Energy? FromDecathermsImperial(int? decathermsimperial)
+        {
+            if (decathermsimperial.HasValue)
+            {
+                return FromDecathermsImperial(decathermsimperial.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable DecathermsImperial.
+        /// </summary>
+        public static Energy? FromDecathermsImperial(long? decathermsimperial)
+        {
+            if (decathermsimperial.HasValue)
+            {
+                return FromDecathermsImperial(decathermsimperial.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from DecathermsImperial of type decimal.
+        /// </summary>
+        public static Energy? FromDecathermsImperial(decimal? decathermsimperial)
+        {
+            if (decathermsimperial.HasValue)
+            {
+                return FromDecathermsImperial(decathermsimperial.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable DecathermsUs.
         /// </summary>
         public static Energy? FromDecathermsUs(double? decathermsus)
+        {
+            if (decathermsus.HasValue)
+            {
+                return FromDecathermsUs(decathermsus.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable DecathermsUs.
+        /// </summary>
+        public static Energy? FromDecathermsUs(int? decathermsus)
+        {
+            if (decathermsus.HasValue)
+            {
+                return FromDecathermsUs(decathermsus.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable DecathermsUs.
+        /// </summary>
+        public static Energy? FromDecathermsUs(long? decathermsus)
+        {
+            if (decathermsus.HasValue)
+            {
+                return FromDecathermsUs(decathermsus.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from DecathermsUs of type decimal.
+        /// </summary>
+        public static Energy? FromDecathermsUs(decimal? decathermsus)
         {
             if (decathermsus.HasValue)
             {
@@ -582,10 +1401,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable ElectronVolts.
+        /// </summary>
+        public static Energy? FromElectronVolts(int? electronvolts)
+        {
+            if (electronvolts.HasValue)
+            {
+                return FromElectronVolts(electronvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable ElectronVolts.
+        /// </summary>
+        public static Energy? FromElectronVolts(long? electronvolts)
+        {
+            if (electronvolts.HasValue)
+            {
+                return FromElectronVolts(electronvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from ElectronVolts of type decimal.
+        /// </summary>
+        public static Energy? FromElectronVolts(decimal? electronvolts)
+        {
+            if (electronvolts.HasValue)
+            {
+                return FromElectronVolts(electronvolts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable Ergs.
         /// </summary>
         public static Energy? FromErgs(double? ergs)
+        {
+            if (ergs.HasValue)
+            {
+                return FromErgs(ergs.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Ergs.
+        /// </summary>
+        public static Energy? FromErgs(int? ergs)
+        {
+            if (ergs.HasValue)
+            {
+                return FromErgs(ergs.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Ergs.
+        /// </summary>
+        public static Energy? FromErgs(long? ergs)
+        {
+            if (ergs.HasValue)
+            {
+                return FromErgs(ergs.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from Ergs of type decimal.
+        /// </summary>
+        public static Energy? FromErgs(decimal? ergs)
         {
             if (ergs.HasValue)
             {
@@ -612,10 +1521,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable FootPounds.
+        /// </summary>
+        public static Energy? FromFootPounds(int? footpounds)
+        {
+            if (footpounds.HasValue)
+            {
+                return FromFootPounds(footpounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable FootPounds.
+        /// </summary>
+        public static Energy? FromFootPounds(long? footpounds)
+        {
+            if (footpounds.HasValue)
+            {
+                return FromFootPounds(footpounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from FootPounds of type decimal.
+        /// </summary>
+        public static Energy? FromFootPounds(decimal? footpounds)
+        {
+            if (footpounds.HasValue)
+            {
+                return FromFootPounds(footpounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable GigabritishThermalUnits.
         /// </summary>
         public static Energy? FromGigabritishThermalUnits(double? gigabritishthermalunits)
+        {
+            if (gigabritishthermalunits.HasValue)
+            {
+                return FromGigabritishThermalUnits(gigabritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable GigabritishThermalUnits.
+        /// </summary>
+        public static Energy? FromGigabritishThermalUnits(int? gigabritishthermalunits)
+        {
+            if (gigabritishthermalunits.HasValue)
+            {
+                return FromGigabritishThermalUnits(gigabritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable GigabritishThermalUnits.
+        /// </summary>
+        public static Energy? FromGigabritishThermalUnits(long? gigabritishthermalunits)
+        {
+            if (gigabritishthermalunits.HasValue)
+            {
+                return FromGigabritishThermalUnits(gigabritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from GigabritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy? FromGigabritishThermalUnits(decimal? gigabritishthermalunits)
         {
             if (gigabritishthermalunits.HasValue)
             {
@@ -642,10 +1641,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable GigawattHours.
+        /// </summary>
+        public static Energy? FromGigawattHours(int? gigawatthours)
+        {
+            if (gigawatthours.HasValue)
+            {
+                return FromGigawattHours(gigawatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable GigawattHours.
+        /// </summary>
+        public static Energy? FromGigawattHours(long? gigawatthours)
+        {
+            if (gigawatthours.HasValue)
+            {
+                return FromGigawattHours(gigawatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from GigawattHours of type decimal.
+        /// </summary>
+        public static Energy? FromGigawattHours(decimal? gigawatthours)
+        {
+            if (gigawatthours.HasValue)
+            {
+                return FromGigawattHours(gigawatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable Joules.
         /// </summary>
         public static Energy? FromJoules(double? joules)
+        {
+            if (joules.HasValue)
+            {
+                return FromJoules(joules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Joules.
+        /// </summary>
+        public static Energy? FromJoules(int? joules)
+        {
+            if (joules.HasValue)
+            {
+                return FromJoules(joules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Joules.
+        /// </summary>
+        public static Energy? FromJoules(long? joules)
+        {
+            if (joules.HasValue)
+            {
+                return FromJoules(joules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from Joules of type decimal.
+        /// </summary>
+        public static Energy? FromJoules(decimal? joules)
         {
             if (joules.HasValue)
             {
@@ -672,10 +1761,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable KilobritishThermalUnits.
+        /// </summary>
+        public static Energy? FromKilobritishThermalUnits(int? kilobritishthermalunits)
+        {
+            if (kilobritishthermalunits.HasValue)
+            {
+                return FromKilobritishThermalUnits(kilobritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable KilobritishThermalUnits.
+        /// </summary>
+        public static Energy? FromKilobritishThermalUnits(long? kilobritishthermalunits)
+        {
+            if (kilobritishthermalunits.HasValue)
+            {
+                return FromKilobritishThermalUnits(kilobritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from KilobritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy? FromKilobritishThermalUnits(decimal? kilobritishthermalunits)
+        {
+            if (kilobritishthermalunits.HasValue)
+            {
+                return FromKilobritishThermalUnits(kilobritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable Kilocalories.
         /// </summary>
         public static Energy? FromKilocalories(double? kilocalories)
+        {
+            if (kilocalories.HasValue)
+            {
+                return FromKilocalories(kilocalories.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Kilocalories.
+        /// </summary>
+        public static Energy? FromKilocalories(int? kilocalories)
+        {
+            if (kilocalories.HasValue)
+            {
+                return FromKilocalories(kilocalories.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Kilocalories.
+        /// </summary>
+        public static Energy? FromKilocalories(long? kilocalories)
+        {
+            if (kilocalories.HasValue)
+            {
+                return FromKilocalories(kilocalories.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from Kilocalories of type decimal.
+        /// </summary>
+        public static Energy? FromKilocalories(decimal? kilocalories)
         {
             if (kilocalories.HasValue)
             {
@@ -702,10 +1881,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable Kilojoules.
+        /// </summary>
+        public static Energy? FromKilojoules(int? kilojoules)
+        {
+            if (kilojoules.HasValue)
+            {
+                return FromKilojoules(kilojoules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Kilojoules.
+        /// </summary>
+        public static Energy? FromKilojoules(long? kilojoules)
+        {
+            if (kilojoules.HasValue)
+            {
+                return FromKilojoules(kilojoules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from Kilojoules of type decimal.
+        /// </summary>
+        public static Energy? FromKilojoules(decimal? kilojoules)
+        {
+            if (kilojoules.HasValue)
+            {
+                return FromKilojoules(kilojoules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable KilowattHours.
         /// </summary>
         public static Energy? FromKilowattHours(double? kilowatthours)
+        {
+            if (kilowatthours.HasValue)
+            {
+                return FromKilowattHours(kilowatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable KilowattHours.
+        /// </summary>
+        public static Energy? FromKilowattHours(int? kilowatthours)
+        {
+            if (kilowatthours.HasValue)
+            {
+                return FromKilowattHours(kilowatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable KilowattHours.
+        /// </summary>
+        public static Energy? FromKilowattHours(long? kilowatthours)
+        {
+            if (kilowatthours.HasValue)
+            {
+                return FromKilowattHours(kilowatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from KilowattHours of type decimal.
+        /// </summary>
+        public static Energy? FromKilowattHours(decimal? kilowatthours)
         {
             if (kilowatthours.HasValue)
             {
@@ -732,10 +2001,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable MegabritishThermalUnits.
+        /// </summary>
+        public static Energy? FromMegabritishThermalUnits(int? megabritishthermalunits)
+        {
+            if (megabritishthermalunits.HasValue)
+            {
+                return FromMegabritishThermalUnits(megabritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable MegabritishThermalUnits.
+        /// </summary>
+        public static Energy? FromMegabritishThermalUnits(long? megabritishthermalunits)
+        {
+            if (megabritishthermalunits.HasValue)
+            {
+                return FromMegabritishThermalUnits(megabritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from MegabritishThermalUnits of type decimal.
+        /// </summary>
+        public static Energy? FromMegabritishThermalUnits(decimal? megabritishthermalunits)
+        {
+            if (megabritishthermalunits.HasValue)
+            {
+                return FromMegabritishThermalUnits(megabritishthermalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable Megajoules.
         /// </summary>
         public static Energy? FromMegajoules(double? megajoules)
+        {
+            if (megajoules.HasValue)
+            {
+                return FromMegajoules(megajoules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Megajoules.
+        /// </summary>
+        public static Energy? FromMegajoules(int? megajoules)
+        {
+            if (megajoules.HasValue)
+            {
+                return FromMegajoules(megajoules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable Megajoules.
+        /// </summary>
+        public static Energy? FromMegajoules(long? megajoules)
+        {
+            if (megajoules.HasValue)
+            {
+                return FromMegajoules(megajoules.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from Megajoules of type decimal.
+        /// </summary>
+        public static Energy? FromMegajoules(decimal? megajoules)
         {
             if (megajoules.HasValue)
             {
@@ -762,10 +2121,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable MegawattHours.
+        /// </summary>
+        public static Energy? FromMegawattHours(int? megawatthours)
+        {
+            if (megawatthours.HasValue)
+            {
+                return FromMegawattHours(megawatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable MegawattHours.
+        /// </summary>
+        public static Energy? FromMegawattHours(long? megawatthours)
+        {
+            if (megawatthours.HasValue)
+            {
+                return FromMegawattHours(megawatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from MegawattHours of type decimal.
+        /// </summary>
+        public static Energy? FromMegawattHours(decimal? megawatthours)
+        {
+            if (megawatthours.HasValue)
+            {
+                return FromMegawattHours(megawatthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable ThermsEc.
         /// </summary>
         public static Energy? FromThermsEc(double? thermsec)
+        {
+            if (thermsec.HasValue)
+            {
+                return FromThermsEc(thermsec.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable ThermsEc.
+        /// </summary>
+        public static Energy? FromThermsEc(int? thermsec)
+        {
+            if (thermsec.HasValue)
+            {
+                return FromThermsEc(thermsec.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable ThermsEc.
+        /// </summary>
+        public static Energy? FromThermsEc(long? thermsec)
+        {
+            if (thermsec.HasValue)
+            {
+                return FromThermsEc(thermsec.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from ThermsEc of type decimal.
+        /// </summary>
+        public static Energy? FromThermsEc(decimal? thermsec)
         {
             if (thermsec.HasValue)
             {
@@ -792,6 +2241,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable ThermsImperial.
+        /// </summary>
+        public static Energy? FromThermsImperial(int? thermsimperial)
+        {
+            if (thermsimperial.HasValue)
+            {
+                return FromThermsImperial(thermsimperial.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable ThermsImperial.
+        /// </summary>
+        public static Energy? FromThermsImperial(long? thermsimperial)
+        {
+            if (thermsimperial.HasValue)
+            {
+                return FromThermsImperial(thermsimperial.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from ThermsImperial of type decimal.
+        /// </summary>
+        public static Energy? FromThermsImperial(decimal? thermsimperial)
+        {
+            if (thermsimperial.HasValue)
+            {
+                return FromThermsImperial(thermsimperial.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable ThermsUs.
         /// </summary>
@@ -807,10 +2301,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Energy from nullable ThermsUs.
+        /// </summary>
+        public static Energy? FromThermsUs(int? thermsus)
+        {
+            if (thermsus.HasValue)
+            {
+                return FromThermsUs(thermsus.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable ThermsUs.
+        /// </summary>
+        public static Energy? FromThermsUs(long? thermsus)
+        {
+            if (thermsus.HasValue)
+            {
+                return FromThermsUs(thermsus.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from ThermsUs of type decimal.
+        /// </summary>
+        public static Energy? FromThermsUs(decimal? thermsus)
+        {
+            if (thermsus.HasValue)
+            {
+                return FromThermsUs(thermsus.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Energy from nullable WattHours.
         /// </summary>
         public static Energy? FromWattHours(double? watthours)
+        {
+            if (watthours.HasValue)
+            {
+                return FromWattHours(watthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable WattHours.
+        /// </summary>
+        public static Energy? FromWattHours(int? watthours)
+        {
+            if (watthours.HasValue)
+            {
+                return FromWattHours(watthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from nullable WattHours.
+        /// </summary>
+        public static Energy? FromWattHours(long? watthours)
+        {
+            if (watthours.HasValue)
+            {
+                return FromWattHours(watthours.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Energy from WattHours of type decimal.
+        /// </summary>
+        public static Energy? FromWattHours(decimal? watthours)
         {
             if (watthours.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _joules;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Energy() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Energy;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static EnergyUnit BaseUnit
         {
             get { return EnergyUnit.Joule; }
@@ -322,7 +322,7 @@ namespace UnitsNet
             return new Energy(britishthermalunits*1055.05585262);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from BritishThermalUnits.
         /// </summary>
         public static Energy FromBritishThermalUnits(int britishthermalunits)
@@ -330,7 +330,7 @@ namespace UnitsNet
             return new Energy(britishthermalunits*1055.05585262);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from BritishThermalUnits.
         /// </summary>
         public static Energy FromBritishThermalUnits(long britishthermalunits)
@@ -338,14 +338,14 @@ namespace UnitsNet
             return new Energy(britishthermalunits*1055.05585262);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from BritishThermalUnits of type decimal.
         /// </summary>
         public static Energy FromBritishThermalUnits(decimal britishthermalunits)
         {
-	        return new Energy(Convert.ToDouble(britishthermalunits)*1055.05585262);
+            return new Energy(Convert.ToDouble(britishthermalunits)*1055.05585262);
         }
 #endif
 
@@ -357,7 +357,7 @@ namespace UnitsNet
             return new Energy(calories*4.184);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
         public static Energy FromCalories(int calories)
@@ -365,7 +365,7 @@ namespace UnitsNet
             return new Energy(calories*4.184);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
         public static Energy FromCalories(long calories)
@@ -373,14 +373,14 @@ namespace UnitsNet
             return new Energy(calories*4.184);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Calories of type decimal.
         /// </summary>
         public static Energy FromCalories(decimal calories)
         {
-	        return new Energy(Convert.ToDouble(calories)*4.184);
+            return new Energy(Convert.ToDouble(calories)*4.184);
         }
 #endif
 
@@ -392,7 +392,7 @@ namespace UnitsNet
             return new Energy((decathermsec*105505585.262) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsEc.
         /// </summary>
         public static Energy FromDecathermsEc(int decathermsec)
@@ -400,7 +400,7 @@ namespace UnitsNet
             return new Energy((decathermsec*105505585.262) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsEc.
         /// </summary>
         public static Energy FromDecathermsEc(long decathermsec)
@@ -408,14 +408,14 @@ namespace UnitsNet
             return new Energy((decathermsec*105505585.262) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsEc of type decimal.
         /// </summary>
         public static Energy FromDecathermsEc(decimal decathermsec)
         {
-	        return new Energy((Convert.ToDouble(decathermsec)*105505585.262) * 1e1d);
+            return new Energy((Convert.ToDouble(decathermsec)*105505585.262) * 1e1d);
         }
 #endif
 
@@ -427,7 +427,7 @@ namespace UnitsNet
             return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
         public static Energy FromDecathermsImperial(int decathermsimperial)
@@ -435,7 +435,7 @@ namespace UnitsNet
             return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
         public static Energy FromDecathermsImperial(long decathermsimperial)
@@ -443,14 +443,14 @@ namespace UnitsNet
             return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsImperial of type decimal.
         /// </summary>
         public static Energy FromDecathermsImperial(decimal decathermsimperial)
         {
-	        return new Energy((Convert.ToDouble(decathermsimperial)*1.05505585257348e+14) * 1e1d);
+            return new Energy((Convert.ToDouble(decathermsimperial)*1.05505585257348e+14) * 1e1d);
         }
 #endif
 
@@ -462,7 +462,7 @@ namespace UnitsNet
             return new Energy((decathermsus*1.054804e+8) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsUs.
         /// </summary>
         public static Energy FromDecathermsUs(int decathermsus)
@@ -470,7 +470,7 @@ namespace UnitsNet
             return new Energy((decathermsus*1.054804e+8) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsUs.
         /// </summary>
         public static Energy FromDecathermsUs(long decathermsus)
@@ -478,14 +478,14 @@ namespace UnitsNet
             return new Energy((decathermsus*1.054804e+8) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from DecathermsUs of type decimal.
         /// </summary>
         public static Energy FromDecathermsUs(decimal decathermsus)
         {
-	        return new Energy((Convert.ToDouble(decathermsus)*1.054804e+8) * 1e1d);
+            return new Energy((Convert.ToDouble(decathermsus)*1.054804e+8) * 1e1d);
         }
 #endif
 
@@ -497,7 +497,7 @@ namespace UnitsNet
             return new Energy(electronvolts*1.602176565e-19);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
         public static Energy FromElectronVolts(int electronvolts)
@@ -505,7 +505,7 @@ namespace UnitsNet
             return new Energy(electronvolts*1.602176565e-19);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
         public static Energy FromElectronVolts(long electronvolts)
@@ -513,14 +513,14 @@ namespace UnitsNet
             return new Energy(electronvolts*1.602176565e-19);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ElectronVolts of type decimal.
         /// </summary>
         public static Energy FromElectronVolts(decimal electronvolts)
         {
-	        return new Energy(Convert.ToDouble(electronvolts)*1.602176565e-19);
+            return new Energy(Convert.ToDouble(electronvolts)*1.602176565e-19);
         }
 #endif
 
@@ -532,7 +532,7 @@ namespace UnitsNet
             return new Energy(ergs*1e-7);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Ergs.
         /// </summary>
         public static Energy FromErgs(int ergs)
@@ -540,7 +540,7 @@ namespace UnitsNet
             return new Energy(ergs*1e-7);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Ergs.
         /// </summary>
         public static Energy FromErgs(long ergs)
@@ -548,14 +548,14 @@ namespace UnitsNet
             return new Energy(ergs*1e-7);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Ergs of type decimal.
         /// </summary>
         public static Energy FromErgs(decimal ergs)
         {
-	        return new Energy(Convert.ToDouble(ergs)*1e-7);
+            return new Energy(Convert.ToDouble(ergs)*1e-7);
         }
 #endif
 
@@ -567,7 +567,7 @@ namespace UnitsNet
             return new Energy(footpounds*1.355817948);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
         public static Energy FromFootPounds(int footpounds)
@@ -575,7 +575,7 @@ namespace UnitsNet
             return new Energy(footpounds*1.355817948);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
         public static Energy FromFootPounds(long footpounds)
@@ -583,14 +583,14 @@ namespace UnitsNet
             return new Energy(footpounds*1.355817948);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from FootPounds of type decimal.
         /// </summary>
         public static Energy FromFootPounds(decimal footpounds)
         {
-	        return new Energy(Convert.ToDouble(footpounds)*1.355817948);
+            return new Energy(Convert.ToDouble(footpounds)*1.355817948);
         }
 #endif
 
@@ -602,7 +602,7 @@ namespace UnitsNet
             return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
         /// </summary>
         public static Energy FromGigabritishThermalUnits(int gigabritishthermalunits)
@@ -610,7 +610,7 @@ namespace UnitsNet
             return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
         /// </summary>
         public static Energy FromGigabritishThermalUnits(long gigabritishthermalunits)
@@ -618,14 +618,14 @@ namespace UnitsNet
             return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from GigabritishThermalUnits of type decimal.
         /// </summary>
         public static Energy FromGigabritishThermalUnits(decimal gigabritishthermalunits)
         {
-	        return new Energy((Convert.ToDouble(gigabritishthermalunits)*1055.05585262) * 1e9d);
+            return new Energy((Convert.ToDouble(gigabritishthermalunits)*1055.05585262) * 1e9d);
         }
 #endif
 
@@ -637,7 +637,7 @@ namespace UnitsNet
             return new Energy((gigawatthours*3600d) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
         public static Energy FromGigawattHours(int gigawatthours)
@@ -645,7 +645,7 @@ namespace UnitsNet
             return new Energy((gigawatthours*3600d) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
         public static Energy FromGigawattHours(long gigawatthours)
@@ -653,14 +653,14 @@ namespace UnitsNet
             return new Energy((gigawatthours*3600d) * 1e9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from GigawattHours of type decimal.
         /// </summary>
         public static Energy FromGigawattHours(decimal gigawatthours)
         {
-	        return new Energy((Convert.ToDouble(gigawatthours)*3600d) * 1e9d);
+            return new Energy((Convert.ToDouble(gigawatthours)*3600d) * 1e9d);
         }
 #endif
 
@@ -672,7 +672,7 @@ namespace UnitsNet
             return new Energy(joules);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Joules.
         /// </summary>
         public static Energy FromJoules(int joules)
@@ -680,7 +680,7 @@ namespace UnitsNet
             return new Energy(joules);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Joules.
         /// </summary>
         public static Energy FromJoules(long joules)
@@ -688,14 +688,14 @@ namespace UnitsNet
             return new Energy(joules);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Joules of type decimal.
         /// </summary>
         public static Energy FromJoules(decimal joules)
         {
-	        return new Energy(Convert.ToDouble(joules));
+            return new Energy(Convert.ToDouble(joules));
         }
 #endif
 
@@ -707,7 +707,7 @@ namespace UnitsNet
             return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
         public static Energy FromKilobritishThermalUnits(int kilobritishthermalunits)
@@ -715,7 +715,7 @@ namespace UnitsNet
             return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
         public static Energy FromKilobritishThermalUnits(long kilobritishthermalunits)
@@ -723,14 +723,14 @@ namespace UnitsNet
             return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from KilobritishThermalUnits of type decimal.
         /// </summary>
         public static Energy FromKilobritishThermalUnits(decimal kilobritishthermalunits)
         {
-	        return new Energy((Convert.ToDouble(kilobritishthermalunits)*1055.05585262) * 1e3d);
+            return new Energy((Convert.ToDouble(kilobritishthermalunits)*1055.05585262) * 1e3d);
         }
 #endif
 
@@ -742,7 +742,7 @@ namespace UnitsNet
             return new Energy((kilocalories*4.184) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Kilocalories.
         /// </summary>
         public static Energy FromKilocalories(int kilocalories)
@@ -750,7 +750,7 @@ namespace UnitsNet
             return new Energy((kilocalories*4.184) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Kilocalories.
         /// </summary>
         public static Energy FromKilocalories(long kilocalories)
@@ -758,14 +758,14 @@ namespace UnitsNet
             return new Energy((kilocalories*4.184) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Kilocalories of type decimal.
         /// </summary>
         public static Energy FromKilocalories(decimal kilocalories)
         {
-	        return new Energy((Convert.ToDouble(kilocalories)*4.184) * 1e3d);
+            return new Energy((Convert.ToDouble(kilocalories)*4.184) * 1e3d);
         }
 #endif
 
@@ -777,7 +777,7 @@ namespace UnitsNet
             return new Energy((kilojoules) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
         public static Energy FromKilojoules(int kilojoules)
@@ -785,7 +785,7 @@ namespace UnitsNet
             return new Energy((kilojoules) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
         public static Energy FromKilojoules(long kilojoules)
@@ -793,14 +793,14 @@ namespace UnitsNet
             return new Energy((kilojoules) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Kilojoules of type decimal.
         /// </summary>
         public static Energy FromKilojoules(decimal kilojoules)
         {
-	        return new Energy((Convert.ToDouble(kilojoules)) * 1e3d);
+            return new Energy((Convert.ToDouble(kilojoules)) * 1e3d);
         }
 #endif
 
@@ -812,7 +812,7 @@ namespace UnitsNet
             return new Energy((kilowatthours*3600d) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from KilowattHours.
         /// </summary>
         public static Energy FromKilowattHours(int kilowatthours)
@@ -820,7 +820,7 @@ namespace UnitsNet
             return new Energy((kilowatthours*3600d) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from KilowattHours.
         /// </summary>
         public static Energy FromKilowattHours(long kilowatthours)
@@ -828,14 +828,14 @@ namespace UnitsNet
             return new Energy((kilowatthours*3600d) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from KilowattHours of type decimal.
         /// </summary>
         public static Energy FromKilowattHours(decimal kilowatthours)
         {
-	        return new Energy((Convert.ToDouble(kilowatthours)*3600d) * 1e3d);
+            return new Energy((Convert.ToDouble(kilowatthours)*3600d) * 1e3d);
         }
 #endif
 
@@ -847,7 +847,7 @@ namespace UnitsNet
             return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
         public static Energy FromMegabritishThermalUnits(int megabritishthermalunits)
@@ -855,7 +855,7 @@ namespace UnitsNet
             return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
         public static Energy FromMegabritishThermalUnits(long megabritishthermalunits)
@@ -863,14 +863,14 @@ namespace UnitsNet
             return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from MegabritishThermalUnits of type decimal.
         /// </summary>
         public static Energy FromMegabritishThermalUnits(decimal megabritishthermalunits)
         {
-	        return new Energy((Convert.ToDouble(megabritishthermalunits)*1055.05585262) * 1e6d);
+            return new Energy((Convert.ToDouble(megabritishthermalunits)*1055.05585262) * 1e6d);
         }
 #endif
 
@@ -882,7 +882,7 @@ namespace UnitsNet
             return new Energy((megajoules) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Megajoules.
         /// </summary>
         public static Energy FromMegajoules(int megajoules)
@@ -890,7 +890,7 @@ namespace UnitsNet
             return new Energy((megajoules) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Megajoules.
         /// </summary>
         public static Energy FromMegajoules(long megajoules)
@@ -898,14 +898,14 @@ namespace UnitsNet
             return new Energy((megajoules) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from Megajoules of type decimal.
         /// </summary>
         public static Energy FromMegajoules(decimal megajoules)
         {
-	        return new Energy((Convert.ToDouble(megajoules)) * 1e6d);
+            return new Energy((Convert.ToDouble(megajoules)) * 1e6d);
         }
 #endif
 
@@ -917,7 +917,7 @@ namespace UnitsNet
             return new Energy((megawatthours*3600d) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
         public static Energy FromMegawattHours(int megawatthours)
@@ -925,7 +925,7 @@ namespace UnitsNet
             return new Energy((megawatthours*3600d) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
         public static Energy FromMegawattHours(long megawatthours)
@@ -933,14 +933,14 @@ namespace UnitsNet
             return new Energy((megawatthours*3600d) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from MegawattHours of type decimal.
         /// </summary>
         public static Energy FromMegawattHours(decimal megawatthours)
         {
-	        return new Energy((Convert.ToDouble(megawatthours)*3600d) * 1e6d);
+            return new Energy((Convert.ToDouble(megawatthours)*3600d) * 1e6d);
         }
 #endif
 
@@ -952,7 +952,7 @@ namespace UnitsNet
             return new Energy(thermsec*105505585.262);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsEc.
         /// </summary>
         public static Energy FromThermsEc(int thermsec)
@@ -960,7 +960,7 @@ namespace UnitsNet
             return new Energy(thermsec*105505585.262);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsEc.
         /// </summary>
         public static Energy FromThermsEc(long thermsec)
@@ -968,14 +968,14 @@ namespace UnitsNet
             return new Energy(thermsec*105505585.262);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsEc of type decimal.
         /// </summary>
         public static Energy FromThermsEc(decimal thermsec)
         {
-	        return new Energy(Convert.ToDouble(thermsec)*105505585.262);
+            return new Energy(Convert.ToDouble(thermsec)*105505585.262);
         }
 #endif
 
@@ -987,7 +987,7 @@ namespace UnitsNet
             return new Energy(thermsimperial*1.05505585257348e+14);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
         public static Energy FromThermsImperial(int thermsimperial)
@@ -995,7 +995,7 @@ namespace UnitsNet
             return new Energy(thermsimperial*1.05505585257348e+14);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
         public static Energy FromThermsImperial(long thermsimperial)
@@ -1003,14 +1003,14 @@ namespace UnitsNet
             return new Energy(thermsimperial*1.05505585257348e+14);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsImperial of type decimal.
         /// </summary>
         public static Energy FromThermsImperial(decimal thermsimperial)
         {
-	        return new Energy(Convert.ToDouble(thermsimperial)*1.05505585257348e+14);
+            return new Energy(Convert.ToDouble(thermsimperial)*1.05505585257348e+14);
         }
 #endif
 
@@ -1022,7 +1022,7 @@ namespace UnitsNet
             return new Energy(thermsus*1.054804e+8);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsUs.
         /// </summary>
         public static Energy FromThermsUs(int thermsus)
@@ -1030,7 +1030,7 @@ namespace UnitsNet
             return new Energy(thermsus*1.054804e+8);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsUs.
         /// </summary>
         public static Energy FromThermsUs(long thermsus)
@@ -1038,14 +1038,14 @@ namespace UnitsNet
             return new Energy(thermsus*1.054804e+8);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from ThermsUs of type decimal.
         /// </summary>
         public static Energy FromThermsUs(decimal thermsus)
         {
-	        return new Energy(Convert.ToDouble(thermsus)*1.054804e+8);
+            return new Energy(Convert.ToDouble(thermsus)*1.054804e+8);
         }
 #endif
 
@@ -1057,7 +1057,7 @@ namespace UnitsNet
             return new Energy(watthours*3600d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
         public static Energy FromWattHours(int watthours)
@@ -1065,7 +1065,7 @@ namespace UnitsNet
             return new Energy(watthours*3600d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
         public static Energy FromWattHours(long watthours)
@@ -1073,14 +1073,14 @@ namespace UnitsNet
             return new Energy(watthours*3600d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Energy from WattHours of type decimal.
         /// </summary>
         public static Energy FromWattHours(decimal watthours)
         {
-	        return new Energy(Convert.ToDouble(watthours)*3600d);
+            return new Energy(Convert.ToDouble(watthours)*3600d);
         }
 #endif
 
@@ -1101,7 +1101,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable BritishThermalUnits.
         /// </summary>
         public static Energy? FromBritishThermalUnits(int? britishthermalunits)
@@ -1116,7 +1116,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable BritishThermalUnits.
         /// </summary>
         public static Energy? FromBritishThermalUnits(long? britishthermalunits)
@@ -1131,7 +1131,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from BritishThermalUnits of type decimal.
         /// </summary>
         public static Energy? FromBritishThermalUnits(decimal? britishthermalunits)
@@ -1161,7 +1161,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Calories.
         /// </summary>
         public static Energy? FromCalories(int? calories)
@@ -1176,7 +1176,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Calories.
         /// </summary>
         public static Energy? FromCalories(long? calories)
@@ -1191,7 +1191,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from Calories of type decimal.
         /// </summary>
         public static Energy? FromCalories(decimal? calories)
@@ -1221,7 +1221,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable DecathermsEc.
         /// </summary>
         public static Energy? FromDecathermsEc(int? decathermsec)
@@ -1236,7 +1236,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable DecathermsEc.
         /// </summary>
         public static Energy? FromDecathermsEc(long? decathermsec)
@@ -1251,7 +1251,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from DecathermsEc of type decimal.
         /// </summary>
         public static Energy? FromDecathermsEc(decimal? decathermsec)
@@ -1281,7 +1281,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable DecathermsImperial.
         /// </summary>
         public static Energy? FromDecathermsImperial(int? decathermsimperial)
@@ -1296,7 +1296,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable DecathermsImperial.
         /// </summary>
         public static Energy? FromDecathermsImperial(long? decathermsimperial)
@@ -1311,7 +1311,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from DecathermsImperial of type decimal.
         /// </summary>
         public static Energy? FromDecathermsImperial(decimal? decathermsimperial)
@@ -1341,7 +1341,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable DecathermsUs.
         /// </summary>
         public static Energy? FromDecathermsUs(int? decathermsus)
@@ -1356,7 +1356,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable DecathermsUs.
         /// </summary>
         public static Energy? FromDecathermsUs(long? decathermsus)
@@ -1371,7 +1371,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from DecathermsUs of type decimal.
         /// </summary>
         public static Energy? FromDecathermsUs(decimal? decathermsus)
@@ -1401,7 +1401,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ElectronVolts.
         /// </summary>
         public static Energy? FromElectronVolts(int? electronvolts)
@@ -1416,7 +1416,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ElectronVolts.
         /// </summary>
         public static Energy? FromElectronVolts(long? electronvolts)
@@ -1431,7 +1431,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from ElectronVolts of type decimal.
         /// </summary>
         public static Energy? FromElectronVolts(decimal? electronvolts)
@@ -1461,7 +1461,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Ergs.
         /// </summary>
         public static Energy? FromErgs(int? ergs)
@@ -1476,7 +1476,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Ergs.
         /// </summary>
         public static Energy? FromErgs(long? ergs)
@@ -1491,7 +1491,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from Ergs of type decimal.
         /// </summary>
         public static Energy? FromErgs(decimal? ergs)
@@ -1521,7 +1521,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable FootPounds.
         /// </summary>
         public static Energy? FromFootPounds(int? footpounds)
@@ -1536,7 +1536,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable FootPounds.
         /// </summary>
         public static Energy? FromFootPounds(long? footpounds)
@@ -1551,7 +1551,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from FootPounds of type decimal.
         /// </summary>
         public static Energy? FromFootPounds(decimal? footpounds)
@@ -1581,7 +1581,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable GigabritishThermalUnits.
         /// </summary>
         public static Energy? FromGigabritishThermalUnits(int? gigabritishthermalunits)
@@ -1596,7 +1596,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable GigabritishThermalUnits.
         /// </summary>
         public static Energy? FromGigabritishThermalUnits(long? gigabritishthermalunits)
@@ -1611,7 +1611,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from GigabritishThermalUnits of type decimal.
         /// </summary>
         public static Energy? FromGigabritishThermalUnits(decimal? gigabritishthermalunits)
@@ -1641,7 +1641,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable GigawattHours.
         /// </summary>
         public static Energy? FromGigawattHours(int? gigawatthours)
@@ -1656,7 +1656,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable GigawattHours.
         /// </summary>
         public static Energy? FromGigawattHours(long? gigawatthours)
@@ -1671,7 +1671,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from GigawattHours of type decimal.
         /// </summary>
         public static Energy? FromGigawattHours(decimal? gigawatthours)
@@ -1701,7 +1701,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Joules.
         /// </summary>
         public static Energy? FromJoules(int? joules)
@@ -1716,7 +1716,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Joules.
         /// </summary>
         public static Energy? FromJoules(long? joules)
@@ -1731,7 +1731,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from Joules of type decimal.
         /// </summary>
         public static Energy? FromJoules(decimal? joules)
@@ -1761,7 +1761,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable KilobritishThermalUnits.
         /// </summary>
         public static Energy? FromKilobritishThermalUnits(int? kilobritishthermalunits)
@@ -1776,7 +1776,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable KilobritishThermalUnits.
         /// </summary>
         public static Energy? FromKilobritishThermalUnits(long? kilobritishthermalunits)
@@ -1791,7 +1791,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from KilobritishThermalUnits of type decimal.
         /// </summary>
         public static Energy? FromKilobritishThermalUnits(decimal? kilobritishthermalunits)
@@ -1821,7 +1821,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Kilocalories.
         /// </summary>
         public static Energy? FromKilocalories(int? kilocalories)
@@ -1836,7 +1836,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Kilocalories.
         /// </summary>
         public static Energy? FromKilocalories(long? kilocalories)
@@ -1851,7 +1851,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from Kilocalories of type decimal.
         /// </summary>
         public static Energy? FromKilocalories(decimal? kilocalories)
@@ -1881,7 +1881,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Kilojoules.
         /// </summary>
         public static Energy? FromKilojoules(int? kilojoules)
@@ -1896,7 +1896,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Kilojoules.
         /// </summary>
         public static Energy? FromKilojoules(long? kilojoules)
@@ -1911,7 +1911,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from Kilojoules of type decimal.
         /// </summary>
         public static Energy? FromKilojoules(decimal? kilojoules)
@@ -1941,7 +1941,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable KilowattHours.
         /// </summary>
         public static Energy? FromKilowattHours(int? kilowatthours)
@@ -1956,7 +1956,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable KilowattHours.
         /// </summary>
         public static Energy? FromKilowattHours(long? kilowatthours)
@@ -1971,7 +1971,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from KilowattHours of type decimal.
         /// </summary>
         public static Energy? FromKilowattHours(decimal? kilowatthours)
@@ -2001,7 +2001,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable MegabritishThermalUnits.
         /// </summary>
         public static Energy? FromMegabritishThermalUnits(int? megabritishthermalunits)
@@ -2016,7 +2016,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable MegabritishThermalUnits.
         /// </summary>
         public static Energy? FromMegabritishThermalUnits(long? megabritishthermalunits)
@@ -2031,7 +2031,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from MegabritishThermalUnits of type decimal.
         /// </summary>
         public static Energy? FromMegabritishThermalUnits(decimal? megabritishthermalunits)
@@ -2061,7 +2061,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Megajoules.
         /// </summary>
         public static Energy? FromMegajoules(int? megajoules)
@@ -2076,7 +2076,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable Megajoules.
         /// </summary>
         public static Energy? FromMegajoules(long? megajoules)
@@ -2091,7 +2091,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from Megajoules of type decimal.
         /// </summary>
         public static Energy? FromMegajoules(decimal? megajoules)
@@ -2121,7 +2121,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable MegawattHours.
         /// </summary>
         public static Energy? FromMegawattHours(int? megawatthours)
@@ -2136,7 +2136,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable MegawattHours.
         /// </summary>
         public static Energy? FromMegawattHours(long? megawatthours)
@@ -2151,7 +2151,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from MegawattHours of type decimal.
         /// </summary>
         public static Energy? FromMegawattHours(decimal? megawatthours)
@@ -2181,7 +2181,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ThermsEc.
         /// </summary>
         public static Energy? FromThermsEc(int? thermsec)
@@ -2196,7 +2196,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ThermsEc.
         /// </summary>
         public static Energy? FromThermsEc(long? thermsec)
@@ -2211,7 +2211,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from ThermsEc of type decimal.
         /// </summary>
         public static Energy? FromThermsEc(decimal? thermsec)
@@ -2241,7 +2241,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ThermsImperial.
         /// </summary>
         public static Energy? FromThermsImperial(int? thermsimperial)
@@ -2256,7 +2256,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ThermsImperial.
         /// </summary>
         public static Energy? FromThermsImperial(long? thermsimperial)
@@ -2271,7 +2271,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from ThermsImperial of type decimal.
         /// </summary>
         public static Energy? FromThermsImperial(decimal? thermsimperial)
@@ -2301,7 +2301,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ThermsUs.
         /// </summary>
         public static Energy? FromThermsUs(int? thermsus)
@@ -2316,7 +2316,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable ThermsUs.
         /// </summary>
         public static Energy? FromThermsUs(long? thermsus)
@@ -2331,7 +2331,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from ThermsUs of type decimal.
         /// </summary>
         public static Energy? FromThermsUs(decimal? thermsus)
@@ -2361,7 +2361,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable WattHours.
         /// </summary>
         public static Energy? FromWattHours(int? watthours)
@@ -2376,7 +2376,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from nullable WattHours.
         /// </summary>
         public static Energy? FromWattHours(long? watthours)
@@ -2391,7 +2391,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Energy from WattHours of type decimal.
         /// </summary>
         public static Energy? FromWattHours(decimal? watthours)

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _cubicMetersPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Flow() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Flow;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static FlowUnit BaseUnit
         {
             get { return FlowUnit.CubicMeterPerSecond; }
@@ -282,7 +282,7 @@ namespace UnitsNet
             return new Flow((centilitersperminute/60000.00000) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CentilitersPerMinute.
         /// </summary>
         public static Flow FromCentilitersPerMinute(int centilitersperminute)
@@ -290,7 +290,7 @@ namespace UnitsNet
             return new Flow((centilitersperminute/60000.00000) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CentilitersPerMinute.
         /// </summary>
         public static Flow FromCentilitersPerMinute(long centilitersperminute)
@@ -298,14 +298,14 @@ namespace UnitsNet
             return new Flow((centilitersperminute/60000.00000) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CentilitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromCentilitersPerMinute(decimal centilitersperminute)
         {
-	        return new Flow((Convert.ToDouble(centilitersperminute)/60000.00000) * 1e-2d);
+            return new Flow((Convert.ToDouble(centilitersperminute)/60000.00000) * 1e-2d);
         }
 #endif
 
@@ -317,7 +317,7 @@ namespace UnitsNet
             return new Flow(cubicdecimetersperminute/60000.00000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicDecimetersPerMinute.
         /// </summary>
         public static Flow FromCubicDecimetersPerMinute(int cubicdecimetersperminute)
@@ -325,7 +325,7 @@ namespace UnitsNet
             return new Flow(cubicdecimetersperminute/60000.00000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicDecimetersPerMinute.
         /// </summary>
         public static Flow FromCubicDecimetersPerMinute(long cubicdecimetersperminute)
@@ -333,14 +333,14 @@ namespace UnitsNet
             return new Flow(cubicdecimetersperminute/60000.00000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicDecimetersPerMinute of type decimal.
         /// </summary>
         public static Flow FromCubicDecimetersPerMinute(decimal cubicdecimetersperminute)
         {
-	        return new Flow(Convert.ToDouble(cubicdecimetersperminute)/60000.00000);
+            return new Flow(Convert.ToDouble(cubicdecimetersperminute)/60000.00000);
         }
 #endif
 
@@ -352,7 +352,7 @@ namespace UnitsNet
             return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicFeetPerHour.
         /// </summary>
         public static Flow FromCubicFeetPerHour(int cubicfeetperhour)
@@ -360,7 +360,7 @@ namespace UnitsNet
             return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicFeetPerHour.
         /// </summary>
         public static Flow FromCubicFeetPerHour(long cubicfeetperhour)
@@ -368,14 +368,14 @@ namespace UnitsNet
             return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicFeetPerHour of type decimal.
         /// </summary>
         public static Flow FromCubicFeetPerHour(decimal cubicfeetperhour)
         {
-	        return new Flow(Convert.ToDouble(cubicfeetperhour)*7.8657907199999087346816086183876e-6);
+            return new Flow(Convert.ToDouble(cubicfeetperhour)*7.8657907199999087346816086183876e-6);
         }
 #endif
 
@@ -387,7 +387,7 @@ namespace UnitsNet
             return new Flow(cubicfeetpersecond/35.314666721);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicFeetPerSecond.
         /// </summary>
         public static Flow FromCubicFeetPerSecond(int cubicfeetpersecond)
@@ -395,7 +395,7 @@ namespace UnitsNet
             return new Flow(cubicfeetpersecond/35.314666721);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicFeetPerSecond.
         /// </summary>
         public static Flow FromCubicFeetPerSecond(long cubicfeetpersecond)
@@ -403,14 +403,14 @@ namespace UnitsNet
             return new Flow(cubicfeetpersecond/35.314666721);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicFeetPerSecond of type decimal.
         /// </summary>
         public static Flow FromCubicFeetPerSecond(decimal cubicfeetpersecond)
         {
-	        return new Flow(Convert.ToDouble(cubicfeetpersecond)/35.314666721);
+            return new Flow(Convert.ToDouble(cubicfeetpersecond)/35.314666721);
         }
 #endif
 
@@ -422,7 +422,7 @@ namespace UnitsNet
             return new Flow(cubicmetersperhour/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicMetersPerHour.
         /// </summary>
         public static Flow FromCubicMetersPerHour(int cubicmetersperhour)
@@ -430,7 +430,7 @@ namespace UnitsNet
             return new Flow(cubicmetersperhour/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicMetersPerHour.
         /// </summary>
         public static Flow FromCubicMetersPerHour(long cubicmetersperhour)
@@ -438,14 +438,14 @@ namespace UnitsNet
             return new Flow(cubicmetersperhour/3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicMetersPerHour of type decimal.
         /// </summary>
         public static Flow FromCubicMetersPerHour(decimal cubicmetersperhour)
         {
-	        return new Flow(Convert.ToDouble(cubicmetersperhour)/3600);
+            return new Flow(Convert.ToDouble(cubicmetersperhour)/3600);
         }
 #endif
 
@@ -457,7 +457,7 @@ namespace UnitsNet
             return new Flow(cubicmeterspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicMetersPerSecond.
         /// </summary>
         public static Flow FromCubicMetersPerSecond(int cubicmeterspersecond)
@@ -465,7 +465,7 @@ namespace UnitsNet
             return new Flow(cubicmeterspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicMetersPerSecond.
         /// </summary>
         public static Flow FromCubicMetersPerSecond(long cubicmeterspersecond)
@@ -473,14 +473,14 @@ namespace UnitsNet
             return new Flow(cubicmeterspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from CubicMetersPerSecond of type decimal.
         /// </summary>
         public static Flow FromCubicMetersPerSecond(decimal cubicmeterspersecond)
         {
-	        return new Flow(Convert.ToDouble(cubicmeterspersecond));
+            return new Flow(Convert.ToDouble(cubicmeterspersecond));
         }
 #endif
 
@@ -492,7 +492,7 @@ namespace UnitsNet
             return new Flow((decilitersperminute/60000.00000) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from DecilitersPerMinute.
         /// </summary>
         public static Flow FromDecilitersPerMinute(int decilitersperminute)
@@ -500,7 +500,7 @@ namespace UnitsNet
             return new Flow((decilitersperminute/60000.00000) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from DecilitersPerMinute.
         /// </summary>
         public static Flow FromDecilitersPerMinute(long decilitersperminute)
@@ -508,14 +508,14 @@ namespace UnitsNet
             return new Flow((decilitersperminute/60000.00000) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from DecilitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromDecilitersPerMinute(decimal decilitersperminute)
         {
-	        return new Flow((Convert.ToDouble(decilitersperminute)/60000.00000) * 1e-1d);
+            return new Flow((Convert.ToDouble(decilitersperminute)/60000.00000) * 1e-1d);
         }
 #endif
 
@@ -527,7 +527,7 @@ namespace UnitsNet
             return new Flow((kilolitersperminute/60000.00000) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from KilolitersPerMinute.
         /// </summary>
         public static Flow FromKilolitersPerMinute(int kilolitersperminute)
@@ -535,7 +535,7 @@ namespace UnitsNet
             return new Flow((kilolitersperminute/60000.00000) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from KilolitersPerMinute.
         /// </summary>
         public static Flow FromKilolitersPerMinute(long kilolitersperminute)
@@ -543,14 +543,14 @@ namespace UnitsNet
             return new Flow((kilolitersperminute/60000.00000) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from KilolitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromKilolitersPerMinute(decimal kilolitersperminute)
         {
-	        return new Flow((Convert.ToDouble(kilolitersperminute)/60000.00000) * 1e3d);
+            return new Flow((Convert.ToDouble(kilolitersperminute)/60000.00000) * 1e3d);
         }
 #endif
 
@@ -562,7 +562,7 @@ namespace UnitsNet
             return new Flow(litersperhour/3600000.000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerHour.
         /// </summary>
         public static Flow FromLitersPerHour(int litersperhour)
@@ -570,7 +570,7 @@ namespace UnitsNet
             return new Flow(litersperhour/3600000.000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerHour.
         /// </summary>
         public static Flow FromLitersPerHour(long litersperhour)
@@ -578,14 +578,14 @@ namespace UnitsNet
             return new Flow(litersperhour/3600000.000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerHour of type decimal.
         /// </summary>
         public static Flow FromLitersPerHour(decimal litersperhour)
         {
-	        return new Flow(Convert.ToDouble(litersperhour)/3600000.000);
+            return new Flow(Convert.ToDouble(litersperhour)/3600000.000);
         }
 #endif
 
@@ -597,7 +597,7 @@ namespace UnitsNet
             return new Flow(litersperminute/60000.00000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerMinute.
         /// </summary>
         public static Flow FromLitersPerMinute(int litersperminute)
@@ -605,7 +605,7 @@ namespace UnitsNet
             return new Flow(litersperminute/60000.00000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerMinute.
         /// </summary>
         public static Flow FromLitersPerMinute(long litersperminute)
@@ -613,14 +613,14 @@ namespace UnitsNet
             return new Flow(litersperminute/60000.00000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromLitersPerMinute(decimal litersperminute)
         {
-	        return new Flow(Convert.ToDouble(litersperminute)/60000.00000);
+            return new Flow(Convert.ToDouble(litersperminute)/60000.00000);
         }
 #endif
 
@@ -632,7 +632,7 @@ namespace UnitsNet
             return new Flow(literspersecond/1000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerSecond.
         /// </summary>
         public static Flow FromLitersPerSecond(int literspersecond)
@@ -640,7 +640,7 @@ namespace UnitsNet
             return new Flow(literspersecond/1000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerSecond.
         /// </summary>
         public static Flow FromLitersPerSecond(long literspersecond)
@@ -648,14 +648,14 @@ namespace UnitsNet
             return new Flow(literspersecond/1000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from LitersPerSecond of type decimal.
         /// </summary>
         public static Flow FromLitersPerSecond(decimal literspersecond)
         {
-	        return new Flow(Convert.ToDouble(literspersecond)/1000);
+            return new Flow(Convert.ToDouble(literspersecond)/1000);
         }
 #endif
 
@@ -667,7 +667,7 @@ namespace UnitsNet
             return new Flow((microlitersperminute/60000.00000) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MicrolitersPerMinute.
         /// </summary>
         public static Flow FromMicrolitersPerMinute(int microlitersperminute)
@@ -675,7 +675,7 @@ namespace UnitsNet
             return new Flow((microlitersperminute/60000.00000) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MicrolitersPerMinute.
         /// </summary>
         public static Flow FromMicrolitersPerMinute(long microlitersperminute)
@@ -683,14 +683,14 @@ namespace UnitsNet
             return new Flow((microlitersperminute/60000.00000) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MicrolitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromMicrolitersPerMinute(decimal microlitersperminute)
         {
-	        return new Flow((Convert.ToDouble(microlitersperminute)/60000.00000) * 1e-6d);
+            return new Flow((Convert.ToDouble(microlitersperminute)/60000.00000) * 1e-6d);
         }
 #endif
 
@@ -702,7 +702,7 @@ namespace UnitsNet
             return new Flow((millilitersperminute/60000.00000) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MillilitersPerMinute.
         /// </summary>
         public static Flow FromMillilitersPerMinute(int millilitersperminute)
@@ -710,7 +710,7 @@ namespace UnitsNet
             return new Flow((millilitersperminute/60000.00000) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MillilitersPerMinute.
         /// </summary>
         public static Flow FromMillilitersPerMinute(long millilitersperminute)
@@ -718,14 +718,14 @@ namespace UnitsNet
             return new Flow((millilitersperminute/60000.00000) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MillilitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromMillilitersPerMinute(decimal millilitersperminute)
         {
-	        return new Flow((Convert.ToDouble(millilitersperminute)/60000.00000) * 1e-3d);
+            return new Flow((Convert.ToDouble(millilitersperminute)/60000.00000) * 1e-3d);
         }
 #endif
 
@@ -737,7 +737,7 @@ namespace UnitsNet
             return new Flow(millionusgallonsperday/22.824465227);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MillionUsGallonsPerDay.
         /// </summary>
         public static Flow FromMillionUsGallonsPerDay(int millionusgallonsperday)
@@ -745,7 +745,7 @@ namespace UnitsNet
             return new Flow(millionusgallonsperday/22.824465227);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MillionUsGallonsPerDay.
         /// </summary>
         public static Flow FromMillionUsGallonsPerDay(long millionusgallonsperday)
@@ -753,14 +753,14 @@ namespace UnitsNet
             return new Flow(millionusgallonsperday/22.824465227);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from MillionUsGallonsPerDay of type decimal.
         /// </summary>
         public static Flow FromMillionUsGallonsPerDay(decimal millionusgallonsperday)
         {
-	        return new Flow(Convert.ToDouble(millionusgallonsperday)/22.824465227);
+            return new Flow(Convert.ToDouble(millionusgallonsperday)/22.824465227);
         }
 #endif
 
@@ -772,7 +772,7 @@ namespace UnitsNet
             return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from NanolitersPerMinute.
         /// </summary>
         public static Flow FromNanolitersPerMinute(int nanolitersperminute)
@@ -780,7 +780,7 @@ namespace UnitsNet
             return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from NanolitersPerMinute.
         /// </summary>
         public static Flow FromNanolitersPerMinute(long nanolitersperminute)
@@ -788,14 +788,14 @@ namespace UnitsNet
             return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from NanolitersPerMinute of type decimal.
         /// </summary>
         public static Flow FromNanolitersPerMinute(decimal nanolitersperminute)
         {
-	        return new Flow((Convert.ToDouble(nanolitersperminute)/60000.00000) * 1e-9d);
+            return new Flow((Convert.ToDouble(nanolitersperminute)/60000.00000) * 1e-9d);
         }
 #endif
 
@@ -807,7 +807,7 @@ namespace UnitsNet
             return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from OilBarrelsPerDay.
         /// </summary>
         public static Flow FromOilBarrelsPerDay(int oilbarrelsperday)
@@ -815,7 +815,7 @@ namespace UnitsNet
             return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from OilBarrelsPerDay.
         /// </summary>
         public static Flow FromOilBarrelsPerDay(long oilbarrelsperday)
@@ -823,14 +823,14 @@ namespace UnitsNet
             return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from OilBarrelsPerDay of type decimal.
         /// </summary>
         public static Flow FromOilBarrelsPerDay(decimal oilbarrelsperday)
         {
-	        return new Flow(Convert.ToDouble(oilbarrelsperday)*1.8401307283333333333333333333333e-6);
+            return new Flow(Convert.ToDouble(oilbarrelsperday)*1.8401307283333333333333333333333e-6);
         }
 #endif
 
@@ -842,7 +842,7 @@ namespace UnitsNet
             return new Flow(usgallonsperminute/15850.323141489);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from UsGallonsPerMinute.
         /// </summary>
         public static Flow FromUsGallonsPerMinute(int usgallonsperminute)
@@ -850,7 +850,7 @@ namespace UnitsNet
             return new Flow(usgallonsperminute/15850.323141489);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Flow from UsGallonsPerMinute.
         /// </summary>
         public static Flow FromUsGallonsPerMinute(long usgallonsperminute)
@@ -858,14 +858,14 @@ namespace UnitsNet
             return new Flow(usgallonsperminute/15850.323141489);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Flow from UsGallonsPerMinute of type decimal.
         /// </summary>
         public static Flow FromUsGallonsPerMinute(decimal usgallonsperminute)
         {
-	        return new Flow(Convert.ToDouble(usgallonsperminute)/15850.323141489);
+            return new Flow(Convert.ToDouble(usgallonsperminute)/15850.323141489);
         }
 #endif
 
@@ -886,7 +886,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CentilitersPerMinute.
         /// </summary>
         public static Flow? FromCentilitersPerMinute(int? centilitersperminute)
@@ -901,7 +901,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CentilitersPerMinute.
         /// </summary>
         public static Flow? FromCentilitersPerMinute(long? centilitersperminute)
@@ -916,7 +916,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from CentilitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromCentilitersPerMinute(decimal? centilitersperminute)
@@ -946,7 +946,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
         /// </summary>
         public static Flow? FromCubicDecimetersPerMinute(int? cubicdecimetersperminute)
@@ -961,7 +961,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
         /// </summary>
         public static Flow? FromCubicDecimetersPerMinute(long? cubicdecimetersperminute)
@@ -976,7 +976,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from CubicDecimetersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromCubicDecimetersPerMinute(decimal? cubicdecimetersperminute)
@@ -1006,7 +1006,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerHour.
         /// </summary>
         public static Flow? FromCubicFeetPerHour(int? cubicfeetperhour)
@@ -1021,7 +1021,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerHour.
         /// </summary>
         public static Flow? FromCubicFeetPerHour(long? cubicfeetperhour)
@@ -1036,7 +1036,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from CubicFeetPerHour of type decimal.
         /// </summary>
         public static Flow? FromCubicFeetPerHour(decimal? cubicfeetperhour)
@@ -1066,7 +1066,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerSecond.
         /// </summary>
         public static Flow? FromCubicFeetPerSecond(int? cubicfeetpersecond)
@@ -1081,7 +1081,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerSecond.
         /// </summary>
         public static Flow? FromCubicFeetPerSecond(long? cubicfeetpersecond)
@@ -1096,7 +1096,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from CubicFeetPerSecond of type decimal.
         /// </summary>
         public static Flow? FromCubicFeetPerSecond(decimal? cubicfeetpersecond)
@@ -1126,7 +1126,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerHour.
         /// </summary>
         public static Flow? FromCubicMetersPerHour(int? cubicmetersperhour)
@@ -1141,7 +1141,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerHour.
         /// </summary>
         public static Flow? FromCubicMetersPerHour(long? cubicmetersperhour)
@@ -1156,7 +1156,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from CubicMetersPerHour of type decimal.
         /// </summary>
         public static Flow? FromCubicMetersPerHour(decimal? cubicmetersperhour)
@@ -1186,7 +1186,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerSecond.
         /// </summary>
         public static Flow? FromCubicMetersPerSecond(int? cubicmeterspersecond)
@@ -1201,7 +1201,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerSecond.
         /// </summary>
         public static Flow? FromCubicMetersPerSecond(long? cubicmeterspersecond)
@@ -1216,7 +1216,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from CubicMetersPerSecond of type decimal.
         /// </summary>
         public static Flow? FromCubicMetersPerSecond(decimal? cubicmeterspersecond)
@@ -1246,7 +1246,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable DecilitersPerMinute.
         /// </summary>
         public static Flow? FromDecilitersPerMinute(int? decilitersperminute)
@@ -1261,7 +1261,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable DecilitersPerMinute.
         /// </summary>
         public static Flow? FromDecilitersPerMinute(long? decilitersperminute)
@@ -1276,7 +1276,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from DecilitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromDecilitersPerMinute(decimal? decilitersperminute)
@@ -1306,7 +1306,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable KilolitersPerMinute.
         /// </summary>
         public static Flow? FromKilolitersPerMinute(int? kilolitersperminute)
@@ -1321,7 +1321,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable KilolitersPerMinute.
         /// </summary>
         public static Flow? FromKilolitersPerMinute(long? kilolitersperminute)
@@ -1336,7 +1336,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from KilolitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromKilolitersPerMinute(decimal? kilolitersperminute)
@@ -1366,7 +1366,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable LitersPerHour.
         /// </summary>
         public static Flow? FromLitersPerHour(int? litersperhour)
@@ -1381,7 +1381,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable LitersPerHour.
         /// </summary>
         public static Flow? FromLitersPerHour(long? litersperhour)
@@ -1396,7 +1396,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from LitersPerHour of type decimal.
         /// </summary>
         public static Flow? FromLitersPerHour(decimal? litersperhour)
@@ -1426,7 +1426,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable LitersPerMinute.
         /// </summary>
         public static Flow? FromLitersPerMinute(int? litersperminute)
@@ -1441,7 +1441,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable LitersPerMinute.
         /// </summary>
         public static Flow? FromLitersPerMinute(long? litersperminute)
@@ -1456,7 +1456,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from LitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromLitersPerMinute(decimal? litersperminute)
@@ -1486,7 +1486,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable LitersPerSecond.
         /// </summary>
         public static Flow? FromLitersPerSecond(int? literspersecond)
@@ -1501,7 +1501,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable LitersPerSecond.
         /// </summary>
         public static Flow? FromLitersPerSecond(long? literspersecond)
@@ -1516,7 +1516,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from LitersPerSecond of type decimal.
         /// </summary>
         public static Flow? FromLitersPerSecond(decimal? literspersecond)
@@ -1546,7 +1546,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable MicrolitersPerMinute.
         /// </summary>
         public static Flow? FromMicrolitersPerMinute(int? microlitersperminute)
@@ -1561,7 +1561,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable MicrolitersPerMinute.
         /// </summary>
         public static Flow? FromMicrolitersPerMinute(long? microlitersperminute)
@@ -1576,7 +1576,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from MicrolitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromMicrolitersPerMinute(decimal? microlitersperminute)
@@ -1606,7 +1606,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable MillilitersPerMinute.
         /// </summary>
         public static Flow? FromMillilitersPerMinute(int? millilitersperminute)
@@ -1621,7 +1621,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable MillilitersPerMinute.
         /// </summary>
         public static Flow? FromMillilitersPerMinute(long? millilitersperminute)
@@ -1636,7 +1636,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from MillilitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromMillilitersPerMinute(decimal? millilitersperminute)
@@ -1666,7 +1666,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
         /// </summary>
         public static Flow? FromMillionUsGallonsPerDay(int? millionusgallonsperday)
@@ -1681,7 +1681,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
         /// </summary>
         public static Flow? FromMillionUsGallonsPerDay(long? millionusgallonsperday)
@@ -1696,7 +1696,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from MillionUsGallonsPerDay of type decimal.
         /// </summary>
         public static Flow? FromMillionUsGallonsPerDay(decimal? millionusgallonsperday)
@@ -1726,7 +1726,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable NanolitersPerMinute.
         /// </summary>
         public static Flow? FromNanolitersPerMinute(int? nanolitersperminute)
@@ -1741,7 +1741,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable NanolitersPerMinute.
         /// </summary>
         public static Flow? FromNanolitersPerMinute(long? nanolitersperminute)
@@ -1756,7 +1756,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from NanolitersPerMinute of type decimal.
         /// </summary>
         public static Flow? FromNanolitersPerMinute(decimal? nanolitersperminute)
@@ -1786,7 +1786,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable OilBarrelsPerDay.
         /// </summary>
         public static Flow? FromOilBarrelsPerDay(int? oilbarrelsperday)
@@ -1801,7 +1801,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable OilBarrelsPerDay.
         /// </summary>
         public static Flow? FromOilBarrelsPerDay(long? oilbarrelsperday)
@@ -1816,7 +1816,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from OilBarrelsPerDay of type decimal.
         /// </summary>
         public static Flow? FromOilBarrelsPerDay(decimal? oilbarrelsperday)
@@ -1846,7 +1846,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable UsGallonsPerMinute.
         /// </summary>
         public static Flow? FromUsGallonsPerMinute(int? usgallonsperminute)
@@ -1861,7 +1861,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from nullable UsGallonsPerMinute.
         /// </summary>
         public static Flow? FromUsGallonsPerMinute(long? usgallonsperminute)
@@ -1876,7 +1876,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Flow from UsGallonsPerMinute of type decimal.
         /// </summary>
         public static Flow? FromUsGallonsPerMinute(decimal? usgallonsperminute)

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -282,6 +282,33 @@ namespace UnitsNet
             return new Flow((centilitersperminute/60000.00000) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Flow from CentilitersPerMinute.
+        /// </summary>
+        public static Flow FromCentilitersPerMinute(int centilitersperminute)
+        {
+            return new Flow((centilitersperminute/60000.00000) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Flow from CentilitersPerMinute.
+        /// </summary>
+        public static Flow FromCentilitersPerMinute(long centilitersperminute)
+        {
+            return new Flow((centilitersperminute/60000.00000) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from CentilitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromCentilitersPerMinute(decimal centilitersperminute)
+        {
+	        return new Flow((Convert.ToDouble(centilitersperminute)/60000.00000) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from CubicDecimetersPerMinute.
         /// </summary>
@@ -289,6 +316,33 @@ namespace UnitsNet
         {
             return new Flow(cubicdecimetersperminute/60000.00000);
         }
+
+		/// <summary>
+        ///     Get Flow from CubicDecimetersPerMinute.
+        /// </summary>
+        public static Flow FromCubicDecimetersPerMinute(int cubicdecimetersperminute)
+        {
+            return new Flow(cubicdecimetersperminute/60000.00000);
+        }
+
+		/// <summary>
+        ///     Get Flow from CubicDecimetersPerMinute.
+        /// </summary>
+        public static Flow FromCubicDecimetersPerMinute(long cubicdecimetersperminute)
+        {
+            return new Flow(cubicdecimetersperminute/60000.00000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from CubicDecimetersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromCubicDecimetersPerMinute(decimal cubicdecimetersperminute)
+        {
+	        return new Flow(Convert.ToDouble(cubicdecimetersperminute)/60000.00000);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from CubicFeetPerHour.
@@ -298,6 +352,33 @@ namespace UnitsNet
             return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
         }
 
+		/// <summary>
+        ///     Get Flow from CubicFeetPerHour.
+        /// </summary>
+        public static Flow FromCubicFeetPerHour(int cubicfeetperhour)
+        {
+            return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
+        }
+
+		/// <summary>
+        ///     Get Flow from CubicFeetPerHour.
+        /// </summary>
+        public static Flow FromCubicFeetPerHour(long cubicfeetperhour)
+        {
+            return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from CubicFeetPerHour of type decimal.
+        /// </summary>
+        public static Flow FromCubicFeetPerHour(decimal cubicfeetperhour)
+        {
+	        return new Flow(Convert.ToDouble(cubicfeetperhour)*7.8657907199999087346816086183876e-6);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from CubicFeetPerSecond.
         /// </summary>
@@ -305,6 +386,33 @@ namespace UnitsNet
         {
             return new Flow(cubicfeetpersecond/35.314666721);
         }
+
+		/// <summary>
+        ///     Get Flow from CubicFeetPerSecond.
+        /// </summary>
+        public static Flow FromCubicFeetPerSecond(int cubicfeetpersecond)
+        {
+            return new Flow(cubicfeetpersecond/35.314666721);
+        }
+
+		/// <summary>
+        ///     Get Flow from CubicFeetPerSecond.
+        /// </summary>
+        public static Flow FromCubicFeetPerSecond(long cubicfeetpersecond)
+        {
+            return new Flow(cubicfeetpersecond/35.314666721);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from CubicFeetPerSecond of type decimal.
+        /// </summary>
+        public static Flow FromCubicFeetPerSecond(decimal cubicfeetpersecond)
+        {
+	        return new Flow(Convert.ToDouble(cubicfeetpersecond)/35.314666721);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from CubicMetersPerHour.
@@ -314,6 +422,33 @@ namespace UnitsNet
             return new Flow(cubicmetersperhour/3600);
         }
 
+		/// <summary>
+        ///     Get Flow from CubicMetersPerHour.
+        /// </summary>
+        public static Flow FromCubicMetersPerHour(int cubicmetersperhour)
+        {
+            return new Flow(cubicmetersperhour/3600);
+        }
+
+		/// <summary>
+        ///     Get Flow from CubicMetersPerHour.
+        /// </summary>
+        public static Flow FromCubicMetersPerHour(long cubicmetersperhour)
+        {
+            return new Flow(cubicmetersperhour/3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from CubicMetersPerHour of type decimal.
+        /// </summary>
+        public static Flow FromCubicMetersPerHour(decimal cubicmetersperhour)
+        {
+	        return new Flow(Convert.ToDouble(cubicmetersperhour)/3600);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from CubicMetersPerSecond.
         /// </summary>
@@ -321,6 +456,33 @@ namespace UnitsNet
         {
             return new Flow(cubicmeterspersecond);
         }
+
+		/// <summary>
+        ///     Get Flow from CubicMetersPerSecond.
+        /// </summary>
+        public static Flow FromCubicMetersPerSecond(int cubicmeterspersecond)
+        {
+            return new Flow(cubicmeterspersecond);
+        }
+
+		/// <summary>
+        ///     Get Flow from CubicMetersPerSecond.
+        /// </summary>
+        public static Flow FromCubicMetersPerSecond(long cubicmeterspersecond)
+        {
+            return new Flow(cubicmeterspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from CubicMetersPerSecond of type decimal.
+        /// </summary>
+        public static Flow FromCubicMetersPerSecond(decimal cubicmeterspersecond)
+        {
+	        return new Flow(Convert.ToDouble(cubicmeterspersecond));
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from DecilitersPerMinute.
@@ -330,6 +492,33 @@ namespace UnitsNet
             return new Flow((decilitersperminute/60000.00000) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get Flow from DecilitersPerMinute.
+        /// </summary>
+        public static Flow FromDecilitersPerMinute(int decilitersperminute)
+        {
+            return new Flow((decilitersperminute/60000.00000) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Flow from DecilitersPerMinute.
+        /// </summary>
+        public static Flow FromDecilitersPerMinute(long decilitersperminute)
+        {
+            return new Flow((decilitersperminute/60000.00000) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from DecilitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromDecilitersPerMinute(decimal decilitersperminute)
+        {
+	        return new Flow((Convert.ToDouble(decilitersperminute)/60000.00000) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from KilolitersPerMinute.
         /// </summary>
@@ -337,6 +526,33 @@ namespace UnitsNet
         {
             return new Flow((kilolitersperminute/60000.00000) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Flow from KilolitersPerMinute.
+        /// </summary>
+        public static Flow FromKilolitersPerMinute(int kilolitersperminute)
+        {
+            return new Flow((kilolitersperminute/60000.00000) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Flow from KilolitersPerMinute.
+        /// </summary>
+        public static Flow FromKilolitersPerMinute(long kilolitersperminute)
+        {
+            return new Flow((kilolitersperminute/60000.00000) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from KilolitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromKilolitersPerMinute(decimal kilolitersperminute)
+        {
+	        return new Flow((Convert.ToDouble(kilolitersperminute)/60000.00000) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from LitersPerHour.
@@ -346,6 +562,33 @@ namespace UnitsNet
             return new Flow(litersperhour/3600000.000);
         }
 
+		/// <summary>
+        ///     Get Flow from LitersPerHour.
+        /// </summary>
+        public static Flow FromLitersPerHour(int litersperhour)
+        {
+            return new Flow(litersperhour/3600000.000);
+        }
+
+		/// <summary>
+        ///     Get Flow from LitersPerHour.
+        /// </summary>
+        public static Flow FromLitersPerHour(long litersperhour)
+        {
+            return new Flow(litersperhour/3600000.000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from LitersPerHour of type decimal.
+        /// </summary>
+        public static Flow FromLitersPerHour(decimal litersperhour)
+        {
+	        return new Flow(Convert.ToDouble(litersperhour)/3600000.000);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from LitersPerMinute.
         /// </summary>
@@ -353,6 +596,33 @@ namespace UnitsNet
         {
             return new Flow(litersperminute/60000.00000);
         }
+
+		/// <summary>
+        ///     Get Flow from LitersPerMinute.
+        /// </summary>
+        public static Flow FromLitersPerMinute(int litersperminute)
+        {
+            return new Flow(litersperminute/60000.00000);
+        }
+
+		/// <summary>
+        ///     Get Flow from LitersPerMinute.
+        /// </summary>
+        public static Flow FromLitersPerMinute(long litersperminute)
+        {
+            return new Flow(litersperminute/60000.00000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from LitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromLitersPerMinute(decimal litersperminute)
+        {
+	        return new Flow(Convert.ToDouble(litersperminute)/60000.00000);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from LitersPerSecond.
@@ -362,6 +632,33 @@ namespace UnitsNet
             return new Flow(literspersecond/1000);
         }
 
+		/// <summary>
+        ///     Get Flow from LitersPerSecond.
+        /// </summary>
+        public static Flow FromLitersPerSecond(int literspersecond)
+        {
+            return new Flow(literspersecond/1000);
+        }
+
+		/// <summary>
+        ///     Get Flow from LitersPerSecond.
+        /// </summary>
+        public static Flow FromLitersPerSecond(long literspersecond)
+        {
+            return new Flow(literspersecond/1000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from LitersPerSecond of type decimal.
+        /// </summary>
+        public static Flow FromLitersPerSecond(decimal literspersecond)
+        {
+	        return new Flow(Convert.ToDouble(literspersecond)/1000);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from MicrolitersPerMinute.
         /// </summary>
@@ -369,6 +666,33 @@ namespace UnitsNet
         {
             return new Flow((microlitersperminute/60000.00000) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get Flow from MicrolitersPerMinute.
+        /// </summary>
+        public static Flow FromMicrolitersPerMinute(int microlitersperminute)
+        {
+            return new Flow((microlitersperminute/60000.00000) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Flow from MicrolitersPerMinute.
+        /// </summary>
+        public static Flow FromMicrolitersPerMinute(long microlitersperminute)
+        {
+            return new Flow((microlitersperminute/60000.00000) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from MicrolitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromMicrolitersPerMinute(decimal microlitersperminute)
+        {
+	        return new Flow((Convert.ToDouble(microlitersperminute)/60000.00000) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from MillilitersPerMinute.
@@ -378,6 +702,33 @@ namespace UnitsNet
             return new Flow((millilitersperminute/60000.00000) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Flow from MillilitersPerMinute.
+        /// </summary>
+        public static Flow FromMillilitersPerMinute(int millilitersperminute)
+        {
+            return new Flow((millilitersperminute/60000.00000) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Flow from MillilitersPerMinute.
+        /// </summary>
+        public static Flow FromMillilitersPerMinute(long millilitersperminute)
+        {
+            return new Flow((millilitersperminute/60000.00000) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from MillilitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromMillilitersPerMinute(decimal millilitersperminute)
+        {
+	        return new Flow((Convert.ToDouble(millilitersperminute)/60000.00000) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from MillionUsGallonsPerDay.
         /// </summary>
@@ -385,6 +736,33 @@ namespace UnitsNet
         {
             return new Flow(millionusgallonsperday/22.824465227);
         }
+
+		/// <summary>
+        ///     Get Flow from MillionUsGallonsPerDay.
+        /// </summary>
+        public static Flow FromMillionUsGallonsPerDay(int millionusgallonsperday)
+        {
+            return new Flow(millionusgallonsperday/22.824465227);
+        }
+
+		/// <summary>
+        ///     Get Flow from MillionUsGallonsPerDay.
+        /// </summary>
+        public static Flow FromMillionUsGallonsPerDay(long millionusgallonsperday)
+        {
+            return new Flow(millionusgallonsperday/22.824465227);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from MillionUsGallonsPerDay of type decimal.
+        /// </summary>
+        public static Flow FromMillionUsGallonsPerDay(decimal millionusgallonsperday)
+        {
+	        return new Flow(Convert.ToDouble(millionusgallonsperday)/22.824465227);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from NanolitersPerMinute.
@@ -394,6 +772,33 @@ namespace UnitsNet
             return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Flow from NanolitersPerMinute.
+        /// </summary>
+        public static Flow FromNanolitersPerMinute(int nanolitersperminute)
+        {
+            return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Flow from NanolitersPerMinute.
+        /// </summary>
+        public static Flow FromNanolitersPerMinute(long nanolitersperminute)
+        {
+            return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from NanolitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromNanolitersPerMinute(decimal nanolitersperminute)
+        {
+	        return new Flow((Convert.ToDouble(nanolitersperminute)/60000.00000) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Flow from OilBarrelsPerDay.
         /// </summary>
@@ -401,6 +806,33 @@ namespace UnitsNet
         {
             return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
         }
+
+		/// <summary>
+        ///     Get Flow from OilBarrelsPerDay.
+        /// </summary>
+        public static Flow FromOilBarrelsPerDay(int oilbarrelsperday)
+        {
+            return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
+        }
+
+		/// <summary>
+        ///     Get Flow from OilBarrelsPerDay.
+        /// </summary>
+        public static Flow FromOilBarrelsPerDay(long oilbarrelsperday)
+        {
+            return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from OilBarrelsPerDay of type decimal.
+        /// </summary>
+        public static Flow FromOilBarrelsPerDay(decimal oilbarrelsperday)
+        {
+	        return new Flow(Convert.ToDouble(oilbarrelsperday)*1.8401307283333333333333333333333e-6);
+        }
+#endif
 
         /// <summary>
         ///     Get Flow from UsGallonsPerMinute.
@@ -410,12 +842,84 @@ namespace UnitsNet
             return new Flow(usgallonsperminute/15850.323141489);
         }
 
+		/// <summary>
+        ///     Get Flow from UsGallonsPerMinute.
+        /// </summary>
+        public static Flow FromUsGallonsPerMinute(int usgallonsperminute)
+        {
+            return new Flow(usgallonsperminute/15850.323141489);
+        }
+
+		/// <summary>
+        ///     Get Flow from UsGallonsPerMinute.
+        /// </summary>
+        public static Flow FromUsGallonsPerMinute(long usgallonsperminute)
+        {
+            return new Flow(usgallonsperminute/15850.323141489);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Flow from UsGallonsPerMinute of type decimal.
+        /// </summary>
+        public static Flow FromUsGallonsPerMinute(decimal usgallonsperminute)
+        {
+	        return new Flow(Convert.ToDouble(usgallonsperminute)/15850.323141489);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Flow from nullable CentilitersPerMinute.
         /// </summary>
         public static Flow? FromCentilitersPerMinute(double? centilitersperminute)
+        {
+            if (centilitersperminute.HasValue)
+            {
+                return FromCentilitersPerMinute(centilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CentilitersPerMinute.
+        /// </summary>
+        public static Flow? FromCentilitersPerMinute(int? centilitersperminute)
+        {
+            if (centilitersperminute.HasValue)
+            {
+                return FromCentilitersPerMinute(centilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CentilitersPerMinute.
+        /// </summary>
+        public static Flow? FromCentilitersPerMinute(long? centilitersperminute)
+        {
+            if (centilitersperminute.HasValue)
+            {
+                return FromCentilitersPerMinute(centilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from CentilitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromCentilitersPerMinute(decimal? centilitersperminute)
         {
             if (centilitersperminute.HasValue)
             {
@@ -442,10 +946,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
+        /// </summary>
+        public static Flow? FromCubicDecimetersPerMinute(int? cubicdecimetersperminute)
+        {
+            if (cubicdecimetersperminute.HasValue)
+            {
+                return FromCubicDecimetersPerMinute(cubicdecimetersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
+        /// </summary>
+        public static Flow? FromCubicDecimetersPerMinute(long? cubicdecimetersperminute)
+        {
+            if (cubicdecimetersperminute.HasValue)
+            {
+                return FromCubicDecimetersPerMinute(cubicdecimetersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from CubicDecimetersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromCubicDecimetersPerMinute(decimal? cubicdecimetersperminute)
+        {
+            if (cubicdecimetersperminute.HasValue)
+            {
+                return FromCubicDecimetersPerMinute(cubicdecimetersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerHour.
         /// </summary>
         public static Flow? FromCubicFeetPerHour(double? cubicfeetperhour)
+        {
+            if (cubicfeetperhour.HasValue)
+            {
+                return FromCubicFeetPerHour(cubicfeetperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicFeetPerHour.
+        /// </summary>
+        public static Flow? FromCubicFeetPerHour(int? cubicfeetperhour)
+        {
+            if (cubicfeetperhour.HasValue)
+            {
+                return FromCubicFeetPerHour(cubicfeetperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicFeetPerHour.
+        /// </summary>
+        public static Flow? FromCubicFeetPerHour(long? cubicfeetperhour)
+        {
+            if (cubicfeetperhour.HasValue)
+            {
+                return FromCubicFeetPerHour(cubicfeetperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from CubicFeetPerHour of type decimal.
+        /// </summary>
+        public static Flow? FromCubicFeetPerHour(decimal? cubicfeetperhour)
         {
             if (cubicfeetperhour.HasValue)
             {
@@ -472,10 +1066,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicFeetPerSecond.
+        /// </summary>
+        public static Flow? FromCubicFeetPerSecond(int? cubicfeetpersecond)
+        {
+            if (cubicfeetpersecond.HasValue)
+            {
+                return FromCubicFeetPerSecond(cubicfeetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicFeetPerSecond.
+        /// </summary>
+        public static Flow? FromCubicFeetPerSecond(long? cubicfeetpersecond)
+        {
+            if (cubicfeetpersecond.HasValue)
+            {
+                return FromCubicFeetPerSecond(cubicfeetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from CubicFeetPerSecond of type decimal.
+        /// </summary>
+        public static Flow? FromCubicFeetPerSecond(decimal? cubicfeetpersecond)
+        {
+            if (cubicfeetpersecond.HasValue)
+            {
+                return FromCubicFeetPerSecond(cubicfeetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerHour.
         /// </summary>
         public static Flow? FromCubicMetersPerHour(double? cubicmetersperhour)
+        {
+            if (cubicmetersperhour.HasValue)
+            {
+                return FromCubicMetersPerHour(cubicmetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicMetersPerHour.
+        /// </summary>
+        public static Flow? FromCubicMetersPerHour(int? cubicmetersperhour)
+        {
+            if (cubicmetersperhour.HasValue)
+            {
+                return FromCubicMetersPerHour(cubicmetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicMetersPerHour.
+        /// </summary>
+        public static Flow? FromCubicMetersPerHour(long? cubicmetersperhour)
+        {
+            if (cubicmetersperhour.HasValue)
+            {
+                return FromCubicMetersPerHour(cubicmetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from CubicMetersPerHour of type decimal.
+        /// </summary>
+        public static Flow? FromCubicMetersPerHour(decimal? cubicmetersperhour)
         {
             if (cubicmetersperhour.HasValue)
             {
@@ -502,10 +1186,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicMetersPerSecond.
+        /// </summary>
+        public static Flow? FromCubicMetersPerSecond(int? cubicmeterspersecond)
+        {
+            if (cubicmeterspersecond.HasValue)
+            {
+                return FromCubicMetersPerSecond(cubicmeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable CubicMetersPerSecond.
+        /// </summary>
+        public static Flow? FromCubicMetersPerSecond(long? cubicmeterspersecond)
+        {
+            if (cubicmeterspersecond.HasValue)
+            {
+                return FromCubicMetersPerSecond(cubicmeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from CubicMetersPerSecond of type decimal.
+        /// </summary>
+        public static Flow? FromCubicMetersPerSecond(decimal? cubicmeterspersecond)
+        {
+            if (cubicmeterspersecond.HasValue)
+            {
+                return FromCubicMetersPerSecond(cubicmeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable DecilitersPerMinute.
         /// </summary>
         public static Flow? FromDecilitersPerMinute(double? decilitersperminute)
+        {
+            if (decilitersperminute.HasValue)
+            {
+                return FromDecilitersPerMinute(decilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable DecilitersPerMinute.
+        /// </summary>
+        public static Flow? FromDecilitersPerMinute(int? decilitersperminute)
+        {
+            if (decilitersperminute.HasValue)
+            {
+                return FromDecilitersPerMinute(decilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable DecilitersPerMinute.
+        /// </summary>
+        public static Flow? FromDecilitersPerMinute(long? decilitersperminute)
+        {
+            if (decilitersperminute.HasValue)
+            {
+                return FromDecilitersPerMinute(decilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from DecilitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromDecilitersPerMinute(decimal? decilitersperminute)
         {
             if (decilitersperminute.HasValue)
             {
@@ -532,10 +1306,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable KilolitersPerMinute.
+        /// </summary>
+        public static Flow? FromKilolitersPerMinute(int? kilolitersperminute)
+        {
+            if (kilolitersperminute.HasValue)
+            {
+                return FromKilolitersPerMinute(kilolitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable KilolitersPerMinute.
+        /// </summary>
+        public static Flow? FromKilolitersPerMinute(long? kilolitersperminute)
+        {
+            if (kilolitersperminute.HasValue)
+            {
+                return FromKilolitersPerMinute(kilolitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from KilolitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromKilolitersPerMinute(decimal? kilolitersperminute)
+        {
+            if (kilolitersperminute.HasValue)
+            {
+                return FromKilolitersPerMinute(kilolitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable LitersPerHour.
         /// </summary>
         public static Flow? FromLitersPerHour(double? litersperhour)
+        {
+            if (litersperhour.HasValue)
+            {
+                return FromLitersPerHour(litersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable LitersPerHour.
+        /// </summary>
+        public static Flow? FromLitersPerHour(int? litersperhour)
+        {
+            if (litersperhour.HasValue)
+            {
+                return FromLitersPerHour(litersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable LitersPerHour.
+        /// </summary>
+        public static Flow? FromLitersPerHour(long? litersperhour)
+        {
+            if (litersperhour.HasValue)
+            {
+                return FromLitersPerHour(litersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from LitersPerHour of type decimal.
+        /// </summary>
+        public static Flow? FromLitersPerHour(decimal? litersperhour)
         {
             if (litersperhour.HasValue)
             {
@@ -562,10 +1426,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable LitersPerMinute.
+        /// </summary>
+        public static Flow? FromLitersPerMinute(int? litersperminute)
+        {
+            if (litersperminute.HasValue)
+            {
+                return FromLitersPerMinute(litersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable LitersPerMinute.
+        /// </summary>
+        public static Flow? FromLitersPerMinute(long? litersperminute)
+        {
+            if (litersperminute.HasValue)
+            {
+                return FromLitersPerMinute(litersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from LitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromLitersPerMinute(decimal? litersperminute)
+        {
+            if (litersperminute.HasValue)
+            {
+                return FromLitersPerMinute(litersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable LitersPerSecond.
         /// </summary>
         public static Flow? FromLitersPerSecond(double? literspersecond)
+        {
+            if (literspersecond.HasValue)
+            {
+                return FromLitersPerSecond(literspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable LitersPerSecond.
+        /// </summary>
+        public static Flow? FromLitersPerSecond(int? literspersecond)
+        {
+            if (literspersecond.HasValue)
+            {
+                return FromLitersPerSecond(literspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable LitersPerSecond.
+        /// </summary>
+        public static Flow? FromLitersPerSecond(long? literspersecond)
+        {
+            if (literspersecond.HasValue)
+            {
+                return FromLitersPerSecond(literspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from LitersPerSecond of type decimal.
+        /// </summary>
+        public static Flow? FromLitersPerSecond(decimal? literspersecond)
         {
             if (literspersecond.HasValue)
             {
@@ -592,10 +1546,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable MicrolitersPerMinute.
+        /// </summary>
+        public static Flow? FromMicrolitersPerMinute(int? microlitersperminute)
+        {
+            if (microlitersperminute.HasValue)
+            {
+                return FromMicrolitersPerMinute(microlitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable MicrolitersPerMinute.
+        /// </summary>
+        public static Flow? FromMicrolitersPerMinute(long? microlitersperminute)
+        {
+            if (microlitersperminute.HasValue)
+            {
+                return FromMicrolitersPerMinute(microlitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from MicrolitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromMicrolitersPerMinute(decimal? microlitersperminute)
+        {
+            if (microlitersperminute.HasValue)
+            {
+                return FromMicrolitersPerMinute(microlitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable MillilitersPerMinute.
         /// </summary>
         public static Flow? FromMillilitersPerMinute(double? millilitersperminute)
+        {
+            if (millilitersperminute.HasValue)
+            {
+                return FromMillilitersPerMinute(millilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable MillilitersPerMinute.
+        /// </summary>
+        public static Flow? FromMillilitersPerMinute(int? millilitersperminute)
+        {
+            if (millilitersperminute.HasValue)
+            {
+                return FromMillilitersPerMinute(millilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable MillilitersPerMinute.
+        /// </summary>
+        public static Flow? FromMillilitersPerMinute(long? millilitersperminute)
+        {
+            if (millilitersperminute.HasValue)
+            {
+                return FromMillilitersPerMinute(millilitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from MillilitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromMillilitersPerMinute(decimal? millilitersperminute)
         {
             if (millilitersperminute.HasValue)
             {
@@ -622,10 +1666,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
+        /// </summary>
+        public static Flow? FromMillionUsGallonsPerDay(int? millionusgallonsperday)
+        {
+            if (millionusgallonsperday.HasValue)
+            {
+                return FromMillionUsGallonsPerDay(millionusgallonsperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
+        /// </summary>
+        public static Flow? FromMillionUsGallonsPerDay(long? millionusgallonsperday)
+        {
+            if (millionusgallonsperday.HasValue)
+            {
+                return FromMillionUsGallonsPerDay(millionusgallonsperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from MillionUsGallonsPerDay of type decimal.
+        /// </summary>
+        public static Flow? FromMillionUsGallonsPerDay(decimal? millionusgallonsperday)
+        {
+            if (millionusgallonsperday.HasValue)
+            {
+                return FromMillionUsGallonsPerDay(millionusgallonsperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable NanolitersPerMinute.
         /// </summary>
         public static Flow? FromNanolitersPerMinute(double? nanolitersperminute)
+        {
+            if (nanolitersperminute.HasValue)
+            {
+                return FromNanolitersPerMinute(nanolitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable NanolitersPerMinute.
+        /// </summary>
+        public static Flow? FromNanolitersPerMinute(int? nanolitersperminute)
+        {
+            if (nanolitersperminute.HasValue)
+            {
+                return FromNanolitersPerMinute(nanolitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable NanolitersPerMinute.
+        /// </summary>
+        public static Flow? FromNanolitersPerMinute(long? nanolitersperminute)
+        {
+            if (nanolitersperminute.HasValue)
+            {
+                return FromNanolitersPerMinute(nanolitersperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from NanolitersPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromNanolitersPerMinute(decimal? nanolitersperminute)
         {
             if (nanolitersperminute.HasValue)
             {
@@ -652,10 +1786,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Flow from nullable OilBarrelsPerDay.
+        /// </summary>
+        public static Flow? FromOilBarrelsPerDay(int? oilbarrelsperday)
+        {
+            if (oilbarrelsperday.HasValue)
+            {
+                return FromOilBarrelsPerDay(oilbarrelsperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable OilBarrelsPerDay.
+        /// </summary>
+        public static Flow? FromOilBarrelsPerDay(long? oilbarrelsperday)
+        {
+            if (oilbarrelsperday.HasValue)
+            {
+                return FromOilBarrelsPerDay(oilbarrelsperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from OilBarrelsPerDay of type decimal.
+        /// </summary>
+        public static Flow? FromOilBarrelsPerDay(decimal? oilbarrelsperday)
+        {
+            if (oilbarrelsperday.HasValue)
+            {
+                return FromOilBarrelsPerDay(oilbarrelsperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Flow from nullable UsGallonsPerMinute.
         /// </summary>
         public static Flow? FromUsGallonsPerMinute(double? usgallonsperminute)
+        {
+            if (usgallonsperminute.HasValue)
+            {
+                return FromUsGallonsPerMinute(usgallonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable UsGallonsPerMinute.
+        /// </summary>
+        public static Flow? FromUsGallonsPerMinute(int? usgallonsperminute)
+        {
+            if (usgallonsperminute.HasValue)
+            {
+                return FromUsGallonsPerMinute(usgallonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from nullable UsGallonsPerMinute.
+        /// </summary>
+        public static Flow? FromUsGallonsPerMinute(long? usgallonsperminute)
+        {
+            if (usgallonsperminute.HasValue)
+            {
+                return FromUsGallonsPerMinute(usgallonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Flow from UsGallonsPerMinute of type decimal.
+        /// </summary>
+        public static Flow? FromUsGallonsPerMinute(decimal? usgallonsperminute)
         {
             if (usgallonsperminute.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -277,6 +277,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CentilitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromCentilitersPerMinute(double centilitersperminute)
         {
             return new Flow((centilitersperminute/60000.00000) * 1e-2d);
@@ -312,6 +315,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CubicDecimetersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromCubicDecimetersPerMinute(double cubicdecimetersperminute)
         {
             return new Flow(cubicdecimetersperminute/60000.00000);
@@ -347,6 +353,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CubicFeetPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromCubicFeetPerHour(double cubicfeetperhour)
         {
             return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
@@ -382,6 +391,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CubicFeetPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromCubicFeetPerSecond(double cubicfeetpersecond)
         {
             return new Flow(cubicfeetpersecond/35.314666721);
@@ -417,6 +429,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CubicMetersPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromCubicMetersPerHour(double cubicmetersperhour)
         {
             return new Flow(cubicmetersperhour/3600);
@@ -452,6 +467,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CubicMetersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromCubicMetersPerSecond(double cubicmeterspersecond)
         {
             return new Flow(cubicmeterspersecond);
@@ -487,6 +505,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from DecilitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromDecilitersPerMinute(double decilitersperminute)
         {
             return new Flow((decilitersperminute/60000.00000) * 1e-1d);
@@ -522,6 +543,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from KilolitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromKilolitersPerMinute(double kilolitersperminute)
         {
             return new Flow((kilolitersperminute/60000.00000) * 1e3d);
@@ -557,6 +581,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from LitersPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromLitersPerHour(double litersperhour)
         {
             return new Flow(litersperhour/3600000.000);
@@ -592,6 +619,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from LitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromLitersPerMinute(double litersperminute)
         {
             return new Flow(litersperminute/60000.00000);
@@ -627,6 +657,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from LitersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromLitersPerSecond(double literspersecond)
         {
             return new Flow(literspersecond/1000);
@@ -662,6 +695,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from MicrolitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromMicrolitersPerMinute(double microlitersperminute)
         {
             return new Flow((microlitersperminute/60000.00000) * 1e-6d);
@@ -697,6 +733,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from MillilitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromMillilitersPerMinute(double millilitersperminute)
         {
             return new Flow((millilitersperminute/60000.00000) * 1e-3d);
@@ -732,6 +771,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from MillionUsGallonsPerDay.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromMillionUsGallonsPerDay(double millionusgallonsperday)
         {
             return new Flow(millionusgallonsperday/22.824465227);
@@ -767,6 +809,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from NanolitersPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromNanolitersPerMinute(double nanolitersperminute)
         {
             return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
@@ -802,6 +847,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from OilBarrelsPerDay.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromOilBarrelsPerDay(double oilbarrelsperday)
         {
             return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
@@ -837,6 +885,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from UsGallonsPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Flow FromUsGallonsPerMinute(double usgallonsperminute)
         {
             return new Flow(usgallonsperminute/15850.323141489);

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -218,6 +218,33 @@ namespace UnitsNet
             return new Force((decanewtons) * 1e1d);
         }
 
+		/// <summary>
+        ///     Get Force from Decanewtons.
+        /// </summary>
+        public static Force FromDecanewtons(int decanewtons)
+        {
+            return new Force((decanewtons) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get Force from Decanewtons.
+        /// </summary>
+        public static Force FromDecanewtons(long decanewtons)
+        {
+            return new Force((decanewtons) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from Decanewtons of type decimal.
+        /// </summary>
+        public static Force FromDecanewtons(decimal decanewtons)
+        {
+	        return new Force((Convert.ToDouble(decanewtons)) * 1e1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
@@ -225,6 +252,33 @@ namespace UnitsNet
         {
             return new Force(dyne/1e5);
         }
+
+		/// <summary>
+        ///     Get Force from Dyne.
+        /// </summary>
+        public static Force FromDyne(int dyne)
+        {
+            return new Force(dyne/1e5);
+        }
+
+		/// <summary>
+        ///     Get Force from Dyne.
+        /// </summary>
+        public static Force FromDyne(long dyne)
+        {
+            return new Force(dyne/1e5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from Dyne of type decimal.
+        /// </summary>
+        public static Force FromDyne(decimal dyne)
+        {
+	        return new Force(Convert.ToDouble(dyne)/1e5);
+        }
+#endif
 
         /// <summary>
         ///     Get Force from KilogramsForce.
@@ -234,6 +288,33 @@ namespace UnitsNet
             return new Force(kilogramsforce*9.80665002864);
         }
 
+		/// <summary>
+        ///     Get Force from KilogramsForce.
+        /// </summary>
+        public static Force FromKilogramsForce(int kilogramsforce)
+        {
+            return new Force(kilogramsforce*9.80665002864);
+        }
+
+		/// <summary>
+        ///     Get Force from KilogramsForce.
+        /// </summary>
+        public static Force FromKilogramsForce(long kilogramsforce)
+        {
+            return new Force(kilogramsforce*9.80665002864);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from KilogramsForce of type decimal.
+        /// </summary>
+        public static Force FromKilogramsForce(decimal kilogramsforce)
+        {
+	        return new Force(Convert.ToDouble(kilogramsforce)*9.80665002864);
+        }
+#endif
+
         /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
@@ -241,6 +322,33 @@ namespace UnitsNet
         {
             return new Force((kilonewtons) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Force from Kilonewtons.
+        /// </summary>
+        public static Force FromKilonewtons(int kilonewtons)
+        {
+            return new Force((kilonewtons) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Force from Kilonewtons.
+        /// </summary>
+        public static Force FromKilonewtons(long kilonewtons)
+        {
+            return new Force((kilonewtons) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from Kilonewtons of type decimal.
+        /// </summary>
+        public static Force FromKilonewtons(decimal kilonewtons)
+        {
+	        return new Force((Convert.ToDouble(kilonewtons)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Force from KiloPonds.
@@ -250,6 +358,33 @@ namespace UnitsNet
             return new Force(kiloponds*9.80665002864);
         }
 
+		/// <summary>
+        ///     Get Force from KiloPonds.
+        /// </summary>
+        public static Force FromKiloPonds(int kiloponds)
+        {
+            return new Force(kiloponds*9.80665002864);
+        }
+
+		/// <summary>
+        ///     Get Force from KiloPonds.
+        /// </summary>
+        public static Force FromKiloPonds(long kiloponds)
+        {
+            return new Force(kiloponds*9.80665002864);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from KiloPonds of type decimal.
+        /// </summary>
+        public static Force FromKiloPonds(decimal kiloponds)
+        {
+	        return new Force(Convert.ToDouble(kiloponds)*9.80665002864);
+        }
+#endif
+
         /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
@@ -257,6 +392,33 @@ namespace UnitsNet
         {
             return new Force(newtons);
         }
+
+		/// <summary>
+        ///     Get Force from Newtons.
+        /// </summary>
+        public static Force FromNewtons(int newtons)
+        {
+            return new Force(newtons);
+        }
+
+		/// <summary>
+        ///     Get Force from Newtons.
+        /// </summary>
+        public static Force FromNewtons(long newtons)
+        {
+            return new Force(newtons);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from Newtons of type decimal.
+        /// </summary>
+        public static Force FromNewtons(decimal newtons)
+        {
+	        return new Force(Convert.ToDouble(newtons));
+        }
+#endif
 
         /// <summary>
         ///     Get Force from Poundals.
@@ -266,6 +428,33 @@ namespace UnitsNet
             return new Force(poundals*0.13825502798973041652092282466083);
         }
 
+		/// <summary>
+        ///     Get Force from Poundals.
+        /// </summary>
+        public static Force FromPoundals(int poundals)
+        {
+            return new Force(poundals*0.13825502798973041652092282466083);
+        }
+
+		/// <summary>
+        ///     Get Force from Poundals.
+        /// </summary>
+        public static Force FromPoundals(long poundals)
+        {
+            return new Force(poundals*0.13825502798973041652092282466083);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from Poundals of type decimal.
+        /// </summary>
+        public static Force FromPoundals(decimal poundals)
+        {
+	        return new Force(Convert.ToDouble(poundals)*0.13825502798973041652092282466083);
+        }
+#endif
+
         /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
@@ -273,6 +462,33 @@ namespace UnitsNet
         {
             return new Force(poundsforce*4.4482216152605095551842641431421);
         }
+
+		/// <summary>
+        ///     Get Force from PoundsForce.
+        /// </summary>
+        public static Force FromPoundsForce(int poundsforce)
+        {
+            return new Force(poundsforce*4.4482216152605095551842641431421);
+        }
+
+		/// <summary>
+        ///     Get Force from PoundsForce.
+        /// </summary>
+        public static Force FromPoundsForce(long poundsforce)
+        {
+            return new Force(poundsforce*4.4482216152605095551842641431421);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from PoundsForce of type decimal.
+        /// </summary>
+        public static Force FromPoundsForce(decimal poundsforce)
+        {
+	        return new Force(Convert.ToDouble(poundsforce)*4.4482216152605095551842641431421);
+        }
+#endif
 
         /// <summary>
         ///     Get Force from TonnesForce.
@@ -282,12 +498,84 @@ namespace UnitsNet
             return new Force(tonnesforce*9.80665002864*1000);
         }
 
+		/// <summary>
+        ///     Get Force from TonnesForce.
+        /// </summary>
+        public static Force FromTonnesForce(int tonnesforce)
+        {
+            return new Force(tonnesforce*9.80665002864*1000);
+        }
+
+		/// <summary>
+        ///     Get Force from TonnesForce.
+        /// </summary>
+        public static Force FromTonnesForce(long tonnesforce)
+        {
+            return new Force(tonnesforce*9.80665002864*1000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Force from TonnesForce of type decimal.
+        /// </summary>
+        public static Force FromTonnesForce(decimal tonnesforce)
+        {
+	        return new Force(Convert.ToDouble(tonnesforce)*9.80665002864*1000);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Force from nullable Decanewtons.
         /// </summary>
         public static Force? FromDecanewtons(double? decanewtons)
+        {
+            if (decanewtons.HasValue)
+            {
+                return FromDecanewtons(decanewtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Decanewtons.
+        /// </summary>
+        public static Force? FromDecanewtons(int? decanewtons)
+        {
+            if (decanewtons.HasValue)
+            {
+                return FromDecanewtons(decanewtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Decanewtons.
+        /// </summary>
+        public static Force? FromDecanewtons(long? decanewtons)
+        {
+            if (decanewtons.HasValue)
+            {
+                return FromDecanewtons(decanewtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from Decanewtons of type decimal.
+        /// </summary>
+        public static Force? FromDecanewtons(decimal? decanewtons)
         {
             if (decanewtons.HasValue)
             {
@@ -314,10 +602,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Force from nullable Dyne.
+        /// </summary>
+        public static Force? FromDyne(int? dyne)
+        {
+            if (dyne.HasValue)
+            {
+                return FromDyne(dyne.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Dyne.
+        /// </summary>
+        public static Force? FromDyne(long? dyne)
+        {
+            if (dyne.HasValue)
+            {
+                return FromDyne(dyne.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from Dyne of type decimal.
+        /// </summary>
+        public static Force? FromDyne(decimal? dyne)
+        {
+            if (dyne.HasValue)
+            {
+                return FromDyne(dyne.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Force from nullable KilogramsForce.
         /// </summary>
         public static Force? FromKilogramsForce(double? kilogramsforce)
+        {
+            if (kilogramsforce.HasValue)
+            {
+                return FromKilogramsForce(kilogramsforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable KilogramsForce.
+        /// </summary>
+        public static Force? FromKilogramsForce(int? kilogramsforce)
+        {
+            if (kilogramsforce.HasValue)
+            {
+                return FromKilogramsForce(kilogramsforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable KilogramsForce.
+        /// </summary>
+        public static Force? FromKilogramsForce(long? kilogramsforce)
+        {
+            if (kilogramsforce.HasValue)
+            {
+                return FromKilogramsForce(kilogramsforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from KilogramsForce of type decimal.
+        /// </summary>
+        public static Force? FromKilogramsForce(decimal? kilogramsforce)
         {
             if (kilogramsforce.HasValue)
             {
@@ -344,10 +722,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Force from nullable Kilonewtons.
+        /// </summary>
+        public static Force? FromKilonewtons(int? kilonewtons)
+        {
+            if (kilonewtons.HasValue)
+            {
+                return FromKilonewtons(kilonewtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Kilonewtons.
+        /// </summary>
+        public static Force? FromKilonewtons(long? kilonewtons)
+        {
+            if (kilonewtons.HasValue)
+            {
+                return FromKilonewtons(kilonewtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from Kilonewtons of type decimal.
+        /// </summary>
+        public static Force? FromKilonewtons(decimal? kilonewtons)
+        {
+            if (kilonewtons.HasValue)
+            {
+                return FromKilonewtons(kilonewtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Force from nullable KiloPonds.
         /// </summary>
         public static Force? FromKiloPonds(double? kiloponds)
+        {
+            if (kiloponds.HasValue)
+            {
+                return FromKiloPonds(kiloponds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable KiloPonds.
+        /// </summary>
+        public static Force? FromKiloPonds(int? kiloponds)
+        {
+            if (kiloponds.HasValue)
+            {
+                return FromKiloPonds(kiloponds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable KiloPonds.
+        /// </summary>
+        public static Force? FromKiloPonds(long? kiloponds)
+        {
+            if (kiloponds.HasValue)
+            {
+                return FromKiloPonds(kiloponds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from KiloPonds of type decimal.
+        /// </summary>
+        public static Force? FromKiloPonds(decimal? kiloponds)
         {
             if (kiloponds.HasValue)
             {
@@ -374,10 +842,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Force from nullable Newtons.
+        /// </summary>
+        public static Force? FromNewtons(int? newtons)
+        {
+            if (newtons.HasValue)
+            {
+                return FromNewtons(newtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Newtons.
+        /// </summary>
+        public static Force? FromNewtons(long? newtons)
+        {
+            if (newtons.HasValue)
+            {
+                return FromNewtons(newtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from Newtons of type decimal.
+        /// </summary>
+        public static Force? FromNewtons(decimal? newtons)
+        {
+            if (newtons.HasValue)
+            {
+                return FromNewtons(newtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Force from nullable Poundals.
         /// </summary>
         public static Force? FromPoundals(double? poundals)
+        {
+            if (poundals.HasValue)
+            {
+                return FromPoundals(poundals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Poundals.
+        /// </summary>
+        public static Force? FromPoundals(int? poundals)
+        {
+            if (poundals.HasValue)
+            {
+                return FromPoundals(poundals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable Poundals.
+        /// </summary>
+        public static Force? FromPoundals(long? poundals)
+        {
+            if (poundals.HasValue)
+            {
+                return FromPoundals(poundals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from Poundals of type decimal.
+        /// </summary>
+        public static Force? FromPoundals(decimal? poundals)
         {
             if (poundals.HasValue)
             {
@@ -404,10 +962,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Force from nullable PoundsForce.
+        /// </summary>
+        public static Force? FromPoundsForce(int? poundsforce)
+        {
+            if (poundsforce.HasValue)
+            {
+                return FromPoundsForce(poundsforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable PoundsForce.
+        /// </summary>
+        public static Force? FromPoundsForce(long? poundsforce)
+        {
+            if (poundsforce.HasValue)
+            {
+                return FromPoundsForce(poundsforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from PoundsForce of type decimal.
+        /// </summary>
+        public static Force? FromPoundsForce(decimal? poundsforce)
+        {
+            if (poundsforce.HasValue)
+            {
+                return FromPoundsForce(poundsforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Force from nullable TonnesForce.
         /// </summary>
         public static Force? FromTonnesForce(double? tonnesforce)
+        {
+            if (tonnesforce.HasValue)
+            {
+                return FromTonnesForce(tonnesforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable TonnesForce.
+        /// </summary>
+        public static Force? FromTonnesForce(int? tonnesforce)
+        {
+            if (tonnesforce.HasValue)
+            {
+                return FromTonnesForce(tonnesforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from nullable TonnesForce.
+        /// </summary>
+        public static Force? FromTonnesForce(long? tonnesforce)
+        {
+            if (tonnesforce.HasValue)
+            {
+                return FromTonnesForce(tonnesforce.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Force from TonnesForce of type decimal.
+        /// </summary>
+        public static Force? FromTonnesForce(decimal? tonnesforce)
         {
             if (tonnesforce.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _newtons;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Force() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Force;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ForceUnit BaseUnit
         {
             get { return ForceUnit.Newton; }
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new Force((decanewtons) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Decanewtons.
         /// </summary>
         public static Force FromDecanewtons(int decanewtons)
@@ -226,7 +226,7 @@ namespace UnitsNet
             return new Force((decanewtons) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Decanewtons.
         /// </summary>
         public static Force FromDecanewtons(long decanewtons)
@@ -234,14 +234,14 @@ namespace UnitsNet
             return new Force((decanewtons) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from Decanewtons of type decimal.
         /// </summary>
         public static Force FromDecanewtons(decimal decanewtons)
         {
-	        return new Force((Convert.ToDouble(decanewtons)) * 1e1d);
+            return new Force((Convert.ToDouble(decanewtons)) * 1e1d);
         }
 #endif
 
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new Force(dyne/1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
         public static Force FromDyne(int dyne)
@@ -261,7 +261,7 @@ namespace UnitsNet
             return new Force(dyne/1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
         public static Force FromDyne(long dyne)
@@ -269,14 +269,14 @@ namespace UnitsNet
             return new Force(dyne/1e5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from Dyne of type decimal.
         /// </summary>
         public static Force FromDyne(decimal dyne)
         {
-	        return new Force(Convert.ToDouble(dyne)/1e5);
+            return new Force(Convert.ToDouble(dyne)/1e5);
         }
 #endif
 
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new Force(kilogramsforce*9.80665002864);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from KilogramsForce.
         /// </summary>
         public static Force FromKilogramsForce(int kilogramsforce)
@@ -296,7 +296,7 @@ namespace UnitsNet
             return new Force(kilogramsforce*9.80665002864);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from KilogramsForce.
         /// </summary>
         public static Force FromKilogramsForce(long kilogramsforce)
@@ -304,14 +304,14 @@ namespace UnitsNet
             return new Force(kilogramsforce*9.80665002864);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from KilogramsForce of type decimal.
         /// </summary>
         public static Force FromKilogramsForce(decimal kilogramsforce)
         {
-	        return new Force(Convert.ToDouble(kilogramsforce)*9.80665002864);
+            return new Force(Convert.ToDouble(kilogramsforce)*9.80665002864);
         }
 #endif
 
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new Force((kilonewtons) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
         public static Force FromKilonewtons(int kilonewtons)
@@ -331,7 +331,7 @@ namespace UnitsNet
             return new Force((kilonewtons) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
         public static Force FromKilonewtons(long kilonewtons)
@@ -339,14 +339,14 @@ namespace UnitsNet
             return new Force((kilonewtons) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from Kilonewtons of type decimal.
         /// </summary>
         public static Force FromKilonewtons(decimal kilonewtons)
         {
-	        return new Force((Convert.ToDouble(kilonewtons)) * 1e3d);
+            return new Force((Convert.ToDouble(kilonewtons)) * 1e3d);
         }
 #endif
 
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new Force(kiloponds*9.80665002864);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from KiloPonds.
         /// </summary>
         public static Force FromKiloPonds(int kiloponds)
@@ -366,7 +366,7 @@ namespace UnitsNet
             return new Force(kiloponds*9.80665002864);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from KiloPonds.
         /// </summary>
         public static Force FromKiloPonds(long kiloponds)
@@ -374,14 +374,14 @@ namespace UnitsNet
             return new Force(kiloponds*9.80665002864);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from KiloPonds of type decimal.
         /// </summary>
         public static Force FromKiloPonds(decimal kiloponds)
         {
-	        return new Force(Convert.ToDouble(kiloponds)*9.80665002864);
+            return new Force(Convert.ToDouble(kiloponds)*9.80665002864);
         }
 #endif
 
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new Force(newtons);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
         public static Force FromNewtons(int newtons)
@@ -401,7 +401,7 @@ namespace UnitsNet
             return new Force(newtons);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
         public static Force FromNewtons(long newtons)
@@ -409,14 +409,14 @@ namespace UnitsNet
             return new Force(newtons);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from Newtons of type decimal.
         /// </summary>
         public static Force FromNewtons(decimal newtons)
         {
-	        return new Force(Convert.ToDouble(newtons));
+            return new Force(Convert.ToDouble(newtons));
         }
 #endif
 
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new Force(poundals*0.13825502798973041652092282466083);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Poundals.
         /// </summary>
         public static Force FromPoundals(int poundals)
@@ -436,7 +436,7 @@ namespace UnitsNet
             return new Force(poundals*0.13825502798973041652092282466083);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from Poundals.
         /// </summary>
         public static Force FromPoundals(long poundals)
@@ -444,14 +444,14 @@ namespace UnitsNet
             return new Force(poundals*0.13825502798973041652092282466083);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from Poundals of type decimal.
         /// </summary>
         public static Force FromPoundals(decimal poundals)
         {
-	        return new Force(Convert.ToDouble(poundals)*0.13825502798973041652092282466083);
+            return new Force(Convert.ToDouble(poundals)*0.13825502798973041652092282466083);
         }
 #endif
 
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new Force(poundsforce*4.4482216152605095551842641431421);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
         public static Force FromPoundsForce(int poundsforce)
@@ -471,7 +471,7 @@ namespace UnitsNet
             return new Force(poundsforce*4.4482216152605095551842641431421);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
         public static Force FromPoundsForce(long poundsforce)
@@ -479,14 +479,14 @@ namespace UnitsNet
             return new Force(poundsforce*4.4482216152605095551842641431421);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from PoundsForce of type decimal.
         /// </summary>
         public static Force FromPoundsForce(decimal poundsforce)
         {
-	        return new Force(Convert.ToDouble(poundsforce)*4.4482216152605095551842641431421);
+            return new Force(Convert.ToDouble(poundsforce)*4.4482216152605095551842641431421);
         }
 #endif
 
@@ -498,7 +498,7 @@ namespace UnitsNet
             return new Force(tonnesforce*9.80665002864*1000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from TonnesForce.
         /// </summary>
         public static Force FromTonnesForce(int tonnesforce)
@@ -506,7 +506,7 @@ namespace UnitsNet
             return new Force(tonnesforce*9.80665002864*1000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Force from TonnesForce.
         /// </summary>
         public static Force FromTonnesForce(long tonnesforce)
@@ -514,14 +514,14 @@ namespace UnitsNet
             return new Force(tonnesforce*9.80665002864*1000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Force from TonnesForce of type decimal.
         /// </summary>
         public static Force FromTonnesForce(decimal tonnesforce)
         {
-	        return new Force(Convert.ToDouble(tonnesforce)*9.80665002864*1000);
+            return new Force(Convert.ToDouble(tonnesforce)*9.80665002864*1000);
         }
 #endif
 
@@ -542,7 +542,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Decanewtons.
         /// </summary>
         public static Force? FromDecanewtons(int? decanewtons)
@@ -557,7 +557,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Decanewtons.
         /// </summary>
         public static Force? FromDecanewtons(long? decanewtons)
@@ -572,7 +572,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from Decanewtons of type decimal.
         /// </summary>
         public static Force? FromDecanewtons(decimal? decanewtons)
@@ -602,7 +602,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Dyne.
         /// </summary>
         public static Force? FromDyne(int? dyne)
@@ -617,7 +617,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Dyne.
         /// </summary>
         public static Force? FromDyne(long? dyne)
@@ -632,7 +632,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from Dyne of type decimal.
         /// </summary>
         public static Force? FromDyne(decimal? dyne)
@@ -662,7 +662,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable KilogramsForce.
         /// </summary>
         public static Force? FromKilogramsForce(int? kilogramsforce)
@@ -677,7 +677,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable KilogramsForce.
         /// </summary>
         public static Force? FromKilogramsForce(long? kilogramsforce)
@@ -692,7 +692,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from KilogramsForce of type decimal.
         /// </summary>
         public static Force? FromKilogramsForce(decimal? kilogramsforce)
@@ -722,7 +722,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Kilonewtons.
         /// </summary>
         public static Force? FromKilonewtons(int? kilonewtons)
@@ -737,7 +737,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Kilonewtons.
         /// </summary>
         public static Force? FromKilonewtons(long? kilonewtons)
@@ -752,7 +752,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from Kilonewtons of type decimal.
         /// </summary>
         public static Force? FromKilonewtons(decimal? kilonewtons)
@@ -782,7 +782,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable KiloPonds.
         /// </summary>
         public static Force? FromKiloPonds(int? kiloponds)
@@ -797,7 +797,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable KiloPonds.
         /// </summary>
         public static Force? FromKiloPonds(long? kiloponds)
@@ -812,7 +812,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from KiloPonds of type decimal.
         /// </summary>
         public static Force? FromKiloPonds(decimal? kiloponds)
@@ -842,7 +842,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Newtons.
         /// </summary>
         public static Force? FromNewtons(int? newtons)
@@ -857,7 +857,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Newtons.
         /// </summary>
         public static Force? FromNewtons(long? newtons)
@@ -872,7 +872,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from Newtons of type decimal.
         /// </summary>
         public static Force? FromNewtons(decimal? newtons)
@@ -902,7 +902,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Poundals.
         /// </summary>
         public static Force? FromPoundals(int? poundals)
@@ -917,7 +917,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable Poundals.
         /// </summary>
         public static Force? FromPoundals(long? poundals)
@@ -932,7 +932,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from Poundals of type decimal.
         /// </summary>
         public static Force? FromPoundals(decimal? poundals)
@@ -962,7 +962,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable PoundsForce.
         /// </summary>
         public static Force? FromPoundsForce(int? poundsforce)
@@ -977,7 +977,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable PoundsForce.
         /// </summary>
         public static Force? FromPoundsForce(long? poundsforce)
@@ -992,7 +992,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from PoundsForce of type decimal.
         /// </summary>
         public static Force? FromPoundsForce(decimal? poundsforce)
@@ -1022,7 +1022,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable TonnesForce.
         /// </summary>
         public static Force? FromTonnesForce(int? tonnesforce)
@@ -1037,7 +1037,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from nullable TonnesForce.
         /// </summary>
         public static Force? FromTonnesForce(long? tonnesforce)
@@ -1052,7 +1052,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Force from TonnesForce of type decimal.
         /// </summary>
         public static Force? FromTonnesForce(decimal? tonnesforce)

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -213,6 +213,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Decanewtons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromDecanewtons(double decanewtons)
         {
             return new Force((decanewtons) * 1e1d);
@@ -248,6 +251,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromDyne(double dyne)
         {
             return new Force(dyne/1e5);
@@ -283,6 +289,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from KilogramsForce.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromKilogramsForce(double kilogramsforce)
         {
             return new Force(kilogramsforce*9.80665002864);
@@ -318,6 +327,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromKilonewtons(double kilonewtons)
         {
             return new Force((kilonewtons) * 1e3d);
@@ -353,6 +365,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from KiloPonds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromKiloPonds(double kiloponds)
         {
             return new Force(kiloponds*9.80665002864);
@@ -388,6 +403,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromNewtons(double newtons)
         {
             return new Force(newtons);
@@ -423,6 +441,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Poundals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromPoundals(double poundals)
         {
             return new Force(poundals*0.13825502798973041652092282466083);
@@ -458,6 +479,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromPoundsForce(double poundsforce)
         {
             return new Force(poundsforce*4.4482216152605095551842641431421);
@@ -493,6 +517,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from TonnesForce.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Force FromTonnesForce(double tonnesforce)
         {
             return new Force(tonnesforce*9.80665002864*1000);

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -234,6 +234,33 @@ namespace UnitsNet
             return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get ForceChangeRate from CentinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromCentinewtonsPerSecond(int centinewtonspersecond)
+        {
+            return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from CentinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromCentinewtonsPerSecond(long centinewtonspersecond)
+        {
+            return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from CentinewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromCentinewtonsPerSecond(decimal centinewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(centinewtonspersecond)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
@@ -241,6 +268,33 @@ namespace UnitsNet
         {
             return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
         }
+
+		/// <summary>
+        ///     Get ForceChangeRate from DecanewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate FromDecanewtonsPerMinute(int decanewtonsperminute)
+        {
+            return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from DecanewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate FromDecanewtonsPerMinute(long decanewtonsperminute)
+        {
+            return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from DecanewtonsPerMinute of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromDecanewtonsPerMinute(decimal decanewtonsperminute)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(decanewtonsperminute)/60) * 1e1d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
@@ -250,6 +304,33 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonspersecond) * 1e1d);
         }
 
+		/// <summary>
+        ///     Get ForceChangeRate from DecanewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromDecanewtonsPerSecond(int decanewtonspersecond)
+        {
+            return new ForceChangeRate((decanewtonspersecond) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from DecanewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromDecanewtonsPerSecond(long decanewtonspersecond)
+        {
+            return new ForceChangeRate((decanewtonspersecond) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from DecanewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromDecanewtonsPerSecond(decimal decanewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(decanewtonspersecond)) * 1e1d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
@@ -257,6 +338,33 @@ namespace UnitsNet
         {
             return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get ForceChangeRate from DecinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromDecinewtonsPerSecond(int decinewtonspersecond)
+        {
+            return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from DecinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromDecinewtonsPerSecond(long decinewtonspersecond)
+        {
+            return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from DecinewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromDecinewtonsPerSecond(decimal decinewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(decinewtonspersecond)) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
@@ -266,6 +374,33 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ForceChangeRate from KilonewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate FromKilonewtonsPerMinute(int kilonewtonsperminute)
+        {
+            return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from KilonewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate FromKilonewtonsPerMinute(long kilonewtonsperminute)
+        {
+            return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from KilonewtonsPerMinute of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromKilonewtonsPerMinute(decimal kilonewtonsperminute)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(kilonewtonsperminute)/60) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
@@ -273,6 +408,33 @@ namespace UnitsNet
         {
             return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get ForceChangeRate from KilonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromKilonewtonsPerSecond(int kilonewtonspersecond)
+        {
+            return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from KilonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromKilonewtonsPerSecond(long kilonewtonspersecond)
+        {
+            return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from KilonewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromKilonewtonsPerSecond(decimal kilonewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(kilonewtonspersecond)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
@@ -282,6 +444,33 @@ namespace UnitsNet
             return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get ForceChangeRate from MicronewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromMicronewtonsPerSecond(int micronewtonspersecond)
+        {
+            return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from MicronewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromMicronewtonsPerSecond(long micronewtonspersecond)
+        {
+            return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from MicronewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromMicronewtonsPerSecond(decimal micronewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(micronewtonspersecond)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
@@ -289,6 +478,33 @@ namespace UnitsNet
         {
             return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get ForceChangeRate from MillinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromMillinewtonsPerSecond(int millinewtonspersecond)
+        {
+            return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from MillinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromMillinewtonsPerSecond(long millinewtonspersecond)
+        {
+            return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from MillinewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromMillinewtonsPerSecond(decimal millinewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(millinewtonspersecond)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
@@ -298,6 +514,33 @@ namespace UnitsNet
             return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get ForceChangeRate from NanonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromNanonewtonsPerSecond(int nanonewtonspersecond)
+        {
+            return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from NanonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromNanonewtonsPerSecond(long nanonewtonspersecond)
+        {
+            return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from NanonewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromNanonewtonsPerSecond(decimal nanonewtonspersecond)
+        {
+	        return new ForceChangeRate((Convert.ToDouble(nanonewtonspersecond)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
@@ -305,6 +548,33 @@ namespace UnitsNet
         {
             return new ForceChangeRate(newtonsperminute/60);
         }
+
+		/// <summary>
+        ///     Get ForceChangeRate from NewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate FromNewtonsPerMinute(int newtonsperminute)
+        {
+            return new ForceChangeRate(newtonsperminute/60);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from NewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate FromNewtonsPerMinute(long newtonsperminute)
+        {
+            return new ForceChangeRate(newtonsperminute/60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from NewtonsPerMinute of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromNewtonsPerMinute(decimal newtonsperminute)
+        {
+	        return new ForceChangeRate(Convert.ToDouble(newtonsperminute)/60);
+        }
+#endif
 
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
@@ -314,12 +584,84 @@ namespace UnitsNet
             return new ForceChangeRate(newtonspersecond);
         }
 
+		/// <summary>
+        ///     Get ForceChangeRate from NewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromNewtonsPerSecond(int newtonspersecond)
+        {
+            return new ForceChangeRate(newtonspersecond);
+        }
+
+		/// <summary>
+        ///     Get ForceChangeRate from NewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate FromNewtonsPerSecond(long newtonspersecond)
+        {
+            return new ForceChangeRate(newtonspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForceChangeRate from NewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate FromNewtonsPerSecond(decimal newtonspersecond)
+        {
+	        return new ForceChangeRate(Convert.ToDouble(newtonspersecond));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromCentinewtonsPerSecond(double? centinewtonspersecond)
+        {
+            if (centinewtonspersecond.HasValue)
+            {
+                return FromCentinewtonsPerSecond(centinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromCentinewtonsPerSecond(int? centinewtonspersecond)
+        {
+            if (centinewtonspersecond.HasValue)
+            {
+                return FromCentinewtonsPerSecond(centinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromCentinewtonsPerSecond(long? centinewtonspersecond)
+        {
+            if (centinewtonspersecond.HasValue)
+            {
+                return FromCentinewtonsPerSecond(centinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from CentinewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromCentinewtonsPerSecond(decimal? centinewtonspersecond)
         {
             if (centinewtonspersecond.HasValue)
             {
@@ -346,10 +688,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate? FromDecanewtonsPerMinute(int? decanewtonsperminute)
+        {
+            if (decanewtonsperminute.HasValue)
+            {
+                return FromDecanewtonsPerMinute(decanewtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate? FromDecanewtonsPerMinute(long? decanewtonsperminute)
+        {
+            if (decanewtonsperminute.HasValue)
+            {
+                return FromDecanewtonsPerMinute(decanewtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from DecanewtonsPerMinute of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromDecanewtonsPerMinute(decimal? decanewtonsperminute)
+        {
+            if (decanewtonsperminute.HasValue)
+            {
+                return FromDecanewtonsPerMinute(decanewtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerSecond(double? decanewtonspersecond)
+        {
+            if (decanewtonspersecond.HasValue)
+            {
+                return FromDecanewtonsPerSecond(decanewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromDecanewtonsPerSecond(int? decanewtonspersecond)
+        {
+            if (decanewtonspersecond.HasValue)
+            {
+                return FromDecanewtonsPerSecond(decanewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromDecanewtonsPerSecond(long? decanewtonspersecond)
+        {
+            if (decanewtonspersecond.HasValue)
+            {
+                return FromDecanewtonsPerSecond(decanewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from DecanewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromDecanewtonsPerSecond(decimal? decanewtonspersecond)
         {
             if (decanewtonspersecond.HasValue)
             {
@@ -376,10 +808,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromDecinewtonsPerSecond(int? decinewtonspersecond)
+        {
+            if (decinewtonspersecond.HasValue)
+            {
+                return FromDecinewtonsPerSecond(decinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromDecinewtonsPerSecond(long? decinewtonspersecond)
+        {
+            if (decinewtonspersecond.HasValue)
+            {
+                return FromDecinewtonsPerSecond(decinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from DecinewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromDecinewtonsPerSecond(decimal? decinewtonspersecond)
+        {
+            if (decinewtonspersecond.HasValue)
+            {
+                return FromDecinewtonsPerSecond(decinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerMinute(double? kilonewtonsperminute)
+        {
+            if (kilonewtonsperminute.HasValue)
+            {
+                return FromKilonewtonsPerMinute(kilonewtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate? FromKilonewtonsPerMinute(int? kilonewtonsperminute)
+        {
+            if (kilonewtonsperminute.HasValue)
+            {
+                return FromKilonewtonsPerMinute(kilonewtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate? FromKilonewtonsPerMinute(long? kilonewtonsperminute)
+        {
+            if (kilonewtonsperminute.HasValue)
+            {
+                return FromKilonewtonsPerMinute(kilonewtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from KilonewtonsPerMinute of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromKilonewtonsPerMinute(decimal? kilonewtonsperminute)
         {
             if (kilonewtonsperminute.HasValue)
             {
@@ -406,10 +928,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromKilonewtonsPerSecond(int? kilonewtonspersecond)
+        {
+            if (kilonewtonspersecond.HasValue)
+            {
+                return FromKilonewtonsPerSecond(kilonewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromKilonewtonsPerSecond(long? kilonewtonspersecond)
+        {
+            if (kilonewtonspersecond.HasValue)
+            {
+                return FromKilonewtonsPerSecond(kilonewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from KilonewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromKilonewtonsPerSecond(decimal? kilonewtonspersecond)
+        {
+            if (kilonewtonspersecond.HasValue)
+            {
+                return FromKilonewtonsPerSecond(kilonewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromMicronewtonsPerSecond(double? micronewtonspersecond)
+        {
+            if (micronewtonspersecond.HasValue)
+            {
+                return FromMicronewtonsPerSecond(micronewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromMicronewtonsPerSecond(int? micronewtonspersecond)
+        {
+            if (micronewtonspersecond.HasValue)
+            {
+                return FromMicronewtonsPerSecond(micronewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromMicronewtonsPerSecond(long? micronewtonspersecond)
+        {
+            if (micronewtonspersecond.HasValue)
+            {
+                return FromMicronewtonsPerSecond(micronewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from MicronewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromMicronewtonsPerSecond(decimal? micronewtonspersecond)
         {
             if (micronewtonspersecond.HasValue)
             {
@@ -436,10 +1048,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromMillinewtonsPerSecond(int? millinewtonspersecond)
+        {
+            if (millinewtonspersecond.HasValue)
+            {
+                return FromMillinewtonsPerSecond(millinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromMillinewtonsPerSecond(long? millinewtonspersecond)
+        {
+            if (millinewtonspersecond.HasValue)
+            {
+                return FromMillinewtonsPerSecond(millinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from MillinewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromMillinewtonsPerSecond(decimal? millinewtonspersecond)
+        {
+            if (millinewtonspersecond.HasValue)
+            {
+                return FromMillinewtonsPerSecond(millinewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromNanonewtonsPerSecond(double? nanonewtonspersecond)
+        {
+            if (nanonewtonspersecond.HasValue)
+            {
+                return FromNanonewtonsPerSecond(nanonewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromNanonewtonsPerSecond(int? nanonewtonspersecond)
+        {
+            if (nanonewtonspersecond.HasValue)
+            {
+                return FromNanonewtonsPerSecond(nanonewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromNanonewtonsPerSecond(long? nanonewtonspersecond)
+        {
+            if (nanonewtonspersecond.HasValue)
+            {
+                return FromNanonewtonsPerSecond(nanonewtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from NanonewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromNanonewtonsPerSecond(decimal? nanonewtonspersecond)
         {
             if (nanonewtonspersecond.HasValue)
             {
@@ -466,10 +1168,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate? FromNewtonsPerMinute(int? newtonsperminute)
+        {
+            if (newtonsperminute.HasValue)
+            {
+                return FromNewtonsPerMinute(newtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
+        /// </summary>
+        public static ForceChangeRate? FromNewtonsPerMinute(long? newtonsperminute)
+        {
+            if (newtonsperminute.HasValue)
+            {
+                return FromNewtonsPerMinute(newtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from NewtonsPerMinute of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromNewtonsPerMinute(decimal? newtonsperminute)
+        {
+            if (newtonsperminute.HasValue)
+            {
+                return FromNewtonsPerMinute(newtonsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerSecond(double? newtonspersecond)
+        {
+            if (newtonspersecond.HasValue)
+            {
+                return FromNewtonsPerSecond(newtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromNewtonsPerSecond(int? newtonspersecond)
+        {
+            if (newtonspersecond.HasValue)
+            {
+                return FromNewtonsPerSecond(newtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
+        /// </summary>
+        public static ForceChangeRate? FromNewtonsPerSecond(long? newtonspersecond)
+        {
+            if (newtonspersecond.HasValue)
+            {
+                return FromNewtonsPerSecond(newtonspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForceChangeRate from NewtonsPerSecond of type decimal.
+        /// </summary>
+        public static ForceChangeRate? FromNewtonsPerSecond(decimal? newtonspersecond)
         {
             if (newtonspersecond.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -229,6 +229,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromCentinewtonsPerSecond(double centinewtonspersecond)
         {
             return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
@@ -264,6 +267,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromDecanewtonsPerMinute(double decanewtonsperminute)
         {
             return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
@@ -299,6 +305,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromDecanewtonsPerSecond(double decanewtonspersecond)
         {
             return new ForceChangeRate((decanewtonspersecond) * 1e1d);
@@ -334,6 +343,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromDecinewtonsPerSecond(double decinewtonspersecond)
         {
             return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
@@ -369,6 +381,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromKilonewtonsPerMinute(double kilonewtonsperminute)
         {
             return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
@@ -404,6 +419,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromKilonewtonsPerSecond(double kilonewtonspersecond)
         {
             return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
@@ -439,6 +457,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromMicronewtonsPerSecond(double micronewtonspersecond)
         {
             return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
@@ -474,6 +495,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromMillinewtonsPerSecond(double millinewtonspersecond)
         {
             return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
@@ -509,6 +533,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromNanonewtonsPerSecond(double nanonewtonspersecond)
         {
             return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
@@ -544,6 +571,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromNewtonsPerMinute(double newtonsperminute)
         {
             return new ForceChangeRate(newtonsperminute/60);
@@ -579,6 +609,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForceChangeRate FromNewtonsPerSecond(double newtonspersecond)
         {
             return new ForceChangeRate(newtonspersecond);

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _newtonsPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ForceChangeRate() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ForceChangeRate;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ForceChangeRateUnit BaseUnit
         {
             get { return ForceChangeRateUnit.NewtonPerSecond; }
@@ -234,7 +234,7 @@ namespace UnitsNet
             return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromCentinewtonsPerSecond(int centinewtonspersecond)
@@ -242,7 +242,7 @@ namespace UnitsNet
             return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromCentinewtonsPerSecond(long centinewtonspersecond)
@@ -250,14 +250,14 @@ namespace UnitsNet
             return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromCentinewtonsPerSecond(decimal centinewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(centinewtonspersecond)) * 1e-2d);
+            return new ForceChangeRate((Convert.ToDouble(centinewtonspersecond)) * 1e-2d);
         }
 #endif
 
@@ -269,7 +269,7 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate FromDecanewtonsPerMinute(int decanewtonsperminute)
@@ -277,7 +277,7 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate FromDecanewtonsPerMinute(long decanewtonsperminute)
@@ -285,14 +285,14 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute of type decimal.
         /// </summary>
         public static ForceChangeRate FromDecanewtonsPerMinute(decimal decanewtonsperminute)
         {
-	        return new ForceChangeRate((Convert.ToDouble(decanewtonsperminute)/60) * 1e1d);
+            return new ForceChangeRate((Convert.ToDouble(decanewtonsperminute)/60) * 1e1d);
         }
 #endif
 
@@ -304,7 +304,7 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonspersecond) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromDecanewtonsPerSecond(int decanewtonspersecond)
@@ -312,7 +312,7 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonspersecond) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromDecanewtonsPerSecond(long decanewtonspersecond)
@@ -320,14 +320,14 @@ namespace UnitsNet
             return new ForceChangeRate((decanewtonspersecond) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromDecanewtonsPerSecond(decimal decanewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(decanewtonspersecond)) * 1e1d);
+            return new ForceChangeRate((Convert.ToDouble(decanewtonspersecond)) * 1e1d);
         }
 #endif
 
@@ -339,7 +339,7 @@ namespace UnitsNet
             return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromDecinewtonsPerSecond(int decinewtonspersecond)
@@ -347,7 +347,7 @@ namespace UnitsNet
             return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromDecinewtonsPerSecond(long decinewtonspersecond)
@@ -355,14 +355,14 @@ namespace UnitsNet
             return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromDecinewtonsPerSecond(decimal decinewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(decinewtonspersecond)) * 1e-1d);
+            return new ForceChangeRate((Convert.ToDouble(decinewtonspersecond)) * 1e-1d);
         }
 #endif
 
@@ -374,7 +374,7 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate FromKilonewtonsPerMinute(int kilonewtonsperminute)
@@ -382,7 +382,7 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate FromKilonewtonsPerMinute(long kilonewtonsperminute)
@@ -390,14 +390,14 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute of type decimal.
         /// </summary>
         public static ForceChangeRate FromKilonewtonsPerMinute(decimal kilonewtonsperminute)
         {
-	        return new ForceChangeRate((Convert.ToDouble(kilonewtonsperminute)/60) * 1e3d);
+            return new ForceChangeRate((Convert.ToDouble(kilonewtonsperminute)/60) * 1e3d);
         }
 #endif
 
@@ -409,7 +409,7 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromKilonewtonsPerSecond(int kilonewtonspersecond)
@@ -417,7 +417,7 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromKilonewtonsPerSecond(long kilonewtonspersecond)
@@ -425,14 +425,14 @@ namespace UnitsNet
             return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromKilonewtonsPerSecond(decimal kilonewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(kilonewtonspersecond)) * 1e3d);
+            return new ForceChangeRate((Convert.ToDouble(kilonewtonspersecond)) * 1e3d);
         }
 #endif
 
@@ -444,7 +444,7 @@ namespace UnitsNet
             return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromMicronewtonsPerSecond(int micronewtonspersecond)
@@ -452,7 +452,7 @@ namespace UnitsNet
             return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromMicronewtonsPerSecond(long micronewtonspersecond)
@@ -460,14 +460,14 @@ namespace UnitsNet
             return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromMicronewtonsPerSecond(decimal micronewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(micronewtonspersecond)) * 1e-6d);
+            return new ForceChangeRate((Convert.ToDouble(micronewtonspersecond)) * 1e-6d);
         }
 #endif
 
@@ -479,7 +479,7 @@ namespace UnitsNet
             return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromMillinewtonsPerSecond(int millinewtonspersecond)
@@ -487,7 +487,7 @@ namespace UnitsNet
             return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromMillinewtonsPerSecond(long millinewtonspersecond)
@@ -495,14 +495,14 @@ namespace UnitsNet
             return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromMillinewtonsPerSecond(decimal millinewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(millinewtonspersecond)) * 1e-3d);
+            return new ForceChangeRate((Convert.ToDouble(millinewtonspersecond)) * 1e-3d);
         }
 #endif
 
@@ -514,7 +514,7 @@ namespace UnitsNet
             return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromNanonewtonsPerSecond(int nanonewtonspersecond)
@@ -522,7 +522,7 @@ namespace UnitsNet
             return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromNanonewtonsPerSecond(long nanonewtonspersecond)
@@ -530,14 +530,14 @@ namespace UnitsNet
             return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromNanonewtonsPerSecond(decimal nanonewtonspersecond)
         {
-	        return new ForceChangeRate((Convert.ToDouble(nanonewtonspersecond)) * 1e-9d);
+            return new ForceChangeRate((Convert.ToDouble(nanonewtonspersecond)) * 1e-9d);
         }
 #endif
 
@@ -549,7 +549,7 @@ namespace UnitsNet
             return new ForceChangeRate(newtonsperminute/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate FromNewtonsPerMinute(int newtonsperminute)
@@ -557,7 +557,7 @@ namespace UnitsNet
             return new ForceChangeRate(newtonsperminute/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate FromNewtonsPerMinute(long newtonsperminute)
@@ -565,14 +565,14 @@ namespace UnitsNet
             return new ForceChangeRate(newtonsperminute/60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute of type decimal.
         /// </summary>
         public static ForceChangeRate FromNewtonsPerMinute(decimal newtonsperminute)
         {
-	        return new ForceChangeRate(Convert.ToDouble(newtonsperminute)/60);
+            return new ForceChangeRate(Convert.ToDouble(newtonsperminute)/60);
         }
 #endif
 
@@ -584,7 +584,7 @@ namespace UnitsNet
             return new ForceChangeRate(newtonspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromNewtonsPerSecond(int newtonspersecond)
@@ -592,7 +592,7 @@ namespace UnitsNet
             return new ForceChangeRate(newtonspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate FromNewtonsPerSecond(long newtonspersecond)
@@ -600,14 +600,14 @@ namespace UnitsNet
             return new ForceChangeRate(newtonspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate FromNewtonsPerSecond(decimal newtonspersecond)
         {
-	        return new ForceChangeRate(Convert.ToDouble(newtonspersecond));
+            return new ForceChangeRate(Convert.ToDouble(newtonspersecond));
         }
 #endif
 
@@ -628,7 +628,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromCentinewtonsPerSecond(int? centinewtonspersecond)
@@ -643,7 +643,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromCentinewtonsPerSecond(long? centinewtonspersecond)
@@ -658,7 +658,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from CentinewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromCentinewtonsPerSecond(decimal? centinewtonspersecond)
@@ -688,7 +688,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerMinute(int? decanewtonsperminute)
@@ -703,7 +703,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerMinute(long? decanewtonsperminute)
@@ -718,7 +718,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from DecanewtonsPerMinute of type decimal.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerMinute(decimal? decanewtonsperminute)
@@ -748,7 +748,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerSecond(int? decanewtonspersecond)
@@ -763,7 +763,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerSecond(long? decanewtonspersecond)
@@ -778,7 +778,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from DecanewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromDecanewtonsPerSecond(decimal? decanewtonspersecond)
@@ -808,7 +808,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromDecinewtonsPerSecond(int? decinewtonspersecond)
@@ -823,7 +823,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromDecinewtonsPerSecond(long? decinewtonspersecond)
@@ -838,7 +838,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from DecinewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromDecinewtonsPerSecond(decimal? decinewtonspersecond)
@@ -868,7 +868,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerMinute(int? kilonewtonsperminute)
@@ -883,7 +883,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerMinute(long? kilonewtonsperminute)
@@ -898,7 +898,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from KilonewtonsPerMinute of type decimal.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerMinute(decimal? kilonewtonsperminute)
@@ -928,7 +928,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerSecond(int? kilonewtonspersecond)
@@ -943,7 +943,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerSecond(long? kilonewtonspersecond)
@@ -958,7 +958,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from KilonewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromKilonewtonsPerSecond(decimal? kilonewtonspersecond)
@@ -988,7 +988,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromMicronewtonsPerSecond(int? micronewtonspersecond)
@@ -1003,7 +1003,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromMicronewtonsPerSecond(long? micronewtonspersecond)
@@ -1018,7 +1018,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from MicronewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromMicronewtonsPerSecond(decimal? micronewtonspersecond)
@@ -1048,7 +1048,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromMillinewtonsPerSecond(int? millinewtonspersecond)
@@ -1063,7 +1063,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromMillinewtonsPerSecond(long? millinewtonspersecond)
@@ -1078,7 +1078,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from MillinewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromMillinewtonsPerSecond(decimal? millinewtonspersecond)
@@ -1108,7 +1108,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromNanonewtonsPerSecond(int? nanonewtonspersecond)
@@ -1123,7 +1123,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromNanonewtonsPerSecond(long? nanonewtonspersecond)
@@ -1138,7 +1138,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from NanonewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromNanonewtonsPerSecond(decimal? nanonewtonspersecond)
@@ -1168,7 +1168,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerMinute(int? newtonsperminute)
@@ -1183,7 +1183,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerMinute(long? newtonsperminute)
@@ -1198,7 +1198,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from NewtonsPerMinute of type decimal.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerMinute(decimal? newtonsperminute)
@@ -1228,7 +1228,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerSecond(int? newtonspersecond)
@@ -1243,7 +1243,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerSecond(long? newtonspersecond)
@@ -1258,7 +1258,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForceChangeRate from NewtonsPerSecond of type decimal.
         /// </summary>
         public static ForceChangeRate? FromNewtonsPerSecond(decimal? newtonspersecond)

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromCentinewtonsPerMeter(double centinewtonspermeter)
         {
             return new ForcePerLength((centinewtonspermeter) * 1e-2d);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromDecinewtonsPerMeter(double decinewtonspermeter)
         {
             return new ForcePerLength((decinewtonspermeter) * 1e-1d);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromKilogramsForcePerMeter(double kilogramsforcepermeter)
         {
             return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromKilonewtonsPerMeter(double kilonewtonspermeter)
         {
             return new ForcePerLength((kilonewtonspermeter) * 1e3d);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromMicronewtonsPerMeter(double micronewtonspermeter)
         {
             return new ForcePerLength((micronewtonspermeter) * 1e-6d);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromMillinewtonsPerMeter(double millinewtonspermeter)
         {
             return new ForcePerLength((millinewtonspermeter) * 1e-3d);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromNanonewtonsPerMeter(double nanonewtonspermeter)
         {
             return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ForcePerLength FromNewtonsPerMeter(double newtonspermeter)
         {
             return new ForcePerLength(newtonspermeter);

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new ForcePerLength((centinewtonspermeter) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get ForcePerLength from CentinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromCentinewtonsPerMeter(int centinewtonspermeter)
+        {
+            return new ForcePerLength((centinewtonspermeter) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from CentinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromCentinewtonsPerMeter(long centinewtonspermeter)
+        {
+            return new ForcePerLength((centinewtonspermeter) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from CentinewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromCentinewtonsPerMeter(decimal centinewtonspermeter)
+        {
+	        return new ForcePerLength((Convert.ToDouble(centinewtonspermeter)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new ForcePerLength((decinewtonspermeter) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get ForcePerLength from DecinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromDecinewtonsPerMeter(int decinewtonspermeter)
+        {
+            return new ForcePerLength((decinewtonspermeter) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from DecinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromDecinewtonsPerMeter(long decinewtonspermeter)
+        {
+            return new ForcePerLength((decinewtonspermeter) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from DecinewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromDecinewtonsPerMeter(decimal decinewtonspermeter)
+        {
+	        return new ForcePerLength((Convert.ToDouble(decinewtonspermeter)) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
         }
 
+		/// <summary>
+        ///     Get ForcePerLength from KilogramsForcePerMeter.
+        /// </summary>
+        public static ForcePerLength FromKilogramsForcePerMeter(int kilogramsforcepermeter)
+        {
+            return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from KilogramsForcePerMeter.
+        /// </summary>
+        public static ForcePerLength FromKilogramsForcePerMeter(long kilogramsforcepermeter)
+        {
+            return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from KilogramsForcePerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromKilogramsForcePerMeter(decimal kilogramsforcepermeter)
+        {
+	        return new ForcePerLength(Convert.ToDouble(kilogramsforcepermeter)*9.80665002864);
+        }
+#endif
+
         /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new ForcePerLength((kilonewtonspermeter) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get ForcePerLength from KilonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromKilonewtonsPerMeter(int kilonewtonspermeter)
+        {
+            return new ForcePerLength((kilonewtonspermeter) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from KilonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromKilonewtonsPerMeter(long kilonewtonspermeter)
+        {
+            return new ForcePerLength((kilonewtonspermeter) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from KilonewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromKilonewtonsPerMeter(decimal kilonewtonspermeter)
+        {
+	        return new ForcePerLength((Convert.ToDouble(kilonewtonspermeter)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new ForcePerLength((micronewtonspermeter) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get ForcePerLength from MicronewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromMicronewtonsPerMeter(int micronewtonspermeter)
+        {
+            return new ForcePerLength((micronewtonspermeter) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from MicronewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromMicronewtonsPerMeter(long micronewtonspermeter)
+        {
+            return new ForcePerLength((micronewtonspermeter) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from MicronewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromMicronewtonsPerMeter(decimal micronewtonspermeter)
+        {
+	        return new ForcePerLength((Convert.ToDouble(micronewtonspermeter)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new ForcePerLength((millinewtonspermeter) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get ForcePerLength from MillinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromMillinewtonsPerMeter(int millinewtonspermeter)
+        {
+            return new ForcePerLength((millinewtonspermeter) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from MillinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromMillinewtonsPerMeter(long millinewtonspermeter)
+        {
+            return new ForcePerLength((millinewtonspermeter) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from MillinewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromMillinewtonsPerMeter(decimal millinewtonspermeter)
+        {
+	        return new ForcePerLength((Convert.ToDouble(millinewtonspermeter)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get ForcePerLength from NanonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromNanonewtonsPerMeter(int nanonewtonspermeter)
+        {
+            return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from NanonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromNanonewtonsPerMeter(long nanonewtonspermeter)
+        {
+            return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from NanonewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromNanonewtonsPerMeter(decimal nanonewtonspermeter)
+        {
+	        return new ForcePerLength((Convert.ToDouble(nanonewtonspermeter)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new ForcePerLength(newtonspermeter);
         }
 
+		/// <summary>
+        ///     Get ForcePerLength from NewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromNewtonsPerMeter(int newtonspermeter)
+        {
+            return new ForcePerLength(newtonspermeter);
+        }
+
+		/// <summary>
+        ///     Get ForcePerLength from NewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength FromNewtonsPerMeter(long newtonspermeter)
+        {
+            return new ForcePerLength(newtonspermeter);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ForcePerLength from NewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength FromNewtonsPerMeter(decimal newtonspermeter)
+        {
+	        return new ForcePerLength(Convert.ToDouble(newtonspermeter));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromCentinewtonsPerMeter(double? centinewtonspermeter)
+        {
+            if (centinewtonspermeter.HasValue)
+            {
+                return FromCentinewtonsPerMeter(centinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromCentinewtonsPerMeter(int? centinewtonspermeter)
+        {
+            if (centinewtonspermeter.HasValue)
+            {
+                return FromCentinewtonsPerMeter(centinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromCentinewtonsPerMeter(long? centinewtonspermeter)
+        {
+            if (centinewtonspermeter.HasValue)
+            {
+                return FromCentinewtonsPerMeter(centinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from CentinewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromCentinewtonsPerMeter(decimal? centinewtonspermeter)
         {
             if (centinewtonspermeter.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromDecinewtonsPerMeter(int? decinewtonspermeter)
+        {
+            if (decinewtonspermeter.HasValue)
+            {
+                return FromDecinewtonsPerMeter(decinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromDecinewtonsPerMeter(long? decinewtonspermeter)
+        {
+            if (decinewtonspermeter.HasValue)
+            {
+                return FromDecinewtonsPerMeter(decinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from DecinewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromDecinewtonsPerMeter(decimal? decinewtonspermeter)
+        {
+            if (decinewtonspermeter.HasValue)
+            {
+                return FromDecinewtonsPerMeter(decinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
         /// </summary>
         public static ForcePerLength? FromKilogramsForcePerMeter(double? kilogramsforcepermeter)
+        {
+            if (kilogramsforcepermeter.HasValue)
+            {
+                return FromKilogramsForcePerMeter(kilogramsforcepermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
+        /// </summary>
+        public static ForcePerLength? FromKilogramsForcePerMeter(int? kilogramsforcepermeter)
+        {
+            if (kilogramsforcepermeter.HasValue)
+            {
+                return FromKilogramsForcePerMeter(kilogramsforcepermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
+        /// </summary>
+        public static ForcePerLength? FromKilogramsForcePerMeter(long? kilogramsforcepermeter)
+        {
+            if (kilogramsforcepermeter.HasValue)
+            {
+                return FromKilogramsForcePerMeter(kilogramsforcepermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from KilogramsForcePerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromKilogramsForcePerMeter(decimal? kilogramsforcepermeter)
         {
             if (kilogramsforcepermeter.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromKilonewtonsPerMeter(int? kilonewtonspermeter)
+        {
+            if (kilonewtonspermeter.HasValue)
+            {
+                return FromKilonewtonsPerMeter(kilonewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromKilonewtonsPerMeter(long? kilonewtonspermeter)
+        {
+            if (kilonewtonspermeter.HasValue)
+            {
+                return FromKilonewtonsPerMeter(kilonewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from KilonewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromKilonewtonsPerMeter(decimal? kilonewtonspermeter)
+        {
+            if (kilonewtonspermeter.HasValue)
+            {
+                return FromKilonewtonsPerMeter(kilonewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromMicronewtonsPerMeter(double? micronewtonspermeter)
+        {
+            if (micronewtonspermeter.HasValue)
+            {
+                return FromMicronewtonsPerMeter(micronewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromMicronewtonsPerMeter(int? micronewtonspermeter)
+        {
+            if (micronewtonspermeter.HasValue)
+            {
+                return FromMicronewtonsPerMeter(micronewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromMicronewtonsPerMeter(long? micronewtonspermeter)
+        {
+            if (micronewtonspermeter.HasValue)
+            {
+                return FromMicronewtonsPerMeter(micronewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from MicronewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromMicronewtonsPerMeter(decimal? micronewtonspermeter)
         {
             if (micronewtonspermeter.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromMillinewtonsPerMeter(int? millinewtonspermeter)
+        {
+            if (millinewtonspermeter.HasValue)
+            {
+                return FromMillinewtonsPerMeter(millinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromMillinewtonsPerMeter(long? millinewtonspermeter)
+        {
+            if (millinewtonspermeter.HasValue)
+            {
+                return FromMillinewtonsPerMeter(millinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from MillinewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromMillinewtonsPerMeter(decimal? millinewtonspermeter)
+        {
+            if (millinewtonspermeter.HasValue)
+            {
+                return FromMillinewtonsPerMeter(millinewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromNanonewtonsPerMeter(int? nanonewtonspermeter)
+        {
+            if (nanonewtonspermeter.HasValue)
+            {
+                return FromNanonewtonsPerMeter(nanonewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromNanonewtonsPerMeter(long? nanonewtonspermeter)
+        {
+            if (nanonewtonspermeter.HasValue)
+            {
+                return FromNanonewtonsPerMeter(nanonewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from NanonewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromNanonewtonsPerMeter(decimal? nanonewtonspermeter)
+        {
+            if (nanonewtonspermeter.HasValue)
+            {
+                return FromNanonewtonsPerMeter(nanonewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromNewtonsPerMeter(double? newtonspermeter)
+        {
+            if (newtonspermeter.HasValue)
+            {
+                return FromNewtonsPerMeter(newtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromNewtonsPerMeter(int? newtonspermeter)
+        {
+            if (newtonspermeter.HasValue)
+            {
+                return FromNewtonsPerMeter(newtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromNewtonsPerMeter(long? newtonspermeter)
+        {
+            if (newtonspermeter.HasValue)
+            {
+                return FromNewtonsPerMeter(newtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ForcePerLength from NewtonsPerMeter of type decimal.
+        /// </summary>
+        public static ForcePerLength? FromNewtonsPerMeter(decimal? newtonspermeter)
         {
             if (newtonspermeter.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _newtonsPerMeter;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ForcePerLength() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ForcePerLength;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ForcePerLengthUnit BaseUnit
         {
             get { return ForcePerLengthUnit.NewtonPerMeter; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new ForcePerLength((centinewtonspermeter) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromCentinewtonsPerMeter(int centinewtonspermeter)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new ForcePerLength((centinewtonspermeter) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromCentinewtonsPerMeter(long centinewtonspermeter)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new ForcePerLength((centinewtonspermeter) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromCentinewtonsPerMeter(decimal centinewtonspermeter)
         {
-	        return new ForcePerLength((Convert.ToDouble(centinewtonspermeter)) * 1e-2d);
+            return new ForcePerLength((Convert.ToDouble(centinewtonspermeter)) * 1e-2d);
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new ForcePerLength((decinewtonspermeter) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromDecinewtonsPerMeter(int decinewtonspermeter)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new ForcePerLength((decinewtonspermeter) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromDecinewtonsPerMeter(long decinewtonspermeter)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new ForcePerLength((decinewtonspermeter) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromDecinewtonsPerMeter(decimal decinewtonspermeter)
         {
-	        return new ForcePerLength((Convert.ToDouble(decinewtonspermeter)) * 1e-1d);
+            return new ForcePerLength((Convert.ToDouble(decinewtonspermeter)) * 1e-1d);
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
         /// </summary>
         public static ForcePerLength FromKilogramsForcePerMeter(int kilogramsforcepermeter)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
         /// </summary>
         public static ForcePerLength FromKilogramsForcePerMeter(long kilogramsforcepermeter)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromKilogramsForcePerMeter(decimal kilogramsforcepermeter)
         {
-	        return new ForcePerLength(Convert.ToDouble(kilogramsforcepermeter)*9.80665002864);
+            return new ForcePerLength(Convert.ToDouble(kilogramsforcepermeter)*9.80665002864);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new ForcePerLength((kilonewtonspermeter) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromKilonewtonsPerMeter(int kilonewtonspermeter)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new ForcePerLength((kilonewtonspermeter) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromKilonewtonsPerMeter(long kilonewtonspermeter)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new ForcePerLength((kilonewtonspermeter) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromKilonewtonsPerMeter(decimal kilonewtonspermeter)
         {
-	        return new ForcePerLength((Convert.ToDouble(kilonewtonspermeter)) * 1e3d);
+            return new ForcePerLength((Convert.ToDouble(kilonewtonspermeter)) * 1e3d);
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new ForcePerLength((micronewtonspermeter) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromMicronewtonsPerMeter(int micronewtonspermeter)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new ForcePerLength((micronewtonspermeter) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromMicronewtonsPerMeter(long micronewtonspermeter)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new ForcePerLength((micronewtonspermeter) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromMicronewtonsPerMeter(decimal micronewtonspermeter)
         {
-	        return new ForcePerLength((Convert.ToDouble(micronewtonspermeter)) * 1e-6d);
+            return new ForcePerLength((Convert.ToDouble(micronewtonspermeter)) * 1e-6d);
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new ForcePerLength((millinewtonspermeter) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromMillinewtonsPerMeter(int millinewtonspermeter)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new ForcePerLength((millinewtonspermeter) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromMillinewtonsPerMeter(long millinewtonspermeter)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new ForcePerLength((millinewtonspermeter) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromMillinewtonsPerMeter(decimal millinewtonspermeter)
         {
-	        return new ForcePerLength((Convert.ToDouble(millinewtonspermeter)) * 1e-3d);
+            return new ForcePerLength((Convert.ToDouble(millinewtonspermeter)) * 1e-3d);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromNanonewtonsPerMeter(int nanonewtonspermeter)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromNanonewtonsPerMeter(long nanonewtonspermeter)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromNanonewtonsPerMeter(decimal nanonewtonspermeter)
         {
-	        return new ForcePerLength((Convert.ToDouble(nanonewtonspermeter)) * 1e-9d);
+            return new ForcePerLength((Convert.ToDouble(nanonewtonspermeter)) * 1e-9d);
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new ForcePerLength(newtonspermeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromNewtonsPerMeter(int newtonspermeter)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new ForcePerLength(newtonspermeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
         public static ForcePerLength FromNewtonsPerMeter(long newtonspermeter)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new ForcePerLength(newtonspermeter);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength FromNewtonsPerMeter(decimal newtonspermeter)
         {
-	        return new ForcePerLength(Convert.ToDouble(newtonspermeter));
+            return new ForcePerLength(Convert.ToDouble(newtonspermeter));
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromCentinewtonsPerMeter(int? centinewtonspermeter)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromCentinewtonsPerMeter(long? centinewtonspermeter)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from CentinewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromCentinewtonsPerMeter(decimal? centinewtonspermeter)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromDecinewtonsPerMeter(int? decinewtonspermeter)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromDecinewtonsPerMeter(long? decinewtonspermeter)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from DecinewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromDecinewtonsPerMeter(decimal? decinewtonspermeter)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
         /// </summary>
         public static ForcePerLength? FromKilogramsForcePerMeter(int? kilogramsforcepermeter)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
         /// </summary>
         public static ForcePerLength? FromKilogramsForcePerMeter(long? kilogramsforcepermeter)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from KilogramsForcePerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromKilogramsForcePerMeter(decimal? kilogramsforcepermeter)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromKilonewtonsPerMeter(int? kilonewtonspermeter)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromKilonewtonsPerMeter(long? kilonewtonspermeter)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from KilonewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromKilonewtonsPerMeter(decimal? kilonewtonspermeter)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromMicronewtonsPerMeter(int? micronewtonspermeter)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromMicronewtonsPerMeter(long? micronewtonspermeter)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from MicronewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromMicronewtonsPerMeter(decimal? micronewtonspermeter)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromMillinewtonsPerMeter(int? millinewtonspermeter)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromMillinewtonsPerMeter(long? millinewtonspermeter)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from MillinewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromMillinewtonsPerMeter(decimal? millinewtonspermeter)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromNanonewtonsPerMeter(int? nanonewtonspermeter)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromNanonewtonsPerMeter(long? nanonewtonspermeter)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from NanonewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromNanonewtonsPerMeter(decimal? nanonewtonspermeter)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromNewtonsPerMeter(int? newtonspermeter)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromNewtonsPerMeter(long? newtonspermeter)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ForcePerLength from NewtonsPerMeter of type decimal.
         /// </summary>
         public static ForcePerLength? FromNewtonsPerMeter(decimal? newtonspermeter)

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new Frequency(cyclesperhour/3600);
         }
 
+		/// <summary>
+        ///     Get Frequency from CyclesPerHour.
+        /// </summary>
+        public static Frequency FromCyclesPerHour(int cyclesperhour)
+        {
+            return new Frequency(cyclesperhour/3600);
+        }
+
+		/// <summary>
+        ///     Get Frequency from CyclesPerHour.
+        /// </summary>
+        public static Frequency FromCyclesPerHour(long cyclesperhour)
+        {
+            return new Frequency(cyclesperhour/3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from CyclesPerHour of type decimal.
+        /// </summary>
+        public static Frequency FromCyclesPerHour(decimal cyclesperhour)
+        {
+	        return new Frequency(Convert.ToDouble(cyclesperhour)/3600);
+        }
+#endif
+
         /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new Frequency(cyclesperminute/60);
         }
+
+		/// <summary>
+        ///     Get Frequency from CyclesPerMinute.
+        /// </summary>
+        public static Frequency FromCyclesPerMinute(int cyclesperminute)
+        {
+            return new Frequency(cyclesperminute/60);
+        }
+
+		/// <summary>
+        ///     Get Frequency from CyclesPerMinute.
+        /// </summary>
+        public static Frequency FromCyclesPerMinute(long cyclesperminute)
+        {
+            return new Frequency(cyclesperminute/60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from CyclesPerMinute of type decimal.
+        /// </summary>
+        public static Frequency FromCyclesPerMinute(decimal cyclesperminute)
+        {
+	        return new Frequency(Convert.ToDouble(cyclesperminute)/60);
+        }
+#endif
 
         /// <summary>
         ///     Get Frequency from Gigahertz.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new Frequency((gigahertz) * 1e9d);
         }
 
+		/// <summary>
+        ///     Get Frequency from Gigahertz.
+        /// </summary>
+        public static Frequency FromGigahertz(int gigahertz)
+        {
+            return new Frequency((gigahertz) * 1e9d);
+        }
+
+		/// <summary>
+        ///     Get Frequency from Gigahertz.
+        /// </summary>
+        public static Frequency FromGigahertz(long gigahertz)
+        {
+            return new Frequency((gigahertz) * 1e9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from Gigahertz of type decimal.
+        /// </summary>
+        public static Frequency FromGigahertz(decimal gigahertz)
+        {
+	        return new Frequency((Convert.ToDouble(gigahertz)) * 1e9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new Frequency(hertz);
         }
+
+		/// <summary>
+        ///     Get Frequency from Hertz.
+        /// </summary>
+        public static Frequency FromHertz(int hertz)
+        {
+            return new Frequency(hertz);
+        }
+
+		/// <summary>
+        ///     Get Frequency from Hertz.
+        /// </summary>
+        public static Frequency FromHertz(long hertz)
+        {
+            return new Frequency(hertz);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from Hertz of type decimal.
+        /// </summary>
+        public static Frequency FromHertz(decimal hertz)
+        {
+	        return new Frequency(Convert.ToDouble(hertz));
+        }
+#endif
 
         /// <summary>
         ///     Get Frequency from Kilohertz.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new Frequency((kilohertz) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Frequency from Kilohertz.
+        /// </summary>
+        public static Frequency FromKilohertz(int kilohertz)
+        {
+            return new Frequency((kilohertz) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Frequency from Kilohertz.
+        /// </summary>
+        public static Frequency FromKilohertz(long kilohertz)
+        {
+            return new Frequency((kilohertz) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from Kilohertz of type decimal.
+        /// </summary>
+        public static Frequency FromKilohertz(decimal kilohertz)
+        {
+	        return new Frequency((Convert.ToDouble(kilohertz)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new Frequency((megahertz) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get Frequency from Megahertz.
+        /// </summary>
+        public static Frequency FromMegahertz(int megahertz)
+        {
+            return new Frequency((megahertz) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Frequency from Megahertz.
+        /// </summary>
+        public static Frequency FromMegahertz(long megahertz)
+        {
+            return new Frequency((megahertz) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from Megahertz of type decimal.
+        /// </summary>
+        public static Frequency FromMegahertz(decimal megahertz)
+        {
+	        return new Frequency((Convert.ToDouble(megahertz)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new Frequency(radianspersecond/6.2831853072);
         }
 
+		/// <summary>
+        ///     Get Frequency from RadiansPerSecond.
+        /// </summary>
+        public static Frequency FromRadiansPerSecond(int radianspersecond)
+        {
+            return new Frequency(radianspersecond/6.2831853072);
+        }
+
+		/// <summary>
+        ///     Get Frequency from RadiansPerSecond.
+        /// </summary>
+        public static Frequency FromRadiansPerSecond(long radianspersecond)
+        {
+            return new Frequency(radianspersecond/6.2831853072);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from RadiansPerSecond of type decimal.
+        /// </summary>
+        public static Frequency FromRadiansPerSecond(decimal radianspersecond)
+        {
+	        return new Frequency(Convert.ToDouble(radianspersecond)/6.2831853072);
+        }
+#endif
+
         /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new Frequency((terahertz) * 1e12d);
         }
 
+		/// <summary>
+        ///     Get Frequency from Terahertz.
+        /// </summary>
+        public static Frequency FromTerahertz(int terahertz)
+        {
+            return new Frequency((terahertz) * 1e12d);
+        }
+
+		/// <summary>
+        ///     Get Frequency from Terahertz.
+        /// </summary>
+        public static Frequency FromTerahertz(long terahertz)
+        {
+            return new Frequency((terahertz) * 1e12d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Frequency from Terahertz of type decimal.
+        /// </summary>
+        public static Frequency FromTerahertz(decimal terahertz)
+        {
+	        return new Frequency((Convert.ToDouble(terahertz)) * 1e12d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerHour.
         /// </summary>
         public static Frequency? FromCyclesPerHour(double? cyclesperhour)
+        {
+            if (cyclesperhour.HasValue)
+            {
+                return FromCyclesPerHour(cyclesperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable CyclesPerHour.
+        /// </summary>
+        public static Frequency? FromCyclesPerHour(int? cyclesperhour)
+        {
+            if (cyclesperhour.HasValue)
+            {
+                return FromCyclesPerHour(cyclesperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable CyclesPerHour.
+        /// </summary>
+        public static Frequency? FromCyclesPerHour(long? cyclesperhour)
+        {
+            if (cyclesperhour.HasValue)
+            {
+                return FromCyclesPerHour(cyclesperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from CyclesPerHour of type decimal.
+        /// </summary>
+        public static Frequency? FromCyclesPerHour(decimal? cyclesperhour)
         {
             if (cyclesperhour.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Frequency from nullable CyclesPerMinute.
+        /// </summary>
+        public static Frequency? FromCyclesPerMinute(int? cyclesperminute)
+        {
+            if (cyclesperminute.HasValue)
+            {
+                return FromCyclesPerMinute(cyclesperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable CyclesPerMinute.
+        /// </summary>
+        public static Frequency? FromCyclesPerMinute(long? cyclesperminute)
+        {
+            if (cyclesperminute.HasValue)
+            {
+                return FromCyclesPerMinute(cyclesperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from CyclesPerMinute of type decimal.
+        /// </summary>
+        public static Frequency? FromCyclesPerMinute(decimal? cyclesperminute)
+        {
+            if (cyclesperminute.HasValue)
+            {
+                return FromCyclesPerMinute(cyclesperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Frequency from nullable Gigahertz.
         /// </summary>
         public static Frequency? FromGigahertz(double? gigahertz)
+        {
+            if (gigahertz.HasValue)
+            {
+                return FromGigahertz(gigahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Gigahertz.
+        /// </summary>
+        public static Frequency? FromGigahertz(int? gigahertz)
+        {
+            if (gigahertz.HasValue)
+            {
+                return FromGigahertz(gigahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Gigahertz.
+        /// </summary>
+        public static Frequency? FromGigahertz(long? gigahertz)
+        {
+            if (gigahertz.HasValue)
+            {
+                return FromGigahertz(gigahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from Gigahertz of type decimal.
+        /// </summary>
+        public static Frequency? FromGigahertz(decimal? gigahertz)
         {
             if (gigahertz.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Frequency from nullable Hertz.
+        /// </summary>
+        public static Frequency? FromHertz(int? hertz)
+        {
+            if (hertz.HasValue)
+            {
+                return FromHertz(hertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Hertz.
+        /// </summary>
+        public static Frequency? FromHertz(long? hertz)
+        {
+            if (hertz.HasValue)
+            {
+                return FromHertz(hertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from Hertz of type decimal.
+        /// </summary>
+        public static Frequency? FromHertz(decimal? hertz)
+        {
+            if (hertz.HasValue)
+            {
+                return FromHertz(hertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Frequency from nullable Kilohertz.
         /// </summary>
         public static Frequency? FromKilohertz(double? kilohertz)
+        {
+            if (kilohertz.HasValue)
+            {
+                return FromKilohertz(kilohertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Kilohertz.
+        /// </summary>
+        public static Frequency? FromKilohertz(int? kilohertz)
+        {
+            if (kilohertz.HasValue)
+            {
+                return FromKilohertz(kilohertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Kilohertz.
+        /// </summary>
+        public static Frequency? FromKilohertz(long? kilohertz)
+        {
+            if (kilohertz.HasValue)
+            {
+                return FromKilohertz(kilohertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from Kilohertz of type decimal.
+        /// </summary>
+        public static Frequency? FromKilohertz(decimal? kilohertz)
         {
             if (kilohertz.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Frequency from nullable Megahertz.
+        /// </summary>
+        public static Frequency? FromMegahertz(int? megahertz)
+        {
+            if (megahertz.HasValue)
+            {
+                return FromMegahertz(megahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Megahertz.
+        /// </summary>
+        public static Frequency? FromMegahertz(long? megahertz)
+        {
+            if (megahertz.HasValue)
+            {
+                return FromMegahertz(megahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from Megahertz of type decimal.
+        /// </summary>
+        public static Frequency? FromMegahertz(decimal? megahertz)
+        {
+            if (megahertz.HasValue)
+            {
+                return FromMegahertz(megahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Frequency from nullable RadiansPerSecond.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Frequency from nullable RadiansPerSecond.
+        /// </summary>
+        public static Frequency? FromRadiansPerSecond(int? radianspersecond)
+        {
+            if (radianspersecond.HasValue)
+            {
+                return FromRadiansPerSecond(radianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable RadiansPerSecond.
+        /// </summary>
+        public static Frequency? FromRadiansPerSecond(long? radianspersecond)
+        {
+            if (radianspersecond.HasValue)
+            {
+                return FromRadiansPerSecond(radianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from RadiansPerSecond of type decimal.
+        /// </summary>
+        public static Frequency? FromRadiansPerSecond(decimal? radianspersecond)
+        {
+            if (radianspersecond.HasValue)
+            {
+                return FromRadiansPerSecond(radianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Frequency from nullable Terahertz.
         /// </summary>
         public static Frequency? FromTerahertz(double? terahertz)
+        {
+            if (terahertz.HasValue)
+            {
+                return FromTerahertz(terahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Terahertz.
+        /// </summary>
+        public static Frequency? FromTerahertz(int? terahertz)
+        {
+            if (terahertz.HasValue)
+            {
+                return FromTerahertz(terahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from nullable Terahertz.
+        /// </summary>
+        public static Frequency? FromTerahertz(long? terahertz)
+        {
+            if (terahertz.HasValue)
+            {
+                return FromTerahertz(terahertz.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Frequency from Terahertz of type decimal.
+        /// </summary>
+        public static Frequency? FromTerahertz(decimal? terahertz)
         {
             if (terahertz.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromCyclesPerHour(double cyclesperhour)
         {
             return new Frequency(cyclesperhour/3600);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromCyclesPerMinute(double cyclesperminute)
         {
             return new Frequency(cyclesperminute/60);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Gigahertz.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromGigahertz(double gigahertz)
         {
             return new Frequency((gigahertz) * 1e9d);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromHertz(double hertz)
         {
             return new Frequency(hertz);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Kilohertz.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromKilohertz(double kilohertz)
         {
             return new Frequency((kilohertz) * 1e3d);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromMegahertz(double megahertz)
         {
             return new Frequency((megahertz) * 1e6d);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromRadiansPerSecond(double radianspersecond)
         {
             return new Frequency(radianspersecond/6.2831853072);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Frequency FromTerahertz(double terahertz)
         {
             return new Frequency((terahertz) * 1e12d);

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _hertz;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Frequency() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Frequency;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static FrequencyUnit BaseUnit
         {
             get { return FrequencyUnit.Hertz; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new Frequency(cyclesperhour/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from CyclesPerHour.
         /// </summary>
         public static Frequency FromCyclesPerHour(int cyclesperhour)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new Frequency(cyclesperhour/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from CyclesPerHour.
         /// </summary>
         public static Frequency FromCyclesPerHour(long cyclesperhour)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new Frequency(cyclesperhour/3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from CyclesPerHour of type decimal.
         /// </summary>
         public static Frequency FromCyclesPerHour(decimal cyclesperhour)
         {
-	        return new Frequency(Convert.ToDouble(cyclesperhour)/3600);
+            return new Frequency(Convert.ToDouble(cyclesperhour)/3600);
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new Frequency(cyclesperminute/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
         public static Frequency FromCyclesPerMinute(int cyclesperminute)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new Frequency(cyclesperminute/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
         public static Frequency FromCyclesPerMinute(long cyclesperminute)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new Frequency(cyclesperminute/60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from CyclesPerMinute of type decimal.
         /// </summary>
         public static Frequency FromCyclesPerMinute(decimal cyclesperminute)
         {
-	        return new Frequency(Convert.ToDouble(cyclesperminute)/60);
+            return new Frequency(Convert.ToDouble(cyclesperminute)/60);
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new Frequency((gigahertz) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Gigahertz.
         /// </summary>
         public static Frequency FromGigahertz(int gigahertz)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new Frequency((gigahertz) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Gigahertz.
         /// </summary>
         public static Frequency FromGigahertz(long gigahertz)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new Frequency((gigahertz) * 1e9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Gigahertz of type decimal.
         /// </summary>
         public static Frequency FromGigahertz(decimal gigahertz)
         {
-	        return new Frequency((Convert.ToDouble(gigahertz)) * 1e9d);
+            return new Frequency((Convert.ToDouble(gigahertz)) * 1e9d);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new Frequency(hertz);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
         public static Frequency FromHertz(int hertz)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new Frequency(hertz);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
         public static Frequency FromHertz(long hertz)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new Frequency(hertz);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Hertz of type decimal.
         /// </summary>
         public static Frequency FromHertz(decimal hertz)
         {
-	        return new Frequency(Convert.ToDouble(hertz));
+            return new Frequency(Convert.ToDouble(hertz));
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new Frequency((kilohertz) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Kilohertz.
         /// </summary>
         public static Frequency FromKilohertz(int kilohertz)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new Frequency((kilohertz) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Kilohertz.
         /// </summary>
         public static Frequency FromKilohertz(long kilohertz)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new Frequency((kilohertz) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Kilohertz of type decimal.
         /// </summary>
         public static Frequency FromKilohertz(decimal kilohertz)
         {
-	        return new Frequency((Convert.ToDouble(kilohertz)) * 1e3d);
+            return new Frequency((Convert.ToDouble(kilohertz)) * 1e3d);
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new Frequency((megahertz) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
         public static Frequency FromMegahertz(int megahertz)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new Frequency((megahertz) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
         public static Frequency FromMegahertz(long megahertz)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new Frequency((megahertz) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Megahertz of type decimal.
         /// </summary>
         public static Frequency FromMegahertz(decimal megahertz)
         {
-	        return new Frequency((Convert.ToDouble(megahertz)) * 1e6d);
+            return new Frequency((Convert.ToDouble(megahertz)) * 1e6d);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new Frequency(radianspersecond/6.2831853072);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from RadiansPerSecond.
         /// </summary>
         public static Frequency FromRadiansPerSecond(int radianspersecond)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new Frequency(radianspersecond/6.2831853072);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from RadiansPerSecond.
         /// </summary>
         public static Frequency FromRadiansPerSecond(long radianspersecond)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new Frequency(radianspersecond/6.2831853072);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from RadiansPerSecond of type decimal.
         /// </summary>
         public static Frequency FromRadiansPerSecond(decimal radianspersecond)
         {
-	        return new Frequency(Convert.ToDouble(radianspersecond)/6.2831853072);
+            return new Frequency(Convert.ToDouble(radianspersecond)/6.2831853072);
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new Frequency((terahertz) * 1e12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
         public static Frequency FromTerahertz(int terahertz)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new Frequency((terahertz) * 1e12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
         public static Frequency FromTerahertz(long terahertz)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new Frequency((terahertz) * 1e12d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Frequency from Terahertz of type decimal.
         /// </summary>
         public static Frequency FromTerahertz(decimal terahertz)
         {
-	        return new Frequency((Convert.ToDouble(terahertz)) * 1e12d);
+            return new Frequency((Convert.ToDouble(terahertz)) * 1e12d);
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerHour.
         /// </summary>
         public static Frequency? FromCyclesPerHour(int? cyclesperhour)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerHour.
         /// </summary>
         public static Frequency? FromCyclesPerHour(long? cyclesperhour)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from CyclesPerHour of type decimal.
         /// </summary>
         public static Frequency? FromCyclesPerHour(decimal? cyclesperhour)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerMinute.
         /// </summary>
         public static Frequency? FromCyclesPerMinute(int? cyclesperminute)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerMinute.
         /// </summary>
         public static Frequency? FromCyclesPerMinute(long? cyclesperminute)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from CyclesPerMinute of type decimal.
         /// </summary>
         public static Frequency? FromCyclesPerMinute(decimal? cyclesperminute)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Gigahertz.
         /// </summary>
         public static Frequency? FromGigahertz(int? gigahertz)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Gigahertz.
         /// </summary>
         public static Frequency? FromGigahertz(long? gigahertz)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from Gigahertz of type decimal.
         /// </summary>
         public static Frequency? FromGigahertz(decimal? gigahertz)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Hertz.
         /// </summary>
         public static Frequency? FromHertz(int? hertz)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Hertz.
         /// </summary>
         public static Frequency? FromHertz(long? hertz)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from Hertz of type decimal.
         /// </summary>
         public static Frequency? FromHertz(decimal? hertz)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Kilohertz.
         /// </summary>
         public static Frequency? FromKilohertz(int? kilohertz)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Kilohertz.
         /// </summary>
         public static Frequency? FromKilohertz(long? kilohertz)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from Kilohertz of type decimal.
         /// </summary>
         public static Frequency? FromKilohertz(decimal? kilohertz)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Megahertz.
         /// </summary>
         public static Frequency? FromMegahertz(int? megahertz)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Megahertz.
         /// </summary>
         public static Frequency? FromMegahertz(long? megahertz)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from Megahertz of type decimal.
         /// </summary>
         public static Frequency? FromMegahertz(decimal? megahertz)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable RadiansPerSecond.
         /// </summary>
         public static Frequency? FromRadiansPerSecond(int? radianspersecond)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable RadiansPerSecond.
         /// </summary>
         public static Frequency? FromRadiansPerSecond(long? radianspersecond)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from RadiansPerSecond of type decimal.
         /// </summary>
         public static Frequency? FromRadiansPerSecond(decimal? radianspersecond)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Terahertz.
         /// </summary>
         public static Frequency? FromTerahertz(int? terahertz)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from nullable Terahertz.
         /// </summary>
         public static Frequency? FromTerahertz(long? terahertz)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Frequency from Terahertz of type decimal.
         /// </summary>
         public static Frequency? FromTerahertz(decimal? terahertz)

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -349,6 +349,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromBits(double bits)
         {
             return new Information(Convert.ToDecimal(bits));
@@ -384,6 +387,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromBytes(double bytes)
         {
             return new Information(Convert.ToDecimal(bytes*8d));
@@ -419,6 +425,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exabits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromExabits(double exabits)
         {
             return new Information(Convert.ToDecimal((exabits) * 1e18d));
@@ -454,6 +463,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromExabytes(double exabytes)
         {
             return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
@@ -489,6 +501,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromExbibits(double exbibits)
         {
             return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
@@ -524,6 +539,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromExbibytes(double exbibytes)
         {
             return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
@@ -559,6 +577,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gibibits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromGibibits(double gibibits)
         {
             return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
@@ -594,6 +615,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromGibibytes(double gibibytes)
         {
             return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
@@ -629,6 +653,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gigabits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromGigabits(double gigabits)
         {
             return new Information(Convert.ToDecimal((gigabits) * 1e9d));
@@ -664,6 +691,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromGigabytes(double gigabytes)
         {
             return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
@@ -699,6 +729,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kibibits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromKibibits(double kibibits)
         {
             return new Information(Convert.ToDecimal((kibibits) * 1024d));
@@ -734,6 +767,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromKibibytes(double kibibytes)
         {
             return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
@@ -769,6 +805,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kilobits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromKilobits(double kilobits)
         {
             return new Information(Convert.ToDecimal((kilobits) * 1e3d));
@@ -804,6 +843,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromKilobytes(double kilobytes)
         {
             return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
@@ -839,6 +881,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Mebibits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromMebibits(double mebibits)
         {
             return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
@@ -874,6 +919,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromMebibytes(double mebibytes)
         {
             return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
@@ -909,6 +957,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Megabits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromMegabits(double megabits)
         {
             return new Information(Convert.ToDecimal((megabits) * 1e6d));
@@ -944,6 +995,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromMegabytes(double megabytes)
         {
             return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
@@ -979,6 +1033,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Pebibits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromPebibits(double pebibits)
         {
             return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
@@ -1014,6 +1071,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromPebibytes(double pebibytes)
         {
             return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
@@ -1049,6 +1109,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Petabits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromPetabits(double petabits)
         {
             return new Information(Convert.ToDecimal((petabits) * 1e15d));
@@ -1084,6 +1147,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromPetabytes(double petabytes)
         {
             return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
@@ -1119,6 +1185,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Tebibits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromTebibits(double tebibits)
         {
             return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
@@ -1154,6 +1223,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromTebibytes(double tebibytes)
         {
             return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
@@ -1189,6 +1261,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Terabits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromTerabits(double terabits)
         {
             return new Information(Convert.ToDecimal((terabits) * 1e12d));
@@ -1224,6 +1299,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Information FromTerabytes(double terabytes)
         {
             return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly decimal _bits;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Information() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Information;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static InformationUnit BaseUnit
         {
             get { return InformationUnit.Bit; }
@@ -354,7 +354,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bits));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Bits.
         /// </summary>
         public static Information FromBits(int bits)
@@ -362,7 +362,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bits));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Bits.
         /// </summary>
         public static Information FromBits(long bits)
@@ -370,14 +370,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bits));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Bits of type decimal.
         /// </summary>
         public static Information FromBits(decimal bits)
         {
-	        return new Information(Convert.ToDecimal(Convert.ToDouble(bits)));
+            return new Information(Convert.ToDecimal(Convert.ToDouble(bits)));
         }
 #endif
 
@@ -389,7 +389,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bytes*8d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
         public static Information FromBytes(int bytes)
@@ -397,7 +397,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bytes*8d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
         public static Information FromBytes(long bytes)
@@ -405,14 +405,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bytes*8d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Bytes of type decimal.
         /// </summary>
         public static Information FromBytes(decimal bytes)
         {
-	        return new Information(Convert.ToDecimal(Convert.ToDouble(bytes)*8d));
+            return new Information(Convert.ToDecimal(Convert.ToDouble(bytes)*8d));
         }
 #endif
 
@@ -424,7 +424,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabits) * 1e18d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exabits.
         /// </summary>
         public static Information FromExabits(int exabits)
@@ -432,7 +432,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabits) * 1e18d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exabits.
         /// </summary>
         public static Information FromExabits(long exabits)
@@ -440,14 +440,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabits) * 1e18d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exabits of type decimal.
         /// </summary>
         public static Information FromExabits(decimal exabits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(exabits)) * 1e18d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(exabits)) * 1e18d));
         }
 #endif
 
@@ -459,7 +459,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
         public static Information FromExabytes(int exabytes)
@@ -467,7 +467,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
         public static Information FromExabytes(long exabytes)
@@ -475,14 +475,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exabytes of type decimal.
         /// </summary>
         public static Information FromExabytes(decimal exabytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(exabytes)*8d) * 1e18d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(exabytes)*8d) * 1e18d));
         }
 #endif
 
@@ -494,7 +494,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>
         public static Information FromExbibits(int exbibits)
@@ -502,7 +502,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>
         public static Information FromExbibits(long exbibits)
@@ -510,14 +510,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exbibits of type decimal.
         /// </summary>
         public static Information FromExbibits(decimal exbibits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(exbibits)) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(exbibits)) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 #endif
 
@@ -529,7 +529,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
         public static Information FromExbibytes(int exbibytes)
@@ -537,7 +537,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
         public static Information FromExbibytes(long exbibytes)
@@ -545,14 +545,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Exbibytes of type decimal.
         /// </summary>
         public static Information FromExbibytes(decimal exbibytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(exbibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(exbibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 #endif
 
@@ -564,7 +564,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gibibits.
         /// </summary>
         public static Information FromGibibits(int gibibits)
@@ -572,7 +572,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gibibits.
         /// </summary>
         public static Information FromGibibits(long gibibits)
@@ -580,14 +580,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gibibits of type decimal.
         /// </summary>
         public static Information FromGibibits(decimal gibibits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(gibibits)) * (1024d * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(gibibits)) * (1024d * 1024 * 1024)));
         }
 #endif
 
@@ -599,7 +599,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
         public static Information FromGibibytes(int gibibytes)
@@ -607,7 +607,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
         public static Information FromGibibytes(long gibibytes)
@@ -615,14 +615,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gibibytes of type decimal.
         /// </summary>
         public static Information FromGibibytes(decimal gibibytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(gibibytes)*8d) * (1024d * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(gibibytes)*8d) * (1024d * 1024 * 1024)));
         }
 #endif
 
@@ -634,7 +634,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabits) * 1e9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gigabits.
         /// </summary>
         public static Information FromGigabits(int gigabits)
@@ -642,7 +642,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabits) * 1e9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gigabits.
         /// </summary>
         public static Information FromGigabits(long gigabits)
@@ -650,14 +650,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabits) * 1e9d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gigabits of type decimal.
         /// </summary>
         public static Information FromGigabits(decimal gigabits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(gigabits)) * 1e9d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(gigabits)) * 1e9d));
         }
 #endif
 
@@ -669,7 +669,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
         public static Information FromGigabytes(int gigabytes)
@@ -677,7 +677,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
         public static Information FromGigabytes(long gigabytes)
@@ -685,14 +685,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Gigabytes of type decimal.
         /// </summary>
         public static Information FromGigabytes(decimal gigabytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(gigabytes)*8d) * 1e9d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(gigabytes)*8d) * 1e9d));
         }
 #endif
 
@@ -704,7 +704,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibits) * 1024d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kibibits.
         /// </summary>
         public static Information FromKibibits(int kibibits)
@@ -712,7 +712,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibits) * 1024d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kibibits.
         /// </summary>
         public static Information FromKibibits(long kibibits)
@@ -720,14 +720,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibits) * 1024d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kibibits of type decimal.
         /// </summary>
         public static Information FromKibibits(decimal kibibits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(kibibits)) * 1024d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(kibibits)) * 1024d));
         }
 #endif
 
@@ -739,7 +739,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
         public static Information FromKibibytes(int kibibytes)
@@ -747,7 +747,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
         public static Information FromKibibytes(long kibibytes)
@@ -755,14 +755,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kibibytes of type decimal.
         /// </summary>
         public static Information FromKibibytes(decimal kibibytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(kibibytes)*8d) * 1024d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(kibibytes)*8d) * 1024d));
         }
 #endif
 
@@ -774,7 +774,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobits) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kilobits.
         /// </summary>
         public static Information FromKilobits(int kilobits)
@@ -782,7 +782,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobits) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kilobits.
         /// </summary>
         public static Information FromKilobits(long kilobits)
@@ -790,14 +790,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobits) * 1e3d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kilobits of type decimal.
         /// </summary>
         public static Information FromKilobits(decimal kilobits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(kilobits)) * 1e3d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(kilobits)) * 1e3d));
         }
 #endif
 
@@ -809,7 +809,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
         public static Information FromKilobytes(int kilobytes)
@@ -817,7 +817,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
         public static Information FromKilobytes(long kilobytes)
@@ -825,14 +825,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Kilobytes of type decimal.
         /// </summary>
         public static Information FromKilobytes(decimal kilobytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(kilobytes)*8d) * 1e3d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(kilobytes)*8d) * 1e3d));
         }
 #endif
 
@@ -844,7 +844,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Mebibits.
         /// </summary>
         public static Information FromMebibits(int mebibits)
@@ -852,7 +852,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Mebibits.
         /// </summary>
         public static Information FromMebibits(long mebibits)
@@ -860,14 +860,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Mebibits of type decimal.
         /// </summary>
         public static Information FromMebibits(decimal mebibits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(mebibits)) * (1024d * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(mebibits)) * (1024d * 1024)));
         }
 #endif
 
@@ -879,7 +879,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
         public static Information FromMebibytes(int mebibytes)
@@ -887,7 +887,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
         public static Information FromMebibytes(long mebibytes)
@@ -895,14 +895,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Mebibytes of type decimal.
         /// </summary>
         public static Information FromMebibytes(decimal mebibytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(mebibytes)*8d) * (1024d * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(mebibytes)*8d) * (1024d * 1024)));
         }
 #endif
 
@@ -914,7 +914,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabits) * 1e6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Megabits.
         /// </summary>
         public static Information FromMegabits(int megabits)
@@ -922,7 +922,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabits) * 1e6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Megabits.
         /// </summary>
         public static Information FromMegabits(long megabits)
@@ -930,14 +930,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabits) * 1e6d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Megabits of type decimal.
         /// </summary>
         public static Information FromMegabits(decimal megabits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(megabits)) * 1e6d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(megabits)) * 1e6d));
         }
 #endif
 
@@ -949,7 +949,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
         public static Information FromMegabytes(int megabytes)
@@ -957,7 +957,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
         public static Information FromMegabytes(long megabytes)
@@ -965,14 +965,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Megabytes of type decimal.
         /// </summary>
         public static Information FromMegabytes(decimal megabytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(megabytes)*8d) * 1e6d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(megabytes)*8d) * 1e6d));
         }
 #endif
 
@@ -984,7 +984,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Pebibits.
         /// </summary>
         public static Information FromPebibits(int pebibits)
@@ -992,7 +992,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Pebibits.
         /// </summary>
         public static Information FromPebibits(long pebibits)
@@ -1000,14 +1000,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Pebibits of type decimal.
         /// </summary>
         public static Information FromPebibits(decimal pebibits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(pebibits)) * (1024d * 1024 * 1024 * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(pebibits)) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 #endif
 
@@ -1019,7 +1019,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
         public static Information FromPebibytes(int pebibytes)
@@ -1027,7 +1027,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
         public static Information FromPebibytes(long pebibytes)
@@ -1035,14 +1035,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Pebibytes of type decimal.
         /// </summary>
         public static Information FromPebibytes(decimal pebibytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(pebibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(pebibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 #endif
 
@@ -1054,7 +1054,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabits) * 1e15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Petabits.
         /// </summary>
         public static Information FromPetabits(int petabits)
@@ -1062,7 +1062,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabits) * 1e15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Petabits.
         /// </summary>
         public static Information FromPetabits(long petabits)
@@ -1070,14 +1070,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabits) * 1e15d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Petabits of type decimal.
         /// </summary>
         public static Information FromPetabits(decimal petabits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(petabits)) * 1e15d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(petabits)) * 1e15d));
         }
 #endif
 
@@ -1089,7 +1089,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
         public static Information FromPetabytes(int petabytes)
@@ -1097,7 +1097,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
         public static Information FromPetabytes(long petabytes)
@@ -1105,14 +1105,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Petabytes of type decimal.
         /// </summary>
         public static Information FromPetabytes(decimal petabytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(petabytes)*8d) * 1e15d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(petabytes)*8d) * 1e15d));
         }
 #endif
 
@@ -1124,7 +1124,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Tebibits.
         /// </summary>
         public static Information FromTebibits(int tebibits)
@@ -1132,7 +1132,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Tebibits.
         /// </summary>
         public static Information FromTebibits(long tebibits)
@@ -1140,14 +1140,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Tebibits of type decimal.
         /// </summary>
         public static Information FromTebibits(decimal tebibits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(tebibits)) * (1024d * 1024 * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(tebibits)) * (1024d * 1024 * 1024 * 1024)));
         }
 #endif
 
@@ -1159,7 +1159,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
         public static Information FromTebibytes(int tebibytes)
@@ -1167,7 +1167,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
         public static Information FromTebibytes(long tebibytes)
@@ -1175,14 +1175,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Tebibytes of type decimal.
         /// </summary>
         public static Information FromTebibytes(decimal tebibytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(tebibytes)*8d) * (1024d * 1024 * 1024 * 1024)));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(tebibytes)*8d) * (1024d * 1024 * 1024 * 1024)));
         }
 #endif
 
@@ -1194,7 +1194,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabits) * 1e12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Terabits.
         /// </summary>
         public static Information FromTerabits(int terabits)
@@ -1202,7 +1202,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabits) * 1e12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Terabits.
         /// </summary>
         public static Information FromTerabits(long terabits)
@@ -1210,14 +1210,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabits) * 1e12d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Terabits of type decimal.
         /// </summary>
         public static Information FromTerabits(decimal terabits)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(terabits)) * 1e12d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(terabits)) * 1e12d));
         }
 #endif
 
@@ -1229,7 +1229,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
         public static Information FromTerabytes(int terabytes)
@@ -1237,7 +1237,7 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
         public static Information FromTerabytes(long terabytes)
@@ -1245,14 +1245,14 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Information from Terabytes of type decimal.
         /// </summary>
         public static Information FromTerabytes(decimal terabytes)
         {
-	        return new Information(Convert.ToDecimal((Convert.ToDouble(terabytes)*8d) * 1e12d));
+            return new Information(Convert.ToDecimal((Convert.ToDouble(terabytes)*8d) * 1e12d));
         }
 #endif
 
@@ -1273,7 +1273,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Bits.
         /// </summary>
         public static Information? FromBits(int? bits)
@@ -1288,7 +1288,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Bits.
         /// </summary>
         public static Information? FromBits(long? bits)
@@ -1303,7 +1303,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Bits of type decimal.
         /// </summary>
         public static Information? FromBits(decimal? bits)
@@ -1333,7 +1333,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Bytes.
         /// </summary>
         public static Information? FromBytes(int? bytes)
@@ -1348,7 +1348,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Bytes.
         /// </summary>
         public static Information? FromBytes(long? bytes)
@@ -1363,7 +1363,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Bytes of type decimal.
         /// </summary>
         public static Information? FromBytes(decimal? bytes)
@@ -1393,7 +1393,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exabits.
         /// </summary>
         public static Information? FromExabits(int? exabits)
@@ -1408,7 +1408,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exabits.
         /// </summary>
         public static Information? FromExabits(long? exabits)
@@ -1423,7 +1423,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Exabits of type decimal.
         /// </summary>
         public static Information? FromExabits(decimal? exabits)
@@ -1453,7 +1453,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exabytes.
         /// </summary>
         public static Information? FromExabytes(int? exabytes)
@@ -1468,7 +1468,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exabytes.
         /// </summary>
         public static Information? FromExabytes(long? exabytes)
@@ -1483,7 +1483,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Exabytes of type decimal.
         /// </summary>
         public static Information? FromExabytes(decimal? exabytes)
@@ -1513,7 +1513,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exbibits.
         /// </summary>
         public static Information? FromExbibits(int? exbibits)
@@ -1528,7 +1528,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exbibits.
         /// </summary>
         public static Information? FromExbibits(long? exbibits)
@@ -1543,7 +1543,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Exbibits of type decimal.
         /// </summary>
         public static Information? FromExbibits(decimal? exbibits)
@@ -1573,7 +1573,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exbibytes.
         /// </summary>
         public static Information? FromExbibytes(int? exbibytes)
@@ -1588,7 +1588,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Exbibytes.
         /// </summary>
         public static Information? FromExbibytes(long? exbibytes)
@@ -1603,7 +1603,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Exbibytes of type decimal.
         /// </summary>
         public static Information? FromExbibytes(decimal? exbibytes)
@@ -1633,7 +1633,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gibibits.
         /// </summary>
         public static Information? FromGibibits(int? gibibits)
@@ -1648,7 +1648,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gibibits.
         /// </summary>
         public static Information? FromGibibits(long? gibibits)
@@ -1663,7 +1663,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Gibibits of type decimal.
         /// </summary>
         public static Information? FromGibibits(decimal? gibibits)
@@ -1693,7 +1693,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gibibytes.
         /// </summary>
         public static Information? FromGibibytes(int? gibibytes)
@@ -1708,7 +1708,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gibibytes.
         /// </summary>
         public static Information? FromGibibytes(long? gibibytes)
@@ -1723,7 +1723,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Gibibytes of type decimal.
         /// </summary>
         public static Information? FromGibibytes(decimal? gibibytes)
@@ -1753,7 +1753,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gigabits.
         /// </summary>
         public static Information? FromGigabits(int? gigabits)
@@ -1768,7 +1768,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gigabits.
         /// </summary>
         public static Information? FromGigabits(long? gigabits)
@@ -1783,7 +1783,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Gigabits of type decimal.
         /// </summary>
         public static Information? FromGigabits(decimal? gigabits)
@@ -1813,7 +1813,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gigabytes.
         /// </summary>
         public static Information? FromGigabytes(int? gigabytes)
@@ -1828,7 +1828,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Gigabytes.
         /// </summary>
         public static Information? FromGigabytes(long? gigabytes)
@@ -1843,7 +1843,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Gigabytes of type decimal.
         /// </summary>
         public static Information? FromGigabytes(decimal? gigabytes)
@@ -1873,7 +1873,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kibibits.
         /// </summary>
         public static Information? FromKibibits(int? kibibits)
@@ -1888,7 +1888,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kibibits.
         /// </summary>
         public static Information? FromKibibits(long? kibibits)
@@ -1903,7 +1903,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Kibibits of type decimal.
         /// </summary>
         public static Information? FromKibibits(decimal? kibibits)
@@ -1933,7 +1933,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kibibytes.
         /// </summary>
         public static Information? FromKibibytes(int? kibibytes)
@@ -1948,7 +1948,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kibibytes.
         /// </summary>
         public static Information? FromKibibytes(long? kibibytes)
@@ -1963,7 +1963,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Kibibytes of type decimal.
         /// </summary>
         public static Information? FromKibibytes(decimal? kibibytes)
@@ -1993,7 +1993,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kilobits.
         /// </summary>
         public static Information? FromKilobits(int? kilobits)
@@ -2008,7 +2008,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kilobits.
         /// </summary>
         public static Information? FromKilobits(long? kilobits)
@@ -2023,7 +2023,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Kilobits of type decimal.
         /// </summary>
         public static Information? FromKilobits(decimal? kilobits)
@@ -2053,7 +2053,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kilobytes.
         /// </summary>
         public static Information? FromKilobytes(int? kilobytes)
@@ -2068,7 +2068,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Kilobytes.
         /// </summary>
         public static Information? FromKilobytes(long? kilobytes)
@@ -2083,7 +2083,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Kilobytes of type decimal.
         /// </summary>
         public static Information? FromKilobytes(decimal? kilobytes)
@@ -2113,7 +2113,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Mebibits.
         /// </summary>
         public static Information? FromMebibits(int? mebibits)
@@ -2128,7 +2128,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Mebibits.
         /// </summary>
         public static Information? FromMebibits(long? mebibits)
@@ -2143,7 +2143,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Mebibits of type decimal.
         /// </summary>
         public static Information? FromMebibits(decimal? mebibits)
@@ -2173,7 +2173,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Mebibytes.
         /// </summary>
         public static Information? FromMebibytes(int? mebibytes)
@@ -2188,7 +2188,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Mebibytes.
         /// </summary>
         public static Information? FromMebibytes(long? mebibytes)
@@ -2203,7 +2203,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Mebibytes of type decimal.
         /// </summary>
         public static Information? FromMebibytes(decimal? mebibytes)
@@ -2233,7 +2233,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Megabits.
         /// </summary>
         public static Information? FromMegabits(int? megabits)
@@ -2248,7 +2248,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Megabits.
         /// </summary>
         public static Information? FromMegabits(long? megabits)
@@ -2263,7 +2263,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Megabits of type decimal.
         /// </summary>
         public static Information? FromMegabits(decimal? megabits)
@@ -2293,7 +2293,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Megabytes.
         /// </summary>
         public static Information? FromMegabytes(int? megabytes)
@@ -2308,7 +2308,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Megabytes.
         /// </summary>
         public static Information? FromMegabytes(long? megabytes)
@@ -2323,7 +2323,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Megabytes of type decimal.
         /// </summary>
         public static Information? FromMegabytes(decimal? megabytes)
@@ -2353,7 +2353,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Pebibits.
         /// </summary>
         public static Information? FromPebibits(int? pebibits)
@@ -2368,7 +2368,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Pebibits.
         /// </summary>
         public static Information? FromPebibits(long? pebibits)
@@ -2383,7 +2383,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Pebibits of type decimal.
         /// </summary>
         public static Information? FromPebibits(decimal? pebibits)
@@ -2413,7 +2413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Pebibytes.
         /// </summary>
         public static Information? FromPebibytes(int? pebibytes)
@@ -2428,7 +2428,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Pebibytes.
         /// </summary>
         public static Information? FromPebibytes(long? pebibytes)
@@ -2443,7 +2443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Pebibytes of type decimal.
         /// </summary>
         public static Information? FromPebibytes(decimal? pebibytes)
@@ -2473,7 +2473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Petabits.
         /// </summary>
         public static Information? FromPetabits(int? petabits)
@@ -2488,7 +2488,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Petabits.
         /// </summary>
         public static Information? FromPetabits(long? petabits)
@@ -2503,7 +2503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Petabits of type decimal.
         /// </summary>
         public static Information? FromPetabits(decimal? petabits)
@@ -2533,7 +2533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Petabytes.
         /// </summary>
         public static Information? FromPetabytes(int? petabytes)
@@ -2548,7 +2548,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Petabytes.
         /// </summary>
         public static Information? FromPetabytes(long? petabytes)
@@ -2563,7 +2563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Petabytes of type decimal.
         /// </summary>
         public static Information? FromPetabytes(decimal? petabytes)
@@ -2593,7 +2593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Tebibits.
         /// </summary>
         public static Information? FromTebibits(int? tebibits)
@@ -2608,7 +2608,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Tebibits.
         /// </summary>
         public static Information? FromTebibits(long? tebibits)
@@ -2623,7 +2623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Tebibits of type decimal.
         /// </summary>
         public static Information? FromTebibits(decimal? tebibits)
@@ -2653,7 +2653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Tebibytes.
         /// </summary>
         public static Information? FromTebibytes(int? tebibytes)
@@ -2668,7 +2668,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Tebibytes.
         /// </summary>
         public static Information? FromTebibytes(long? tebibytes)
@@ -2683,7 +2683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Tebibytes of type decimal.
         /// </summary>
         public static Information? FromTebibytes(decimal? tebibytes)
@@ -2713,7 +2713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Terabits.
         /// </summary>
         public static Information? FromTerabits(int? terabits)
@@ -2728,7 +2728,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Terabits.
         /// </summary>
         public static Information? FromTerabits(long? terabits)
@@ -2743,7 +2743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Terabits of type decimal.
         /// </summary>
         public static Information? FromTerabits(decimal? terabits)
@@ -2773,7 +2773,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Terabytes.
         /// </summary>
         public static Information? FromTerabytes(int? terabytes)
@@ -2788,7 +2788,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from nullable Terabytes.
         /// </summary>
         public static Information? FromTerabytes(long? terabytes)
@@ -2803,7 +2803,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Information from Terabytes of type decimal.
         /// </summary>
         public static Information? FromTerabytes(decimal? terabytes)

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -354,6 +354,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal(bits));
         }
 
+		/// <summary>
+        ///     Get Information from Bits.
+        /// </summary>
+        public static Information FromBits(int bits)
+        {
+            return new Information(Convert.ToDecimal(bits));
+        }
+
+		/// <summary>
+        ///     Get Information from Bits.
+        /// </summary>
+        public static Information FromBits(long bits)
+        {
+            return new Information(Convert.ToDecimal(bits));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Bits of type decimal.
+        /// </summary>
+        public static Information FromBits(decimal bits)
+        {
+	        return new Information(Convert.ToDecimal(Convert.ToDouble(bits)));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
@@ -361,6 +388,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal(bytes*8d));
         }
+
+		/// <summary>
+        ///     Get Information from Bytes.
+        /// </summary>
+        public static Information FromBytes(int bytes)
+        {
+            return new Information(Convert.ToDecimal(bytes*8d));
+        }
+
+		/// <summary>
+        ///     Get Information from Bytes.
+        /// </summary>
+        public static Information FromBytes(long bytes)
+        {
+            return new Information(Convert.ToDecimal(bytes*8d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Bytes of type decimal.
+        /// </summary>
+        public static Information FromBytes(decimal bytes)
+        {
+	        return new Information(Convert.ToDecimal(Convert.ToDouble(bytes)*8d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Exabits.
@@ -370,6 +424,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exabits) * 1e18d));
         }
 
+		/// <summary>
+        ///     Get Information from Exabits.
+        /// </summary>
+        public static Information FromExabits(int exabits)
+        {
+            return new Information(Convert.ToDecimal((exabits) * 1e18d));
+        }
+
+		/// <summary>
+        ///     Get Information from Exabits.
+        /// </summary>
+        public static Information FromExabits(long exabits)
+        {
+            return new Information(Convert.ToDecimal((exabits) * 1e18d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Exabits of type decimal.
+        /// </summary>
+        public static Information FromExabits(decimal exabits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(exabits)) * 1e18d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
@@ -377,6 +458,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
         }
+
+		/// <summary>
+        ///     Get Information from Exabytes.
+        /// </summary>
+        public static Information FromExabytes(int exabytes)
+        {
+            return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
+        }
+
+		/// <summary>
+        ///     Get Information from Exabytes.
+        /// </summary>
+        public static Information FromExabytes(long exabytes)
+        {
+            return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Exabytes of type decimal.
+        /// </summary>
+        public static Information FromExabytes(decimal exabytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(exabytes)*8d) * 1e18d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Exbibits.
@@ -386,6 +494,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
 
+		/// <summary>
+        ///     Get Information from Exbibits.
+        /// </summary>
+        public static Information FromExbibits(int exbibits)
+        {
+            return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Exbibits.
+        /// </summary>
+        public static Information FromExbibits(long exbibits)
+        {
+            return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Exbibits of type decimal.
+        /// </summary>
+        public static Information FromExbibits(decimal exbibits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(exbibits)) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
@@ -393,6 +528,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
+
+		/// <summary>
+        ///     Get Information from Exbibytes.
+        /// </summary>
+        public static Information FromExbibytes(int exbibytes)
+        {
+            return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Exbibytes.
+        /// </summary>
+        public static Information FromExbibytes(long exbibytes)
+        {
+            return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Exbibytes of type decimal.
+        /// </summary>
+        public static Information FromExbibytes(decimal exbibytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(exbibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Gibibits.
@@ -402,6 +564,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
         }
 
+		/// <summary>
+        ///     Get Information from Gibibits.
+        /// </summary>
+        public static Information FromGibibits(int gibibits)
+        {
+            return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Gibibits.
+        /// </summary>
+        public static Information FromGibibits(long gibibits)
+        {
+            return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Gibibits of type decimal.
+        /// </summary>
+        public static Information FromGibibits(decimal gibibits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(gibibits)) * (1024d * 1024 * 1024)));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
@@ -409,6 +598,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
         }
+
+		/// <summary>
+        ///     Get Information from Gibibytes.
+        /// </summary>
+        public static Information FromGibibytes(int gibibytes)
+        {
+            return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Gibibytes.
+        /// </summary>
+        public static Information FromGibibytes(long gibibytes)
+        {
+            return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Gibibytes of type decimal.
+        /// </summary>
+        public static Information FromGibibytes(decimal gibibytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(gibibytes)*8d) * (1024d * 1024 * 1024)));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Gigabits.
@@ -418,6 +634,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((gigabits) * 1e9d));
         }
 
+		/// <summary>
+        ///     Get Information from Gigabits.
+        /// </summary>
+        public static Information FromGigabits(int gigabits)
+        {
+            return new Information(Convert.ToDecimal((gigabits) * 1e9d));
+        }
+
+		/// <summary>
+        ///     Get Information from Gigabits.
+        /// </summary>
+        public static Information FromGigabits(long gigabits)
+        {
+            return new Information(Convert.ToDecimal((gigabits) * 1e9d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Gigabits of type decimal.
+        /// </summary>
+        public static Information FromGigabits(decimal gigabits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(gigabits)) * 1e9d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
@@ -425,6 +668,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
         }
+
+		/// <summary>
+        ///     Get Information from Gigabytes.
+        /// </summary>
+        public static Information FromGigabytes(int gigabytes)
+        {
+            return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
+        }
+
+		/// <summary>
+        ///     Get Information from Gigabytes.
+        /// </summary>
+        public static Information FromGigabytes(long gigabytes)
+        {
+            return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Gigabytes of type decimal.
+        /// </summary>
+        public static Information FromGigabytes(decimal gigabytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(gigabytes)*8d) * 1e9d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Kibibits.
@@ -434,6 +704,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kibibits) * 1024d));
         }
 
+		/// <summary>
+        ///     Get Information from Kibibits.
+        /// </summary>
+        public static Information FromKibibits(int kibibits)
+        {
+            return new Information(Convert.ToDecimal((kibibits) * 1024d));
+        }
+
+		/// <summary>
+        ///     Get Information from Kibibits.
+        /// </summary>
+        public static Information FromKibibits(long kibibits)
+        {
+            return new Information(Convert.ToDecimal((kibibits) * 1024d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Kibibits of type decimal.
+        /// </summary>
+        public static Information FromKibibits(decimal kibibits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(kibibits)) * 1024d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
@@ -441,6 +738,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
         }
+
+		/// <summary>
+        ///     Get Information from Kibibytes.
+        /// </summary>
+        public static Information FromKibibytes(int kibibytes)
+        {
+            return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
+        }
+
+		/// <summary>
+        ///     Get Information from Kibibytes.
+        /// </summary>
+        public static Information FromKibibytes(long kibibytes)
+        {
+            return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Kibibytes of type decimal.
+        /// </summary>
+        public static Information FromKibibytes(decimal kibibytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(kibibytes)*8d) * 1024d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Kilobits.
@@ -450,6 +774,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((kilobits) * 1e3d));
         }
 
+		/// <summary>
+        ///     Get Information from Kilobits.
+        /// </summary>
+        public static Information FromKilobits(int kilobits)
+        {
+            return new Information(Convert.ToDecimal((kilobits) * 1e3d));
+        }
+
+		/// <summary>
+        ///     Get Information from Kilobits.
+        /// </summary>
+        public static Information FromKilobits(long kilobits)
+        {
+            return new Information(Convert.ToDecimal((kilobits) * 1e3d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Kilobits of type decimal.
+        /// </summary>
+        public static Information FromKilobits(decimal kilobits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(kilobits)) * 1e3d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
@@ -457,6 +808,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
         }
+
+		/// <summary>
+        ///     Get Information from Kilobytes.
+        /// </summary>
+        public static Information FromKilobytes(int kilobytes)
+        {
+            return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
+        }
+
+		/// <summary>
+        ///     Get Information from Kilobytes.
+        /// </summary>
+        public static Information FromKilobytes(long kilobytes)
+        {
+            return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Kilobytes of type decimal.
+        /// </summary>
+        public static Information FromKilobytes(decimal kilobytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(kilobytes)*8d) * 1e3d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Mebibits.
@@ -466,6 +844,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
         }
 
+		/// <summary>
+        ///     Get Information from Mebibits.
+        /// </summary>
+        public static Information FromMebibits(int mebibits)
+        {
+            return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Mebibits.
+        /// </summary>
+        public static Information FromMebibits(long mebibits)
+        {
+            return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Mebibits of type decimal.
+        /// </summary>
+        public static Information FromMebibits(decimal mebibits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(mebibits)) * (1024d * 1024)));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
@@ -473,6 +878,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
         }
+
+		/// <summary>
+        ///     Get Information from Mebibytes.
+        /// </summary>
+        public static Information FromMebibytes(int mebibytes)
+        {
+            return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Mebibytes.
+        /// </summary>
+        public static Information FromMebibytes(long mebibytes)
+        {
+            return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Mebibytes of type decimal.
+        /// </summary>
+        public static Information FromMebibytes(decimal mebibytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(mebibytes)*8d) * (1024d * 1024)));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Megabits.
@@ -482,6 +914,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((megabits) * 1e6d));
         }
 
+		/// <summary>
+        ///     Get Information from Megabits.
+        /// </summary>
+        public static Information FromMegabits(int megabits)
+        {
+            return new Information(Convert.ToDecimal((megabits) * 1e6d));
+        }
+
+		/// <summary>
+        ///     Get Information from Megabits.
+        /// </summary>
+        public static Information FromMegabits(long megabits)
+        {
+            return new Information(Convert.ToDecimal((megabits) * 1e6d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Megabits of type decimal.
+        /// </summary>
+        public static Information FromMegabits(decimal megabits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(megabits)) * 1e6d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
@@ -489,6 +948,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
         }
+
+		/// <summary>
+        ///     Get Information from Megabytes.
+        /// </summary>
+        public static Information FromMegabytes(int megabytes)
+        {
+            return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
+        }
+
+		/// <summary>
+        ///     Get Information from Megabytes.
+        /// </summary>
+        public static Information FromMegabytes(long megabytes)
+        {
+            return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Megabytes of type decimal.
+        /// </summary>
+        public static Information FromMegabytes(decimal megabytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(megabytes)*8d) * 1e6d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Pebibits.
@@ -498,6 +984,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
 
+		/// <summary>
+        ///     Get Information from Pebibits.
+        /// </summary>
+        public static Information FromPebibits(int pebibits)
+        {
+            return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Pebibits.
+        /// </summary>
+        public static Information FromPebibits(long pebibits)
+        {
+            return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Pebibits of type decimal.
+        /// </summary>
+        public static Information FromPebibits(decimal pebibits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(pebibits)) * (1024d * 1024 * 1024 * 1024 * 1024)));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
@@ -505,6 +1018,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
+
+		/// <summary>
+        ///     Get Information from Pebibytes.
+        /// </summary>
+        public static Information FromPebibytes(int pebibytes)
+        {
+            return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Pebibytes.
+        /// </summary>
+        public static Information FromPebibytes(long pebibytes)
+        {
+            return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Pebibytes of type decimal.
+        /// </summary>
+        public static Information FromPebibytes(decimal pebibytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(pebibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Petabits.
@@ -514,6 +1054,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((petabits) * 1e15d));
         }
 
+		/// <summary>
+        ///     Get Information from Petabits.
+        /// </summary>
+        public static Information FromPetabits(int petabits)
+        {
+            return new Information(Convert.ToDecimal((petabits) * 1e15d));
+        }
+
+		/// <summary>
+        ///     Get Information from Petabits.
+        /// </summary>
+        public static Information FromPetabits(long petabits)
+        {
+            return new Information(Convert.ToDecimal((petabits) * 1e15d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Petabits of type decimal.
+        /// </summary>
+        public static Information FromPetabits(decimal petabits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(petabits)) * 1e15d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
@@ -521,6 +1088,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
         }
+
+		/// <summary>
+        ///     Get Information from Petabytes.
+        /// </summary>
+        public static Information FromPetabytes(int petabytes)
+        {
+            return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
+        }
+
+		/// <summary>
+        ///     Get Information from Petabytes.
+        /// </summary>
+        public static Information FromPetabytes(long petabytes)
+        {
+            return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Petabytes of type decimal.
+        /// </summary>
+        public static Information FromPetabytes(decimal petabytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(petabytes)*8d) * 1e15d));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Tebibits.
@@ -530,6 +1124,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
         }
 
+		/// <summary>
+        ///     Get Information from Tebibits.
+        /// </summary>
+        public static Information FromTebibits(int tebibits)
+        {
+            return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Tebibits.
+        /// </summary>
+        public static Information FromTebibits(long tebibits)
+        {
+            return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Tebibits of type decimal.
+        /// </summary>
+        public static Information FromTebibits(decimal tebibits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(tebibits)) * (1024d * 1024 * 1024 * 1024)));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
@@ -537,6 +1158,33 @@ namespace UnitsNet
         {
             return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
         }
+
+		/// <summary>
+        ///     Get Information from Tebibytes.
+        /// </summary>
+        public static Information FromTebibytes(int tebibytes)
+        {
+            return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
+        }
+
+		/// <summary>
+        ///     Get Information from Tebibytes.
+        /// </summary>
+        public static Information FromTebibytes(long tebibytes)
+        {
+            return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Tebibytes of type decimal.
+        /// </summary>
+        public static Information FromTebibytes(decimal tebibytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(tebibytes)*8d) * (1024d * 1024 * 1024 * 1024)));
+        }
+#endif
 
         /// <summary>
         ///     Get Information from Terabits.
@@ -546,6 +1194,33 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabits) * 1e12d));
         }
 
+		/// <summary>
+        ///     Get Information from Terabits.
+        /// </summary>
+        public static Information FromTerabits(int terabits)
+        {
+            return new Information(Convert.ToDecimal((terabits) * 1e12d));
+        }
+
+		/// <summary>
+        ///     Get Information from Terabits.
+        /// </summary>
+        public static Information FromTerabits(long terabits)
+        {
+            return new Information(Convert.ToDecimal((terabits) * 1e12d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Terabits of type decimal.
+        /// </summary>
+        public static Information FromTerabits(decimal terabits)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(terabits)) * 1e12d));
+        }
+#endif
+
         /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
@@ -554,12 +1229,84 @@ namespace UnitsNet
             return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
         }
 
+		/// <summary>
+        ///     Get Information from Terabytes.
+        /// </summary>
+        public static Information FromTerabytes(int terabytes)
+        {
+            return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
+        }
+
+		/// <summary>
+        ///     Get Information from Terabytes.
+        /// </summary>
+        public static Information FromTerabytes(long terabytes)
+        {
+            return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Information from Terabytes of type decimal.
+        /// </summary>
+        public static Information FromTerabytes(decimal terabytes)
+        {
+	        return new Information(Convert.ToDecimal((Convert.ToDouble(terabytes)*8d) * 1e12d));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Information from nullable Bits.
         /// </summary>
         public static Information? FromBits(double? bits)
+        {
+            if (bits.HasValue)
+            {
+                return FromBits(bits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Bits.
+        /// </summary>
+        public static Information? FromBits(int? bits)
+        {
+            if (bits.HasValue)
+            {
+                return FromBits(bits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Bits.
+        /// </summary>
+        public static Information? FromBits(long? bits)
+        {
+            if (bits.HasValue)
+            {
+                return FromBits(bits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Bits of type decimal.
+        /// </summary>
+        public static Information? FromBits(decimal? bits)
         {
             if (bits.HasValue)
             {
@@ -586,10 +1333,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Bytes.
+        /// </summary>
+        public static Information? FromBytes(int? bytes)
+        {
+            if (bytes.HasValue)
+            {
+                return FromBytes(bytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Bytes.
+        /// </summary>
+        public static Information? FromBytes(long? bytes)
+        {
+            if (bytes.HasValue)
+            {
+                return FromBytes(bytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Bytes of type decimal.
+        /// </summary>
+        public static Information? FromBytes(decimal? bytes)
+        {
+            if (bytes.HasValue)
+            {
+                return FromBytes(bytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Exabits.
         /// </summary>
         public static Information? FromExabits(double? exabits)
+        {
+            if (exabits.HasValue)
+            {
+                return FromExabits(exabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Exabits.
+        /// </summary>
+        public static Information? FromExabits(int? exabits)
+        {
+            if (exabits.HasValue)
+            {
+                return FromExabits(exabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Exabits.
+        /// </summary>
+        public static Information? FromExabits(long? exabits)
+        {
+            if (exabits.HasValue)
+            {
+                return FromExabits(exabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Exabits of type decimal.
+        /// </summary>
+        public static Information? FromExabits(decimal? exabits)
         {
             if (exabits.HasValue)
             {
@@ -616,10 +1453,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Exabytes.
+        /// </summary>
+        public static Information? FromExabytes(int? exabytes)
+        {
+            if (exabytes.HasValue)
+            {
+                return FromExabytes(exabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Exabytes.
+        /// </summary>
+        public static Information? FromExabytes(long? exabytes)
+        {
+            if (exabytes.HasValue)
+            {
+                return FromExabytes(exabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Exabytes of type decimal.
+        /// </summary>
+        public static Information? FromExabytes(decimal? exabytes)
+        {
+            if (exabytes.HasValue)
+            {
+                return FromExabytes(exabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Exbibits.
         /// </summary>
         public static Information? FromExbibits(double? exbibits)
+        {
+            if (exbibits.HasValue)
+            {
+                return FromExbibits(exbibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Exbibits.
+        /// </summary>
+        public static Information? FromExbibits(int? exbibits)
+        {
+            if (exbibits.HasValue)
+            {
+                return FromExbibits(exbibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Exbibits.
+        /// </summary>
+        public static Information? FromExbibits(long? exbibits)
+        {
+            if (exbibits.HasValue)
+            {
+                return FromExbibits(exbibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Exbibits of type decimal.
+        /// </summary>
+        public static Information? FromExbibits(decimal? exbibits)
         {
             if (exbibits.HasValue)
             {
@@ -646,10 +1573,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Exbibytes.
+        /// </summary>
+        public static Information? FromExbibytes(int? exbibytes)
+        {
+            if (exbibytes.HasValue)
+            {
+                return FromExbibytes(exbibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Exbibytes.
+        /// </summary>
+        public static Information? FromExbibytes(long? exbibytes)
+        {
+            if (exbibytes.HasValue)
+            {
+                return FromExbibytes(exbibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Exbibytes of type decimal.
+        /// </summary>
+        public static Information? FromExbibytes(decimal? exbibytes)
+        {
+            if (exbibytes.HasValue)
+            {
+                return FromExbibytes(exbibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Gibibits.
         /// </summary>
         public static Information? FromGibibits(double? gibibits)
+        {
+            if (gibibits.HasValue)
+            {
+                return FromGibibits(gibibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Gibibits.
+        /// </summary>
+        public static Information? FromGibibits(int? gibibits)
+        {
+            if (gibibits.HasValue)
+            {
+                return FromGibibits(gibibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Gibibits.
+        /// </summary>
+        public static Information? FromGibibits(long? gibibits)
+        {
+            if (gibibits.HasValue)
+            {
+                return FromGibibits(gibibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Gibibits of type decimal.
+        /// </summary>
+        public static Information? FromGibibits(decimal? gibibits)
         {
             if (gibibits.HasValue)
             {
@@ -676,10 +1693,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Gibibytes.
+        /// </summary>
+        public static Information? FromGibibytes(int? gibibytes)
+        {
+            if (gibibytes.HasValue)
+            {
+                return FromGibibytes(gibibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Gibibytes.
+        /// </summary>
+        public static Information? FromGibibytes(long? gibibytes)
+        {
+            if (gibibytes.HasValue)
+            {
+                return FromGibibytes(gibibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Gibibytes of type decimal.
+        /// </summary>
+        public static Information? FromGibibytes(decimal? gibibytes)
+        {
+            if (gibibytes.HasValue)
+            {
+                return FromGibibytes(gibibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Gigabits.
         /// </summary>
         public static Information? FromGigabits(double? gigabits)
+        {
+            if (gigabits.HasValue)
+            {
+                return FromGigabits(gigabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Gigabits.
+        /// </summary>
+        public static Information? FromGigabits(int? gigabits)
+        {
+            if (gigabits.HasValue)
+            {
+                return FromGigabits(gigabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Gigabits.
+        /// </summary>
+        public static Information? FromGigabits(long? gigabits)
+        {
+            if (gigabits.HasValue)
+            {
+                return FromGigabits(gigabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Gigabits of type decimal.
+        /// </summary>
+        public static Information? FromGigabits(decimal? gigabits)
         {
             if (gigabits.HasValue)
             {
@@ -706,10 +1813,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Gigabytes.
+        /// </summary>
+        public static Information? FromGigabytes(int? gigabytes)
+        {
+            if (gigabytes.HasValue)
+            {
+                return FromGigabytes(gigabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Gigabytes.
+        /// </summary>
+        public static Information? FromGigabytes(long? gigabytes)
+        {
+            if (gigabytes.HasValue)
+            {
+                return FromGigabytes(gigabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Gigabytes of type decimal.
+        /// </summary>
+        public static Information? FromGigabytes(decimal? gigabytes)
+        {
+            if (gigabytes.HasValue)
+            {
+                return FromGigabytes(gigabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Kibibits.
         /// </summary>
         public static Information? FromKibibits(double? kibibits)
+        {
+            if (kibibits.HasValue)
+            {
+                return FromKibibits(kibibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Kibibits.
+        /// </summary>
+        public static Information? FromKibibits(int? kibibits)
+        {
+            if (kibibits.HasValue)
+            {
+                return FromKibibits(kibibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Kibibits.
+        /// </summary>
+        public static Information? FromKibibits(long? kibibits)
+        {
+            if (kibibits.HasValue)
+            {
+                return FromKibibits(kibibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Kibibits of type decimal.
+        /// </summary>
+        public static Information? FromKibibits(decimal? kibibits)
         {
             if (kibibits.HasValue)
             {
@@ -736,10 +1933,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Kibibytes.
+        /// </summary>
+        public static Information? FromKibibytes(int? kibibytes)
+        {
+            if (kibibytes.HasValue)
+            {
+                return FromKibibytes(kibibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Kibibytes.
+        /// </summary>
+        public static Information? FromKibibytes(long? kibibytes)
+        {
+            if (kibibytes.HasValue)
+            {
+                return FromKibibytes(kibibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Kibibytes of type decimal.
+        /// </summary>
+        public static Information? FromKibibytes(decimal? kibibytes)
+        {
+            if (kibibytes.HasValue)
+            {
+                return FromKibibytes(kibibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Kilobits.
         /// </summary>
         public static Information? FromKilobits(double? kilobits)
+        {
+            if (kilobits.HasValue)
+            {
+                return FromKilobits(kilobits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Kilobits.
+        /// </summary>
+        public static Information? FromKilobits(int? kilobits)
+        {
+            if (kilobits.HasValue)
+            {
+                return FromKilobits(kilobits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Kilobits.
+        /// </summary>
+        public static Information? FromKilobits(long? kilobits)
+        {
+            if (kilobits.HasValue)
+            {
+                return FromKilobits(kilobits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Kilobits of type decimal.
+        /// </summary>
+        public static Information? FromKilobits(decimal? kilobits)
         {
             if (kilobits.HasValue)
             {
@@ -766,10 +2053,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Kilobytes.
+        /// </summary>
+        public static Information? FromKilobytes(int? kilobytes)
+        {
+            if (kilobytes.HasValue)
+            {
+                return FromKilobytes(kilobytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Kilobytes.
+        /// </summary>
+        public static Information? FromKilobytes(long? kilobytes)
+        {
+            if (kilobytes.HasValue)
+            {
+                return FromKilobytes(kilobytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Kilobytes of type decimal.
+        /// </summary>
+        public static Information? FromKilobytes(decimal? kilobytes)
+        {
+            if (kilobytes.HasValue)
+            {
+                return FromKilobytes(kilobytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Mebibits.
         /// </summary>
         public static Information? FromMebibits(double? mebibits)
+        {
+            if (mebibits.HasValue)
+            {
+                return FromMebibits(mebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Mebibits.
+        /// </summary>
+        public static Information? FromMebibits(int? mebibits)
+        {
+            if (mebibits.HasValue)
+            {
+                return FromMebibits(mebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Mebibits.
+        /// </summary>
+        public static Information? FromMebibits(long? mebibits)
+        {
+            if (mebibits.HasValue)
+            {
+                return FromMebibits(mebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Mebibits of type decimal.
+        /// </summary>
+        public static Information? FromMebibits(decimal? mebibits)
         {
             if (mebibits.HasValue)
             {
@@ -796,10 +2173,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Mebibytes.
+        /// </summary>
+        public static Information? FromMebibytes(int? mebibytes)
+        {
+            if (mebibytes.HasValue)
+            {
+                return FromMebibytes(mebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Mebibytes.
+        /// </summary>
+        public static Information? FromMebibytes(long? mebibytes)
+        {
+            if (mebibytes.HasValue)
+            {
+                return FromMebibytes(mebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Mebibytes of type decimal.
+        /// </summary>
+        public static Information? FromMebibytes(decimal? mebibytes)
+        {
+            if (mebibytes.HasValue)
+            {
+                return FromMebibytes(mebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Megabits.
         /// </summary>
         public static Information? FromMegabits(double? megabits)
+        {
+            if (megabits.HasValue)
+            {
+                return FromMegabits(megabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Megabits.
+        /// </summary>
+        public static Information? FromMegabits(int? megabits)
+        {
+            if (megabits.HasValue)
+            {
+                return FromMegabits(megabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Megabits.
+        /// </summary>
+        public static Information? FromMegabits(long? megabits)
+        {
+            if (megabits.HasValue)
+            {
+                return FromMegabits(megabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Megabits of type decimal.
+        /// </summary>
+        public static Information? FromMegabits(decimal? megabits)
         {
             if (megabits.HasValue)
             {
@@ -826,10 +2293,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Megabytes.
+        /// </summary>
+        public static Information? FromMegabytes(int? megabytes)
+        {
+            if (megabytes.HasValue)
+            {
+                return FromMegabytes(megabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Megabytes.
+        /// </summary>
+        public static Information? FromMegabytes(long? megabytes)
+        {
+            if (megabytes.HasValue)
+            {
+                return FromMegabytes(megabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Megabytes of type decimal.
+        /// </summary>
+        public static Information? FromMegabytes(decimal? megabytes)
+        {
+            if (megabytes.HasValue)
+            {
+                return FromMegabytes(megabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Pebibits.
         /// </summary>
         public static Information? FromPebibits(double? pebibits)
+        {
+            if (pebibits.HasValue)
+            {
+                return FromPebibits(pebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Pebibits.
+        /// </summary>
+        public static Information? FromPebibits(int? pebibits)
+        {
+            if (pebibits.HasValue)
+            {
+                return FromPebibits(pebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Pebibits.
+        /// </summary>
+        public static Information? FromPebibits(long? pebibits)
+        {
+            if (pebibits.HasValue)
+            {
+                return FromPebibits(pebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Pebibits of type decimal.
+        /// </summary>
+        public static Information? FromPebibits(decimal? pebibits)
         {
             if (pebibits.HasValue)
             {
@@ -856,10 +2413,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Pebibytes.
+        /// </summary>
+        public static Information? FromPebibytes(int? pebibytes)
+        {
+            if (pebibytes.HasValue)
+            {
+                return FromPebibytes(pebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Pebibytes.
+        /// </summary>
+        public static Information? FromPebibytes(long? pebibytes)
+        {
+            if (pebibytes.HasValue)
+            {
+                return FromPebibytes(pebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Pebibytes of type decimal.
+        /// </summary>
+        public static Information? FromPebibytes(decimal? pebibytes)
+        {
+            if (pebibytes.HasValue)
+            {
+                return FromPebibytes(pebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Petabits.
         /// </summary>
         public static Information? FromPetabits(double? petabits)
+        {
+            if (petabits.HasValue)
+            {
+                return FromPetabits(petabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Petabits.
+        /// </summary>
+        public static Information? FromPetabits(int? petabits)
+        {
+            if (petabits.HasValue)
+            {
+                return FromPetabits(petabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Petabits.
+        /// </summary>
+        public static Information? FromPetabits(long? petabits)
+        {
+            if (petabits.HasValue)
+            {
+                return FromPetabits(petabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Petabits of type decimal.
+        /// </summary>
+        public static Information? FromPetabits(decimal? petabits)
         {
             if (petabits.HasValue)
             {
@@ -886,10 +2533,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Petabytes.
+        /// </summary>
+        public static Information? FromPetabytes(int? petabytes)
+        {
+            if (petabytes.HasValue)
+            {
+                return FromPetabytes(petabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Petabytes.
+        /// </summary>
+        public static Information? FromPetabytes(long? petabytes)
+        {
+            if (petabytes.HasValue)
+            {
+                return FromPetabytes(petabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Petabytes of type decimal.
+        /// </summary>
+        public static Information? FromPetabytes(decimal? petabytes)
+        {
+            if (petabytes.HasValue)
+            {
+                return FromPetabytes(petabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Tebibits.
         /// </summary>
         public static Information? FromTebibits(double? tebibits)
+        {
+            if (tebibits.HasValue)
+            {
+                return FromTebibits(tebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Tebibits.
+        /// </summary>
+        public static Information? FromTebibits(int? tebibits)
+        {
+            if (tebibits.HasValue)
+            {
+                return FromTebibits(tebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Tebibits.
+        /// </summary>
+        public static Information? FromTebibits(long? tebibits)
+        {
+            if (tebibits.HasValue)
+            {
+                return FromTebibits(tebibits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Tebibits of type decimal.
+        /// </summary>
+        public static Information? FromTebibits(decimal? tebibits)
         {
             if (tebibits.HasValue)
             {
@@ -916,6 +2653,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Tebibytes.
+        /// </summary>
+        public static Information? FromTebibytes(int? tebibytes)
+        {
+            if (tebibytes.HasValue)
+            {
+                return FromTebibytes(tebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Tebibytes.
+        /// </summary>
+        public static Information? FromTebibytes(long? tebibytes)
+        {
+            if (tebibytes.HasValue)
+            {
+                return FromTebibytes(tebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Tebibytes of type decimal.
+        /// </summary>
+        public static Information? FromTebibytes(decimal? tebibytes)
+        {
+            if (tebibytes.HasValue)
+            {
+                return FromTebibytes(tebibytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Terabits.
         /// </summary>
@@ -931,10 +2713,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Information from nullable Terabits.
+        /// </summary>
+        public static Information? FromTerabits(int? terabits)
+        {
+            if (terabits.HasValue)
+            {
+                return FromTerabits(terabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Terabits.
+        /// </summary>
+        public static Information? FromTerabits(long? terabits)
+        {
+            if (terabits.HasValue)
+            {
+                return FromTerabits(terabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Terabits of type decimal.
+        /// </summary>
+        public static Information? FromTerabits(decimal? terabits)
+        {
+            if (terabits.HasValue)
+            {
+                return FromTerabits(terabits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Information from nullable Terabytes.
         /// </summary>
         public static Information? FromTerabytes(double? terabytes)
+        {
+            if (terabytes.HasValue)
+            {
+                return FromTerabytes(terabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Terabytes.
+        /// </summary>
+        public static Information? FromTerabytes(int? terabytes)
+        {
+            if (terabytes.HasValue)
+            {
+                return FromTerabytes(terabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from nullable Terabytes.
+        /// </summary>
+        public static Information? FromTerabytes(long? terabytes)
+        {
+            if (terabytes.HasValue)
+            {
+                return FromTerabytes(terabytes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Information from Terabytes of type decimal.
+        /// </summary>
+        public static Information? FromTerabytes(decimal? terabytes)
         {
             if (terabytes.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _squareMetersPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public KinematicViscosity() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.KinematicViscosity;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static KinematicViscosityUnit BaseUnit
         {
             get { return KinematicViscosityUnit.SquareMeterPerSecond; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new KinematicViscosity((centistokes/1e4) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Centistokes.
         /// </summary>
         public static KinematicViscosity FromCentistokes(int centistokes)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new KinematicViscosity((centistokes/1e4) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Centistokes.
         /// </summary>
         public static KinematicViscosity FromCentistokes(long centistokes)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new KinematicViscosity((centistokes/1e4) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Centistokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromCentistokes(decimal centistokes)
         {
-	        return new KinematicViscosity((Convert.ToDouble(centistokes)/1e4) * 1e-2d);
+            return new KinematicViscosity((Convert.ToDouble(centistokes)/1e4) * 1e-2d);
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new KinematicViscosity((decistokes/1e4) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
         public static KinematicViscosity FromDecistokes(int decistokes)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new KinematicViscosity((decistokes/1e4) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
         public static KinematicViscosity FromDecistokes(long decistokes)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new KinematicViscosity((decistokes/1e4) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Decistokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromDecistokes(decimal decistokes)
         {
-	        return new KinematicViscosity((Convert.ToDouble(decistokes)/1e4) * 1e-1d);
+            return new KinematicViscosity((Convert.ToDouble(decistokes)/1e4) * 1e-1d);
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new KinematicViscosity((kilostokes/1e4) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
         /// </summary>
         public static KinematicViscosity FromKilostokes(int kilostokes)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new KinematicViscosity((kilostokes/1e4) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
         /// </summary>
         public static KinematicViscosity FromKilostokes(long kilostokes)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new KinematicViscosity((kilostokes/1e4) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Kilostokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromKilostokes(decimal kilostokes)
         {
-	        return new KinematicViscosity((Convert.ToDouble(kilostokes)/1e4) * 1e3d);
+            return new KinematicViscosity((Convert.ToDouble(kilostokes)/1e4) * 1e3d);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new KinematicViscosity((microstokes/1e4) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
         public static KinematicViscosity FromMicrostokes(int microstokes)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new KinematicViscosity((microstokes/1e4) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
         public static KinematicViscosity FromMicrostokes(long microstokes)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new KinematicViscosity((microstokes/1e4) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Microstokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromMicrostokes(decimal microstokes)
         {
-	        return new KinematicViscosity((Convert.ToDouble(microstokes)/1e4) * 1e-6d);
+            return new KinematicViscosity((Convert.ToDouble(microstokes)/1e4) * 1e-6d);
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new KinematicViscosity((millistokes/1e4) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Millistokes.
         /// </summary>
         public static KinematicViscosity FromMillistokes(int millistokes)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new KinematicViscosity((millistokes/1e4) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Millistokes.
         /// </summary>
         public static KinematicViscosity FromMillistokes(long millistokes)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new KinematicViscosity((millistokes/1e4) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Millistokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromMillistokes(decimal millistokes)
         {
-	        return new KinematicViscosity((Convert.ToDouble(millistokes)/1e4) * 1e-3d);
+            return new KinematicViscosity((Convert.ToDouble(millistokes)/1e4) * 1e-3d);
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
         public static KinematicViscosity FromNanostokes(int nanostokes)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
         public static KinematicViscosity FromNanostokes(long nanostokes)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Nanostokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromNanostokes(decimal nanostokes)
         {
-	        return new KinematicViscosity((Convert.ToDouble(nanostokes)/1e4) * 1e-9d);
+            return new KinematicViscosity((Convert.ToDouble(nanostokes)/1e4) * 1e-9d);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new KinematicViscosity(squaremeterspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
         /// </summary>
         public static KinematicViscosity FromSquareMetersPerSecond(int squaremeterspersecond)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new KinematicViscosity(squaremeterspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
         /// </summary>
         public static KinematicViscosity FromSquareMetersPerSecond(long squaremeterspersecond)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new KinematicViscosity(squaremeterspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond of type decimal.
         /// </summary>
         public static KinematicViscosity FromSquareMetersPerSecond(decimal squaremeterspersecond)
         {
-	        return new KinematicViscosity(Convert.ToDouble(squaremeterspersecond));
+            return new KinematicViscosity(Convert.ToDouble(squaremeterspersecond));
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new KinematicViscosity(stokes/1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
         public static KinematicViscosity FromStokes(int stokes)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new KinematicViscosity(stokes/1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
         public static KinematicViscosity FromStokes(long stokes)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new KinematicViscosity(stokes/1e4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get KinematicViscosity from Stokes of type decimal.
         /// </summary>
         public static KinematicViscosity FromStokes(decimal stokes)
         {
-	        return new KinematicViscosity(Convert.ToDouble(stokes)/1e4);
+            return new KinematicViscosity(Convert.ToDouble(stokes)/1e4);
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Centistokes.
         /// </summary>
         public static KinematicViscosity? FromCentistokes(int? centistokes)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Centistokes.
         /// </summary>
         public static KinematicViscosity? FromCentistokes(long? centistokes)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Centistokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromCentistokes(decimal? centistokes)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Decistokes.
         /// </summary>
         public static KinematicViscosity? FromDecistokes(int? decistokes)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Decistokes.
         /// </summary>
         public static KinematicViscosity? FromDecistokes(long? decistokes)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Decistokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromDecistokes(decimal? decistokes)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Kilostokes.
         /// </summary>
         public static KinematicViscosity? FromKilostokes(int? kilostokes)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Kilostokes.
         /// </summary>
         public static KinematicViscosity? FromKilostokes(long? kilostokes)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Kilostokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromKilostokes(decimal? kilostokes)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Microstokes.
         /// </summary>
         public static KinematicViscosity? FromMicrostokes(int? microstokes)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Microstokes.
         /// </summary>
         public static KinematicViscosity? FromMicrostokes(long? microstokes)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Microstokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromMicrostokes(decimal? microstokes)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Millistokes.
         /// </summary>
         public static KinematicViscosity? FromMillistokes(int? millistokes)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Millistokes.
         /// </summary>
         public static KinematicViscosity? FromMillistokes(long? millistokes)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Millistokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromMillistokes(decimal? millistokes)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Nanostokes.
         /// </summary>
         public static KinematicViscosity? FromNanostokes(int? nanostokes)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Nanostokes.
         /// </summary>
         public static KinematicViscosity? FromNanostokes(long? nanostokes)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Nanostokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromNanostokes(decimal? nanostokes)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
         /// </summary>
         public static KinematicViscosity? FromSquareMetersPerSecond(int? squaremeterspersecond)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
         /// </summary>
         public static KinematicViscosity? FromSquareMetersPerSecond(long? squaremeterspersecond)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from SquareMetersPerSecond of type decimal.
         /// </summary>
         public static KinematicViscosity? FromSquareMetersPerSecond(decimal? squaremeterspersecond)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Stokes.
         /// </summary>
         public static KinematicViscosity? FromStokes(int? stokes)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from nullable Stokes.
         /// </summary>
         public static KinematicViscosity? FromStokes(long? stokes)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable KinematicViscosity from Stokes of type decimal.
         /// </summary>
         public static KinematicViscosity? FromStokes(decimal? stokes)

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new KinematicViscosity((centistokes/1e4) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get KinematicViscosity from Centistokes.
+        /// </summary>
+        public static KinematicViscosity FromCentistokes(int centistokes)
+        {
+            return new KinematicViscosity((centistokes/1e4) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Centistokes.
+        /// </summary>
+        public static KinematicViscosity FromCentistokes(long centistokes)
+        {
+            return new KinematicViscosity((centistokes/1e4) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Centistokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromCentistokes(decimal centistokes)
+        {
+	        return new KinematicViscosity((Convert.ToDouble(centistokes)/1e4) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new KinematicViscosity((decistokes/1e4) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Decistokes.
+        /// </summary>
+        public static KinematicViscosity FromDecistokes(int decistokes)
+        {
+            return new KinematicViscosity((decistokes/1e4) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Decistokes.
+        /// </summary>
+        public static KinematicViscosity FromDecistokes(long decistokes)
+        {
+            return new KinematicViscosity((decistokes/1e4) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Decistokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromDecistokes(decimal decistokes)
+        {
+	        return new KinematicViscosity((Convert.ToDouble(decistokes)/1e4) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new KinematicViscosity((kilostokes/1e4) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get KinematicViscosity from Kilostokes.
+        /// </summary>
+        public static KinematicViscosity FromKilostokes(int kilostokes)
+        {
+            return new KinematicViscosity((kilostokes/1e4) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Kilostokes.
+        /// </summary>
+        public static KinematicViscosity FromKilostokes(long kilostokes)
+        {
+            return new KinematicViscosity((kilostokes/1e4) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Kilostokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromKilostokes(decimal kilostokes)
+        {
+	        return new KinematicViscosity((Convert.ToDouble(kilostokes)/1e4) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new KinematicViscosity((microstokes/1e4) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Microstokes.
+        /// </summary>
+        public static KinematicViscosity FromMicrostokes(int microstokes)
+        {
+            return new KinematicViscosity((microstokes/1e4) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Microstokes.
+        /// </summary>
+        public static KinematicViscosity FromMicrostokes(long microstokes)
+        {
+            return new KinematicViscosity((microstokes/1e4) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Microstokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromMicrostokes(decimal microstokes)
+        {
+	        return new KinematicViscosity((Convert.ToDouble(microstokes)/1e4) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get KinematicViscosity from Millistokes.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new KinematicViscosity((millistokes/1e4) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get KinematicViscosity from Millistokes.
+        /// </summary>
+        public static KinematicViscosity FromMillistokes(int millistokes)
+        {
+            return new KinematicViscosity((millistokes/1e4) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Millistokes.
+        /// </summary>
+        public static KinematicViscosity FromMillistokes(long millistokes)
+        {
+            return new KinematicViscosity((millistokes/1e4) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Millistokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromMillistokes(decimal millistokes)
+        {
+	        return new KinematicViscosity((Convert.ToDouble(millistokes)/1e4) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Nanostokes.
+        /// </summary>
+        public static KinematicViscosity FromNanostokes(int nanostokes)
+        {
+            return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Nanostokes.
+        /// </summary>
+        public static KinematicViscosity FromNanostokes(long nanostokes)
+        {
+            return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Nanostokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromNanostokes(decimal nanostokes)
+        {
+	        return new KinematicViscosity((Convert.ToDouble(nanostokes)/1e4) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new KinematicViscosity(squaremeterspersecond);
         }
 
+		/// <summary>
+        ///     Get KinematicViscosity from SquareMetersPerSecond.
+        /// </summary>
+        public static KinematicViscosity FromSquareMetersPerSecond(int squaremeterspersecond)
+        {
+            return new KinematicViscosity(squaremeterspersecond);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from SquareMetersPerSecond.
+        /// </summary>
+        public static KinematicViscosity FromSquareMetersPerSecond(long squaremeterspersecond)
+        {
+            return new KinematicViscosity(squaremeterspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from SquareMetersPerSecond of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromSquareMetersPerSecond(decimal squaremeterspersecond)
+        {
+	        return new KinematicViscosity(Convert.ToDouble(squaremeterspersecond));
+        }
+#endif
+
         /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new KinematicViscosity(stokes/1e4);
         }
 
+		/// <summary>
+        ///     Get KinematicViscosity from Stokes.
+        /// </summary>
+        public static KinematicViscosity FromStokes(int stokes)
+        {
+            return new KinematicViscosity(stokes/1e4);
+        }
+
+		/// <summary>
+        ///     Get KinematicViscosity from Stokes.
+        /// </summary>
+        public static KinematicViscosity FromStokes(long stokes)
+        {
+            return new KinematicViscosity(stokes/1e4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get KinematicViscosity from Stokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity FromStokes(decimal stokes)
+        {
+	        return new KinematicViscosity(Convert.ToDouble(stokes)/1e4);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Centistokes.
         /// </summary>
         public static KinematicViscosity? FromCentistokes(double? centistokes)
+        {
+            if (centistokes.HasValue)
+            {
+                return FromCentistokes(centistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Centistokes.
+        /// </summary>
+        public static KinematicViscosity? FromCentistokes(int? centistokes)
+        {
+            if (centistokes.HasValue)
+            {
+                return FromCentistokes(centistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Centistokes.
+        /// </summary>
+        public static KinematicViscosity? FromCentistokes(long? centistokes)
+        {
+            if (centistokes.HasValue)
+            {
+                return FromCentistokes(centistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Centistokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromCentistokes(decimal? centistokes)
         {
             if (centistokes.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Decistokes.
+        /// </summary>
+        public static KinematicViscosity? FromDecistokes(int? decistokes)
+        {
+            if (decistokes.HasValue)
+            {
+                return FromDecistokes(decistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Decistokes.
+        /// </summary>
+        public static KinematicViscosity? FromDecistokes(long? decistokes)
+        {
+            if (decistokes.HasValue)
+            {
+                return FromDecistokes(decistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Decistokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromDecistokes(decimal? decistokes)
+        {
+            if (decistokes.HasValue)
+            {
+                return FromDecistokes(decistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Kilostokes.
         /// </summary>
         public static KinematicViscosity? FromKilostokes(double? kilostokes)
+        {
+            if (kilostokes.HasValue)
+            {
+                return FromKilostokes(kilostokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Kilostokes.
+        /// </summary>
+        public static KinematicViscosity? FromKilostokes(int? kilostokes)
+        {
+            if (kilostokes.HasValue)
+            {
+                return FromKilostokes(kilostokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Kilostokes.
+        /// </summary>
+        public static KinematicViscosity? FromKilostokes(long? kilostokes)
+        {
+            if (kilostokes.HasValue)
+            {
+                return FromKilostokes(kilostokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Kilostokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromKilostokes(decimal? kilostokes)
         {
             if (kilostokes.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Microstokes.
+        /// </summary>
+        public static KinematicViscosity? FromMicrostokes(int? microstokes)
+        {
+            if (microstokes.HasValue)
+            {
+                return FromMicrostokes(microstokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Microstokes.
+        /// </summary>
+        public static KinematicViscosity? FromMicrostokes(long? microstokes)
+        {
+            if (microstokes.HasValue)
+            {
+                return FromMicrostokes(microstokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Microstokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromMicrostokes(decimal? microstokes)
+        {
+            if (microstokes.HasValue)
+            {
+                return FromMicrostokes(microstokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Millistokes.
         /// </summary>
         public static KinematicViscosity? FromMillistokes(double? millistokes)
+        {
+            if (millistokes.HasValue)
+            {
+                return FromMillistokes(millistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Millistokes.
+        /// </summary>
+        public static KinematicViscosity? FromMillistokes(int? millistokes)
+        {
+            if (millistokes.HasValue)
+            {
+                return FromMillistokes(millistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Millistokes.
+        /// </summary>
+        public static KinematicViscosity? FromMillistokes(long? millistokes)
+        {
+            if (millistokes.HasValue)
+            {
+                return FromMillistokes(millistokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Millistokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromMillistokes(decimal? millistokes)
         {
             if (millistokes.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Nanostokes.
+        /// </summary>
+        public static KinematicViscosity? FromNanostokes(int? nanostokes)
+        {
+            if (nanostokes.HasValue)
+            {
+                return FromNanostokes(nanostokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Nanostokes.
+        /// </summary>
+        public static KinematicViscosity? FromNanostokes(long? nanostokes)
+        {
+            if (nanostokes.HasValue)
+            {
+                return FromNanostokes(nanostokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Nanostokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromNanostokes(decimal? nanostokes)
+        {
+            if (nanostokes.HasValue)
+            {
+                return FromNanostokes(nanostokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
+        /// </summary>
+        public static KinematicViscosity? FromSquareMetersPerSecond(int? squaremeterspersecond)
+        {
+            if (squaremeterspersecond.HasValue)
+            {
+                return FromSquareMetersPerSecond(squaremeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
+        /// </summary>
+        public static KinematicViscosity? FromSquareMetersPerSecond(long? squaremeterspersecond)
+        {
+            if (squaremeterspersecond.HasValue)
+            {
+                return FromSquareMetersPerSecond(squaremeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from SquareMetersPerSecond of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromSquareMetersPerSecond(decimal? squaremeterspersecond)
+        {
+            if (squaremeterspersecond.HasValue)
+            {
+                return FromSquareMetersPerSecond(squaremeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Stokes.
         /// </summary>
         public static KinematicViscosity? FromStokes(double? stokes)
+        {
+            if (stokes.HasValue)
+            {
+                return FromStokes(stokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Stokes.
+        /// </summary>
+        public static KinematicViscosity? FromStokes(int? stokes)
+        {
+            if (stokes.HasValue)
+            {
+                return FromStokes(stokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from nullable Stokes.
+        /// </summary>
+        public static KinematicViscosity? FromStokes(long? stokes)
+        {
+            if (stokes.HasValue)
+            {
+                return FromStokes(stokes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable KinematicViscosity from Stokes of type decimal.
+        /// </summary>
+        public static KinematicViscosity? FromStokes(decimal? stokes)
         {
             if (stokes.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Centistokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromCentistokes(double centistokes)
         {
             return new KinematicViscosity((centistokes/1e4) * 1e-2d);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromDecistokes(double decistokes)
         {
             return new KinematicViscosity((decistokes/1e4) * 1e-1d);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromKilostokes(double kilostokes)
         {
             return new KinematicViscosity((kilostokes/1e4) * 1e3d);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromMicrostokes(double microstokes)
         {
             return new KinematicViscosity((microstokes/1e4) * 1e-6d);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Millistokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromMillistokes(double millistokes)
         {
             return new KinematicViscosity((millistokes/1e4) * 1e-3d);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromNanostokes(double nanostokes)
         {
             return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromSquareMetersPerSecond(double squaremeterspersecond)
         {
             return new KinematicViscosity(squaremeterspersecond);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static KinematicViscosity FromStokes(double stokes)
         {
             return new KinematicViscosity(stokes/1e4);

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -322,6 +322,33 @@ namespace UnitsNet
             return new Length((centimeters) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Length from Centimeters.
+        /// </summary>
+        public static Length FromCentimeters(int centimeters)
+        {
+            return new Length((centimeters) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Length from Centimeters.
+        /// </summary>
+        public static Length FromCentimeters(long centimeters)
+        {
+            return new Length((centimeters) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Centimeters of type decimal.
+        /// </summary>
+        public static Length FromCentimeters(decimal centimeters)
+        {
+	        return new Length((Convert.ToDouble(centimeters)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
@@ -329,6 +356,33 @@ namespace UnitsNet
         {
             return new Length((decimeters) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Length from Decimeters.
+        /// </summary>
+        public static Length FromDecimeters(int decimeters)
+        {
+            return new Length((decimeters) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Length from Decimeters.
+        /// </summary>
+        public static Length FromDecimeters(long decimeters)
+        {
+            return new Length((decimeters) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Decimeters of type decimal.
+        /// </summary>
+        public static Length FromDecimeters(decimal decimeters)
+        {
+	        return new Length((Convert.ToDouble(decimeters)) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from DtpPicas.
@@ -338,6 +392,33 @@ namespace UnitsNet
             return new Length(dtppicas/236.220472441);
         }
 
+		/// <summary>
+        ///     Get Length from DtpPicas.
+        /// </summary>
+        public static Length FromDtpPicas(int dtppicas)
+        {
+            return new Length(dtppicas/236.220472441);
+        }
+
+		/// <summary>
+        ///     Get Length from DtpPicas.
+        /// </summary>
+        public static Length FromDtpPicas(long dtppicas)
+        {
+            return new Length(dtppicas/236.220472441);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from DtpPicas of type decimal.
+        /// </summary>
+        public static Length FromDtpPicas(decimal dtppicas)
+        {
+	        return new Length(Convert.ToDouble(dtppicas)/236.220472441);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
@@ -345,6 +426,33 @@ namespace UnitsNet
         {
             return new Length((dtppoints/72)*2.54e-2);
         }
+
+		/// <summary>
+        ///     Get Length from DtpPoints.
+        /// </summary>
+        public static Length FromDtpPoints(int dtppoints)
+        {
+            return new Length((dtppoints/72)*2.54e-2);
+        }
+
+		/// <summary>
+        ///     Get Length from DtpPoints.
+        /// </summary>
+        public static Length FromDtpPoints(long dtppoints)
+        {
+            return new Length((dtppoints/72)*2.54e-2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from DtpPoints of type decimal.
+        /// </summary>
+        public static Length FromDtpPoints(decimal dtppoints)
+        {
+	        return new Length((Convert.ToDouble(dtppoints)/72)*2.54e-2);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Fathoms.
@@ -354,6 +462,33 @@ namespace UnitsNet
             return new Length(fathoms*1.8288);
         }
 
+		/// <summary>
+        ///     Get Length from Fathoms.
+        /// </summary>
+        public static Length FromFathoms(int fathoms)
+        {
+            return new Length(fathoms*1.8288);
+        }
+
+		/// <summary>
+        ///     Get Length from Fathoms.
+        /// </summary>
+        public static Length FromFathoms(long fathoms)
+        {
+            return new Length(fathoms*1.8288);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Fathoms of type decimal.
+        /// </summary>
+        public static Length FromFathoms(decimal fathoms)
+        {
+	        return new Length(Convert.ToDouble(fathoms)*1.8288);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Feet.
         /// </summary>
@@ -361,6 +496,33 @@ namespace UnitsNet
         {
             return new Length(feet*0.3048);
         }
+
+		/// <summary>
+        ///     Get Length from Feet.
+        /// </summary>
+        public static Length FromFeet(int feet)
+        {
+            return new Length(feet*0.3048);
+        }
+
+		/// <summary>
+        ///     Get Length from Feet.
+        /// </summary>
+        public static Length FromFeet(long feet)
+        {
+            return new Length(feet*0.3048);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Feet of type decimal.
+        /// </summary>
+        public static Length FromFeet(decimal feet)
+        {
+	        return new Length(Convert.ToDouble(feet)*0.3048);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Inches.
@@ -370,6 +532,33 @@ namespace UnitsNet
             return new Length(inches*2.54e-2);
         }
 
+		/// <summary>
+        ///     Get Length from Inches.
+        /// </summary>
+        public static Length FromInches(int inches)
+        {
+            return new Length(inches*2.54e-2);
+        }
+
+		/// <summary>
+        ///     Get Length from Inches.
+        /// </summary>
+        public static Length FromInches(long inches)
+        {
+            return new Length(inches*2.54e-2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Inches of type decimal.
+        /// </summary>
+        public static Length FromInches(decimal inches)
+        {
+	        return new Length(Convert.ToDouble(inches)*2.54e-2);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
@@ -377,6 +566,33 @@ namespace UnitsNet
         {
             return new Length((kilometers) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Length from Kilometers.
+        /// </summary>
+        public static Length FromKilometers(int kilometers)
+        {
+            return new Length((kilometers) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Length from Kilometers.
+        /// </summary>
+        public static Length FromKilometers(long kilometers)
+        {
+            return new Length((kilometers) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Kilometers of type decimal.
+        /// </summary>
+        public static Length FromKilometers(decimal kilometers)
+        {
+	        return new Length((Convert.ToDouble(kilometers)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Meters.
@@ -386,6 +602,33 @@ namespace UnitsNet
             return new Length(meters);
         }
 
+		/// <summary>
+        ///     Get Length from Meters.
+        /// </summary>
+        public static Length FromMeters(int meters)
+        {
+            return new Length(meters);
+        }
+
+		/// <summary>
+        ///     Get Length from Meters.
+        /// </summary>
+        public static Length FromMeters(long meters)
+        {
+            return new Length(meters);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Meters of type decimal.
+        /// </summary>
+        public static Length FromMeters(decimal meters)
+        {
+	        return new Length(Convert.ToDouble(meters));
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
@@ -393,6 +636,33 @@ namespace UnitsNet
         {
             return new Length(microinches*2.54e-8);
         }
+
+		/// <summary>
+        ///     Get Length from Microinches.
+        /// </summary>
+        public static Length FromMicroinches(int microinches)
+        {
+            return new Length(microinches*2.54e-8);
+        }
+
+		/// <summary>
+        ///     Get Length from Microinches.
+        /// </summary>
+        public static Length FromMicroinches(long microinches)
+        {
+            return new Length(microinches*2.54e-8);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Microinches of type decimal.
+        /// </summary>
+        public static Length FromMicroinches(decimal microinches)
+        {
+	        return new Length(Convert.ToDouble(microinches)*2.54e-8);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Micrometers.
@@ -402,6 +672,33 @@ namespace UnitsNet
             return new Length((micrometers) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Length from Micrometers.
+        /// </summary>
+        public static Length FromMicrometers(int micrometers)
+        {
+            return new Length((micrometers) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Length from Micrometers.
+        /// </summary>
+        public static Length FromMicrometers(long micrometers)
+        {
+            return new Length((micrometers) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Micrometers of type decimal.
+        /// </summary>
+        public static Length FromMicrometers(decimal micrometers)
+        {
+	        return new Length((Convert.ToDouble(micrometers)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Mils.
         /// </summary>
@@ -409,6 +706,33 @@ namespace UnitsNet
         {
             return new Length(mils*2.54e-5);
         }
+
+		/// <summary>
+        ///     Get Length from Mils.
+        /// </summary>
+        public static Length FromMils(int mils)
+        {
+            return new Length(mils*2.54e-5);
+        }
+
+		/// <summary>
+        ///     Get Length from Mils.
+        /// </summary>
+        public static Length FromMils(long mils)
+        {
+            return new Length(mils*2.54e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Mils of type decimal.
+        /// </summary>
+        public static Length FromMils(decimal mils)
+        {
+	        return new Length(Convert.ToDouble(mils)*2.54e-5);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Miles.
@@ -418,6 +742,33 @@ namespace UnitsNet
             return new Length(miles*1609.34);
         }
 
+		/// <summary>
+        ///     Get Length from Miles.
+        /// </summary>
+        public static Length FromMiles(int miles)
+        {
+            return new Length(miles*1609.34);
+        }
+
+		/// <summary>
+        ///     Get Length from Miles.
+        /// </summary>
+        public static Length FromMiles(long miles)
+        {
+            return new Length(miles*1609.34);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Miles of type decimal.
+        /// </summary>
+        public static Length FromMiles(decimal miles)
+        {
+	        return new Length(Convert.ToDouble(miles)*1609.34);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
@@ -425,6 +776,33 @@ namespace UnitsNet
         {
             return new Length((millimeters) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Length from Millimeters.
+        /// </summary>
+        public static Length FromMillimeters(int millimeters)
+        {
+            return new Length((millimeters) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Length from Millimeters.
+        /// </summary>
+        public static Length FromMillimeters(long millimeters)
+        {
+            return new Length((millimeters) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Millimeters of type decimal.
+        /// </summary>
+        public static Length FromMillimeters(decimal millimeters)
+        {
+	        return new Length((Convert.ToDouble(millimeters)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Nanometers.
@@ -434,6 +812,33 @@ namespace UnitsNet
             return new Length((nanometers) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Length from Nanometers.
+        /// </summary>
+        public static Length FromNanometers(int nanometers)
+        {
+            return new Length((nanometers) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Length from Nanometers.
+        /// </summary>
+        public static Length FromNanometers(long nanometers)
+        {
+            return new Length((nanometers) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Nanometers of type decimal.
+        /// </summary>
+        public static Length FromNanometers(decimal nanometers)
+        {
+	        return new Length((Convert.ToDouble(nanometers)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
@@ -441,6 +846,33 @@ namespace UnitsNet
         {
             return new Length(nauticalmiles*1852);
         }
+
+		/// <summary>
+        ///     Get Length from NauticalMiles.
+        /// </summary>
+        public static Length FromNauticalMiles(int nauticalmiles)
+        {
+            return new Length(nauticalmiles*1852);
+        }
+
+		/// <summary>
+        ///     Get Length from NauticalMiles.
+        /// </summary>
+        public static Length FromNauticalMiles(long nauticalmiles)
+        {
+            return new Length(nauticalmiles*1852);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from NauticalMiles of type decimal.
+        /// </summary>
+        public static Length FromNauticalMiles(decimal nauticalmiles)
+        {
+	        return new Length(Convert.ToDouble(nauticalmiles)*1852);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from PrinterPicas.
@@ -450,6 +882,33 @@ namespace UnitsNet
             return new Length(printerpicas/237.106301584);
         }
 
+		/// <summary>
+        ///     Get Length from PrinterPicas.
+        /// </summary>
+        public static Length FromPrinterPicas(int printerpicas)
+        {
+            return new Length(printerpicas/237.106301584);
+        }
+
+		/// <summary>
+        ///     Get Length from PrinterPicas.
+        /// </summary>
+        public static Length FromPrinterPicas(long printerpicas)
+        {
+            return new Length(printerpicas/237.106301584);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from PrinterPicas of type decimal.
+        /// </summary>
+        public static Length FromPrinterPicas(decimal printerpicas)
+        {
+	        return new Length(Convert.ToDouble(printerpicas)/237.106301584);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
@@ -457,6 +916,33 @@ namespace UnitsNet
         {
             return new Length((printerpoints/72.27)*2.54e-2);
         }
+
+		/// <summary>
+        ///     Get Length from PrinterPoints.
+        /// </summary>
+        public static Length FromPrinterPoints(int printerpoints)
+        {
+            return new Length((printerpoints/72.27)*2.54e-2);
+        }
+
+		/// <summary>
+        ///     Get Length from PrinterPoints.
+        /// </summary>
+        public static Length FromPrinterPoints(long printerpoints)
+        {
+            return new Length((printerpoints/72.27)*2.54e-2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from PrinterPoints of type decimal.
+        /// </summary>
+        public static Length FromPrinterPoints(decimal printerpoints)
+        {
+	        return new Length((Convert.ToDouble(printerpoints)/72.27)*2.54e-2);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from Shackles.
@@ -466,6 +952,33 @@ namespace UnitsNet
             return new Length(shackles*27.432);
         }
 
+		/// <summary>
+        ///     Get Length from Shackles.
+        /// </summary>
+        public static Length FromShackles(int shackles)
+        {
+            return new Length(shackles*27.432);
+        }
+
+		/// <summary>
+        ///     Get Length from Shackles.
+        /// </summary>
+        public static Length FromShackles(long shackles)
+        {
+            return new Length(shackles*27.432);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Shackles of type decimal.
+        /// </summary>
+        public static Length FromShackles(decimal shackles)
+        {
+	        return new Length(Convert.ToDouble(shackles)*27.432);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Twips.
         /// </summary>
@@ -473,6 +986,33 @@ namespace UnitsNet
         {
             return new Length(twips/56692.913385826);
         }
+
+		/// <summary>
+        ///     Get Length from Twips.
+        /// </summary>
+        public static Length FromTwips(int twips)
+        {
+            return new Length(twips/56692.913385826);
+        }
+
+		/// <summary>
+        ///     Get Length from Twips.
+        /// </summary>
+        public static Length FromTwips(long twips)
+        {
+            return new Length(twips/56692.913385826);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Twips of type decimal.
+        /// </summary>
+        public static Length FromTwips(decimal twips)
+        {
+	        return new Length(Convert.ToDouble(twips)/56692.913385826);
+        }
+#endif
 
         /// <summary>
         ///     Get Length from UsSurveyFeet.
@@ -482,6 +1022,33 @@ namespace UnitsNet
             return new Length(ussurveyfeet*1200/3937);
         }
 
+		/// <summary>
+        ///     Get Length from UsSurveyFeet.
+        /// </summary>
+        public static Length FromUsSurveyFeet(int ussurveyfeet)
+        {
+            return new Length(ussurveyfeet*1200/3937);
+        }
+
+		/// <summary>
+        ///     Get Length from UsSurveyFeet.
+        /// </summary>
+        public static Length FromUsSurveyFeet(long ussurveyfeet)
+        {
+            return new Length(ussurveyfeet*1200/3937);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from UsSurveyFeet of type decimal.
+        /// </summary>
+        public static Length FromUsSurveyFeet(decimal ussurveyfeet)
+        {
+	        return new Length(Convert.ToDouble(ussurveyfeet)*1200/3937);
+        }
+#endif
+
         /// <summary>
         ///     Get Length from Yards.
         /// </summary>
@@ -490,12 +1057,84 @@ namespace UnitsNet
             return new Length(yards*0.9144);
         }
 
+		/// <summary>
+        ///     Get Length from Yards.
+        /// </summary>
+        public static Length FromYards(int yards)
+        {
+            return new Length(yards*0.9144);
+        }
+
+		/// <summary>
+        ///     Get Length from Yards.
+        /// </summary>
+        public static Length FromYards(long yards)
+        {
+            return new Length(yards*0.9144);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Length from Yards of type decimal.
+        /// </summary>
+        public static Length FromYards(decimal yards)
+        {
+	        return new Length(Convert.ToDouble(yards)*0.9144);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Length from nullable Centimeters.
         /// </summary>
         public static Length? FromCentimeters(double? centimeters)
+        {
+            if (centimeters.HasValue)
+            {
+                return FromCentimeters(centimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Centimeters.
+        /// </summary>
+        public static Length? FromCentimeters(int? centimeters)
+        {
+            if (centimeters.HasValue)
+            {
+                return FromCentimeters(centimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Centimeters.
+        /// </summary>
+        public static Length? FromCentimeters(long? centimeters)
+        {
+            if (centimeters.HasValue)
+            {
+                return FromCentimeters(centimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Centimeters of type decimal.
+        /// </summary>
+        public static Length? FromCentimeters(decimal? centimeters)
         {
             if (centimeters.HasValue)
             {
@@ -522,10 +1161,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Decimeters.
+        /// </summary>
+        public static Length? FromDecimeters(int? decimeters)
+        {
+            if (decimeters.HasValue)
+            {
+                return FromDecimeters(decimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Decimeters.
+        /// </summary>
+        public static Length? FromDecimeters(long? decimeters)
+        {
+            if (decimeters.HasValue)
+            {
+                return FromDecimeters(decimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Decimeters of type decimal.
+        /// </summary>
+        public static Length? FromDecimeters(decimal? decimeters)
+        {
+            if (decimeters.HasValue)
+            {
+                return FromDecimeters(decimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable DtpPicas.
         /// </summary>
         public static Length? FromDtpPicas(double? dtppicas)
+        {
+            if (dtppicas.HasValue)
+            {
+                return FromDtpPicas(dtppicas.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable DtpPicas.
+        /// </summary>
+        public static Length? FromDtpPicas(int? dtppicas)
+        {
+            if (dtppicas.HasValue)
+            {
+                return FromDtpPicas(dtppicas.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable DtpPicas.
+        /// </summary>
+        public static Length? FromDtpPicas(long? dtppicas)
+        {
+            if (dtppicas.HasValue)
+            {
+                return FromDtpPicas(dtppicas.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from DtpPicas of type decimal.
+        /// </summary>
+        public static Length? FromDtpPicas(decimal? dtppicas)
         {
             if (dtppicas.HasValue)
             {
@@ -552,10 +1281,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable DtpPoints.
+        /// </summary>
+        public static Length? FromDtpPoints(int? dtppoints)
+        {
+            if (dtppoints.HasValue)
+            {
+                return FromDtpPoints(dtppoints.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable DtpPoints.
+        /// </summary>
+        public static Length? FromDtpPoints(long? dtppoints)
+        {
+            if (dtppoints.HasValue)
+            {
+                return FromDtpPoints(dtppoints.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from DtpPoints of type decimal.
+        /// </summary>
+        public static Length? FromDtpPoints(decimal? dtppoints)
+        {
+            if (dtppoints.HasValue)
+            {
+                return FromDtpPoints(dtppoints.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Fathoms.
         /// </summary>
         public static Length? FromFathoms(double? fathoms)
+        {
+            if (fathoms.HasValue)
+            {
+                return FromFathoms(fathoms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Fathoms.
+        /// </summary>
+        public static Length? FromFathoms(int? fathoms)
+        {
+            if (fathoms.HasValue)
+            {
+                return FromFathoms(fathoms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Fathoms.
+        /// </summary>
+        public static Length? FromFathoms(long? fathoms)
+        {
+            if (fathoms.HasValue)
+            {
+                return FromFathoms(fathoms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Fathoms of type decimal.
+        /// </summary>
+        public static Length? FromFathoms(decimal? fathoms)
         {
             if (fathoms.HasValue)
             {
@@ -582,10 +1401,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Feet.
+        /// </summary>
+        public static Length? FromFeet(int? feet)
+        {
+            if (feet.HasValue)
+            {
+                return FromFeet(feet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Feet.
+        /// </summary>
+        public static Length? FromFeet(long? feet)
+        {
+            if (feet.HasValue)
+            {
+                return FromFeet(feet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Feet of type decimal.
+        /// </summary>
+        public static Length? FromFeet(decimal? feet)
+        {
+            if (feet.HasValue)
+            {
+                return FromFeet(feet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Inches.
         /// </summary>
         public static Length? FromInches(double? inches)
+        {
+            if (inches.HasValue)
+            {
+                return FromInches(inches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Inches.
+        /// </summary>
+        public static Length? FromInches(int? inches)
+        {
+            if (inches.HasValue)
+            {
+                return FromInches(inches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Inches.
+        /// </summary>
+        public static Length? FromInches(long? inches)
+        {
+            if (inches.HasValue)
+            {
+                return FromInches(inches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Inches of type decimal.
+        /// </summary>
+        public static Length? FromInches(decimal? inches)
         {
             if (inches.HasValue)
             {
@@ -612,10 +1521,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Kilometers.
+        /// </summary>
+        public static Length? FromKilometers(int? kilometers)
+        {
+            if (kilometers.HasValue)
+            {
+                return FromKilometers(kilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Kilometers.
+        /// </summary>
+        public static Length? FromKilometers(long? kilometers)
+        {
+            if (kilometers.HasValue)
+            {
+                return FromKilometers(kilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Kilometers of type decimal.
+        /// </summary>
+        public static Length? FromKilometers(decimal? kilometers)
+        {
+            if (kilometers.HasValue)
+            {
+                return FromKilometers(kilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Meters.
         /// </summary>
         public static Length? FromMeters(double? meters)
+        {
+            if (meters.HasValue)
+            {
+                return FromMeters(meters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Meters.
+        /// </summary>
+        public static Length? FromMeters(int? meters)
+        {
+            if (meters.HasValue)
+            {
+                return FromMeters(meters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Meters.
+        /// </summary>
+        public static Length? FromMeters(long? meters)
+        {
+            if (meters.HasValue)
+            {
+                return FromMeters(meters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Meters of type decimal.
+        /// </summary>
+        public static Length? FromMeters(decimal? meters)
         {
             if (meters.HasValue)
             {
@@ -642,10 +1641,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Microinches.
+        /// </summary>
+        public static Length? FromMicroinches(int? microinches)
+        {
+            if (microinches.HasValue)
+            {
+                return FromMicroinches(microinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Microinches.
+        /// </summary>
+        public static Length? FromMicroinches(long? microinches)
+        {
+            if (microinches.HasValue)
+            {
+                return FromMicroinches(microinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Microinches of type decimal.
+        /// </summary>
+        public static Length? FromMicroinches(decimal? microinches)
+        {
+            if (microinches.HasValue)
+            {
+                return FromMicroinches(microinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Micrometers.
         /// </summary>
         public static Length? FromMicrometers(double? micrometers)
+        {
+            if (micrometers.HasValue)
+            {
+                return FromMicrometers(micrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Micrometers.
+        /// </summary>
+        public static Length? FromMicrometers(int? micrometers)
+        {
+            if (micrometers.HasValue)
+            {
+                return FromMicrometers(micrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Micrometers.
+        /// </summary>
+        public static Length? FromMicrometers(long? micrometers)
+        {
+            if (micrometers.HasValue)
+            {
+                return FromMicrometers(micrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Micrometers of type decimal.
+        /// </summary>
+        public static Length? FromMicrometers(decimal? micrometers)
         {
             if (micrometers.HasValue)
             {
@@ -672,10 +1761,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Mils.
+        /// </summary>
+        public static Length? FromMils(int? mils)
+        {
+            if (mils.HasValue)
+            {
+                return FromMils(mils.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Mils.
+        /// </summary>
+        public static Length? FromMils(long? mils)
+        {
+            if (mils.HasValue)
+            {
+                return FromMils(mils.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Mils of type decimal.
+        /// </summary>
+        public static Length? FromMils(decimal? mils)
+        {
+            if (mils.HasValue)
+            {
+                return FromMils(mils.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Miles.
         /// </summary>
         public static Length? FromMiles(double? miles)
+        {
+            if (miles.HasValue)
+            {
+                return FromMiles(miles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Miles.
+        /// </summary>
+        public static Length? FromMiles(int? miles)
+        {
+            if (miles.HasValue)
+            {
+                return FromMiles(miles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Miles.
+        /// </summary>
+        public static Length? FromMiles(long? miles)
+        {
+            if (miles.HasValue)
+            {
+                return FromMiles(miles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Miles of type decimal.
+        /// </summary>
+        public static Length? FromMiles(decimal? miles)
         {
             if (miles.HasValue)
             {
@@ -702,10 +1881,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Millimeters.
+        /// </summary>
+        public static Length? FromMillimeters(int? millimeters)
+        {
+            if (millimeters.HasValue)
+            {
+                return FromMillimeters(millimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Millimeters.
+        /// </summary>
+        public static Length? FromMillimeters(long? millimeters)
+        {
+            if (millimeters.HasValue)
+            {
+                return FromMillimeters(millimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Millimeters of type decimal.
+        /// </summary>
+        public static Length? FromMillimeters(decimal? millimeters)
+        {
+            if (millimeters.HasValue)
+            {
+                return FromMillimeters(millimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Nanometers.
         /// </summary>
         public static Length? FromNanometers(double? nanometers)
+        {
+            if (nanometers.HasValue)
+            {
+                return FromNanometers(nanometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Nanometers.
+        /// </summary>
+        public static Length? FromNanometers(int? nanometers)
+        {
+            if (nanometers.HasValue)
+            {
+                return FromNanometers(nanometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Nanometers.
+        /// </summary>
+        public static Length? FromNanometers(long? nanometers)
+        {
+            if (nanometers.HasValue)
+            {
+                return FromNanometers(nanometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Nanometers of type decimal.
+        /// </summary>
+        public static Length? FromNanometers(decimal? nanometers)
         {
             if (nanometers.HasValue)
             {
@@ -732,10 +2001,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable NauticalMiles.
+        /// </summary>
+        public static Length? FromNauticalMiles(int? nauticalmiles)
+        {
+            if (nauticalmiles.HasValue)
+            {
+                return FromNauticalMiles(nauticalmiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable NauticalMiles.
+        /// </summary>
+        public static Length? FromNauticalMiles(long? nauticalmiles)
+        {
+            if (nauticalmiles.HasValue)
+            {
+                return FromNauticalMiles(nauticalmiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from NauticalMiles of type decimal.
+        /// </summary>
+        public static Length? FromNauticalMiles(decimal? nauticalmiles)
+        {
+            if (nauticalmiles.HasValue)
+            {
+                return FromNauticalMiles(nauticalmiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable PrinterPicas.
         /// </summary>
         public static Length? FromPrinterPicas(double? printerpicas)
+        {
+            if (printerpicas.HasValue)
+            {
+                return FromPrinterPicas(printerpicas.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable PrinterPicas.
+        /// </summary>
+        public static Length? FromPrinterPicas(int? printerpicas)
+        {
+            if (printerpicas.HasValue)
+            {
+                return FromPrinterPicas(printerpicas.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable PrinterPicas.
+        /// </summary>
+        public static Length? FromPrinterPicas(long? printerpicas)
+        {
+            if (printerpicas.HasValue)
+            {
+                return FromPrinterPicas(printerpicas.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from PrinterPicas of type decimal.
+        /// </summary>
+        public static Length? FromPrinterPicas(decimal? printerpicas)
         {
             if (printerpicas.HasValue)
             {
@@ -762,10 +2121,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable PrinterPoints.
+        /// </summary>
+        public static Length? FromPrinterPoints(int? printerpoints)
+        {
+            if (printerpoints.HasValue)
+            {
+                return FromPrinterPoints(printerpoints.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable PrinterPoints.
+        /// </summary>
+        public static Length? FromPrinterPoints(long? printerpoints)
+        {
+            if (printerpoints.HasValue)
+            {
+                return FromPrinterPoints(printerpoints.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from PrinterPoints of type decimal.
+        /// </summary>
+        public static Length? FromPrinterPoints(decimal? printerpoints)
+        {
+            if (printerpoints.HasValue)
+            {
+                return FromPrinterPoints(printerpoints.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Shackles.
         /// </summary>
         public static Length? FromShackles(double? shackles)
+        {
+            if (shackles.HasValue)
+            {
+                return FromShackles(shackles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Shackles.
+        /// </summary>
+        public static Length? FromShackles(int? shackles)
+        {
+            if (shackles.HasValue)
+            {
+                return FromShackles(shackles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Shackles.
+        /// </summary>
+        public static Length? FromShackles(long? shackles)
+        {
+            if (shackles.HasValue)
+            {
+                return FromShackles(shackles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Shackles of type decimal.
+        /// </summary>
+        public static Length? FromShackles(decimal? shackles)
         {
             if (shackles.HasValue)
             {
@@ -792,6 +2241,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable Twips.
+        /// </summary>
+        public static Length? FromTwips(int? twips)
+        {
+            if (twips.HasValue)
+            {
+                return FromTwips(twips.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Twips.
+        /// </summary>
+        public static Length? FromTwips(long? twips)
+        {
+            if (twips.HasValue)
+            {
+                return FromTwips(twips.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Twips of type decimal.
+        /// </summary>
+        public static Length? FromTwips(decimal? twips)
+        {
+            if (twips.HasValue)
+            {
+                return FromTwips(twips.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable UsSurveyFeet.
         /// </summary>
@@ -807,10 +2301,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Length from nullable UsSurveyFeet.
+        /// </summary>
+        public static Length? FromUsSurveyFeet(int? ussurveyfeet)
+        {
+            if (ussurveyfeet.HasValue)
+            {
+                return FromUsSurveyFeet(ussurveyfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable UsSurveyFeet.
+        /// </summary>
+        public static Length? FromUsSurveyFeet(long? ussurveyfeet)
+        {
+            if (ussurveyfeet.HasValue)
+            {
+                return FromUsSurveyFeet(ussurveyfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from UsSurveyFeet of type decimal.
+        /// </summary>
+        public static Length? FromUsSurveyFeet(decimal? ussurveyfeet)
+        {
+            if (ussurveyfeet.HasValue)
+            {
+                return FromUsSurveyFeet(ussurveyfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Length from nullable Yards.
         /// </summary>
         public static Length? FromYards(double? yards)
+        {
+            if (yards.HasValue)
+            {
+                return FromYards(yards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Yards.
+        /// </summary>
+        public static Length? FromYards(int? yards)
+        {
+            if (yards.HasValue)
+            {
+                return FromYards(yards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from nullable Yards.
+        /// </summary>
+        public static Length? FromYards(long? yards)
+        {
+            if (yards.HasValue)
+            {
+                return FromYards(yards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Length from Yards of type decimal.
+        /// </summary>
+        public static Length? FromYards(decimal? yards)
         {
             if (yards.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -317,6 +317,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Centimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromCentimeters(double centimeters)
         {
             return new Length((centimeters) * 1e-2d);
@@ -352,6 +355,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromDecimeters(double decimeters)
         {
             return new Length((decimeters) * 1e-1d);
@@ -387,6 +393,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from DtpPicas.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromDtpPicas(double dtppicas)
         {
             return new Length(dtppicas/236.220472441);
@@ -422,6 +431,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromDtpPoints(double dtppoints)
         {
             return new Length((dtppoints/72)*2.54e-2);
@@ -457,6 +469,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Fathoms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromFathoms(double fathoms)
         {
             return new Length(fathoms*1.8288);
@@ -492,6 +507,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Feet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromFeet(double feet)
         {
             return new Length(feet*0.3048);
@@ -527,6 +545,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Inches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromInches(double inches)
         {
             return new Length(inches*2.54e-2);
@@ -562,6 +583,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromKilometers(double kilometers)
         {
             return new Length((kilometers) * 1e3d);
@@ -597,6 +621,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Meters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromMeters(double meters)
         {
             return new Length(meters);
@@ -632,6 +659,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromMicroinches(double microinches)
         {
             return new Length(microinches*2.54e-8);
@@ -667,6 +697,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Micrometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromMicrometers(double micrometers)
         {
             return new Length((micrometers) * 1e-6d);
@@ -702,6 +735,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Mils.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromMils(double mils)
         {
             return new Length(mils*2.54e-5);
@@ -737,6 +773,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Miles.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromMiles(double miles)
         {
             return new Length(miles*1609.34);
@@ -772,6 +811,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromMillimeters(double millimeters)
         {
             return new Length((millimeters) * 1e-3d);
@@ -807,6 +849,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Nanometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromNanometers(double nanometers)
         {
             return new Length((nanometers) * 1e-9d);
@@ -842,6 +887,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromNauticalMiles(double nauticalmiles)
         {
             return new Length(nauticalmiles*1852);
@@ -877,6 +925,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from PrinterPicas.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromPrinterPicas(double printerpicas)
         {
             return new Length(printerpicas/237.106301584);
@@ -912,6 +963,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromPrinterPoints(double printerpoints)
         {
             return new Length((printerpoints/72.27)*2.54e-2);
@@ -947,6 +1001,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Shackles.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromShackles(double shackles)
         {
             return new Length(shackles*27.432);
@@ -982,6 +1039,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Twips.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromTwips(double twips)
         {
             return new Length(twips/56692.913385826);
@@ -1017,6 +1077,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from UsSurveyFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromUsSurveyFeet(double ussurveyfeet)
         {
             return new Length(ussurveyfeet*1200/3937);
@@ -1052,6 +1115,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Yards.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Length FromYards(double yards)
         {
             return new Length(yards*0.9144);

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _meters;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Length() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Length;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static LengthUnit BaseUnit
         {
             get { return LengthUnit.Meter; }
@@ -322,7 +322,7 @@ namespace UnitsNet
             return new Length((centimeters) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Centimeters.
         /// </summary>
         public static Length FromCentimeters(int centimeters)
@@ -330,7 +330,7 @@ namespace UnitsNet
             return new Length((centimeters) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Centimeters.
         /// </summary>
         public static Length FromCentimeters(long centimeters)
@@ -338,14 +338,14 @@ namespace UnitsNet
             return new Length((centimeters) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Centimeters of type decimal.
         /// </summary>
         public static Length FromCentimeters(decimal centimeters)
         {
-	        return new Length((Convert.ToDouble(centimeters)) * 1e-2d);
+            return new Length((Convert.ToDouble(centimeters)) * 1e-2d);
         }
 #endif
 
@@ -357,7 +357,7 @@ namespace UnitsNet
             return new Length((decimeters) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
         public static Length FromDecimeters(int decimeters)
@@ -365,7 +365,7 @@ namespace UnitsNet
             return new Length((decimeters) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
         public static Length FromDecimeters(long decimeters)
@@ -373,14 +373,14 @@ namespace UnitsNet
             return new Length((decimeters) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Decimeters of type decimal.
         /// </summary>
         public static Length FromDecimeters(decimal decimeters)
         {
-	        return new Length((Convert.ToDouble(decimeters)) * 1e-1d);
+            return new Length((Convert.ToDouble(decimeters)) * 1e-1d);
         }
 #endif
 
@@ -392,7 +392,7 @@ namespace UnitsNet
             return new Length(dtppicas/236.220472441);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from DtpPicas.
         /// </summary>
         public static Length FromDtpPicas(int dtppicas)
@@ -400,7 +400,7 @@ namespace UnitsNet
             return new Length(dtppicas/236.220472441);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from DtpPicas.
         /// </summary>
         public static Length FromDtpPicas(long dtppicas)
@@ -408,14 +408,14 @@ namespace UnitsNet
             return new Length(dtppicas/236.220472441);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from DtpPicas of type decimal.
         /// </summary>
         public static Length FromDtpPicas(decimal dtppicas)
         {
-	        return new Length(Convert.ToDouble(dtppicas)/236.220472441);
+            return new Length(Convert.ToDouble(dtppicas)/236.220472441);
         }
 #endif
 
@@ -427,7 +427,7 @@ namespace UnitsNet
             return new Length((dtppoints/72)*2.54e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
         public static Length FromDtpPoints(int dtppoints)
@@ -435,7 +435,7 @@ namespace UnitsNet
             return new Length((dtppoints/72)*2.54e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
         public static Length FromDtpPoints(long dtppoints)
@@ -443,14 +443,14 @@ namespace UnitsNet
             return new Length((dtppoints/72)*2.54e-2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from DtpPoints of type decimal.
         /// </summary>
         public static Length FromDtpPoints(decimal dtppoints)
         {
-	        return new Length((Convert.ToDouble(dtppoints)/72)*2.54e-2);
+            return new Length((Convert.ToDouble(dtppoints)/72)*2.54e-2);
         }
 #endif
 
@@ -462,7 +462,7 @@ namespace UnitsNet
             return new Length(fathoms*1.8288);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Fathoms.
         /// </summary>
         public static Length FromFathoms(int fathoms)
@@ -470,7 +470,7 @@ namespace UnitsNet
             return new Length(fathoms*1.8288);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Fathoms.
         /// </summary>
         public static Length FromFathoms(long fathoms)
@@ -478,14 +478,14 @@ namespace UnitsNet
             return new Length(fathoms*1.8288);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Fathoms of type decimal.
         /// </summary>
         public static Length FromFathoms(decimal fathoms)
         {
-	        return new Length(Convert.ToDouble(fathoms)*1.8288);
+            return new Length(Convert.ToDouble(fathoms)*1.8288);
         }
 #endif
 
@@ -497,7 +497,7 @@ namespace UnitsNet
             return new Length(feet*0.3048);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Feet.
         /// </summary>
         public static Length FromFeet(int feet)
@@ -505,7 +505,7 @@ namespace UnitsNet
             return new Length(feet*0.3048);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Feet.
         /// </summary>
         public static Length FromFeet(long feet)
@@ -513,14 +513,14 @@ namespace UnitsNet
             return new Length(feet*0.3048);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Feet of type decimal.
         /// </summary>
         public static Length FromFeet(decimal feet)
         {
-	        return new Length(Convert.ToDouble(feet)*0.3048);
+            return new Length(Convert.ToDouble(feet)*0.3048);
         }
 #endif
 
@@ -532,7 +532,7 @@ namespace UnitsNet
             return new Length(inches*2.54e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Inches.
         /// </summary>
         public static Length FromInches(int inches)
@@ -540,7 +540,7 @@ namespace UnitsNet
             return new Length(inches*2.54e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Inches.
         /// </summary>
         public static Length FromInches(long inches)
@@ -548,14 +548,14 @@ namespace UnitsNet
             return new Length(inches*2.54e-2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Inches of type decimal.
         /// </summary>
         public static Length FromInches(decimal inches)
         {
-	        return new Length(Convert.ToDouble(inches)*2.54e-2);
+            return new Length(Convert.ToDouble(inches)*2.54e-2);
         }
 #endif
 
@@ -567,7 +567,7 @@ namespace UnitsNet
             return new Length((kilometers) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
         public static Length FromKilometers(int kilometers)
@@ -575,7 +575,7 @@ namespace UnitsNet
             return new Length((kilometers) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
         public static Length FromKilometers(long kilometers)
@@ -583,14 +583,14 @@ namespace UnitsNet
             return new Length((kilometers) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Kilometers of type decimal.
         /// </summary>
         public static Length FromKilometers(decimal kilometers)
         {
-	        return new Length((Convert.ToDouble(kilometers)) * 1e3d);
+            return new Length((Convert.ToDouble(kilometers)) * 1e3d);
         }
 #endif
 
@@ -602,7 +602,7 @@ namespace UnitsNet
             return new Length(meters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Meters.
         /// </summary>
         public static Length FromMeters(int meters)
@@ -610,7 +610,7 @@ namespace UnitsNet
             return new Length(meters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Meters.
         /// </summary>
         public static Length FromMeters(long meters)
@@ -618,14 +618,14 @@ namespace UnitsNet
             return new Length(meters);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Meters of type decimal.
         /// </summary>
         public static Length FromMeters(decimal meters)
         {
-	        return new Length(Convert.ToDouble(meters));
+            return new Length(Convert.ToDouble(meters));
         }
 #endif
 
@@ -637,7 +637,7 @@ namespace UnitsNet
             return new Length(microinches*2.54e-8);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
         public static Length FromMicroinches(int microinches)
@@ -645,7 +645,7 @@ namespace UnitsNet
             return new Length(microinches*2.54e-8);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
         public static Length FromMicroinches(long microinches)
@@ -653,14 +653,14 @@ namespace UnitsNet
             return new Length(microinches*2.54e-8);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Microinches of type decimal.
         /// </summary>
         public static Length FromMicroinches(decimal microinches)
         {
-	        return new Length(Convert.ToDouble(microinches)*2.54e-8);
+            return new Length(Convert.ToDouble(microinches)*2.54e-8);
         }
 #endif
 
@@ -672,7 +672,7 @@ namespace UnitsNet
             return new Length((micrometers) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Micrometers.
         /// </summary>
         public static Length FromMicrometers(int micrometers)
@@ -680,7 +680,7 @@ namespace UnitsNet
             return new Length((micrometers) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Micrometers.
         /// </summary>
         public static Length FromMicrometers(long micrometers)
@@ -688,14 +688,14 @@ namespace UnitsNet
             return new Length((micrometers) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Micrometers of type decimal.
         /// </summary>
         public static Length FromMicrometers(decimal micrometers)
         {
-	        return new Length((Convert.ToDouble(micrometers)) * 1e-6d);
+            return new Length((Convert.ToDouble(micrometers)) * 1e-6d);
         }
 #endif
 
@@ -707,7 +707,7 @@ namespace UnitsNet
             return new Length(mils*2.54e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Mils.
         /// </summary>
         public static Length FromMils(int mils)
@@ -715,7 +715,7 @@ namespace UnitsNet
             return new Length(mils*2.54e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Mils.
         /// </summary>
         public static Length FromMils(long mils)
@@ -723,14 +723,14 @@ namespace UnitsNet
             return new Length(mils*2.54e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Mils of type decimal.
         /// </summary>
         public static Length FromMils(decimal mils)
         {
-	        return new Length(Convert.ToDouble(mils)*2.54e-5);
+            return new Length(Convert.ToDouble(mils)*2.54e-5);
         }
 #endif
 
@@ -742,7 +742,7 @@ namespace UnitsNet
             return new Length(miles*1609.34);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Miles.
         /// </summary>
         public static Length FromMiles(int miles)
@@ -750,7 +750,7 @@ namespace UnitsNet
             return new Length(miles*1609.34);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Miles.
         /// </summary>
         public static Length FromMiles(long miles)
@@ -758,14 +758,14 @@ namespace UnitsNet
             return new Length(miles*1609.34);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Miles of type decimal.
         /// </summary>
         public static Length FromMiles(decimal miles)
         {
-	        return new Length(Convert.ToDouble(miles)*1609.34);
+            return new Length(Convert.ToDouble(miles)*1609.34);
         }
 #endif
 
@@ -777,7 +777,7 @@ namespace UnitsNet
             return new Length((millimeters) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
         public static Length FromMillimeters(int millimeters)
@@ -785,7 +785,7 @@ namespace UnitsNet
             return new Length((millimeters) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
         public static Length FromMillimeters(long millimeters)
@@ -793,14 +793,14 @@ namespace UnitsNet
             return new Length((millimeters) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Millimeters of type decimal.
         /// </summary>
         public static Length FromMillimeters(decimal millimeters)
         {
-	        return new Length((Convert.ToDouble(millimeters)) * 1e-3d);
+            return new Length((Convert.ToDouble(millimeters)) * 1e-3d);
         }
 #endif
 
@@ -812,7 +812,7 @@ namespace UnitsNet
             return new Length((nanometers) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Nanometers.
         /// </summary>
         public static Length FromNanometers(int nanometers)
@@ -820,7 +820,7 @@ namespace UnitsNet
             return new Length((nanometers) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Nanometers.
         /// </summary>
         public static Length FromNanometers(long nanometers)
@@ -828,14 +828,14 @@ namespace UnitsNet
             return new Length((nanometers) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Nanometers of type decimal.
         /// </summary>
         public static Length FromNanometers(decimal nanometers)
         {
-	        return new Length((Convert.ToDouble(nanometers)) * 1e-9d);
+            return new Length((Convert.ToDouble(nanometers)) * 1e-9d);
         }
 #endif
 
@@ -847,7 +847,7 @@ namespace UnitsNet
             return new Length(nauticalmiles*1852);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
         public static Length FromNauticalMiles(int nauticalmiles)
@@ -855,7 +855,7 @@ namespace UnitsNet
             return new Length(nauticalmiles*1852);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
         public static Length FromNauticalMiles(long nauticalmiles)
@@ -863,14 +863,14 @@ namespace UnitsNet
             return new Length(nauticalmiles*1852);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from NauticalMiles of type decimal.
         /// </summary>
         public static Length FromNauticalMiles(decimal nauticalmiles)
         {
-	        return new Length(Convert.ToDouble(nauticalmiles)*1852);
+            return new Length(Convert.ToDouble(nauticalmiles)*1852);
         }
 #endif
 
@@ -882,7 +882,7 @@ namespace UnitsNet
             return new Length(printerpicas/237.106301584);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from PrinterPicas.
         /// </summary>
         public static Length FromPrinterPicas(int printerpicas)
@@ -890,7 +890,7 @@ namespace UnitsNet
             return new Length(printerpicas/237.106301584);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from PrinterPicas.
         /// </summary>
         public static Length FromPrinterPicas(long printerpicas)
@@ -898,14 +898,14 @@ namespace UnitsNet
             return new Length(printerpicas/237.106301584);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from PrinterPicas of type decimal.
         /// </summary>
         public static Length FromPrinterPicas(decimal printerpicas)
         {
-	        return new Length(Convert.ToDouble(printerpicas)/237.106301584);
+            return new Length(Convert.ToDouble(printerpicas)/237.106301584);
         }
 #endif
 
@@ -917,7 +917,7 @@ namespace UnitsNet
             return new Length((printerpoints/72.27)*2.54e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
         public static Length FromPrinterPoints(int printerpoints)
@@ -925,7 +925,7 @@ namespace UnitsNet
             return new Length((printerpoints/72.27)*2.54e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
         public static Length FromPrinterPoints(long printerpoints)
@@ -933,14 +933,14 @@ namespace UnitsNet
             return new Length((printerpoints/72.27)*2.54e-2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from PrinterPoints of type decimal.
         /// </summary>
         public static Length FromPrinterPoints(decimal printerpoints)
         {
-	        return new Length((Convert.ToDouble(printerpoints)/72.27)*2.54e-2);
+            return new Length((Convert.ToDouble(printerpoints)/72.27)*2.54e-2);
         }
 #endif
 
@@ -952,7 +952,7 @@ namespace UnitsNet
             return new Length(shackles*27.432);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Shackles.
         /// </summary>
         public static Length FromShackles(int shackles)
@@ -960,7 +960,7 @@ namespace UnitsNet
             return new Length(shackles*27.432);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Shackles.
         /// </summary>
         public static Length FromShackles(long shackles)
@@ -968,14 +968,14 @@ namespace UnitsNet
             return new Length(shackles*27.432);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Shackles of type decimal.
         /// </summary>
         public static Length FromShackles(decimal shackles)
         {
-	        return new Length(Convert.ToDouble(shackles)*27.432);
+            return new Length(Convert.ToDouble(shackles)*27.432);
         }
 #endif
 
@@ -987,7 +987,7 @@ namespace UnitsNet
             return new Length(twips/56692.913385826);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Twips.
         /// </summary>
         public static Length FromTwips(int twips)
@@ -995,7 +995,7 @@ namespace UnitsNet
             return new Length(twips/56692.913385826);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Twips.
         /// </summary>
         public static Length FromTwips(long twips)
@@ -1003,14 +1003,14 @@ namespace UnitsNet
             return new Length(twips/56692.913385826);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Twips of type decimal.
         /// </summary>
         public static Length FromTwips(decimal twips)
         {
-	        return new Length(Convert.ToDouble(twips)/56692.913385826);
+            return new Length(Convert.ToDouble(twips)/56692.913385826);
         }
 #endif
 
@@ -1022,7 +1022,7 @@ namespace UnitsNet
             return new Length(ussurveyfeet*1200/3937);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from UsSurveyFeet.
         /// </summary>
         public static Length FromUsSurveyFeet(int ussurveyfeet)
@@ -1030,7 +1030,7 @@ namespace UnitsNet
             return new Length(ussurveyfeet*1200/3937);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from UsSurveyFeet.
         /// </summary>
         public static Length FromUsSurveyFeet(long ussurveyfeet)
@@ -1038,14 +1038,14 @@ namespace UnitsNet
             return new Length(ussurveyfeet*1200/3937);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from UsSurveyFeet of type decimal.
         /// </summary>
         public static Length FromUsSurveyFeet(decimal ussurveyfeet)
         {
-	        return new Length(Convert.ToDouble(ussurveyfeet)*1200/3937);
+            return new Length(Convert.ToDouble(ussurveyfeet)*1200/3937);
         }
 #endif
 
@@ -1057,7 +1057,7 @@ namespace UnitsNet
             return new Length(yards*0.9144);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Yards.
         /// </summary>
         public static Length FromYards(int yards)
@@ -1065,7 +1065,7 @@ namespace UnitsNet
             return new Length(yards*0.9144);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Length from Yards.
         /// </summary>
         public static Length FromYards(long yards)
@@ -1073,14 +1073,14 @@ namespace UnitsNet
             return new Length(yards*0.9144);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Length from Yards of type decimal.
         /// </summary>
         public static Length FromYards(decimal yards)
         {
-	        return new Length(Convert.ToDouble(yards)*0.9144);
+            return new Length(Convert.ToDouble(yards)*0.9144);
         }
 #endif
 
@@ -1101,7 +1101,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Centimeters.
         /// </summary>
         public static Length? FromCentimeters(int? centimeters)
@@ -1116,7 +1116,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Centimeters.
         /// </summary>
         public static Length? FromCentimeters(long? centimeters)
@@ -1131,7 +1131,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Centimeters of type decimal.
         /// </summary>
         public static Length? FromCentimeters(decimal? centimeters)
@@ -1161,7 +1161,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Decimeters.
         /// </summary>
         public static Length? FromDecimeters(int? decimeters)
@@ -1176,7 +1176,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Decimeters.
         /// </summary>
         public static Length? FromDecimeters(long? decimeters)
@@ -1191,7 +1191,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Decimeters of type decimal.
         /// </summary>
         public static Length? FromDecimeters(decimal? decimeters)
@@ -1221,7 +1221,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable DtpPicas.
         /// </summary>
         public static Length? FromDtpPicas(int? dtppicas)
@@ -1236,7 +1236,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable DtpPicas.
         /// </summary>
         public static Length? FromDtpPicas(long? dtppicas)
@@ -1251,7 +1251,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from DtpPicas of type decimal.
         /// </summary>
         public static Length? FromDtpPicas(decimal? dtppicas)
@@ -1281,7 +1281,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable DtpPoints.
         /// </summary>
         public static Length? FromDtpPoints(int? dtppoints)
@@ -1296,7 +1296,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable DtpPoints.
         /// </summary>
         public static Length? FromDtpPoints(long? dtppoints)
@@ -1311,7 +1311,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from DtpPoints of type decimal.
         /// </summary>
         public static Length? FromDtpPoints(decimal? dtppoints)
@@ -1341,7 +1341,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Fathoms.
         /// </summary>
         public static Length? FromFathoms(int? fathoms)
@@ -1356,7 +1356,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Fathoms.
         /// </summary>
         public static Length? FromFathoms(long? fathoms)
@@ -1371,7 +1371,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Fathoms of type decimal.
         /// </summary>
         public static Length? FromFathoms(decimal? fathoms)
@@ -1401,7 +1401,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Feet.
         /// </summary>
         public static Length? FromFeet(int? feet)
@@ -1416,7 +1416,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Feet.
         /// </summary>
         public static Length? FromFeet(long? feet)
@@ -1431,7 +1431,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Feet of type decimal.
         /// </summary>
         public static Length? FromFeet(decimal? feet)
@@ -1461,7 +1461,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Inches.
         /// </summary>
         public static Length? FromInches(int? inches)
@@ -1476,7 +1476,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Inches.
         /// </summary>
         public static Length? FromInches(long? inches)
@@ -1491,7 +1491,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Inches of type decimal.
         /// </summary>
         public static Length? FromInches(decimal? inches)
@@ -1521,7 +1521,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Kilometers.
         /// </summary>
         public static Length? FromKilometers(int? kilometers)
@@ -1536,7 +1536,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Kilometers.
         /// </summary>
         public static Length? FromKilometers(long? kilometers)
@@ -1551,7 +1551,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Kilometers of type decimal.
         /// </summary>
         public static Length? FromKilometers(decimal? kilometers)
@@ -1581,7 +1581,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Meters.
         /// </summary>
         public static Length? FromMeters(int? meters)
@@ -1596,7 +1596,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Meters.
         /// </summary>
         public static Length? FromMeters(long? meters)
@@ -1611,7 +1611,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Meters of type decimal.
         /// </summary>
         public static Length? FromMeters(decimal? meters)
@@ -1641,7 +1641,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Microinches.
         /// </summary>
         public static Length? FromMicroinches(int? microinches)
@@ -1656,7 +1656,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Microinches.
         /// </summary>
         public static Length? FromMicroinches(long? microinches)
@@ -1671,7 +1671,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Microinches of type decimal.
         /// </summary>
         public static Length? FromMicroinches(decimal? microinches)
@@ -1701,7 +1701,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Micrometers.
         /// </summary>
         public static Length? FromMicrometers(int? micrometers)
@@ -1716,7 +1716,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Micrometers.
         /// </summary>
         public static Length? FromMicrometers(long? micrometers)
@@ -1731,7 +1731,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Micrometers of type decimal.
         /// </summary>
         public static Length? FromMicrometers(decimal? micrometers)
@@ -1761,7 +1761,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Mils.
         /// </summary>
         public static Length? FromMils(int? mils)
@@ -1776,7 +1776,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Mils.
         /// </summary>
         public static Length? FromMils(long? mils)
@@ -1791,7 +1791,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Mils of type decimal.
         /// </summary>
         public static Length? FromMils(decimal? mils)
@@ -1821,7 +1821,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Miles.
         /// </summary>
         public static Length? FromMiles(int? miles)
@@ -1836,7 +1836,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Miles.
         /// </summary>
         public static Length? FromMiles(long? miles)
@@ -1851,7 +1851,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Miles of type decimal.
         /// </summary>
         public static Length? FromMiles(decimal? miles)
@@ -1881,7 +1881,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Millimeters.
         /// </summary>
         public static Length? FromMillimeters(int? millimeters)
@@ -1896,7 +1896,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Millimeters.
         /// </summary>
         public static Length? FromMillimeters(long? millimeters)
@@ -1911,7 +1911,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Millimeters of type decimal.
         /// </summary>
         public static Length? FromMillimeters(decimal? millimeters)
@@ -1941,7 +1941,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Nanometers.
         /// </summary>
         public static Length? FromNanometers(int? nanometers)
@@ -1956,7 +1956,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Nanometers.
         /// </summary>
         public static Length? FromNanometers(long? nanometers)
@@ -1971,7 +1971,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Nanometers of type decimal.
         /// </summary>
         public static Length? FromNanometers(decimal? nanometers)
@@ -2001,7 +2001,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable NauticalMiles.
         /// </summary>
         public static Length? FromNauticalMiles(int? nauticalmiles)
@@ -2016,7 +2016,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable NauticalMiles.
         /// </summary>
         public static Length? FromNauticalMiles(long? nauticalmiles)
@@ -2031,7 +2031,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from NauticalMiles of type decimal.
         /// </summary>
         public static Length? FromNauticalMiles(decimal? nauticalmiles)
@@ -2061,7 +2061,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable PrinterPicas.
         /// </summary>
         public static Length? FromPrinterPicas(int? printerpicas)
@@ -2076,7 +2076,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable PrinterPicas.
         /// </summary>
         public static Length? FromPrinterPicas(long? printerpicas)
@@ -2091,7 +2091,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from PrinterPicas of type decimal.
         /// </summary>
         public static Length? FromPrinterPicas(decimal? printerpicas)
@@ -2121,7 +2121,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable PrinterPoints.
         /// </summary>
         public static Length? FromPrinterPoints(int? printerpoints)
@@ -2136,7 +2136,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable PrinterPoints.
         /// </summary>
         public static Length? FromPrinterPoints(long? printerpoints)
@@ -2151,7 +2151,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from PrinterPoints of type decimal.
         /// </summary>
         public static Length? FromPrinterPoints(decimal? printerpoints)
@@ -2181,7 +2181,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Shackles.
         /// </summary>
         public static Length? FromShackles(int? shackles)
@@ -2196,7 +2196,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Shackles.
         /// </summary>
         public static Length? FromShackles(long? shackles)
@@ -2211,7 +2211,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Shackles of type decimal.
         /// </summary>
         public static Length? FromShackles(decimal? shackles)
@@ -2241,7 +2241,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Twips.
         /// </summary>
         public static Length? FromTwips(int? twips)
@@ -2256,7 +2256,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Twips.
         /// </summary>
         public static Length? FromTwips(long? twips)
@@ -2271,7 +2271,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Twips of type decimal.
         /// </summary>
         public static Length? FromTwips(decimal? twips)
@@ -2301,7 +2301,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable UsSurveyFeet.
         /// </summary>
         public static Length? FromUsSurveyFeet(int? ussurveyfeet)
@@ -2316,7 +2316,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable UsSurveyFeet.
         /// </summary>
         public static Length? FromUsSurveyFeet(long? ussurveyfeet)
@@ -2331,7 +2331,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from UsSurveyFeet of type decimal.
         /// </summary>
         public static Length? FromUsSurveyFeet(decimal? ussurveyfeet)
@@ -2361,7 +2361,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Yards.
         /// </summary>
         public static Length? FromYards(int? yards)
@@ -2376,7 +2376,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from nullable Yards.
         /// </summary>
         public static Length? FromYards(long? yards)
@@ -2391,7 +2391,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Length from Yards of type decimal.
         /// </summary>
         public static Length? FromYards(decimal? yards)

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -162,6 +162,33 @@ namespace UnitsNet
             return new Level(decibels);
         }
 
+		/// <summary>
+        ///     Get Level from Decibels.
+        /// </summary>
+        public static Level FromDecibels(int decibels)
+        {
+            return new Level(decibels);
+        }
+
+		/// <summary>
+        ///     Get Level from Decibels.
+        /// </summary>
+        public static Level FromDecibels(long decibels)
+        {
+            return new Level(decibels);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Level from Decibels of type decimal.
+        /// </summary>
+        public static Level FromDecibels(decimal decibels)
+        {
+	        return new Level(Convert.ToDouble(decibels));
+        }
+#endif
+
         /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
@@ -169,6 +196,33 @@ namespace UnitsNet
         {
             return new Level((1/0.115129254)*nepers);
         }
+
+		/// <summary>
+        ///     Get Level from Nepers.
+        /// </summary>
+        public static Level FromNepers(int nepers)
+        {
+            return new Level((1/0.115129254)*nepers);
+        }
+
+		/// <summary>
+        ///     Get Level from Nepers.
+        /// </summary>
+        public static Level FromNepers(long nepers)
+        {
+            return new Level((1/0.115129254)*nepers);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Level from Nepers of type decimal.
+        /// </summary>
+        public static Level FromNepers(decimal nepers)
+        {
+	        return new Level((1/0.115129254)*Convert.ToDouble(nepers));
+        }
+#endif
 
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
@@ -187,10 +241,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Level from nullable Decibels.
+        /// </summary>
+        public static Level? FromDecibels(int? decibels)
+        {
+            if (decibels.HasValue)
+            {
+                return FromDecibels(decibels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Level from nullable Decibels.
+        /// </summary>
+        public static Level? FromDecibels(long? decibels)
+        {
+            if (decibels.HasValue)
+            {
+                return FromDecibels(decibels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Level from Decibels of type decimal.
+        /// </summary>
+        public static Level? FromDecibels(decimal? decibels)
+        {
+            if (decibels.HasValue)
+            {
+                return FromDecibels(decibels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Level from nullable Nepers.
         /// </summary>
         public static Level? FromNepers(double? nepers)
+        {
+            if (nepers.HasValue)
+            {
+                return FromNepers(nepers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Level from nullable Nepers.
+        /// </summary>
+        public static Level? FromNepers(int? nepers)
+        {
+            if (nepers.HasValue)
+            {
+                return FromNepers(nepers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Level from nullable Nepers.
+        /// </summary>
+        public static Level? FromNepers(long? nepers)
+        {
+            if (nepers.HasValue)
+            {
+                return FromNepers(nepers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Level from Nepers of type decimal.
+        /// </summary>
+        public static Level? FromNepers(decimal? nepers)
         {
             if (nepers.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -157,6 +157,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Decibels.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Level FromDecibels(double decibels)
         {
             return new Level(decibels);
@@ -192,6 +195,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Level FromNepers(double nepers)
         {
             return new Level((1/0.115129254)*nepers);

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _decibels;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Level() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Level;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static LevelUnit BaseUnit
         {
             get { return LevelUnit.Decibel; }
@@ -162,7 +162,7 @@ namespace UnitsNet
             return new Level(decibels);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Level from Decibels.
         /// </summary>
         public static Level FromDecibels(int decibels)
@@ -170,7 +170,7 @@ namespace UnitsNet
             return new Level(decibels);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Level from Decibels.
         /// </summary>
         public static Level FromDecibels(long decibels)
@@ -178,14 +178,14 @@ namespace UnitsNet
             return new Level(decibels);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Level from Decibels of type decimal.
         /// </summary>
         public static Level FromDecibels(decimal decibels)
         {
-	        return new Level(Convert.ToDouble(decibels));
+            return new Level(Convert.ToDouble(decibels));
         }
 #endif
 
@@ -197,7 +197,7 @@ namespace UnitsNet
             return new Level((1/0.115129254)*nepers);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
         public static Level FromNepers(int nepers)
@@ -205,7 +205,7 @@ namespace UnitsNet
             return new Level((1/0.115129254)*nepers);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
         public static Level FromNepers(long nepers)
@@ -213,14 +213,14 @@ namespace UnitsNet
             return new Level((1/0.115129254)*nepers);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Level from Nepers of type decimal.
         /// </summary>
         public static Level FromNepers(decimal nepers)
         {
-	        return new Level((1/0.115129254)*Convert.ToDouble(nepers));
+            return new Level((1/0.115129254)*Convert.ToDouble(nepers));
         }
 #endif
 
@@ -241,7 +241,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Level from nullable Decibels.
         /// </summary>
         public static Level? FromDecibels(int? decibels)
@@ -256,7 +256,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Level from nullable Decibels.
         /// </summary>
         public static Level? FromDecibels(long? decibels)
@@ -271,7 +271,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Level from Decibels of type decimal.
         /// </summary>
         public static Level? FromDecibels(decimal? decibels)
@@ -301,7 +301,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Level from nullable Nepers.
         /// </summary>
         public static Level? FromNepers(int? nepers)
@@ -316,7 +316,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Level from nullable Nepers.
         /// </summary>
         public static Level? FromNepers(long? nepers)
@@ -331,7 +331,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Level from Nepers of type decimal.
         /// </summary>
         public static Level? FromNepers(decimal? nepers)

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _kilograms;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Mass() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Mass;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static MassUnit BaseUnit
         {
             get { return MassUnit.Kilogram; }
@@ -314,7 +314,7 @@ namespace UnitsNet
             return new Mass((centigrams/1e3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Centigrams.
         /// </summary>
         public static Mass FromCentigrams(int centigrams)
@@ -322,7 +322,7 @@ namespace UnitsNet
             return new Mass((centigrams/1e3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Centigrams.
         /// </summary>
         public static Mass FromCentigrams(long centigrams)
@@ -330,14 +330,14 @@ namespace UnitsNet
             return new Mass((centigrams/1e3) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Centigrams of type decimal.
         /// </summary>
         public static Mass FromCentigrams(decimal centigrams)
         {
-	        return new Mass((Convert.ToDouble(centigrams)/1e3) * 1e-2d);
+            return new Mass((Convert.ToDouble(centigrams)/1e3) * 1e-2d);
         }
 #endif
 
@@ -349,7 +349,7 @@ namespace UnitsNet
             return new Mass((decagrams/1e3) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
         public static Mass FromDecagrams(int decagrams)
@@ -357,7 +357,7 @@ namespace UnitsNet
             return new Mass((decagrams/1e3) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
         public static Mass FromDecagrams(long decagrams)
@@ -365,14 +365,14 @@ namespace UnitsNet
             return new Mass((decagrams/1e3) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Decagrams of type decimal.
         /// </summary>
         public static Mass FromDecagrams(decimal decagrams)
         {
-	        return new Mass((Convert.ToDouble(decagrams)/1e3) * 1e1d);
+            return new Mass((Convert.ToDouble(decagrams)/1e3) * 1e1d);
         }
 #endif
 
@@ -384,7 +384,7 @@ namespace UnitsNet
             return new Mass((decigrams/1e3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Decigrams.
         /// </summary>
         public static Mass FromDecigrams(int decigrams)
@@ -392,7 +392,7 @@ namespace UnitsNet
             return new Mass((decigrams/1e3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Decigrams.
         /// </summary>
         public static Mass FromDecigrams(long decigrams)
@@ -400,14 +400,14 @@ namespace UnitsNet
             return new Mass((decigrams/1e3) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Decigrams of type decimal.
         /// </summary>
         public static Mass FromDecigrams(decimal decigrams)
         {
-	        return new Mass((Convert.ToDouble(decigrams)/1e3) * 1e-1d);
+            return new Mass((Convert.ToDouble(decigrams)/1e3) * 1e-1d);
         }
 #endif
 
@@ -419,7 +419,7 @@ namespace UnitsNet
             return new Mass(grams/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
         public static Mass FromGrams(int grams)
@@ -427,7 +427,7 @@ namespace UnitsNet
             return new Mass(grams/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
         public static Mass FromGrams(long grams)
@@ -435,14 +435,14 @@ namespace UnitsNet
             return new Mass(grams/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Grams of type decimal.
         /// </summary>
         public static Mass FromGrams(decimal grams)
         {
-	        return new Mass(Convert.ToDouble(grams)/1e3);
+            return new Mass(Convert.ToDouble(grams)/1e3);
         }
 #endif
 
@@ -454,7 +454,7 @@ namespace UnitsNet
             return new Mass((hectograms/1e3) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Hectograms.
         /// </summary>
         public static Mass FromHectograms(int hectograms)
@@ -462,7 +462,7 @@ namespace UnitsNet
             return new Mass((hectograms/1e3) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Hectograms.
         /// </summary>
         public static Mass FromHectograms(long hectograms)
@@ -470,14 +470,14 @@ namespace UnitsNet
             return new Mass((hectograms/1e3) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Hectograms of type decimal.
         /// </summary>
         public static Mass FromHectograms(decimal hectograms)
         {
-	        return new Mass((Convert.ToDouble(hectograms)/1e3) * 1e2d);
+            return new Mass((Convert.ToDouble(hectograms)/1e3) * 1e2d);
         }
 #endif
 
@@ -489,7 +489,7 @@ namespace UnitsNet
             return new Mass((kilograms/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
         public static Mass FromKilograms(int kilograms)
@@ -497,7 +497,7 @@ namespace UnitsNet
             return new Mass((kilograms/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
         public static Mass FromKilograms(long kilograms)
@@ -505,14 +505,14 @@ namespace UnitsNet
             return new Mass((kilograms/1e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilograms of type decimal.
         /// </summary>
         public static Mass FromKilograms(decimal kilograms)
         {
-	        return new Mass((Convert.ToDouble(kilograms)/1e3) * 1e3d);
+            return new Mass((Convert.ToDouble(kilograms)/1e3) * 1e3d);
         }
 #endif
 
@@ -524,7 +524,7 @@ namespace UnitsNet
             return new Mass((kilopounds*0.45359237) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilopounds.
         /// </summary>
         public static Mass FromKilopounds(int kilopounds)
@@ -532,7 +532,7 @@ namespace UnitsNet
             return new Mass((kilopounds*0.45359237) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilopounds.
         /// </summary>
         public static Mass FromKilopounds(long kilopounds)
@@ -540,14 +540,14 @@ namespace UnitsNet
             return new Mass((kilopounds*0.45359237) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilopounds of type decimal.
         /// </summary>
         public static Mass FromKilopounds(decimal kilopounds)
         {
-	        return new Mass((Convert.ToDouble(kilopounds)*0.45359237) * 1e3d);
+            return new Mass((Convert.ToDouble(kilopounds)*0.45359237) * 1e3d);
         }
 #endif
 
@@ -559,7 +559,7 @@ namespace UnitsNet
             return new Mass((kilotonnes*1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
         public static Mass FromKilotonnes(int kilotonnes)
@@ -567,7 +567,7 @@ namespace UnitsNet
             return new Mass((kilotonnes*1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
         public static Mass FromKilotonnes(long kilotonnes)
@@ -575,14 +575,14 @@ namespace UnitsNet
             return new Mass((kilotonnes*1e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Kilotonnes of type decimal.
         /// </summary>
         public static Mass FromKilotonnes(decimal kilotonnes)
         {
-	        return new Mass((Convert.ToDouble(kilotonnes)*1e3) * 1e3d);
+            return new Mass((Convert.ToDouble(kilotonnes)*1e3) * 1e3d);
         }
 #endif
 
@@ -594,7 +594,7 @@ namespace UnitsNet
             return new Mass(longhundredweight/0.01968413055222121);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from LongHundredweight.
         /// </summary>
         public static Mass FromLongHundredweight(int longhundredweight)
@@ -602,7 +602,7 @@ namespace UnitsNet
             return new Mass(longhundredweight/0.01968413055222121);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from LongHundredweight.
         /// </summary>
         public static Mass FromLongHundredweight(long longhundredweight)
@@ -610,14 +610,14 @@ namespace UnitsNet
             return new Mass(longhundredweight/0.01968413055222121);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from LongHundredweight of type decimal.
         /// </summary>
         public static Mass FromLongHundredweight(decimal longhundredweight)
         {
-	        return new Mass(Convert.ToDouble(longhundredweight)/0.01968413055222121);
+            return new Mass(Convert.ToDouble(longhundredweight)/0.01968413055222121);
         }
 #endif
 
@@ -629,7 +629,7 @@ namespace UnitsNet
             return new Mass(longtons*1016.0469088);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
         public static Mass FromLongTons(int longtons)
@@ -637,7 +637,7 @@ namespace UnitsNet
             return new Mass(longtons*1016.0469088);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
         public static Mass FromLongTons(long longtons)
@@ -645,14 +645,14 @@ namespace UnitsNet
             return new Mass(longtons*1016.0469088);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from LongTons of type decimal.
         /// </summary>
         public static Mass FromLongTons(decimal longtons)
         {
-	        return new Mass(Convert.ToDouble(longtons)*1016.0469088);
+            return new Mass(Convert.ToDouble(longtons)*1016.0469088);
         }
 #endif
 
@@ -664,7 +664,7 @@ namespace UnitsNet
             return new Mass((megapounds*0.45359237) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Megapounds.
         /// </summary>
         public static Mass FromMegapounds(int megapounds)
@@ -672,7 +672,7 @@ namespace UnitsNet
             return new Mass((megapounds*0.45359237) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Megapounds.
         /// </summary>
         public static Mass FromMegapounds(long megapounds)
@@ -680,14 +680,14 @@ namespace UnitsNet
             return new Mass((megapounds*0.45359237) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Megapounds of type decimal.
         /// </summary>
         public static Mass FromMegapounds(decimal megapounds)
         {
-	        return new Mass((Convert.ToDouble(megapounds)*0.45359237) * 1e6d);
+            return new Mass((Convert.ToDouble(megapounds)*0.45359237) * 1e6d);
         }
 #endif
 
@@ -699,7 +699,7 @@ namespace UnitsNet
             return new Mass((megatonnes*1e3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
         public static Mass FromMegatonnes(int megatonnes)
@@ -707,7 +707,7 @@ namespace UnitsNet
             return new Mass((megatonnes*1e3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
         public static Mass FromMegatonnes(long megatonnes)
@@ -715,14 +715,14 @@ namespace UnitsNet
             return new Mass((megatonnes*1e3) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Megatonnes of type decimal.
         /// </summary>
         public static Mass FromMegatonnes(decimal megatonnes)
         {
-	        return new Mass((Convert.ToDouble(megatonnes)*1e3) * 1e6d);
+            return new Mass((Convert.ToDouble(megatonnes)*1e3) * 1e6d);
         }
 #endif
 
@@ -734,7 +734,7 @@ namespace UnitsNet
             return new Mass((micrograms/1e3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Micrograms.
         /// </summary>
         public static Mass FromMicrograms(int micrograms)
@@ -742,7 +742,7 @@ namespace UnitsNet
             return new Mass((micrograms/1e3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Micrograms.
         /// </summary>
         public static Mass FromMicrograms(long micrograms)
@@ -750,14 +750,14 @@ namespace UnitsNet
             return new Mass((micrograms/1e3) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Micrograms of type decimal.
         /// </summary>
         public static Mass FromMicrograms(decimal micrograms)
         {
-	        return new Mass((Convert.ToDouble(micrograms)/1e3) * 1e-6d);
+            return new Mass((Convert.ToDouble(micrograms)/1e3) * 1e-6d);
         }
 #endif
 
@@ -769,7 +769,7 @@ namespace UnitsNet
             return new Mass((milligrams/1e3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
         public static Mass FromMilligrams(int milligrams)
@@ -777,7 +777,7 @@ namespace UnitsNet
             return new Mass((milligrams/1e3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
         public static Mass FromMilligrams(long milligrams)
@@ -785,14 +785,14 @@ namespace UnitsNet
             return new Mass((milligrams/1e3) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Milligrams of type decimal.
         /// </summary>
         public static Mass FromMilligrams(decimal milligrams)
         {
-	        return new Mass((Convert.ToDouble(milligrams)/1e3) * 1e-3d);
+            return new Mass((Convert.ToDouble(milligrams)/1e3) * 1e-3d);
         }
 #endif
 
@@ -804,7 +804,7 @@ namespace UnitsNet
             return new Mass((nanograms/1e3) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Nanograms.
         /// </summary>
         public static Mass FromNanograms(int nanograms)
@@ -812,7 +812,7 @@ namespace UnitsNet
             return new Mass((nanograms/1e3) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Nanograms.
         /// </summary>
         public static Mass FromNanograms(long nanograms)
@@ -820,14 +820,14 @@ namespace UnitsNet
             return new Mass((nanograms/1e3) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Nanograms of type decimal.
         /// </summary>
         public static Mass FromNanograms(decimal nanograms)
         {
-	        return new Mass((Convert.ToDouble(nanograms)/1e3) * 1e-9d);
+            return new Mass((Convert.ToDouble(nanograms)/1e3) * 1e-9d);
         }
 #endif
 
@@ -839,7 +839,7 @@ namespace UnitsNet
             return new Mass(ounces/35.2739619);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
         public static Mass FromOunces(int ounces)
@@ -847,7 +847,7 @@ namespace UnitsNet
             return new Mass(ounces/35.2739619);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
         public static Mass FromOunces(long ounces)
@@ -855,14 +855,14 @@ namespace UnitsNet
             return new Mass(ounces/35.2739619);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Ounces of type decimal.
         /// </summary>
         public static Mass FromOunces(decimal ounces)
         {
-	        return new Mass(Convert.ToDouble(ounces)/35.2739619);
+            return new Mass(Convert.ToDouble(ounces)/35.2739619);
         }
 #endif
 
@@ -874,7 +874,7 @@ namespace UnitsNet
             return new Mass(pounds*0.45359237);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Pounds.
         /// </summary>
         public static Mass FromPounds(int pounds)
@@ -882,7 +882,7 @@ namespace UnitsNet
             return new Mass(pounds*0.45359237);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Pounds.
         /// </summary>
         public static Mass FromPounds(long pounds)
@@ -890,14 +890,14 @@ namespace UnitsNet
             return new Mass(pounds*0.45359237);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Pounds of type decimal.
         /// </summary>
         public static Mass FromPounds(decimal pounds)
         {
-	        return new Mass(Convert.ToDouble(pounds)*0.45359237);
+            return new Mass(Convert.ToDouble(pounds)*0.45359237);
         }
 #endif
 
@@ -909,7 +909,7 @@ namespace UnitsNet
             return new Mass(shorthundredweight/0.022046226218487758);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
         public static Mass FromShortHundredweight(int shorthundredweight)
@@ -917,7 +917,7 @@ namespace UnitsNet
             return new Mass(shorthundredweight/0.022046226218487758);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
         public static Mass FromShortHundredweight(long shorthundredweight)
@@ -925,14 +925,14 @@ namespace UnitsNet
             return new Mass(shorthundredweight/0.022046226218487758);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from ShortHundredweight of type decimal.
         /// </summary>
         public static Mass FromShortHundredweight(decimal shorthundredweight)
         {
-	        return new Mass(Convert.ToDouble(shorthundredweight)/0.022046226218487758);
+            return new Mass(Convert.ToDouble(shorthundredweight)/0.022046226218487758);
         }
 #endif
 
@@ -944,7 +944,7 @@ namespace UnitsNet
             return new Mass(shorttons*907.18474);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from ShortTons.
         /// </summary>
         public static Mass FromShortTons(int shorttons)
@@ -952,7 +952,7 @@ namespace UnitsNet
             return new Mass(shorttons*907.18474);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from ShortTons.
         /// </summary>
         public static Mass FromShortTons(long shorttons)
@@ -960,14 +960,14 @@ namespace UnitsNet
             return new Mass(shorttons*907.18474);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from ShortTons of type decimal.
         /// </summary>
         public static Mass FromShortTons(decimal shorttons)
         {
-	        return new Mass(Convert.ToDouble(shorttons)*907.18474);
+            return new Mass(Convert.ToDouble(shorttons)*907.18474);
         }
 #endif
 
@@ -979,7 +979,7 @@ namespace UnitsNet
             return new Mass(stone/0.1574731728702698);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
         public static Mass FromStone(int stone)
@@ -987,7 +987,7 @@ namespace UnitsNet
             return new Mass(stone/0.1574731728702698);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
         public static Mass FromStone(long stone)
@@ -995,14 +995,14 @@ namespace UnitsNet
             return new Mass(stone/0.1574731728702698);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Stone of type decimal.
         /// </summary>
         public static Mass FromStone(decimal stone)
         {
-	        return new Mass(Convert.ToDouble(stone)/0.1574731728702698);
+            return new Mass(Convert.ToDouble(stone)/0.1574731728702698);
         }
 #endif
 
@@ -1014,7 +1014,7 @@ namespace UnitsNet
             return new Mass(tonnes*1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Tonnes.
         /// </summary>
         public static Mass FromTonnes(int tonnes)
@@ -1022,7 +1022,7 @@ namespace UnitsNet
             return new Mass(tonnes*1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Tonnes.
         /// </summary>
         public static Mass FromTonnes(long tonnes)
@@ -1030,14 +1030,14 @@ namespace UnitsNet
             return new Mass(tonnes*1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Mass from Tonnes of type decimal.
         /// </summary>
         public static Mass FromTonnes(decimal tonnes)
         {
-	        return new Mass(Convert.ToDouble(tonnes)*1e3);
+            return new Mass(Convert.ToDouble(tonnes)*1e3);
         }
 #endif
 
@@ -1058,7 +1058,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Centigrams.
         /// </summary>
         public static Mass? FromCentigrams(int? centigrams)
@@ -1073,7 +1073,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Centigrams.
         /// </summary>
         public static Mass? FromCentigrams(long? centigrams)
@@ -1088,7 +1088,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Centigrams of type decimal.
         /// </summary>
         public static Mass? FromCentigrams(decimal? centigrams)
@@ -1118,7 +1118,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Decagrams.
         /// </summary>
         public static Mass? FromDecagrams(int? decagrams)
@@ -1133,7 +1133,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Decagrams.
         /// </summary>
         public static Mass? FromDecagrams(long? decagrams)
@@ -1148,7 +1148,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Decagrams of type decimal.
         /// </summary>
         public static Mass? FromDecagrams(decimal? decagrams)
@@ -1178,7 +1178,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Decigrams.
         /// </summary>
         public static Mass? FromDecigrams(int? decigrams)
@@ -1193,7 +1193,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Decigrams.
         /// </summary>
         public static Mass? FromDecigrams(long? decigrams)
@@ -1208,7 +1208,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Decigrams of type decimal.
         /// </summary>
         public static Mass? FromDecigrams(decimal? decigrams)
@@ -1238,7 +1238,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Grams.
         /// </summary>
         public static Mass? FromGrams(int? grams)
@@ -1253,7 +1253,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Grams.
         /// </summary>
         public static Mass? FromGrams(long? grams)
@@ -1268,7 +1268,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Grams of type decimal.
         /// </summary>
         public static Mass? FromGrams(decimal? grams)
@@ -1298,7 +1298,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Hectograms.
         /// </summary>
         public static Mass? FromHectograms(int? hectograms)
@@ -1313,7 +1313,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Hectograms.
         /// </summary>
         public static Mass? FromHectograms(long? hectograms)
@@ -1328,7 +1328,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Hectograms of type decimal.
         /// </summary>
         public static Mass? FromHectograms(decimal? hectograms)
@@ -1358,7 +1358,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Kilograms.
         /// </summary>
         public static Mass? FromKilograms(int? kilograms)
@@ -1373,7 +1373,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Kilograms.
         /// </summary>
         public static Mass? FromKilograms(long? kilograms)
@@ -1388,7 +1388,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Kilograms of type decimal.
         /// </summary>
         public static Mass? FromKilograms(decimal? kilograms)
@@ -1418,7 +1418,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Kilopounds.
         /// </summary>
         public static Mass? FromKilopounds(int? kilopounds)
@@ -1433,7 +1433,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Kilopounds.
         /// </summary>
         public static Mass? FromKilopounds(long? kilopounds)
@@ -1448,7 +1448,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Kilopounds of type decimal.
         /// </summary>
         public static Mass? FromKilopounds(decimal? kilopounds)
@@ -1478,7 +1478,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Kilotonnes.
         /// </summary>
         public static Mass? FromKilotonnes(int? kilotonnes)
@@ -1493,7 +1493,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Kilotonnes.
         /// </summary>
         public static Mass? FromKilotonnes(long? kilotonnes)
@@ -1508,7 +1508,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Kilotonnes of type decimal.
         /// </summary>
         public static Mass? FromKilotonnes(decimal? kilotonnes)
@@ -1538,7 +1538,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable LongHundredweight.
         /// </summary>
         public static Mass? FromLongHundredweight(int? longhundredweight)
@@ -1553,7 +1553,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable LongHundredweight.
         /// </summary>
         public static Mass? FromLongHundredweight(long? longhundredweight)
@@ -1568,7 +1568,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from LongHundredweight of type decimal.
         /// </summary>
         public static Mass? FromLongHundredweight(decimal? longhundredweight)
@@ -1598,7 +1598,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable LongTons.
         /// </summary>
         public static Mass? FromLongTons(int? longtons)
@@ -1613,7 +1613,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable LongTons.
         /// </summary>
         public static Mass? FromLongTons(long? longtons)
@@ -1628,7 +1628,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from LongTons of type decimal.
         /// </summary>
         public static Mass? FromLongTons(decimal? longtons)
@@ -1658,7 +1658,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Megapounds.
         /// </summary>
         public static Mass? FromMegapounds(int? megapounds)
@@ -1673,7 +1673,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Megapounds.
         /// </summary>
         public static Mass? FromMegapounds(long? megapounds)
@@ -1688,7 +1688,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Megapounds of type decimal.
         /// </summary>
         public static Mass? FromMegapounds(decimal? megapounds)
@@ -1718,7 +1718,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Megatonnes.
         /// </summary>
         public static Mass? FromMegatonnes(int? megatonnes)
@@ -1733,7 +1733,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Megatonnes.
         /// </summary>
         public static Mass? FromMegatonnes(long? megatonnes)
@@ -1748,7 +1748,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Megatonnes of type decimal.
         /// </summary>
         public static Mass? FromMegatonnes(decimal? megatonnes)
@@ -1778,7 +1778,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Micrograms.
         /// </summary>
         public static Mass? FromMicrograms(int? micrograms)
@@ -1793,7 +1793,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Micrograms.
         /// </summary>
         public static Mass? FromMicrograms(long? micrograms)
@@ -1808,7 +1808,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Micrograms of type decimal.
         /// </summary>
         public static Mass? FromMicrograms(decimal? micrograms)
@@ -1838,7 +1838,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Milligrams.
         /// </summary>
         public static Mass? FromMilligrams(int? milligrams)
@@ -1853,7 +1853,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Milligrams.
         /// </summary>
         public static Mass? FromMilligrams(long? milligrams)
@@ -1868,7 +1868,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Milligrams of type decimal.
         /// </summary>
         public static Mass? FromMilligrams(decimal? milligrams)
@@ -1898,7 +1898,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Nanograms.
         /// </summary>
         public static Mass? FromNanograms(int? nanograms)
@@ -1913,7 +1913,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Nanograms.
         /// </summary>
         public static Mass? FromNanograms(long? nanograms)
@@ -1928,7 +1928,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Nanograms of type decimal.
         /// </summary>
         public static Mass? FromNanograms(decimal? nanograms)
@@ -1958,7 +1958,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Ounces.
         /// </summary>
         public static Mass? FromOunces(int? ounces)
@@ -1973,7 +1973,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Ounces.
         /// </summary>
         public static Mass? FromOunces(long? ounces)
@@ -1988,7 +1988,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Ounces of type decimal.
         /// </summary>
         public static Mass? FromOunces(decimal? ounces)
@@ -2018,7 +2018,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Pounds.
         /// </summary>
         public static Mass? FromPounds(int? pounds)
@@ -2033,7 +2033,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Pounds.
         /// </summary>
         public static Mass? FromPounds(long? pounds)
@@ -2048,7 +2048,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Pounds of type decimal.
         /// </summary>
         public static Mass? FromPounds(decimal? pounds)
@@ -2078,7 +2078,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable ShortHundredweight.
         /// </summary>
         public static Mass? FromShortHundredweight(int? shorthundredweight)
@@ -2093,7 +2093,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable ShortHundredweight.
         /// </summary>
         public static Mass? FromShortHundredweight(long? shorthundredweight)
@@ -2108,7 +2108,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from ShortHundredweight of type decimal.
         /// </summary>
         public static Mass? FromShortHundredweight(decimal? shorthundredweight)
@@ -2138,7 +2138,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable ShortTons.
         /// </summary>
         public static Mass? FromShortTons(int? shorttons)
@@ -2153,7 +2153,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable ShortTons.
         /// </summary>
         public static Mass? FromShortTons(long? shorttons)
@@ -2168,7 +2168,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from ShortTons of type decimal.
         /// </summary>
         public static Mass? FromShortTons(decimal? shorttons)
@@ -2198,7 +2198,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Stone.
         /// </summary>
         public static Mass? FromStone(int? stone)
@@ -2213,7 +2213,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Stone.
         /// </summary>
         public static Mass? FromStone(long? stone)
@@ -2228,7 +2228,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Stone of type decimal.
         /// </summary>
         public static Mass? FromStone(decimal? stone)
@@ -2258,7 +2258,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Tonnes.
         /// </summary>
         public static Mass? FromTonnes(int? tonnes)
@@ -2273,7 +2273,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from nullable Tonnes.
         /// </summary>
         public static Mass? FromTonnes(long? tonnes)
@@ -2288,7 +2288,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Mass from Tonnes of type decimal.
         /// </summary>
         public static Mass? FromTonnes(decimal? tonnes)

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -314,6 +314,33 @@ namespace UnitsNet
             return new Mass((centigrams/1e3) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Mass from Centigrams.
+        /// </summary>
+        public static Mass FromCentigrams(int centigrams)
+        {
+            return new Mass((centigrams/1e3) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Centigrams.
+        /// </summary>
+        public static Mass FromCentigrams(long centigrams)
+        {
+            return new Mass((centigrams/1e3) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Centigrams of type decimal.
+        /// </summary>
+        public static Mass FromCentigrams(decimal centigrams)
+        {
+	        return new Mass((Convert.ToDouble(centigrams)/1e3) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
@@ -321,6 +348,33 @@ namespace UnitsNet
         {
             return new Mass((decagrams/1e3) * 1e1d);
         }
+
+		/// <summary>
+        ///     Get Mass from Decagrams.
+        /// </summary>
+        public static Mass FromDecagrams(int decagrams)
+        {
+            return new Mass((decagrams/1e3) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Decagrams.
+        /// </summary>
+        public static Mass FromDecagrams(long decagrams)
+        {
+            return new Mass((decagrams/1e3) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Decagrams of type decimal.
+        /// </summary>
+        public static Mass FromDecagrams(decimal decagrams)
+        {
+	        return new Mass((Convert.ToDouble(decagrams)/1e3) * 1e1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Decigrams.
@@ -330,6 +384,33 @@ namespace UnitsNet
             return new Mass((decigrams/1e3) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get Mass from Decigrams.
+        /// </summary>
+        public static Mass FromDecigrams(int decigrams)
+        {
+            return new Mass((decigrams/1e3) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Decigrams.
+        /// </summary>
+        public static Mass FromDecigrams(long decigrams)
+        {
+            return new Mass((decigrams/1e3) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Decigrams of type decimal.
+        /// </summary>
+        public static Mass FromDecigrams(decimal decigrams)
+        {
+	        return new Mass((Convert.ToDouble(decigrams)/1e3) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
@@ -337,6 +418,33 @@ namespace UnitsNet
         {
             return new Mass(grams/1e3);
         }
+
+		/// <summary>
+        ///     Get Mass from Grams.
+        /// </summary>
+        public static Mass FromGrams(int grams)
+        {
+            return new Mass(grams/1e3);
+        }
+
+		/// <summary>
+        ///     Get Mass from Grams.
+        /// </summary>
+        public static Mass FromGrams(long grams)
+        {
+            return new Mass(grams/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Grams of type decimal.
+        /// </summary>
+        public static Mass FromGrams(decimal grams)
+        {
+	        return new Mass(Convert.ToDouble(grams)/1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Hectograms.
@@ -346,6 +454,33 @@ namespace UnitsNet
             return new Mass((hectograms/1e3) * 1e2d);
         }
 
+		/// <summary>
+        ///     Get Mass from Hectograms.
+        /// </summary>
+        public static Mass FromHectograms(int hectograms)
+        {
+            return new Mass((hectograms/1e3) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Hectograms.
+        /// </summary>
+        public static Mass FromHectograms(long hectograms)
+        {
+            return new Mass((hectograms/1e3) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Hectograms of type decimal.
+        /// </summary>
+        public static Mass FromHectograms(decimal hectograms)
+        {
+	        return new Mass((Convert.ToDouble(hectograms)/1e3) * 1e2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
@@ -353,6 +488,33 @@ namespace UnitsNet
         {
             return new Mass((kilograms/1e3) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Mass from Kilograms.
+        /// </summary>
+        public static Mass FromKilograms(int kilograms)
+        {
+            return new Mass((kilograms/1e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Kilograms.
+        /// </summary>
+        public static Mass FromKilograms(long kilograms)
+        {
+            return new Mass((kilograms/1e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Kilograms of type decimal.
+        /// </summary>
+        public static Mass FromKilograms(decimal kilograms)
+        {
+	        return new Mass((Convert.ToDouble(kilograms)/1e3) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Kilopounds.
@@ -362,6 +524,33 @@ namespace UnitsNet
             return new Mass((kilopounds*0.45359237) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Mass from Kilopounds.
+        /// </summary>
+        public static Mass FromKilopounds(int kilopounds)
+        {
+            return new Mass((kilopounds*0.45359237) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Kilopounds.
+        /// </summary>
+        public static Mass FromKilopounds(long kilopounds)
+        {
+            return new Mass((kilopounds*0.45359237) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Kilopounds of type decimal.
+        /// </summary>
+        public static Mass FromKilopounds(decimal kilopounds)
+        {
+	        return new Mass((Convert.ToDouble(kilopounds)*0.45359237) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
@@ -369,6 +558,33 @@ namespace UnitsNet
         {
             return new Mass((kilotonnes*1e3) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Mass from Kilotonnes.
+        /// </summary>
+        public static Mass FromKilotonnes(int kilotonnes)
+        {
+            return new Mass((kilotonnes*1e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Kilotonnes.
+        /// </summary>
+        public static Mass FromKilotonnes(long kilotonnes)
+        {
+            return new Mass((kilotonnes*1e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Kilotonnes of type decimal.
+        /// </summary>
+        public static Mass FromKilotonnes(decimal kilotonnes)
+        {
+	        return new Mass((Convert.ToDouble(kilotonnes)*1e3) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from LongHundredweight.
@@ -378,6 +594,33 @@ namespace UnitsNet
             return new Mass(longhundredweight/0.01968413055222121);
         }
 
+		/// <summary>
+        ///     Get Mass from LongHundredweight.
+        /// </summary>
+        public static Mass FromLongHundredweight(int longhundredweight)
+        {
+            return new Mass(longhundredweight/0.01968413055222121);
+        }
+
+		/// <summary>
+        ///     Get Mass from LongHundredweight.
+        /// </summary>
+        public static Mass FromLongHundredweight(long longhundredweight)
+        {
+            return new Mass(longhundredweight/0.01968413055222121);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from LongHundredweight of type decimal.
+        /// </summary>
+        public static Mass FromLongHundredweight(decimal longhundredweight)
+        {
+	        return new Mass(Convert.ToDouble(longhundredweight)/0.01968413055222121);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
@@ -385,6 +628,33 @@ namespace UnitsNet
         {
             return new Mass(longtons*1016.0469088);
         }
+
+		/// <summary>
+        ///     Get Mass from LongTons.
+        /// </summary>
+        public static Mass FromLongTons(int longtons)
+        {
+            return new Mass(longtons*1016.0469088);
+        }
+
+		/// <summary>
+        ///     Get Mass from LongTons.
+        /// </summary>
+        public static Mass FromLongTons(long longtons)
+        {
+            return new Mass(longtons*1016.0469088);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from LongTons of type decimal.
+        /// </summary>
+        public static Mass FromLongTons(decimal longtons)
+        {
+	        return new Mass(Convert.ToDouble(longtons)*1016.0469088);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Megapounds.
@@ -394,6 +664,33 @@ namespace UnitsNet
             return new Mass((megapounds*0.45359237) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get Mass from Megapounds.
+        /// </summary>
+        public static Mass FromMegapounds(int megapounds)
+        {
+            return new Mass((megapounds*0.45359237) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Megapounds.
+        /// </summary>
+        public static Mass FromMegapounds(long megapounds)
+        {
+            return new Mass((megapounds*0.45359237) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Megapounds of type decimal.
+        /// </summary>
+        public static Mass FromMegapounds(decimal megapounds)
+        {
+	        return new Mass((Convert.ToDouble(megapounds)*0.45359237) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
@@ -401,6 +698,33 @@ namespace UnitsNet
         {
             return new Mass((megatonnes*1e3) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get Mass from Megatonnes.
+        /// </summary>
+        public static Mass FromMegatonnes(int megatonnes)
+        {
+            return new Mass((megatonnes*1e3) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Megatonnes.
+        /// </summary>
+        public static Mass FromMegatonnes(long megatonnes)
+        {
+            return new Mass((megatonnes*1e3) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Megatonnes of type decimal.
+        /// </summary>
+        public static Mass FromMegatonnes(decimal megatonnes)
+        {
+	        return new Mass((Convert.ToDouble(megatonnes)*1e3) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Micrograms.
@@ -410,6 +734,33 @@ namespace UnitsNet
             return new Mass((micrograms/1e3) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Mass from Micrograms.
+        /// </summary>
+        public static Mass FromMicrograms(int micrograms)
+        {
+            return new Mass((micrograms/1e3) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Micrograms.
+        /// </summary>
+        public static Mass FromMicrograms(long micrograms)
+        {
+            return new Mass((micrograms/1e3) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Micrograms of type decimal.
+        /// </summary>
+        public static Mass FromMicrograms(decimal micrograms)
+        {
+	        return new Mass((Convert.ToDouble(micrograms)/1e3) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
@@ -417,6 +768,33 @@ namespace UnitsNet
         {
             return new Mass((milligrams/1e3) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Mass from Milligrams.
+        /// </summary>
+        public static Mass FromMilligrams(int milligrams)
+        {
+            return new Mass((milligrams/1e3) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Milligrams.
+        /// </summary>
+        public static Mass FromMilligrams(long milligrams)
+        {
+            return new Mass((milligrams/1e3) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Milligrams of type decimal.
+        /// </summary>
+        public static Mass FromMilligrams(decimal milligrams)
+        {
+	        return new Mass((Convert.ToDouble(milligrams)/1e3) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Nanograms.
@@ -426,6 +804,33 @@ namespace UnitsNet
             return new Mass((nanograms/1e3) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Mass from Nanograms.
+        /// </summary>
+        public static Mass FromNanograms(int nanograms)
+        {
+            return new Mass((nanograms/1e3) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Mass from Nanograms.
+        /// </summary>
+        public static Mass FromNanograms(long nanograms)
+        {
+            return new Mass((nanograms/1e3) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Nanograms of type decimal.
+        /// </summary>
+        public static Mass FromNanograms(decimal nanograms)
+        {
+	        return new Mass((Convert.ToDouble(nanograms)/1e3) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
@@ -433,6 +838,33 @@ namespace UnitsNet
         {
             return new Mass(ounces/35.2739619);
         }
+
+		/// <summary>
+        ///     Get Mass from Ounces.
+        /// </summary>
+        public static Mass FromOunces(int ounces)
+        {
+            return new Mass(ounces/35.2739619);
+        }
+
+		/// <summary>
+        ///     Get Mass from Ounces.
+        /// </summary>
+        public static Mass FromOunces(long ounces)
+        {
+            return new Mass(ounces/35.2739619);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Ounces of type decimal.
+        /// </summary>
+        public static Mass FromOunces(decimal ounces)
+        {
+	        return new Mass(Convert.ToDouble(ounces)/35.2739619);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Pounds.
@@ -442,6 +874,33 @@ namespace UnitsNet
             return new Mass(pounds*0.45359237);
         }
 
+		/// <summary>
+        ///     Get Mass from Pounds.
+        /// </summary>
+        public static Mass FromPounds(int pounds)
+        {
+            return new Mass(pounds*0.45359237);
+        }
+
+		/// <summary>
+        ///     Get Mass from Pounds.
+        /// </summary>
+        public static Mass FromPounds(long pounds)
+        {
+            return new Mass(pounds*0.45359237);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Pounds of type decimal.
+        /// </summary>
+        public static Mass FromPounds(decimal pounds)
+        {
+	        return new Mass(Convert.ToDouble(pounds)*0.45359237);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
@@ -449,6 +908,33 @@ namespace UnitsNet
         {
             return new Mass(shorthundredweight/0.022046226218487758);
         }
+
+		/// <summary>
+        ///     Get Mass from ShortHundredweight.
+        /// </summary>
+        public static Mass FromShortHundredweight(int shorthundredweight)
+        {
+            return new Mass(shorthundredweight/0.022046226218487758);
+        }
+
+		/// <summary>
+        ///     Get Mass from ShortHundredweight.
+        /// </summary>
+        public static Mass FromShortHundredweight(long shorthundredweight)
+        {
+            return new Mass(shorthundredweight/0.022046226218487758);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from ShortHundredweight of type decimal.
+        /// </summary>
+        public static Mass FromShortHundredweight(decimal shorthundredweight)
+        {
+	        return new Mass(Convert.ToDouble(shorthundredweight)/0.022046226218487758);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from ShortTons.
@@ -458,6 +944,33 @@ namespace UnitsNet
             return new Mass(shorttons*907.18474);
         }
 
+		/// <summary>
+        ///     Get Mass from ShortTons.
+        /// </summary>
+        public static Mass FromShortTons(int shorttons)
+        {
+            return new Mass(shorttons*907.18474);
+        }
+
+		/// <summary>
+        ///     Get Mass from ShortTons.
+        /// </summary>
+        public static Mass FromShortTons(long shorttons)
+        {
+            return new Mass(shorttons*907.18474);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from ShortTons of type decimal.
+        /// </summary>
+        public static Mass FromShortTons(decimal shorttons)
+        {
+	        return new Mass(Convert.ToDouble(shorttons)*907.18474);
+        }
+#endif
+
         /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
@@ -465,6 +978,33 @@ namespace UnitsNet
         {
             return new Mass(stone/0.1574731728702698);
         }
+
+		/// <summary>
+        ///     Get Mass from Stone.
+        /// </summary>
+        public static Mass FromStone(int stone)
+        {
+            return new Mass(stone/0.1574731728702698);
+        }
+
+		/// <summary>
+        ///     Get Mass from Stone.
+        /// </summary>
+        public static Mass FromStone(long stone)
+        {
+            return new Mass(stone/0.1574731728702698);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Stone of type decimal.
+        /// </summary>
+        public static Mass FromStone(decimal stone)
+        {
+	        return new Mass(Convert.ToDouble(stone)/0.1574731728702698);
+        }
+#endif
 
         /// <summary>
         ///     Get Mass from Tonnes.
@@ -474,12 +1014,84 @@ namespace UnitsNet
             return new Mass(tonnes*1e3);
         }
 
+		/// <summary>
+        ///     Get Mass from Tonnes.
+        /// </summary>
+        public static Mass FromTonnes(int tonnes)
+        {
+            return new Mass(tonnes*1e3);
+        }
+
+		/// <summary>
+        ///     Get Mass from Tonnes.
+        /// </summary>
+        public static Mass FromTonnes(long tonnes)
+        {
+            return new Mass(tonnes*1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Mass from Tonnes of type decimal.
+        /// </summary>
+        public static Mass FromTonnes(decimal tonnes)
+        {
+	        return new Mass(Convert.ToDouble(tonnes)*1e3);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Mass from nullable Centigrams.
         /// </summary>
         public static Mass? FromCentigrams(double? centigrams)
+        {
+            if (centigrams.HasValue)
+            {
+                return FromCentigrams(centigrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Centigrams.
+        /// </summary>
+        public static Mass? FromCentigrams(int? centigrams)
+        {
+            if (centigrams.HasValue)
+            {
+                return FromCentigrams(centigrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Centigrams.
+        /// </summary>
+        public static Mass? FromCentigrams(long? centigrams)
+        {
+            if (centigrams.HasValue)
+            {
+                return FromCentigrams(centigrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Centigrams of type decimal.
+        /// </summary>
+        public static Mass? FromCentigrams(decimal? centigrams)
         {
             if (centigrams.HasValue)
             {
@@ -506,10 +1118,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Decagrams.
+        /// </summary>
+        public static Mass? FromDecagrams(int? decagrams)
+        {
+            if (decagrams.HasValue)
+            {
+                return FromDecagrams(decagrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Decagrams.
+        /// </summary>
+        public static Mass? FromDecagrams(long? decagrams)
+        {
+            if (decagrams.HasValue)
+            {
+                return FromDecagrams(decagrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Decagrams of type decimal.
+        /// </summary>
+        public static Mass? FromDecagrams(decimal? decagrams)
+        {
+            if (decagrams.HasValue)
+            {
+                return FromDecagrams(decagrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Decigrams.
         /// </summary>
         public static Mass? FromDecigrams(double? decigrams)
+        {
+            if (decigrams.HasValue)
+            {
+                return FromDecigrams(decigrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Decigrams.
+        /// </summary>
+        public static Mass? FromDecigrams(int? decigrams)
+        {
+            if (decigrams.HasValue)
+            {
+                return FromDecigrams(decigrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Decigrams.
+        /// </summary>
+        public static Mass? FromDecigrams(long? decigrams)
+        {
+            if (decigrams.HasValue)
+            {
+                return FromDecigrams(decigrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Decigrams of type decimal.
+        /// </summary>
+        public static Mass? FromDecigrams(decimal? decigrams)
         {
             if (decigrams.HasValue)
             {
@@ -536,10 +1238,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Grams.
+        /// </summary>
+        public static Mass? FromGrams(int? grams)
+        {
+            if (grams.HasValue)
+            {
+                return FromGrams(grams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Grams.
+        /// </summary>
+        public static Mass? FromGrams(long? grams)
+        {
+            if (grams.HasValue)
+            {
+                return FromGrams(grams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Grams of type decimal.
+        /// </summary>
+        public static Mass? FromGrams(decimal? grams)
+        {
+            if (grams.HasValue)
+            {
+                return FromGrams(grams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Hectograms.
         /// </summary>
         public static Mass? FromHectograms(double? hectograms)
+        {
+            if (hectograms.HasValue)
+            {
+                return FromHectograms(hectograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Hectograms.
+        /// </summary>
+        public static Mass? FromHectograms(int? hectograms)
+        {
+            if (hectograms.HasValue)
+            {
+                return FromHectograms(hectograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Hectograms.
+        /// </summary>
+        public static Mass? FromHectograms(long? hectograms)
+        {
+            if (hectograms.HasValue)
+            {
+                return FromHectograms(hectograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Hectograms of type decimal.
+        /// </summary>
+        public static Mass? FromHectograms(decimal? hectograms)
         {
             if (hectograms.HasValue)
             {
@@ -566,10 +1358,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Kilograms.
+        /// </summary>
+        public static Mass? FromKilograms(int? kilograms)
+        {
+            if (kilograms.HasValue)
+            {
+                return FromKilograms(kilograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Kilograms.
+        /// </summary>
+        public static Mass? FromKilograms(long? kilograms)
+        {
+            if (kilograms.HasValue)
+            {
+                return FromKilograms(kilograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Kilograms of type decimal.
+        /// </summary>
+        public static Mass? FromKilograms(decimal? kilograms)
+        {
+            if (kilograms.HasValue)
+            {
+                return FromKilograms(kilograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Kilopounds.
         /// </summary>
         public static Mass? FromKilopounds(double? kilopounds)
+        {
+            if (kilopounds.HasValue)
+            {
+                return FromKilopounds(kilopounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Kilopounds.
+        /// </summary>
+        public static Mass? FromKilopounds(int? kilopounds)
+        {
+            if (kilopounds.HasValue)
+            {
+                return FromKilopounds(kilopounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Kilopounds.
+        /// </summary>
+        public static Mass? FromKilopounds(long? kilopounds)
+        {
+            if (kilopounds.HasValue)
+            {
+                return FromKilopounds(kilopounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Kilopounds of type decimal.
+        /// </summary>
+        public static Mass? FromKilopounds(decimal? kilopounds)
         {
             if (kilopounds.HasValue)
             {
@@ -596,10 +1478,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Kilotonnes.
+        /// </summary>
+        public static Mass? FromKilotonnes(int? kilotonnes)
+        {
+            if (kilotonnes.HasValue)
+            {
+                return FromKilotonnes(kilotonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Kilotonnes.
+        /// </summary>
+        public static Mass? FromKilotonnes(long? kilotonnes)
+        {
+            if (kilotonnes.HasValue)
+            {
+                return FromKilotonnes(kilotonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Kilotonnes of type decimal.
+        /// </summary>
+        public static Mass? FromKilotonnes(decimal? kilotonnes)
+        {
+            if (kilotonnes.HasValue)
+            {
+                return FromKilotonnes(kilotonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable LongHundredweight.
         /// </summary>
         public static Mass? FromLongHundredweight(double? longhundredweight)
+        {
+            if (longhundredweight.HasValue)
+            {
+                return FromLongHundredweight(longhundredweight.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable LongHundredweight.
+        /// </summary>
+        public static Mass? FromLongHundredweight(int? longhundredweight)
+        {
+            if (longhundredweight.HasValue)
+            {
+                return FromLongHundredweight(longhundredweight.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable LongHundredweight.
+        /// </summary>
+        public static Mass? FromLongHundredweight(long? longhundredweight)
+        {
+            if (longhundredweight.HasValue)
+            {
+                return FromLongHundredweight(longhundredweight.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from LongHundredweight of type decimal.
+        /// </summary>
+        public static Mass? FromLongHundredweight(decimal? longhundredweight)
         {
             if (longhundredweight.HasValue)
             {
@@ -626,10 +1598,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable LongTons.
+        /// </summary>
+        public static Mass? FromLongTons(int? longtons)
+        {
+            if (longtons.HasValue)
+            {
+                return FromLongTons(longtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable LongTons.
+        /// </summary>
+        public static Mass? FromLongTons(long? longtons)
+        {
+            if (longtons.HasValue)
+            {
+                return FromLongTons(longtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from LongTons of type decimal.
+        /// </summary>
+        public static Mass? FromLongTons(decimal? longtons)
+        {
+            if (longtons.HasValue)
+            {
+                return FromLongTons(longtons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Megapounds.
         /// </summary>
         public static Mass? FromMegapounds(double? megapounds)
+        {
+            if (megapounds.HasValue)
+            {
+                return FromMegapounds(megapounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Megapounds.
+        /// </summary>
+        public static Mass? FromMegapounds(int? megapounds)
+        {
+            if (megapounds.HasValue)
+            {
+                return FromMegapounds(megapounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Megapounds.
+        /// </summary>
+        public static Mass? FromMegapounds(long? megapounds)
+        {
+            if (megapounds.HasValue)
+            {
+                return FromMegapounds(megapounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Megapounds of type decimal.
+        /// </summary>
+        public static Mass? FromMegapounds(decimal? megapounds)
         {
             if (megapounds.HasValue)
             {
@@ -656,10 +1718,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Megatonnes.
+        /// </summary>
+        public static Mass? FromMegatonnes(int? megatonnes)
+        {
+            if (megatonnes.HasValue)
+            {
+                return FromMegatonnes(megatonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Megatonnes.
+        /// </summary>
+        public static Mass? FromMegatonnes(long? megatonnes)
+        {
+            if (megatonnes.HasValue)
+            {
+                return FromMegatonnes(megatonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Megatonnes of type decimal.
+        /// </summary>
+        public static Mass? FromMegatonnes(decimal? megatonnes)
+        {
+            if (megatonnes.HasValue)
+            {
+                return FromMegatonnes(megatonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Micrograms.
         /// </summary>
         public static Mass? FromMicrograms(double? micrograms)
+        {
+            if (micrograms.HasValue)
+            {
+                return FromMicrograms(micrograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Micrograms.
+        /// </summary>
+        public static Mass? FromMicrograms(int? micrograms)
+        {
+            if (micrograms.HasValue)
+            {
+                return FromMicrograms(micrograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Micrograms.
+        /// </summary>
+        public static Mass? FromMicrograms(long? micrograms)
+        {
+            if (micrograms.HasValue)
+            {
+                return FromMicrograms(micrograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Micrograms of type decimal.
+        /// </summary>
+        public static Mass? FromMicrograms(decimal? micrograms)
         {
             if (micrograms.HasValue)
             {
@@ -686,10 +1838,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Milligrams.
+        /// </summary>
+        public static Mass? FromMilligrams(int? milligrams)
+        {
+            if (milligrams.HasValue)
+            {
+                return FromMilligrams(milligrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Milligrams.
+        /// </summary>
+        public static Mass? FromMilligrams(long? milligrams)
+        {
+            if (milligrams.HasValue)
+            {
+                return FromMilligrams(milligrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Milligrams of type decimal.
+        /// </summary>
+        public static Mass? FromMilligrams(decimal? milligrams)
+        {
+            if (milligrams.HasValue)
+            {
+                return FromMilligrams(milligrams.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Nanograms.
         /// </summary>
         public static Mass? FromNanograms(double? nanograms)
+        {
+            if (nanograms.HasValue)
+            {
+                return FromNanograms(nanograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Nanograms.
+        /// </summary>
+        public static Mass? FromNanograms(int? nanograms)
+        {
+            if (nanograms.HasValue)
+            {
+                return FromNanograms(nanograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Nanograms.
+        /// </summary>
+        public static Mass? FromNanograms(long? nanograms)
+        {
+            if (nanograms.HasValue)
+            {
+                return FromNanograms(nanograms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Nanograms of type decimal.
+        /// </summary>
+        public static Mass? FromNanograms(decimal? nanograms)
         {
             if (nanograms.HasValue)
             {
@@ -716,10 +1958,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Ounces.
+        /// </summary>
+        public static Mass? FromOunces(int? ounces)
+        {
+            if (ounces.HasValue)
+            {
+                return FromOunces(ounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Ounces.
+        /// </summary>
+        public static Mass? FromOunces(long? ounces)
+        {
+            if (ounces.HasValue)
+            {
+                return FromOunces(ounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Ounces of type decimal.
+        /// </summary>
+        public static Mass? FromOunces(decimal? ounces)
+        {
+            if (ounces.HasValue)
+            {
+                return FromOunces(ounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Pounds.
         /// </summary>
         public static Mass? FromPounds(double? pounds)
+        {
+            if (pounds.HasValue)
+            {
+                return FromPounds(pounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Pounds.
+        /// </summary>
+        public static Mass? FromPounds(int? pounds)
+        {
+            if (pounds.HasValue)
+            {
+                return FromPounds(pounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Pounds.
+        /// </summary>
+        public static Mass? FromPounds(long? pounds)
+        {
+            if (pounds.HasValue)
+            {
+                return FromPounds(pounds.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Pounds of type decimal.
+        /// </summary>
+        public static Mass? FromPounds(decimal? pounds)
         {
             if (pounds.HasValue)
             {
@@ -746,10 +2078,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable ShortHundredweight.
+        /// </summary>
+        public static Mass? FromShortHundredweight(int? shorthundredweight)
+        {
+            if (shorthundredweight.HasValue)
+            {
+                return FromShortHundredweight(shorthundredweight.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable ShortHundredweight.
+        /// </summary>
+        public static Mass? FromShortHundredweight(long? shorthundredweight)
+        {
+            if (shorthundredweight.HasValue)
+            {
+                return FromShortHundredweight(shorthundredweight.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from ShortHundredweight of type decimal.
+        /// </summary>
+        public static Mass? FromShortHundredweight(decimal? shorthundredweight)
+        {
+            if (shorthundredweight.HasValue)
+            {
+                return FromShortHundredweight(shorthundredweight.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable ShortTons.
         /// </summary>
         public static Mass? FromShortTons(double? shorttons)
+        {
+            if (shorttons.HasValue)
+            {
+                return FromShortTons(shorttons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable ShortTons.
+        /// </summary>
+        public static Mass? FromShortTons(int? shorttons)
+        {
+            if (shorttons.HasValue)
+            {
+                return FromShortTons(shorttons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable ShortTons.
+        /// </summary>
+        public static Mass? FromShortTons(long? shorttons)
+        {
+            if (shorttons.HasValue)
+            {
+                return FromShortTons(shorttons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from ShortTons of type decimal.
+        /// </summary>
+        public static Mass? FromShortTons(decimal? shorttons)
         {
             if (shorttons.HasValue)
             {
@@ -776,10 +2198,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Mass from nullable Stone.
+        /// </summary>
+        public static Mass? FromStone(int? stone)
+        {
+            if (stone.HasValue)
+            {
+                return FromStone(stone.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Stone.
+        /// </summary>
+        public static Mass? FromStone(long? stone)
+        {
+            if (stone.HasValue)
+            {
+                return FromStone(stone.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Stone of type decimal.
+        /// </summary>
+        public static Mass? FromStone(decimal? stone)
+        {
+            if (stone.HasValue)
+            {
+                return FromStone(stone.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Mass from nullable Tonnes.
         /// </summary>
         public static Mass? FromTonnes(double? tonnes)
+        {
+            if (tonnes.HasValue)
+            {
+                return FromTonnes(tonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Tonnes.
+        /// </summary>
+        public static Mass? FromTonnes(int? tonnes)
+        {
+            if (tonnes.HasValue)
+            {
+                return FromTonnes(tonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from nullable Tonnes.
+        /// </summary>
+        public static Mass? FromTonnes(long? tonnes)
+        {
+            if (tonnes.HasValue)
+            {
+                return FromTonnes(tonnes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Mass from Tonnes of type decimal.
+        /// </summary>
+        public static Mass? FromTonnes(decimal? tonnes)
         {
             if (tonnes.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -309,6 +309,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Centigrams.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromCentigrams(double centigrams)
         {
             return new Mass((centigrams/1e3) * 1e-2d);
@@ -344,6 +347,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromDecagrams(double decagrams)
         {
             return new Mass((decagrams/1e3) * 1e1d);
@@ -379,6 +385,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Decigrams.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromDecigrams(double decigrams)
         {
             return new Mass((decigrams/1e3) * 1e-1d);
@@ -414,6 +423,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromGrams(double grams)
         {
             return new Mass(grams/1e3);
@@ -449,6 +461,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Hectograms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromHectograms(double hectograms)
         {
             return new Mass((hectograms/1e3) * 1e2d);
@@ -484,6 +499,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromKilograms(double kilograms)
         {
             return new Mass((kilograms/1e3) * 1e3d);
@@ -519,6 +537,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilopounds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromKilopounds(double kilopounds)
         {
             return new Mass((kilopounds*0.45359237) * 1e3d);
@@ -554,6 +575,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromKilotonnes(double kilotonnes)
         {
             return new Mass((kilotonnes*1e3) * 1e3d);
@@ -589,6 +613,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from LongHundredweight.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromLongHundredweight(double longhundredweight)
         {
             return new Mass(longhundredweight/0.01968413055222121);
@@ -624,6 +651,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromLongTons(double longtons)
         {
             return new Mass(longtons*1016.0469088);
@@ -659,6 +689,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Megapounds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromMegapounds(double megapounds)
         {
             return new Mass((megapounds*0.45359237) * 1e6d);
@@ -694,6 +727,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromMegatonnes(double megatonnes)
         {
             return new Mass((megatonnes*1e3) * 1e6d);
@@ -729,6 +765,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Micrograms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromMicrograms(double micrograms)
         {
             return new Mass((micrograms/1e3) * 1e-6d);
@@ -764,6 +803,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromMilligrams(double milligrams)
         {
             return new Mass((milligrams/1e3) * 1e-3d);
@@ -799,6 +841,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Nanograms.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromNanograms(double nanograms)
         {
             return new Mass((nanograms/1e3) * 1e-9d);
@@ -834,6 +879,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromOunces(double ounces)
         {
             return new Mass(ounces/35.2739619);
@@ -869,6 +917,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Pounds.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromPounds(double pounds)
         {
             return new Mass(pounds*0.45359237);
@@ -904,6 +955,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromShortHundredweight(double shorthundredweight)
         {
             return new Mass(shorthundredweight/0.022046226218487758);
@@ -939,6 +993,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from ShortTons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromShortTons(double shorttons)
         {
             return new Mass(shorttons*907.18474);
@@ -974,6 +1031,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromStone(double stone)
         {
             return new Mass(stone/0.1574731728702698);
@@ -1009,6 +1069,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Tonnes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Mass FromTonnes(double tonnes)
         {
             return new Mass(tonnes*1e3);

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _gramsPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public MassFlow() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.MassFlow;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static MassFlowUnit BaseUnit
         {
             get { return MassFlowUnit.GramPerSecond; }
@@ -258,7 +258,7 @@ namespace UnitsNet
             return new MassFlow((centigramspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from CentigramsPerSecond.
         /// </summary>
         public static MassFlow FromCentigramsPerSecond(int centigramspersecond)
@@ -266,7 +266,7 @@ namespace UnitsNet
             return new MassFlow((centigramspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from CentigramsPerSecond.
         /// </summary>
         public static MassFlow FromCentigramsPerSecond(long centigramspersecond)
@@ -274,14 +274,14 @@ namespace UnitsNet
             return new MassFlow((centigramspersecond) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from CentigramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromCentigramsPerSecond(decimal centigramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(centigramspersecond)) * 1e-2d);
+            return new MassFlow((Convert.ToDouble(centigramspersecond)) * 1e-2d);
         }
 #endif
 
@@ -293,7 +293,7 @@ namespace UnitsNet
             return new MassFlow((decagramspersecond) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
         public static MassFlow FromDecagramsPerSecond(int decagramspersecond)
@@ -301,7 +301,7 @@ namespace UnitsNet
             return new MassFlow((decagramspersecond) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
         public static MassFlow FromDecagramsPerSecond(long decagramspersecond)
@@ -309,14 +309,14 @@ namespace UnitsNet
             return new MassFlow((decagramspersecond) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from DecagramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromDecagramsPerSecond(decimal decagramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(decagramspersecond)) * 1e1d);
+            return new MassFlow((Convert.ToDouble(decagramspersecond)) * 1e1d);
         }
 #endif
 
@@ -328,7 +328,7 @@ namespace UnitsNet
             return new MassFlow((decigramspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
         /// </summary>
         public static MassFlow FromDecigramsPerSecond(int decigramspersecond)
@@ -336,7 +336,7 @@ namespace UnitsNet
             return new MassFlow((decigramspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
         /// </summary>
         public static MassFlow FromDecigramsPerSecond(long decigramspersecond)
@@ -344,14 +344,14 @@ namespace UnitsNet
             return new MassFlow((decigramspersecond) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from DecigramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromDecigramsPerSecond(decimal decigramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(decigramspersecond)) * 1e-1d);
+            return new MassFlow((Convert.ToDouble(decigramspersecond)) * 1e-1d);
         }
 #endif
 
@@ -363,7 +363,7 @@ namespace UnitsNet
             return new MassFlow(gramspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
         public static MassFlow FromGramsPerSecond(int gramspersecond)
@@ -371,7 +371,7 @@ namespace UnitsNet
             return new MassFlow(gramspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
         public static MassFlow FromGramsPerSecond(long gramspersecond)
@@ -379,14 +379,14 @@ namespace UnitsNet
             return new MassFlow(gramspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from GramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromGramsPerSecond(decimal gramspersecond)
         {
-	        return new MassFlow(Convert.ToDouble(gramspersecond));
+            return new MassFlow(Convert.ToDouble(gramspersecond));
         }
 #endif
 
@@ -398,7 +398,7 @@ namespace UnitsNet
             return new MassFlow((hectogramspersecond) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
         /// </summary>
         public static MassFlow FromHectogramsPerSecond(int hectogramspersecond)
@@ -406,7 +406,7 @@ namespace UnitsNet
             return new MassFlow((hectogramspersecond) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
         /// </summary>
         public static MassFlow FromHectogramsPerSecond(long hectogramspersecond)
@@ -414,14 +414,14 @@ namespace UnitsNet
             return new MassFlow((hectogramspersecond) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from HectogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromHectogramsPerSecond(decimal hectogramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(hectogramspersecond)) * 1e2d);
+            return new MassFlow((Convert.ToDouble(hectogramspersecond)) * 1e2d);
         }
 #endif
 
@@ -433,7 +433,7 @@ namespace UnitsNet
             return new MassFlow(kilogramsperhour/3.6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
         public static MassFlow FromKilogramsPerHour(int kilogramsperhour)
@@ -441,7 +441,7 @@ namespace UnitsNet
             return new MassFlow(kilogramsperhour/3.6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
         public static MassFlow FromKilogramsPerHour(long kilogramsperhour)
@@ -449,14 +449,14 @@ namespace UnitsNet
             return new MassFlow(kilogramsperhour/3.6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from KilogramsPerHour of type decimal.
         /// </summary>
         public static MassFlow FromKilogramsPerHour(decimal kilogramsperhour)
         {
-	        return new MassFlow(Convert.ToDouble(kilogramsperhour)/3.6);
+            return new MassFlow(Convert.ToDouble(kilogramsperhour)/3.6);
         }
 #endif
 
@@ -468,7 +468,7 @@ namespace UnitsNet
             return new MassFlow((kilogramspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
         /// </summary>
         public static MassFlow FromKilogramsPerSecond(int kilogramspersecond)
@@ -476,7 +476,7 @@ namespace UnitsNet
             return new MassFlow((kilogramspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
         /// </summary>
         public static MassFlow FromKilogramsPerSecond(long kilogramspersecond)
@@ -484,14 +484,14 @@ namespace UnitsNet
             return new MassFlow((kilogramspersecond) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from KilogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromKilogramsPerSecond(decimal kilogramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(kilogramspersecond)) * 1e3d);
+            return new MassFlow((Convert.ToDouble(kilogramspersecond)) * 1e3d);
         }
 #endif
 
@@ -503,7 +503,7 @@ namespace UnitsNet
             return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
         public static MassFlow FromMegapoundsPerHour(int megapoundsperhour)
@@ -511,7 +511,7 @@ namespace UnitsNet
             return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
         public static MassFlow FromMegapoundsPerHour(long megapoundsperhour)
@@ -519,14 +519,14 @@ namespace UnitsNet
             return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MegapoundsPerHour of type decimal.
         /// </summary>
         public static MassFlow FromMegapoundsPerHour(decimal megapoundsperhour)
         {
-	        return new MassFlow((Convert.ToDouble(megapoundsperhour)/7.93664) * 1e6d);
+            return new MassFlow((Convert.ToDouble(megapoundsperhour)/7.93664) * 1e6d);
         }
 #endif
 
@@ -538,7 +538,7 @@ namespace UnitsNet
             return new MassFlow((microgramspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
         /// </summary>
         public static MassFlow FromMicrogramsPerSecond(int microgramspersecond)
@@ -546,7 +546,7 @@ namespace UnitsNet
             return new MassFlow((microgramspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
         /// </summary>
         public static MassFlow FromMicrogramsPerSecond(long microgramspersecond)
@@ -554,14 +554,14 @@ namespace UnitsNet
             return new MassFlow((microgramspersecond) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromMicrogramsPerSecond(decimal microgramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(microgramspersecond)) * 1e-6d);
+            return new MassFlow((Convert.ToDouble(microgramspersecond)) * 1e-6d);
         }
 #endif
 
@@ -573,7 +573,7 @@ namespace UnitsNet
             return new MassFlow((milligramspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
         public static MassFlow FromMilligramsPerSecond(int milligramspersecond)
@@ -581,7 +581,7 @@ namespace UnitsNet
             return new MassFlow((milligramspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
         public static MassFlow FromMilligramsPerSecond(long milligramspersecond)
@@ -589,14 +589,14 @@ namespace UnitsNet
             return new MassFlow((milligramspersecond) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from MilligramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromMilligramsPerSecond(decimal milligramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(milligramspersecond)) * 1e-3d);
+            return new MassFlow((Convert.ToDouble(milligramspersecond)) * 1e-3d);
         }
 #endif
 
@@ -608,7 +608,7 @@ namespace UnitsNet
             return new MassFlow((nanogramspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
         /// </summary>
         public static MassFlow FromNanogramsPerSecond(int nanogramspersecond)
@@ -616,7 +616,7 @@ namespace UnitsNet
             return new MassFlow((nanogramspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
         /// </summary>
         public static MassFlow FromNanogramsPerSecond(long nanogramspersecond)
@@ -624,14 +624,14 @@ namespace UnitsNet
             return new MassFlow((nanogramspersecond) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from NanogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow FromNanogramsPerSecond(decimal nanogramspersecond)
         {
-	        return new MassFlow((Convert.ToDouble(nanogramspersecond)) * 1e-9d);
+            return new MassFlow((Convert.ToDouble(nanogramspersecond)) * 1e-9d);
         }
 #endif
 
@@ -643,7 +643,7 @@ namespace UnitsNet
             return new MassFlow(poundsperhour/7.93664);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
         public static MassFlow FromPoundsPerHour(int poundsperhour)
@@ -651,7 +651,7 @@ namespace UnitsNet
             return new MassFlow(poundsperhour/7.93664);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
         public static MassFlow FromPoundsPerHour(long poundsperhour)
@@ -659,14 +659,14 @@ namespace UnitsNet
             return new MassFlow(poundsperhour/7.93664);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from PoundsPerHour of type decimal.
         /// </summary>
         public static MassFlow FromPoundsPerHour(decimal poundsperhour)
         {
-	        return new MassFlow(Convert.ToDouble(poundsperhour)/7.93664);
+            return new MassFlow(Convert.ToDouble(poundsperhour)/7.93664);
         }
 #endif
 
@@ -678,7 +678,7 @@ namespace UnitsNet
             return new MassFlow(shorttonsperhour*251.9957611);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
         /// </summary>
         public static MassFlow FromShortTonsPerHour(int shorttonsperhour)
@@ -686,7 +686,7 @@ namespace UnitsNet
             return new MassFlow(shorttonsperhour*251.9957611);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
         /// </summary>
         public static MassFlow FromShortTonsPerHour(long shorttonsperhour)
@@ -694,14 +694,14 @@ namespace UnitsNet
             return new MassFlow(shorttonsperhour*251.9957611);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from ShortTonsPerHour of type decimal.
         /// </summary>
         public static MassFlow FromShortTonsPerHour(decimal shorttonsperhour)
         {
-	        return new MassFlow(Convert.ToDouble(shorttonsperhour)*251.9957611);
+            return new MassFlow(Convert.ToDouble(shorttonsperhour)*251.9957611);
         }
 #endif
 
@@ -713,7 +713,7 @@ namespace UnitsNet
             return new MassFlow(tonnesperday/0.0864000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
         public static MassFlow FromTonnesPerDay(int tonnesperday)
@@ -721,7 +721,7 @@ namespace UnitsNet
             return new MassFlow(tonnesperday/0.0864000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
         public static MassFlow FromTonnesPerDay(long tonnesperday)
@@ -729,14 +729,14 @@ namespace UnitsNet
             return new MassFlow(tonnesperday/0.0864000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassFlow from TonnesPerDay of type decimal.
         /// </summary>
         public static MassFlow FromTonnesPerDay(decimal tonnesperday)
         {
-	        return new MassFlow(Convert.ToDouble(tonnesperday)/0.0864000);
+            return new MassFlow(Convert.ToDouble(tonnesperday)/0.0864000);
         }
 #endif
 
@@ -757,7 +757,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable CentigramsPerSecond.
         /// </summary>
         public static MassFlow? FromCentigramsPerSecond(int? centigramspersecond)
@@ -772,7 +772,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable CentigramsPerSecond.
         /// </summary>
         public static MassFlow? FromCentigramsPerSecond(long? centigramspersecond)
@@ -787,7 +787,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from CentigramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromCentigramsPerSecond(decimal? centigramspersecond)
@@ -817,7 +817,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable DecagramsPerSecond.
         /// </summary>
         public static MassFlow? FromDecagramsPerSecond(int? decagramspersecond)
@@ -832,7 +832,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable DecagramsPerSecond.
         /// </summary>
         public static MassFlow? FromDecagramsPerSecond(long? decagramspersecond)
@@ -847,7 +847,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from DecagramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromDecagramsPerSecond(decimal? decagramspersecond)
@@ -877,7 +877,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable DecigramsPerSecond.
         /// </summary>
         public static MassFlow? FromDecigramsPerSecond(int? decigramspersecond)
@@ -892,7 +892,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable DecigramsPerSecond.
         /// </summary>
         public static MassFlow? FromDecigramsPerSecond(long? decigramspersecond)
@@ -907,7 +907,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from DecigramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromDecigramsPerSecond(decimal? decigramspersecond)
@@ -937,7 +937,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable GramsPerSecond.
         /// </summary>
         public static MassFlow? FromGramsPerSecond(int? gramspersecond)
@@ -952,7 +952,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable GramsPerSecond.
         /// </summary>
         public static MassFlow? FromGramsPerSecond(long? gramspersecond)
@@ -967,7 +967,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from GramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromGramsPerSecond(decimal? gramspersecond)
@@ -997,7 +997,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable HectogramsPerSecond.
         /// </summary>
         public static MassFlow? FromHectogramsPerSecond(int? hectogramspersecond)
@@ -1012,7 +1012,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable HectogramsPerSecond.
         /// </summary>
         public static MassFlow? FromHectogramsPerSecond(long? hectogramspersecond)
@@ -1027,7 +1027,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from HectogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromHectogramsPerSecond(decimal? hectogramspersecond)
@@ -1057,7 +1057,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerHour.
         /// </summary>
         public static MassFlow? FromKilogramsPerHour(int? kilogramsperhour)
@@ -1072,7 +1072,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerHour.
         /// </summary>
         public static MassFlow? FromKilogramsPerHour(long? kilogramsperhour)
@@ -1087,7 +1087,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from KilogramsPerHour of type decimal.
         /// </summary>
         public static MassFlow? FromKilogramsPerHour(decimal? kilogramsperhour)
@@ -1117,7 +1117,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerSecond.
         /// </summary>
         public static MassFlow? FromKilogramsPerSecond(int? kilogramspersecond)
@@ -1132,7 +1132,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerSecond.
         /// </summary>
         public static MassFlow? FromKilogramsPerSecond(long? kilogramspersecond)
@@ -1147,7 +1147,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from KilogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromKilogramsPerSecond(decimal? kilogramspersecond)
@@ -1177,7 +1177,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable MegapoundsPerHour.
         /// </summary>
         public static MassFlow? FromMegapoundsPerHour(int? megapoundsperhour)
@@ -1192,7 +1192,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable MegapoundsPerHour.
         /// </summary>
         public static MassFlow? FromMegapoundsPerHour(long? megapoundsperhour)
@@ -1207,7 +1207,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from MegapoundsPerHour of type decimal.
         /// </summary>
         public static MassFlow? FromMegapoundsPerHour(decimal? megapoundsperhour)
@@ -1237,7 +1237,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
         /// </summary>
         public static MassFlow? FromMicrogramsPerSecond(int? microgramspersecond)
@@ -1252,7 +1252,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
         /// </summary>
         public static MassFlow? FromMicrogramsPerSecond(long? microgramspersecond)
@@ -1267,7 +1267,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from MicrogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromMicrogramsPerSecond(decimal? microgramspersecond)
@@ -1297,7 +1297,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable MilligramsPerSecond.
         /// </summary>
         public static MassFlow? FromMilligramsPerSecond(int? milligramspersecond)
@@ -1312,7 +1312,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable MilligramsPerSecond.
         /// </summary>
         public static MassFlow? FromMilligramsPerSecond(long? milligramspersecond)
@@ -1327,7 +1327,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from MilligramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromMilligramsPerSecond(decimal? milligramspersecond)
@@ -1357,7 +1357,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable NanogramsPerSecond.
         /// </summary>
         public static MassFlow? FromNanogramsPerSecond(int? nanogramspersecond)
@@ -1372,7 +1372,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable NanogramsPerSecond.
         /// </summary>
         public static MassFlow? FromNanogramsPerSecond(long? nanogramspersecond)
@@ -1387,7 +1387,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from NanogramsPerSecond of type decimal.
         /// </summary>
         public static MassFlow? FromNanogramsPerSecond(decimal? nanogramspersecond)
@@ -1417,7 +1417,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable PoundsPerHour.
         /// </summary>
         public static MassFlow? FromPoundsPerHour(int? poundsperhour)
@@ -1432,7 +1432,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable PoundsPerHour.
         /// </summary>
         public static MassFlow? FromPoundsPerHour(long? poundsperhour)
@@ -1447,7 +1447,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from PoundsPerHour of type decimal.
         /// </summary>
         public static MassFlow? FromPoundsPerHour(decimal? poundsperhour)
@@ -1477,7 +1477,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable ShortTonsPerHour.
         /// </summary>
         public static MassFlow? FromShortTonsPerHour(int? shorttonsperhour)
@@ -1492,7 +1492,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable ShortTonsPerHour.
         /// </summary>
         public static MassFlow? FromShortTonsPerHour(long? shorttonsperhour)
@@ -1507,7 +1507,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from ShortTonsPerHour of type decimal.
         /// </summary>
         public static MassFlow? FromShortTonsPerHour(decimal? shorttonsperhour)
@@ -1537,7 +1537,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable TonnesPerDay.
         /// </summary>
         public static MassFlow? FromTonnesPerDay(int? tonnesperday)
@@ -1552,7 +1552,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from nullable TonnesPerDay.
         /// </summary>
         public static MassFlow? FromTonnesPerDay(long? tonnesperday)
@@ -1567,7 +1567,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassFlow from TonnesPerDay of type decimal.
         /// </summary>
         public static MassFlow? FromTonnesPerDay(decimal? tonnesperday)

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -258,6 +258,33 @@ namespace UnitsNet
             return new MassFlow((centigramspersecond) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get MassFlow from CentigramsPerSecond.
+        /// </summary>
+        public static MassFlow FromCentigramsPerSecond(int centigramspersecond)
+        {
+            return new MassFlow((centigramspersecond) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from CentigramsPerSecond.
+        /// </summary>
+        public static MassFlow FromCentigramsPerSecond(long centigramspersecond)
+        {
+            return new MassFlow((centigramspersecond) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from CentigramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromCentigramsPerSecond(decimal centigramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(centigramspersecond)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
@@ -265,6 +292,33 @@ namespace UnitsNet
         {
             return new MassFlow((decagramspersecond) * 1e1d);
         }
+
+		/// <summary>
+        ///     Get MassFlow from DecagramsPerSecond.
+        /// </summary>
+        public static MassFlow FromDecagramsPerSecond(int decagramspersecond)
+        {
+            return new MassFlow((decagramspersecond) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from DecagramsPerSecond.
+        /// </summary>
+        public static MassFlow FromDecagramsPerSecond(long decagramspersecond)
+        {
+            return new MassFlow((decagramspersecond) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from DecagramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromDecagramsPerSecond(decimal decagramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(decagramspersecond)) * 1e1d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
@@ -274,6 +328,33 @@ namespace UnitsNet
             return new MassFlow((decigramspersecond) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get MassFlow from DecigramsPerSecond.
+        /// </summary>
+        public static MassFlow FromDecigramsPerSecond(int decigramspersecond)
+        {
+            return new MassFlow((decigramspersecond) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from DecigramsPerSecond.
+        /// </summary>
+        public static MassFlow FromDecigramsPerSecond(long decigramspersecond)
+        {
+            return new MassFlow((decigramspersecond) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from DecigramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromDecigramsPerSecond(decimal decigramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(decigramspersecond)) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
@@ -281,6 +362,33 @@ namespace UnitsNet
         {
             return new MassFlow(gramspersecond);
         }
+
+		/// <summary>
+        ///     Get MassFlow from GramsPerSecond.
+        /// </summary>
+        public static MassFlow FromGramsPerSecond(int gramspersecond)
+        {
+            return new MassFlow(gramspersecond);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from GramsPerSecond.
+        /// </summary>
+        public static MassFlow FromGramsPerSecond(long gramspersecond)
+        {
+            return new MassFlow(gramspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from GramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromGramsPerSecond(decimal gramspersecond)
+        {
+	        return new MassFlow(Convert.ToDouble(gramspersecond));
+        }
+#endif
 
         /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
@@ -290,6 +398,33 @@ namespace UnitsNet
             return new MassFlow((hectogramspersecond) * 1e2d);
         }
 
+		/// <summary>
+        ///     Get MassFlow from HectogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromHectogramsPerSecond(int hectogramspersecond)
+        {
+            return new MassFlow((hectogramspersecond) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from HectogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromHectogramsPerSecond(long hectogramspersecond)
+        {
+            return new MassFlow((hectogramspersecond) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from HectogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromHectogramsPerSecond(decimal hectogramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(hectogramspersecond)) * 1e2d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
@@ -297,6 +432,33 @@ namespace UnitsNet
         {
             return new MassFlow(kilogramsperhour/3.6);
         }
+
+		/// <summary>
+        ///     Get MassFlow from KilogramsPerHour.
+        /// </summary>
+        public static MassFlow FromKilogramsPerHour(int kilogramsperhour)
+        {
+            return new MassFlow(kilogramsperhour/3.6);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from KilogramsPerHour.
+        /// </summary>
+        public static MassFlow FromKilogramsPerHour(long kilogramsperhour)
+        {
+            return new MassFlow(kilogramsperhour/3.6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from KilogramsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow FromKilogramsPerHour(decimal kilogramsperhour)
+        {
+	        return new MassFlow(Convert.ToDouble(kilogramsperhour)/3.6);
+        }
+#endif
 
         /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
@@ -306,6 +468,33 @@ namespace UnitsNet
             return new MassFlow((kilogramspersecond) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get MassFlow from KilogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromKilogramsPerSecond(int kilogramspersecond)
+        {
+            return new MassFlow((kilogramspersecond) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from KilogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromKilogramsPerSecond(long kilogramspersecond)
+        {
+            return new MassFlow((kilogramspersecond) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from KilogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromKilogramsPerSecond(decimal kilogramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(kilogramspersecond)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
@@ -313,6 +502,33 @@ namespace UnitsNet
         {
             return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get MassFlow from MegapoundsPerHour.
+        /// </summary>
+        public static MassFlow FromMegapoundsPerHour(int megapoundsperhour)
+        {
+            return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from MegapoundsPerHour.
+        /// </summary>
+        public static MassFlow FromMegapoundsPerHour(long megapoundsperhour)
+        {
+            return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from MegapoundsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow FromMegapoundsPerHour(decimal megapoundsperhour)
+        {
+	        return new MassFlow((Convert.ToDouble(megapoundsperhour)/7.93664) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
@@ -322,6 +538,33 @@ namespace UnitsNet
             return new MassFlow((microgramspersecond) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get MassFlow from MicrogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromMicrogramsPerSecond(int microgramspersecond)
+        {
+            return new MassFlow((microgramspersecond) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from MicrogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromMicrogramsPerSecond(long microgramspersecond)
+        {
+            return new MassFlow((microgramspersecond) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from MicrogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromMicrogramsPerSecond(decimal microgramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(microgramspersecond)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
@@ -329,6 +572,33 @@ namespace UnitsNet
         {
             return new MassFlow((milligramspersecond) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get MassFlow from MilligramsPerSecond.
+        /// </summary>
+        public static MassFlow FromMilligramsPerSecond(int milligramspersecond)
+        {
+            return new MassFlow((milligramspersecond) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from MilligramsPerSecond.
+        /// </summary>
+        public static MassFlow FromMilligramsPerSecond(long milligramspersecond)
+        {
+            return new MassFlow((milligramspersecond) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from MilligramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromMilligramsPerSecond(decimal milligramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(milligramspersecond)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
@@ -338,6 +608,33 @@ namespace UnitsNet
             return new MassFlow((nanogramspersecond) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get MassFlow from NanogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromNanogramsPerSecond(int nanogramspersecond)
+        {
+            return new MassFlow((nanogramspersecond) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from NanogramsPerSecond.
+        /// </summary>
+        public static MassFlow FromNanogramsPerSecond(long nanogramspersecond)
+        {
+            return new MassFlow((nanogramspersecond) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from NanogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow FromNanogramsPerSecond(decimal nanogramspersecond)
+        {
+	        return new MassFlow((Convert.ToDouble(nanogramspersecond)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
@@ -345,6 +642,33 @@ namespace UnitsNet
         {
             return new MassFlow(poundsperhour/7.93664);
         }
+
+		/// <summary>
+        ///     Get MassFlow from PoundsPerHour.
+        /// </summary>
+        public static MassFlow FromPoundsPerHour(int poundsperhour)
+        {
+            return new MassFlow(poundsperhour/7.93664);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from PoundsPerHour.
+        /// </summary>
+        public static MassFlow FromPoundsPerHour(long poundsperhour)
+        {
+            return new MassFlow(poundsperhour/7.93664);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from PoundsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow FromPoundsPerHour(decimal poundsperhour)
+        {
+	        return new MassFlow(Convert.ToDouble(poundsperhour)/7.93664);
+        }
+#endif
 
         /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
@@ -354,6 +678,33 @@ namespace UnitsNet
             return new MassFlow(shorttonsperhour*251.9957611);
         }
 
+		/// <summary>
+        ///     Get MassFlow from ShortTonsPerHour.
+        /// </summary>
+        public static MassFlow FromShortTonsPerHour(int shorttonsperhour)
+        {
+            return new MassFlow(shorttonsperhour*251.9957611);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from ShortTonsPerHour.
+        /// </summary>
+        public static MassFlow FromShortTonsPerHour(long shorttonsperhour)
+        {
+            return new MassFlow(shorttonsperhour*251.9957611);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from ShortTonsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow FromShortTonsPerHour(decimal shorttonsperhour)
+        {
+	        return new MassFlow(Convert.ToDouble(shorttonsperhour)*251.9957611);
+        }
+#endif
+
         /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
@@ -362,12 +713,84 @@ namespace UnitsNet
             return new MassFlow(tonnesperday/0.0864000);
         }
 
+		/// <summary>
+        ///     Get MassFlow from TonnesPerDay.
+        /// </summary>
+        public static MassFlow FromTonnesPerDay(int tonnesperday)
+        {
+            return new MassFlow(tonnesperday/0.0864000);
+        }
+
+		/// <summary>
+        ///     Get MassFlow from TonnesPerDay.
+        /// </summary>
+        public static MassFlow FromTonnesPerDay(long tonnesperday)
+        {
+            return new MassFlow(tonnesperday/0.0864000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassFlow from TonnesPerDay of type decimal.
+        /// </summary>
+        public static MassFlow FromTonnesPerDay(decimal tonnesperday)
+        {
+	        return new MassFlow(Convert.ToDouble(tonnesperday)/0.0864000);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable MassFlow from nullable CentigramsPerSecond.
         /// </summary>
         public static MassFlow? FromCentigramsPerSecond(double? centigramspersecond)
+        {
+            if (centigramspersecond.HasValue)
+            {
+                return FromCentigramsPerSecond(centigramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable CentigramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromCentigramsPerSecond(int? centigramspersecond)
+        {
+            if (centigramspersecond.HasValue)
+            {
+                return FromCentigramsPerSecond(centigramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable CentigramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromCentigramsPerSecond(long? centigramspersecond)
+        {
+            if (centigramspersecond.HasValue)
+            {
+                return FromCentigramsPerSecond(centigramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from CentigramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromCentigramsPerSecond(decimal? centigramspersecond)
         {
             if (centigramspersecond.HasValue)
             {
@@ -394,10 +817,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable DecagramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromDecagramsPerSecond(int? decagramspersecond)
+        {
+            if (decagramspersecond.HasValue)
+            {
+                return FromDecagramsPerSecond(decagramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable DecagramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromDecagramsPerSecond(long? decagramspersecond)
+        {
+            if (decagramspersecond.HasValue)
+            {
+                return FromDecagramsPerSecond(decagramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from DecagramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromDecagramsPerSecond(decimal? decagramspersecond)
+        {
+            if (decagramspersecond.HasValue)
+            {
+                return FromDecagramsPerSecond(decagramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable DecigramsPerSecond.
         /// </summary>
         public static MassFlow? FromDecigramsPerSecond(double? decigramspersecond)
+        {
+            if (decigramspersecond.HasValue)
+            {
+                return FromDecigramsPerSecond(decigramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable DecigramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromDecigramsPerSecond(int? decigramspersecond)
+        {
+            if (decigramspersecond.HasValue)
+            {
+                return FromDecigramsPerSecond(decigramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable DecigramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromDecigramsPerSecond(long? decigramspersecond)
+        {
+            if (decigramspersecond.HasValue)
+            {
+                return FromDecigramsPerSecond(decigramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from DecigramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromDecigramsPerSecond(decimal? decigramspersecond)
         {
             if (decigramspersecond.HasValue)
             {
@@ -424,10 +937,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable GramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromGramsPerSecond(int? gramspersecond)
+        {
+            if (gramspersecond.HasValue)
+            {
+                return FromGramsPerSecond(gramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable GramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromGramsPerSecond(long? gramspersecond)
+        {
+            if (gramspersecond.HasValue)
+            {
+                return FromGramsPerSecond(gramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from GramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromGramsPerSecond(decimal? gramspersecond)
+        {
+            if (gramspersecond.HasValue)
+            {
+                return FromGramsPerSecond(gramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable HectogramsPerSecond.
         /// </summary>
         public static MassFlow? FromHectogramsPerSecond(double? hectogramspersecond)
+        {
+            if (hectogramspersecond.HasValue)
+            {
+                return FromHectogramsPerSecond(hectogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable HectogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromHectogramsPerSecond(int? hectogramspersecond)
+        {
+            if (hectogramspersecond.HasValue)
+            {
+                return FromHectogramsPerSecond(hectogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable HectogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromHectogramsPerSecond(long? hectogramspersecond)
+        {
+            if (hectogramspersecond.HasValue)
+            {
+                return FromHectogramsPerSecond(hectogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from HectogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromHectogramsPerSecond(decimal? hectogramspersecond)
         {
             if (hectogramspersecond.HasValue)
             {
@@ -454,10 +1057,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable KilogramsPerHour.
+        /// </summary>
+        public static MassFlow? FromKilogramsPerHour(int? kilogramsperhour)
+        {
+            if (kilogramsperhour.HasValue)
+            {
+                return FromKilogramsPerHour(kilogramsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable KilogramsPerHour.
+        /// </summary>
+        public static MassFlow? FromKilogramsPerHour(long? kilogramsperhour)
+        {
+            if (kilogramsperhour.HasValue)
+            {
+                return FromKilogramsPerHour(kilogramsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from KilogramsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow? FromKilogramsPerHour(decimal? kilogramsperhour)
+        {
+            if (kilogramsperhour.HasValue)
+            {
+                return FromKilogramsPerHour(kilogramsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerSecond.
         /// </summary>
         public static MassFlow? FromKilogramsPerSecond(double? kilogramspersecond)
+        {
+            if (kilogramspersecond.HasValue)
+            {
+                return FromKilogramsPerSecond(kilogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable KilogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromKilogramsPerSecond(int? kilogramspersecond)
+        {
+            if (kilogramspersecond.HasValue)
+            {
+                return FromKilogramsPerSecond(kilogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable KilogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromKilogramsPerSecond(long? kilogramspersecond)
+        {
+            if (kilogramspersecond.HasValue)
+            {
+                return FromKilogramsPerSecond(kilogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from KilogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromKilogramsPerSecond(decimal? kilogramspersecond)
         {
             if (kilogramspersecond.HasValue)
             {
@@ -484,10 +1177,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable MegapoundsPerHour.
+        /// </summary>
+        public static MassFlow? FromMegapoundsPerHour(int? megapoundsperhour)
+        {
+            if (megapoundsperhour.HasValue)
+            {
+                return FromMegapoundsPerHour(megapoundsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable MegapoundsPerHour.
+        /// </summary>
+        public static MassFlow? FromMegapoundsPerHour(long? megapoundsperhour)
+        {
+            if (megapoundsperhour.HasValue)
+            {
+                return FromMegapoundsPerHour(megapoundsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from MegapoundsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow? FromMegapoundsPerHour(decimal? megapoundsperhour)
+        {
+            if (megapoundsperhour.HasValue)
+            {
+                return FromMegapoundsPerHour(megapoundsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
         /// </summary>
         public static MassFlow? FromMicrogramsPerSecond(double? microgramspersecond)
+        {
+            if (microgramspersecond.HasValue)
+            {
+                return FromMicrogramsPerSecond(microgramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromMicrogramsPerSecond(int? microgramspersecond)
+        {
+            if (microgramspersecond.HasValue)
+            {
+                return FromMicrogramsPerSecond(microgramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromMicrogramsPerSecond(long? microgramspersecond)
+        {
+            if (microgramspersecond.HasValue)
+            {
+                return FromMicrogramsPerSecond(microgramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from MicrogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromMicrogramsPerSecond(decimal? microgramspersecond)
         {
             if (microgramspersecond.HasValue)
             {
@@ -514,10 +1297,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable MilligramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromMilligramsPerSecond(int? milligramspersecond)
+        {
+            if (milligramspersecond.HasValue)
+            {
+                return FromMilligramsPerSecond(milligramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable MilligramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromMilligramsPerSecond(long? milligramspersecond)
+        {
+            if (milligramspersecond.HasValue)
+            {
+                return FromMilligramsPerSecond(milligramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from MilligramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromMilligramsPerSecond(decimal? milligramspersecond)
+        {
+            if (milligramspersecond.HasValue)
+            {
+                return FromMilligramsPerSecond(milligramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable NanogramsPerSecond.
         /// </summary>
         public static MassFlow? FromNanogramsPerSecond(double? nanogramspersecond)
+        {
+            if (nanogramspersecond.HasValue)
+            {
+                return FromNanogramsPerSecond(nanogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable NanogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromNanogramsPerSecond(int? nanogramspersecond)
+        {
+            if (nanogramspersecond.HasValue)
+            {
+                return FromNanogramsPerSecond(nanogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable NanogramsPerSecond.
+        /// </summary>
+        public static MassFlow? FromNanogramsPerSecond(long? nanogramspersecond)
+        {
+            if (nanogramspersecond.HasValue)
+            {
+                return FromNanogramsPerSecond(nanogramspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from NanogramsPerSecond of type decimal.
+        /// </summary>
+        public static MassFlow? FromNanogramsPerSecond(decimal? nanogramspersecond)
         {
             if (nanogramspersecond.HasValue)
             {
@@ -544,6 +1417,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable PoundsPerHour.
+        /// </summary>
+        public static MassFlow? FromPoundsPerHour(int? poundsperhour)
+        {
+            if (poundsperhour.HasValue)
+            {
+                return FromPoundsPerHour(poundsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable PoundsPerHour.
+        /// </summary>
+        public static MassFlow? FromPoundsPerHour(long? poundsperhour)
+        {
+            if (poundsperhour.HasValue)
+            {
+                return FromPoundsPerHour(poundsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from PoundsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow? FromPoundsPerHour(decimal? poundsperhour)
+        {
+            if (poundsperhour.HasValue)
+            {
+                return FromPoundsPerHour(poundsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable ShortTonsPerHour.
         /// </summary>
@@ -559,10 +1477,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassFlow from nullable ShortTonsPerHour.
+        /// </summary>
+        public static MassFlow? FromShortTonsPerHour(int? shorttonsperhour)
+        {
+            if (shorttonsperhour.HasValue)
+            {
+                return FromShortTonsPerHour(shorttonsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable ShortTonsPerHour.
+        /// </summary>
+        public static MassFlow? FromShortTonsPerHour(long? shorttonsperhour)
+        {
+            if (shorttonsperhour.HasValue)
+            {
+                return FromShortTonsPerHour(shorttonsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from ShortTonsPerHour of type decimal.
+        /// </summary>
+        public static MassFlow? FromShortTonsPerHour(decimal? shorttonsperhour)
+        {
+            if (shorttonsperhour.HasValue)
+            {
+                return FromShortTonsPerHour(shorttonsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassFlow from nullable TonnesPerDay.
         /// </summary>
         public static MassFlow? FromTonnesPerDay(double? tonnesperday)
+        {
+            if (tonnesperday.HasValue)
+            {
+                return FromTonnesPerDay(tonnesperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable TonnesPerDay.
+        /// </summary>
+        public static MassFlow? FromTonnesPerDay(int? tonnesperday)
+        {
+            if (tonnesperday.HasValue)
+            {
+                return FromTonnesPerDay(tonnesperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from nullable TonnesPerDay.
+        /// </summary>
+        public static MassFlow? FromTonnesPerDay(long? tonnesperday)
+        {
+            if (tonnesperday.HasValue)
+            {
+                return FromTonnesPerDay(tonnesperday.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassFlow from TonnesPerDay of type decimal.
+        /// </summary>
+        public static MassFlow? FromTonnesPerDay(decimal? tonnesperday)
         {
             if (tonnesperday.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -253,6 +253,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from CentigramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromCentigramsPerSecond(double centigramspersecond)
         {
             return new MassFlow((centigramspersecond) * 1e-2d);
@@ -288,6 +291,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromDecagramsPerSecond(double decagramspersecond)
         {
             return new MassFlow((decagramspersecond) * 1e1d);
@@ -323,6 +329,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromDecigramsPerSecond(double decigramspersecond)
         {
             return new MassFlow((decigramspersecond) * 1e-1d);
@@ -358,6 +367,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromGramsPerSecond(double gramspersecond)
         {
             return new MassFlow(gramspersecond);
@@ -393,6 +405,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromHectogramsPerSecond(double hectogramspersecond)
         {
             return new MassFlow((hectogramspersecond) * 1e2d);
@@ -428,6 +443,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromKilogramsPerHour(double kilogramsperhour)
         {
             return new MassFlow(kilogramsperhour/3.6);
@@ -463,6 +481,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromKilogramsPerSecond(double kilogramspersecond)
         {
             return new MassFlow((kilogramspersecond) * 1e3d);
@@ -498,6 +519,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromMegapoundsPerHour(double megapoundsperhour)
         {
             return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
@@ -533,6 +557,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromMicrogramsPerSecond(double microgramspersecond)
         {
             return new MassFlow((microgramspersecond) * 1e-6d);
@@ -568,6 +595,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromMilligramsPerSecond(double milligramspersecond)
         {
             return new MassFlow((milligramspersecond) * 1e-3d);
@@ -603,6 +633,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromNanogramsPerSecond(double nanogramspersecond)
         {
             return new MassFlow((nanogramspersecond) * 1e-9d);
@@ -638,6 +671,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromPoundsPerHour(double poundsperhour)
         {
             return new MassFlow(poundsperhour/7.93664);
@@ -673,6 +709,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromShortTonsPerHour(double shorttonsperhour)
         {
             return new MassFlow(shorttonsperhour*251.9957611);
@@ -708,6 +747,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassFlow FromTonnesPerDay(double tonnesperday)
         {
             return new MassFlow(tonnesperday/0.0864000);

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _kilogramSquareMeters;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public MassMomentOfInertia() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.MassMomentOfInertia;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static MassMomentOfInertiaUnit BaseUnit
         {
             get { return MassMomentOfInertiaUnit.KilogramSquareMeter; }
@@ -354,7 +354,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquarecentimeters/1e7);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareCentimeters(int gramsquarecentimeters)
@@ -362,7 +362,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquarecentimeters/1e7);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareCentimeters(long gramsquarecentimeters)
@@ -370,14 +370,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquarecentimeters/1e7);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareCentimeters(decimal gramsquarecentimeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(gramsquarecentimeters)/1e7);
+            return new MassMomentOfInertia(Convert.ToDouble(gramsquarecentimeters)/1e7);
         }
 #endif
 
@@ -389,7 +389,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaredecimeters/1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareDecimeters(int gramsquaredecimeters)
@@ -397,7 +397,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaredecimeters/1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareDecimeters(long gramsquaredecimeters)
@@ -405,14 +405,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaredecimeters/1e5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareDecimeters(decimal gramsquaredecimeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(gramsquaredecimeters)/1e5);
+            return new MassMomentOfInertia(Convert.ToDouble(gramsquaredecimeters)/1e5);
         }
 #endif
 
@@ -424,7 +424,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremeters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareMeters(int gramsquaremeters)
@@ -432,7 +432,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremeters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareMeters(long gramsquaremeters)
@@ -440,14 +440,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremeters/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareMeters(decimal gramsquaremeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(gramsquaremeters)/1e3);
+            return new MassMomentOfInertia(Convert.ToDouble(gramsquaremeters)/1e3);
         }
 #endif
 
@@ -459,7 +459,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremillimeters/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareMillimeters(int gramsquaremillimeters)
@@ -467,7 +467,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremillimeters/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareMillimeters(long gramsquaremillimeters)
@@ -475,14 +475,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremillimeters/1e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromGramSquareMillimeters(decimal gramsquaremillimeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(gramsquaremillimeters)/1e9);
+            return new MassMomentOfInertia(Convert.ToDouble(gramsquaremillimeters)/1e9);
         }
 #endif
 
@@ -494,7 +494,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareCentimeters(int kilogramsquarecentimeters)
@@ -502,7 +502,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareCentimeters(long kilogramsquarecentimeters)
@@ -510,14 +510,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareCentimeters(decimal kilogramsquarecentimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquarecentimeters)/1e7) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquarecentimeters)/1e7) * 1e3d);
         }
 #endif
 
@@ -529,7 +529,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareDecimeters(int kilogramsquaredecimeters)
@@ -537,7 +537,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareDecimeters(long kilogramsquaredecimeters)
@@ -545,14 +545,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareDecimeters(decimal kilogramsquaredecimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaredecimeters)/1e5) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaredecimeters)/1e5) * 1e3d);
         }
 #endif
 
@@ -564,7 +564,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareMeters(int kilogramsquaremeters)
@@ -572,7 +572,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareMeters(long kilogramsquaremeters)
@@ -580,14 +580,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareMeters(decimal kilogramsquaremeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremeters)/1e3) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremeters)/1e3) * 1e3d);
         }
 #endif
 
@@ -599,7 +599,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareMillimeters(int kilogramsquaremillimeters)
@@ -607,7 +607,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareMillimeters(long kilogramsquaremillimeters)
@@ -615,14 +615,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilogramSquareMillimeters(decimal kilogramsquaremillimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremillimeters)/1e9) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremillimeters)/1e9) * 1e3d);
         }
 #endif
 
@@ -634,7 +634,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(int kilotonnesquarecentimeters)
@@ -642,7 +642,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(long kilotonnesquarecentimeters)
@@ -650,14 +650,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(decimal kilotonnesquarecentimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquarecentimeters)/1e1) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquarecentimeters)/1e1) * 1e3d);
         }
 #endif
 
@@ -669,7 +669,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(int kilotonnesquaredecimeters)
@@ -677,7 +677,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(long kilotonnesquaredecimeters)
@@ -685,14 +685,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(decimal kilotonnesquaredecimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaredecimeters)/1e-1) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaredecimeters)/1e-1) * 1e3d);
         }
 #endif
 
@@ -704,7 +704,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareMeters(int kilotonnesquaremeters)
@@ -712,7 +712,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareMeters(long kilotonnesquaremeters)
@@ -720,14 +720,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareMeters(decimal kilotonnesquaremeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremeters)/1e-3) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremeters)/1e-3) * 1e3d);
         }
 #endif
 
@@ -739,7 +739,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(int kilotonnesquaremilimeters)
@@ -747,7 +747,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(long kilotonnesquaremilimeters)
@@ -755,14 +755,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(decimal kilotonnesquaremilimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremilimeters)/1e3) * 1e3d);
+            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremilimeters)/1e3) * 1e3d);
         }
 #endif
 
@@ -774,7 +774,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(int megatonnesquarecentimeters)
@@ -782,7 +782,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(long megatonnesquarecentimeters)
@@ -790,14 +790,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(decimal megatonnesquarecentimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquarecentimeters)/1e1) * 1e6d);
+            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquarecentimeters)/1e1) * 1e6d);
         }
 #endif
 
@@ -809,7 +809,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(int megatonnesquaredecimeters)
@@ -817,7 +817,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(long megatonnesquaredecimeters)
@@ -825,14 +825,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(decimal megatonnesquaredecimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaredecimeters)/1e-1) * 1e6d);
+            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaredecimeters)/1e-1) * 1e6d);
         }
 #endif
 
@@ -844,7 +844,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareMeters(int megatonnesquaremeters)
@@ -852,7 +852,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareMeters(long megatonnesquaremeters)
@@ -860,14 +860,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareMeters(decimal megatonnesquaremeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremeters)/1e-3) * 1e6d);
+            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremeters)/1e-3) * 1e6d);
         }
 #endif
 
@@ -879,7 +879,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(int megatonnesquaremilimeters)
@@ -887,7 +887,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(long megatonnesquaremilimeters)
@@ -895,14 +895,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(decimal megatonnesquaremilimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremilimeters)/1e3) * 1e6d);
+            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremilimeters)/1e3) * 1e6d);
         }
 #endif
 
@@ -914,7 +914,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareCentimeters(int milligramsquarecentimeters)
@@ -922,7 +922,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareCentimeters(long milligramsquarecentimeters)
@@ -930,14 +930,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareCentimeters(decimal milligramsquarecentimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquarecentimeters)/1e7) * 1e-3d);
+            return new MassMomentOfInertia((Convert.ToDouble(milligramsquarecentimeters)/1e7) * 1e-3d);
         }
 #endif
 
@@ -949,7 +949,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareDecimeters(int milligramsquaredecimeters)
@@ -957,7 +957,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareDecimeters(long milligramsquaredecimeters)
@@ -965,14 +965,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareDecimeters(decimal milligramsquaredecimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquaredecimeters)/1e5) * 1e-3d);
+            return new MassMomentOfInertia((Convert.ToDouble(milligramsquaredecimeters)/1e5) * 1e-3d);
         }
 #endif
 
@@ -984,7 +984,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareMeters(int milligramsquaremeters)
@@ -992,7 +992,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareMeters(long milligramsquaremeters)
@@ -1000,14 +1000,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareMeters(decimal milligramsquaremeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremeters)/1e3) * 1e-3d);
+            return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremeters)/1e3) * 1e-3d);
         }
 #endif
 
@@ -1019,7 +1019,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareMillimeters(int milligramsquaremillimeters)
@@ -1027,7 +1027,7 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareMillimeters(long milligramsquaremillimeters)
@@ -1035,14 +1035,14 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromMilligramSquareMillimeters(decimal milligramsquaremillimeters)
         {
-	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremillimeters)/1e9) * 1e-3d);
+            return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremillimeters)/1e9) * 1e-3d);
         }
 #endif
 
@@ -1054,7 +1054,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
         /// </summary>
         public static MassMomentOfInertia FromPoundSquareFeet(int poundsquarefeet)
@@ -1062,7 +1062,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
         /// </summary>
         public static MassMomentOfInertia FromPoundSquareFeet(long poundsquarefeet)
@@ -1070,14 +1070,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromPoundSquareFeet(decimal poundsquarefeet)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(poundsquarefeet)*4.21401101e-2);
+            return new MassMomentOfInertia(Convert.ToDouble(poundsquarefeet)*4.21401101e-2);
         }
 #endif
 
@@ -1089,7 +1089,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
         public static MassMomentOfInertia FromPoundSquareInches(int poundsquareinches)
@@ -1097,7 +1097,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
         public static MassMomentOfInertia FromPoundSquareInches(long poundsquareinches)
@@ -1105,14 +1105,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromPoundSquareInches(decimal poundsquareinches)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(poundsquareinches)*2.9263965e-4);
+            return new MassMomentOfInertia(Convert.ToDouble(poundsquareinches)*2.9263965e-4);
         }
 #endif
 
@@ -1124,7 +1124,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareCentimeters(int tonnesquarecentimeters)
@@ -1132,7 +1132,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareCentimeters(long tonnesquarecentimeters)
@@ -1140,14 +1140,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareCentimeters(decimal tonnesquarecentimeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquarecentimeters)/1e1);
+            return new MassMomentOfInertia(Convert.ToDouble(tonnesquarecentimeters)/1e1);
         }
 #endif
 
@@ -1159,7 +1159,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareDecimeters(int tonnesquaredecimeters)
@@ -1167,7 +1167,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareDecimeters(long tonnesquaredecimeters)
@@ -1175,14 +1175,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareDecimeters(decimal tonnesquaredecimeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquaredecimeters)/1e-1);
+            return new MassMomentOfInertia(Convert.ToDouble(tonnesquaredecimeters)/1e-1);
         }
 #endif
 
@@ -1194,7 +1194,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremeters/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareMeters(int tonnesquaremeters)
@@ -1202,7 +1202,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremeters/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareMeters(long tonnesquaremeters)
@@ -1210,14 +1210,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremeters/1e-3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareMeters(decimal tonnesquaremeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremeters)/1e-3);
+            return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremeters)/1e-3);
         }
 #endif
 
@@ -1229,7 +1229,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareMilimeters(int tonnesquaremilimeters)
@@ -1237,7 +1237,7 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareMilimeters(long tonnesquaremilimeters)
@@ -1245,14 +1245,14 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia FromTonneSquareMilimeters(decimal tonnesquaremilimeters)
         {
-	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremilimeters)/1e3);
+            return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremilimeters)/1e3);
         }
 #endif
 
@@ -1273,7 +1273,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareCentimeters(int? gramsquarecentimeters)
@@ -1288,7 +1288,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareCentimeters(long? gramsquarecentimeters)
@@ -1303,7 +1303,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from GramSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareCentimeters(decimal? gramsquarecentimeters)
@@ -1333,7 +1333,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareDecimeters(int? gramsquaredecimeters)
@@ -1348,7 +1348,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareDecimeters(long? gramsquaredecimeters)
@@ -1363,7 +1363,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from GramSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareDecimeters(decimal? gramsquaredecimeters)
@@ -1393,7 +1393,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMeters(int? gramsquaremeters)
@@ -1408,7 +1408,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMeters(long? gramsquaremeters)
@@ -1423,7 +1423,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from GramSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMeters(decimal? gramsquaremeters)
@@ -1453,7 +1453,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMillimeters(int? gramsquaremillimeters)
@@ -1468,7 +1468,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMillimeters(long? gramsquaremillimeters)
@@ -1483,7 +1483,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from GramSquareMillimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMillimeters(decimal? gramsquaremillimeters)
@@ -1513,7 +1513,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareCentimeters(int? kilogramsquarecentimeters)
@@ -1528,7 +1528,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareCentimeters(long? kilogramsquarecentimeters)
@@ -1543,7 +1543,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilogramSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareCentimeters(decimal? kilogramsquarecentimeters)
@@ -1573,7 +1573,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareDecimeters(int? kilogramsquaredecimeters)
@@ -1588,7 +1588,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareDecimeters(long? kilogramsquaredecimeters)
@@ -1603,7 +1603,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilogramSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareDecimeters(decimal? kilogramsquaredecimeters)
@@ -1633,7 +1633,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMeters(int? kilogramsquaremeters)
@@ -1648,7 +1648,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMeters(long? kilogramsquaremeters)
@@ -1663,7 +1663,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilogramSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMeters(decimal? kilogramsquaremeters)
@@ -1693,7 +1693,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMillimeters(int? kilogramsquaremillimeters)
@@ -1708,7 +1708,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMillimeters(long? kilogramsquaremillimeters)
@@ -1723,7 +1723,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilogramSquareMillimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMillimeters(decimal? kilogramsquaremillimeters)
@@ -1753,7 +1753,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareCentimeters(int? kilotonnesquarecentimeters)
@@ -1768,7 +1768,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareCentimeters(long? kilotonnesquarecentimeters)
@@ -1783,7 +1783,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilotonneSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareCentimeters(decimal? kilotonnesquarecentimeters)
@@ -1813,7 +1813,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareDecimeters(int? kilotonnesquaredecimeters)
@@ -1828,7 +1828,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareDecimeters(long? kilotonnesquaredecimeters)
@@ -1843,7 +1843,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilotonneSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareDecimeters(decimal? kilotonnesquaredecimeters)
@@ -1873,7 +1873,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMeters(int? kilotonnesquaremeters)
@@ -1888,7 +1888,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMeters(long? kilotonnesquaremeters)
@@ -1903,7 +1903,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilotonneSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMeters(decimal? kilotonnesquaremeters)
@@ -1933,7 +1933,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMilimeters(int? kilotonnesquaremilimeters)
@@ -1948,7 +1948,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMilimeters(long? kilotonnesquaremilimeters)
@@ -1963,7 +1963,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from KilotonneSquareMilimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMilimeters(decimal? kilotonnesquaremilimeters)
@@ -1993,7 +1993,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareCentimeters(int? megatonnesquarecentimeters)
@@ -2008,7 +2008,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareCentimeters(long? megatonnesquarecentimeters)
@@ -2023,7 +2023,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MegatonneSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareCentimeters(decimal? megatonnesquarecentimeters)
@@ -2053,7 +2053,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareDecimeters(int? megatonnesquaredecimeters)
@@ -2068,7 +2068,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareDecimeters(long? megatonnesquaredecimeters)
@@ -2083,7 +2083,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MegatonneSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareDecimeters(decimal? megatonnesquaredecimeters)
@@ -2113,7 +2113,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMeters(int? megatonnesquaremeters)
@@ -2128,7 +2128,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMeters(long? megatonnesquaremeters)
@@ -2143,7 +2143,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MegatonneSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMeters(decimal? megatonnesquaremeters)
@@ -2173,7 +2173,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMilimeters(int? megatonnesquaremilimeters)
@@ -2188,7 +2188,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMilimeters(long? megatonnesquaremilimeters)
@@ -2203,7 +2203,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MegatonneSquareMilimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMilimeters(decimal? megatonnesquaremilimeters)
@@ -2233,7 +2233,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareCentimeters(int? milligramsquarecentimeters)
@@ -2248,7 +2248,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareCentimeters(long? milligramsquarecentimeters)
@@ -2263,7 +2263,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MilligramSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareCentimeters(decimal? milligramsquarecentimeters)
@@ -2293,7 +2293,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareDecimeters(int? milligramsquaredecimeters)
@@ -2308,7 +2308,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareDecimeters(long? milligramsquaredecimeters)
@@ -2323,7 +2323,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MilligramSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareDecimeters(decimal? milligramsquaredecimeters)
@@ -2353,7 +2353,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMeters(int? milligramsquaremeters)
@@ -2368,7 +2368,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMeters(long? milligramsquaremeters)
@@ -2383,7 +2383,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MilligramSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMeters(decimal? milligramsquaremeters)
@@ -2413,7 +2413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMillimeters(int? milligramsquaremillimeters)
@@ -2428,7 +2428,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMillimeters(long? milligramsquaremillimeters)
@@ -2443,7 +2443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from MilligramSquareMillimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMillimeters(decimal? milligramsquaremillimeters)
@@ -2473,7 +2473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareFeet(int? poundsquarefeet)
@@ -2488,7 +2488,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareFeet(long? poundsquarefeet)
@@ -2503,7 +2503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from PoundSquareFeet of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareFeet(decimal? poundsquarefeet)
@@ -2533,7 +2533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareInches(int? poundsquareinches)
@@ -2548,7 +2548,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareInches(long? poundsquareinches)
@@ -2563,7 +2563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from PoundSquareInches of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareInches(decimal? poundsquareinches)
@@ -2593,7 +2593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareCentimeters(int? tonnesquarecentimeters)
@@ -2608,7 +2608,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareCentimeters(long? tonnesquarecentimeters)
@@ -2623,7 +2623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from TonneSquareCentimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareCentimeters(decimal? tonnesquarecentimeters)
@@ -2653,7 +2653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareDecimeters(int? tonnesquaredecimeters)
@@ -2668,7 +2668,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareDecimeters(long? tonnesquaredecimeters)
@@ -2683,7 +2683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from TonneSquareDecimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareDecimeters(decimal? tonnesquaredecimeters)
@@ -2713,7 +2713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMeters(int? tonnesquaremeters)
@@ -2728,7 +2728,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMeters(long? tonnesquaremeters)
@@ -2743,7 +2743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from TonneSquareMeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMeters(decimal? tonnesquaremeters)
@@ -2773,7 +2773,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMilimeters(int? tonnesquaremilimeters)
@@ -2788,7 +2788,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMilimeters(long? tonnesquaremilimeters)
@@ -2803,7 +2803,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable MassMomentOfInertia from TonneSquareMilimeters of type decimal.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMilimeters(decimal? tonnesquaremilimeters)

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -354,6 +354,33 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquarecentimeters/1e7);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareCentimeters(int gramsquarecentimeters)
+        {
+            return new MassMomentOfInertia(gramsquarecentimeters/1e7);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareCentimeters(long gramsquarecentimeters)
+        {
+            return new MassMomentOfInertia(gramsquarecentimeters/1e7);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareCentimeters(decimal gramsquarecentimeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(gramsquarecentimeters)/1e7);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
@@ -361,6 +388,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia(gramsquaredecimeters/1e5);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareDecimeters(int gramsquaredecimeters)
+        {
+            return new MassMomentOfInertia(gramsquaredecimeters/1e5);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareDecimeters(long gramsquaredecimeters)
+        {
+            return new MassMomentOfInertia(gramsquaredecimeters/1e5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareDecimeters(decimal gramsquaredecimeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(gramsquaredecimeters)/1e5);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
@@ -370,6 +424,33 @@ namespace UnitsNet
             return new MassMomentOfInertia(gramsquaremeters/1e3);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareMeters(int gramsquaremeters)
+        {
+            return new MassMomentOfInertia(gramsquaremeters/1e3);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareMeters(long gramsquaremeters)
+        {
+            return new MassMomentOfInertia(gramsquaremeters/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareMeters(decimal gramsquaremeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(gramsquaremeters)/1e3);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
@@ -377,6 +458,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia(gramsquaremillimeters/1e9);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareMillimeters(int gramsquaremillimeters)
+        {
+            return new MassMomentOfInertia(gramsquaremillimeters/1e9);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareMillimeters(long gramsquaremillimeters)
+        {
+            return new MassMomentOfInertia(gramsquaremillimeters/1e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from GramSquareMillimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromGramSquareMillimeters(decimal gramsquaremillimeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(gramsquaremillimeters)/1e9);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
@@ -386,6 +494,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareCentimeters(int kilogramsquarecentimeters)
+        {
+            return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareCentimeters(long kilogramsquarecentimeters)
+        {
+            return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareCentimeters(decimal kilogramsquarecentimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquarecentimeters)/1e7) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
@@ -393,6 +528,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareDecimeters(int kilogramsquaredecimeters)
+        {
+            return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareDecimeters(long kilogramsquaredecimeters)
+        {
+            return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareDecimeters(decimal kilogramsquaredecimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaredecimeters)/1e5) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
@@ -402,6 +564,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareMeters(int kilogramsquaremeters)
+        {
+            return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareMeters(long kilogramsquaremeters)
+        {
+            return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareMeters(decimal kilogramsquaremeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremeters)/1e3) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
@@ -409,6 +598,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareMillimeters(int kilogramsquaremillimeters)
+        {
+            return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareMillimeters(long kilogramsquaremillimeters)
+        {
+            return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilogramSquareMillimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilogramSquareMillimeters(decimal kilogramsquaremillimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremillimeters)/1e9) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
@@ -418,6 +634,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareCentimeters(int kilotonnesquarecentimeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareCentimeters(long kilotonnesquarecentimeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareCentimeters(decimal kilotonnesquarecentimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquarecentimeters)/1e1) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
@@ -425,6 +668,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareDecimeters(int kilotonnesquaredecimeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareDecimeters(long kilotonnesquaredecimeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareDecimeters(decimal kilotonnesquaredecimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaredecimeters)/1e-1) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
@@ -434,6 +704,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareMeters(int kilotonnesquaremeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareMeters(long kilotonnesquaremeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareMeters(decimal kilotonnesquaremeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremeters)/1e-3) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
@@ -441,6 +738,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareMilimeters(int kilotonnesquaremilimeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareMilimeters(long kilotonnesquaremilimeters)
+        {
+            return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from KilotonneSquareMilimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromKilotonneSquareMilimeters(decimal kilotonnesquaremilimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremilimeters)/1e3) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
@@ -450,6 +774,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareCentimeters(int megatonnesquarecentimeters)
+        {
+            return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareCentimeters(long megatonnesquarecentimeters)
+        {
+            return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareCentimeters(decimal megatonnesquarecentimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquarecentimeters)/1e1) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
@@ -457,6 +808,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareDecimeters(int megatonnesquaredecimeters)
+        {
+            return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareDecimeters(long megatonnesquaredecimeters)
+        {
+            return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareDecimeters(decimal megatonnesquaredecimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaredecimeters)/1e-1) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
@@ -466,6 +844,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareMeters(int megatonnesquaremeters)
+        {
+            return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareMeters(long megatonnesquaremeters)
+        {
+            return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareMeters(decimal megatonnesquaremeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremeters)/1e-3) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
@@ -473,6 +878,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareMilimeters(int megatonnesquaremilimeters)
+        {
+            return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareMilimeters(long megatonnesquaremilimeters)
+        {
+            return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MegatonneSquareMilimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMegatonneSquareMilimeters(decimal megatonnesquaremilimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremilimeters)/1e3) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
@@ -482,6 +914,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareCentimeters(int milligramsquarecentimeters)
+        {
+            return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareCentimeters(long milligramsquarecentimeters)
+        {
+            return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareCentimeters(decimal milligramsquarecentimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquarecentimeters)/1e7) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
@@ -489,6 +948,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareDecimeters(int milligramsquaredecimeters)
+        {
+            return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareDecimeters(long milligramsquaredecimeters)
+        {
+            return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareDecimeters(decimal milligramsquaredecimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquaredecimeters)/1e5) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
@@ -498,6 +984,33 @@ namespace UnitsNet
             return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareMeters(int milligramsquaremeters)
+        {
+            return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareMeters(long milligramsquaremeters)
+        {
+            return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareMeters(decimal milligramsquaremeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremeters)/1e3) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
@@ -505,6 +1018,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareMillimeters(int milligramsquaremillimeters)
+        {
+            return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareMillimeters(long milligramsquaremillimeters)
+        {
+            return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from MilligramSquareMillimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromMilligramSquareMillimeters(decimal milligramsquaremillimeters)
+        {
+	        return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremillimeters)/1e9) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
@@ -514,6 +1054,33 @@ namespace UnitsNet
             return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from PoundSquareFeet.
+        /// </summary>
+        public static MassMomentOfInertia FromPoundSquareFeet(int poundsquarefeet)
+        {
+            return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from PoundSquareFeet.
+        /// </summary>
+        public static MassMomentOfInertia FromPoundSquareFeet(long poundsquarefeet)
+        {
+            return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from PoundSquareFeet of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromPoundSquareFeet(decimal poundsquarefeet)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(poundsquarefeet)*4.21401101e-2);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
@@ -521,6 +1088,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from PoundSquareInches.
+        /// </summary>
+        public static MassMomentOfInertia FromPoundSquareInches(int poundsquareinches)
+        {
+            return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from PoundSquareInches.
+        /// </summary>
+        public static MassMomentOfInertia FromPoundSquareInches(long poundsquareinches)
+        {
+            return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from PoundSquareInches of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromPoundSquareInches(decimal poundsquareinches)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(poundsquareinches)*2.9263965e-4);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
@@ -530,6 +1124,33 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareCentimeters(int tonnesquarecentimeters)
+        {
+            return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareCentimeters(long tonnesquarecentimeters)
+        {
+            return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareCentimeters(decimal tonnesquarecentimeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquarecentimeters)/1e1);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
@@ -537,6 +1158,33 @@ namespace UnitsNet
         {
             return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
         }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareDecimeters(int tonnesquaredecimeters)
+        {
+            return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareDecimeters(long tonnesquaredecimeters)
+        {
+            return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareDecimeters(decimal tonnesquaredecimeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquaredecimeters)/1e-1);
+        }
+#endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
@@ -546,6 +1194,33 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremeters/1e-3);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareMeters(int tonnesquaremeters)
+        {
+            return new MassMomentOfInertia(tonnesquaremeters/1e-3);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareMeters(long tonnesquaremeters)
+        {
+            return new MassMomentOfInertia(tonnesquaremeters/1e-3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareMeters(decimal tonnesquaremeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremeters)/1e-3);
+        }
+#endif
+
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
@@ -554,12 +1229,84 @@ namespace UnitsNet
             return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
         }
 
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareMilimeters(int tonnesquaremilimeters)
+        {
+            return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
+        }
+
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareMilimeters(long tonnesquaremilimeters)
+        {
+            return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get MassMomentOfInertia from TonneSquareMilimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia FromTonneSquareMilimeters(decimal tonnesquaremilimeters)
+        {
+	        return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremilimeters)/1e3);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareCentimeters(double? gramsquarecentimeters)
+        {
+            if (gramsquarecentimeters.HasValue)
+            {
+                return FromGramSquareCentimeters(gramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareCentimeters(int? gramsquarecentimeters)
+        {
+            if (gramsquarecentimeters.HasValue)
+            {
+                return FromGramSquareCentimeters(gramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareCentimeters(long? gramsquarecentimeters)
+        {
+            if (gramsquarecentimeters.HasValue)
+            {
+                return FromGramSquareCentimeters(gramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from GramSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareCentimeters(decimal? gramsquarecentimeters)
         {
             if (gramsquarecentimeters.HasValue)
             {
@@ -586,10 +1333,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareDecimeters(int? gramsquaredecimeters)
+        {
+            if (gramsquaredecimeters.HasValue)
+            {
+                return FromGramSquareDecimeters(gramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareDecimeters(long? gramsquaredecimeters)
+        {
+            if (gramsquaredecimeters.HasValue)
+            {
+                return FromGramSquareDecimeters(gramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from GramSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareDecimeters(decimal? gramsquaredecimeters)
+        {
+            if (gramsquaredecimeters.HasValue)
+            {
+                return FromGramSquareDecimeters(gramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromGramSquareMeters(double? gramsquaremeters)
+        {
+            if (gramsquaremeters.HasValue)
+            {
+                return FromGramSquareMeters(gramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareMeters(int? gramsquaremeters)
+        {
+            if (gramsquaremeters.HasValue)
+            {
+                return FromGramSquareMeters(gramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareMeters(long? gramsquaremeters)
+        {
+            if (gramsquaremeters.HasValue)
+            {
+                return FromGramSquareMeters(gramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from GramSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareMeters(decimal? gramsquaremeters)
         {
             if (gramsquaremeters.HasValue)
             {
@@ -616,10 +1453,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareMillimeters(int? gramsquaremillimeters)
+        {
+            if (gramsquaremillimeters.HasValue)
+            {
+                return FromGramSquareMillimeters(gramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareMillimeters(long? gramsquaremillimeters)
+        {
+            if (gramsquaremillimeters.HasValue)
+            {
+                return FromGramSquareMillimeters(gramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from GramSquareMillimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromGramSquareMillimeters(decimal? gramsquaremillimeters)
+        {
+            if (gramsquaremillimeters.HasValue)
+            {
+                return FromGramSquareMillimeters(gramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareCentimeters(double? kilogramsquarecentimeters)
+        {
+            if (kilogramsquarecentimeters.HasValue)
+            {
+                return FromKilogramSquareCentimeters(kilogramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareCentimeters(int? kilogramsquarecentimeters)
+        {
+            if (kilogramsquarecentimeters.HasValue)
+            {
+                return FromKilogramSquareCentimeters(kilogramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareCentimeters(long? kilogramsquarecentimeters)
+        {
+            if (kilogramsquarecentimeters.HasValue)
+            {
+                return FromKilogramSquareCentimeters(kilogramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilogramSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareCentimeters(decimal? kilogramsquarecentimeters)
         {
             if (kilogramsquarecentimeters.HasValue)
             {
@@ -646,10 +1573,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareDecimeters(int? kilogramsquaredecimeters)
+        {
+            if (kilogramsquaredecimeters.HasValue)
+            {
+                return FromKilogramSquareDecimeters(kilogramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareDecimeters(long? kilogramsquaredecimeters)
+        {
+            if (kilogramsquaredecimeters.HasValue)
+            {
+                return FromKilogramSquareDecimeters(kilogramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilogramSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareDecimeters(decimal? kilogramsquaredecimeters)
+        {
+            if (kilogramsquaredecimeters.HasValue)
+            {
+                return FromKilogramSquareDecimeters(kilogramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilogramSquareMeters(double? kilogramsquaremeters)
+        {
+            if (kilogramsquaremeters.HasValue)
+            {
+                return FromKilogramSquareMeters(kilogramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareMeters(int? kilogramsquaremeters)
+        {
+            if (kilogramsquaremeters.HasValue)
+            {
+                return FromKilogramSquareMeters(kilogramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareMeters(long? kilogramsquaremeters)
+        {
+            if (kilogramsquaremeters.HasValue)
+            {
+                return FromKilogramSquareMeters(kilogramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilogramSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareMeters(decimal? kilogramsquaremeters)
         {
             if (kilogramsquaremeters.HasValue)
             {
@@ -676,10 +1693,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareMillimeters(int? kilogramsquaremillimeters)
+        {
+            if (kilogramsquaremillimeters.HasValue)
+            {
+                return FromKilogramSquareMillimeters(kilogramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareMillimeters(long? kilogramsquaremillimeters)
+        {
+            if (kilogramsquaremillimeters.HasValue)
+            {
+                return FromKilogramSquareMillimeters(kilogramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilogramSquareMillimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilogramSquareMillimeters(decimal? kilogramsquaremillimeters)
+        {
+            if (kilogramsquaremillimeters.HasValue)
+            {
+                return FromKilogramSquareMillimeters(kilogramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareCentimeters(double? kilotonnesquarecentimeters)
+        {
+            if (kilotonnesquarecentimeters.HasValue)
+            {
+                return FromKilotonneSquareCentimeters(kilotonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(int? kilotonnesquarecentimeters)
+        {
+            if (kilotonnesquarecentimeters.HasValue)
+            {
+                return FromKilotonneSquareCentimeters(kilotonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(long? kilotonnesquarecentimeters)
+        {
+            if (kilotonnesquarecentimeters.HasValue)
+            {
+                return FromKilotonneSquareCentimeters(kilotonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilotonneSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(decimal? kilotonnesquarecentimeters)
         {
             if (kilotonnesquarecentimeters.HasValue)
             {
@@ -706,10 +1813,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(int? kilotonnesquaredecimeters)
+        {
+            if (kilotonnesquaredecimeters.HasValue)
+            {
+                return FromKilotonneSquareDecimeters(kilotonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(long? kilotonnesquaredecimeters)
+        {
+            if (kilotonnesquaredecimeters.HasValue)
+            {
+                return FromKilotonneSquareDecimeters(kilotonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilotonneSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(decimal? kilotonnesquaredecimeters)
+        {
+            if (kilotonnesquaredecimeters.HasValue)
+            {
+                return FromKilotonneSquareDecimeters(kilotonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromKilotonneSquareMeters(double? kilotonnesquaremeters)
+        {
+            if (kilotonnesquaremeters.HasValue)
+            {
+                return FromKilotonneSquareMeters(kilotonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareMeters(int? kilotonnesquaremeters)
+        {
+            if (kilotonnesquaremeters.HasValue)
+            {
+                return FromKilotonneSquareMeters(kilotonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareMeters(long? kilotonnesquaremeters)
+        {
+            if (kilotonnesquaremeters.HasValue)
+            {
+                return FromKilotonneSquareMeters(kilotonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilotonneSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareMeters(decimal? kilotonnesquaremeters)
         {
             if (kilotonnesquaremeters.HasValue)
             {
@@ -736,10 +1933,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(int? kilotonnesquaremilimeters)
+        {
+            if (kilotonnesquaremilimeters.HasValue)
+            {
+                return FromKilotonneSquareMilimeters(kilotonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(long? kilotonnesquaremilimeters)
+        {
+            if (kilotonnesquaremilimeters.HasValue)
+            {
+                return FromKilotonneSquareMilimeters(kilotonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from KilotonneSquareMilimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(decimal? kilotonnesquaremilimeters)
+        {
+            if (kilotonnesquaremilimeters.HasValue)
+            {
+                return FromKilotonneSquareMilimeters(kilotonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareCentimeters(double? megatonnesquarecentimeters)
+        {
+            if (megatonnesquarecentimeters.HasValue)
+            {
+                return FromMegatonneSquareCentimeters(megatonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(int? megatonnesquarecentimeters)
+        {
+            if (megatonnesquarecentimeters.HasValue)
+            {
+                return FromMegatonneSquareCentimeters(megatonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(long? megatonnesquarecentimeters)
+        {
+            if (megatonnesquarecentimeters.HasValue)
+            {
+                return FromMegatonneSquareCentimeters(megatonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MegatonneSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(decimal? megatonnesquarecentimeters)
         {
             if (megatonnesquarecentimeters.HasValue)
             {
@@ -766,10 +2053,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(int? megatonnesquaredecimeters)
+        {
+            if (megatonnesquaredecimeters.HasValue)
+            {
+                return FromMegatonneSquareDecimeters(megatonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(long? megatonnesquaredecimeters)
+        {
+            if (megatonnesquaredecimeters.HasValue)
+            {
+                return FromMegatonneSquareDecimeters(megatonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MegatonneSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(decimal? megatonnesquaredecimeters)
+        {
+            if (megatonnesquaredecimeters.HasValue)
+            {
+                return FromMegatonneSquareDecimeters(megatonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromMegatonneSquareMeters(double? megatonnesquaremeters)
+        {
+            if (megatonnesquaremeters.HasValue)
+            {
+                return FromMegatonneSquareMeters(megatonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareMeters(int? megatonnesquaremeters)
+        {
+            if (megatonnesquaremeters.HasValue)
+            {
+                return FromMegatonneSquareMeters(megatonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareMeters(long? megatonnesquaremeters)
+        {
+            if (megatonnesquaremeters.HasValue)
+            {
+                return FromMegatonneSquareMeters(megatonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MegatonneSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareMeters(decimal? megatonnesquaremeters)
         {
             if (megatonnesquaremeters.HasValue)
             {
@@ -796,10 +2173,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(int? megatonnesquaremilimeters)
+        {
+            if (megatonnesquaremilimeters.HasValue)
+            {
+                return FromMegatonneSquareMilimeters(megatonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(long? megatonnesquaremilimeters)
+        {
+            if (megatonnesquaremilimeters.HasValue)
+            {
+                return FromMegatonneSquareMilimeters(megatonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MegatonneSquareMilimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(decimal? megatonnesquaremilimeters)
+        {
+            if (megatonnesquaremilimeters.HasValue)
+            {
+                return FromMegatonneSquareMilimeters(megatonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareCentimeters(double? milligramsquarecentimeters)
+        {
+            if (milligramsquarecentimeters.HasValue)
+            {
+                return FromMilligramSquareCentimeters(milligramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareCentimeters(int? milligramsquarecentimeters)
+        {
+            if (milligramsquarecentimeters.HasValue)
+            {
+                return FromMilligramSquareCentimeters(milligramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareCentimeters(long? milligramsquarecentimeters)
+        {
+            if (milligramsquarecentimeters.HasValue)
+            {
+                return FromMilligramSquareCentimeters(milligramsquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MilligramSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareCentimeters(decimal? milligramsquarecentimeters)
         {
             if (milligramsquarecentimeters.HasValue)
             {
@@ -826,10 +2293,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareDecimeters(int? milligramsquaredecimeters)
+        {
+            if (milligramsquaredecimeters.HasValue)
+            {
+                return FromMilligramSquareDecimeters(milligramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareDecimeters(long? milligramsquaredecimeters)
+        {
+            if (milligramsquaredecimeters.HasValue)
+            {
+                return FromMilligramSquareDecimeters(milligramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MilligramSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareDecimeters(decimal? milligramsquaredecimeters)
+        {
+            if (milligramsquaredecimeters.HasValue)
+            {
+                return FromMilligramSquareDecimeters(milligramsquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
         /// </summary>
         public static MassMomentOfInertia? FromMilligramSquareMeters(double? milligramsquaremeters)
+        {
+            if (milligramsquaremeters.HasValue)
+            {
+                return FromMilligramSquareMeters(milligramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareMeters(int? milligramsquaremeters)
+        {
+            if (milligramsquaremeters.HasValue)
+            {
+                return FromMilligramSquareMeters(milligramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareMeters(long? milligramsquaremeters)
+        {
+            if (milligramsquaremeters.HasValue)
+            {
+                return FromMilligramSquareMeters(milligramsquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MilligramSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareMeters(decimal? milligramsquaremeters)
         {
             if (milligramsquaremeters.HasValue)
             {
@@ -856,10 +2413,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareMillimeters(int? milligramsquaremillimeters)
+        {
+            if (milligramsquaremillimeters.HasValue)
+            {
+                return FromMilligramSquareMillimeters(milligramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareMillimeters(long? milligramsquaremillimeters)
+        {
+            if (milligramsquaremillimeters.HasValue)
+            {
+                return FromMilligramSquareMillimeters(milligramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from MilligramSquareMillimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromMilligramSquareMillimeters(decimal? milligramsquaremillimeters)
+        {
+            if (milligramsquaremillimeters.HasValue)
+            {
+                return FromMilligramSquareMillimeters(milligramsquaremillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
         /// </summary>
         public static MassMomentOfInertia? FromPoundSquareFeet(double? poundsquarefeet)
+        {
+            if (poundsquarefeet.HasValue)
+            {
+                return FromPoundSquareFeet(poundsquarefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
+        /// </summary>
+        public static MassMomentOfInertia? FromPoundSquareFeet(int? poundsquarefeet)
+        {
+            if (poundsquarefeet.HasValue)
+            {
+                return FromPoundSquareFeet(poundsquarefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
+        /// </summary>
+        public static MassMomentOfInertia? FromPoundSquareFeet(long? poundsquarefeet)
+        {
+            if (poundsquarefeet.HasValue)
+            {
+                return FromPoundSquareFeet(poundsquarefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from PoundSquareFeet of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromPoundSquareFeet(decimal? poundsquarefeet)
         {
             if (poundsquarefeet.HasValue)
             {
@@ -886,10 +2533,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
+        /// </summary>
+        public static MassMomentOfInertia? FromPoundSquareInches(int? poundsquareinches)
+        {
+            if (poundsquareinches.HasValue)
+            {
+                return FromPoundSquareInches(poundsquareinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
+        /// </summary>
+        public static MassMomentOfInertia? FromPoundSquareInches(long? poundsquareinches)
+        {
+            if (poundsquareinches.HasValue)
+            {
+                return FromPoundSquareInches(poundsquareinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from PoundSquareInches of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromPoundSquareInches(decimal? poundsquareinches)
+        {
+            if (poundsquareinches.HasValue)
+            {
+                return FromPoundSquareInches(poundsquareinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareCentimeters(double? tonnesquarecentimeters)
+        {
+            if (tonnesquarecentimeters.HasValue)
+            {
+                return FromTonneSquareCentimeters(tonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareCentimeters(int? tonnesquarecentimeters)
+        {
+            if (tonnesquarecentimeters.HasValue)
+            {
+                return FromTonneSquareCentimeters(tonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareCentimeters(long? tonnesquarecentimeters)
+        {
+            if (tonnesquarecentimeters.HasValue)
+            {
+                return FromTonneSquareCentimeters(tonnesquarecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from TonneSquareCentimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareCentimeters(decimal? tonnesquarecentimeters)
         {
             if (tonnesquarecentimeters.HasValue)
             {
@@ -916,6 +2653,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareDecimeters(int? tonnesquaredecimeters)
+        {
+            if (tonnesquaredecimeters.HasValue)
+            {
+                return FromTonneSquareDecimeters(tonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareDecimeters(long? tonnesquaredecimeters)
+        {
+            if (tonnesquaredecimeters.HasValue)
+            {
+                return FromTonneSquareDecimeters(tonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from TonneSquareDecimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareDecimeters(decimal? tonnesquaredecimeters)
+        {
+            if (tonnesquaredecimeters.HasValue)
+            {
+                return FromTonneSquareDecimeters(tonnesquaredecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
         /// </summary>
@@ -931,10 +2713,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareMeters(int? tonnesquaremeters)
+        {
+            if (tonnesquaremeters.HasValue)
+            {
+                return FromTonneSquareMeters(tonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareMeters(long? tonnesquaremeters)
+        {
+            if (tonnesquaremeters.HasValue)
+            {
+                return FromTonneSquareMeters(tonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from TonneSquareMeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareMeters(decimal? tonnesquaremeters)
+        {
+            if (tonnesquaremeters.HasValue)
+            {
+                return FromTonneSquareMeters(tonnesquaremeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
         /// </summary>
         public static MassMomentOfInertia? FromTonneSquareMilimeters(double? tonnesquaremilimeters)
+        {
+            if (tonnesquaremilimeters.HasValue)
+            {
+                return FromTonneSquareMilimeters(tonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareMilimeters(int? tonnesquaremilimeters)
+        {
+            if (tonnesquaremilimeters.HasValue)
+            {
+                return FromTonneSquareMilimeters(tonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareMilimeters(long? tonnesquaremilimeters)
+        {
+            if (tonnesquaremilimeters.HasValue)
+            {
+                return FromTonneSquareMilimeters(tonnesquaremilimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable MassMomentOfInertia from TonneSquareMilimeters of type decimal.
+        /// </summary>
+        public static MassMomentOfInertia? FromTonneSquareMilimeters(decimal? tonnesquaremilimeters)
         {
             if (tonnesquaremilimeters.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -349,6 +349,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromGramSquareCentimeters(double gramsquarecentimeters)
         {
             return new MassMomentOfInertia(gramsquarecentimeters/1e7);
@@ -384,6 +387,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromGramSquareDecimeters(double gramsquaredecimeters)
         {
             return new MassMomentOfInertia(gramsquaredecimeters/1e5);
@@ -419,6 +425,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromGramSquareMeters(double gramsquaremeters)
         {
             return new MassMomentOfInertia(gramsquaremeters/1e3);
@@ -454,6 +463,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromGramSquareMillimeters(double gramsquaremillimeters)
         {
             return new MassMomentOfInertia(gramsquaremillimeters/1e9);
@@ -489,6 +501,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilogramSquareCentimeters(double kilogramsquarecentimeters)
         {
             return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
@@ -524,6 +539,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilogramSquareDecimeters(double kilogramsquaredecimeters)
         {
             return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
@@ -559,6 +577,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilogramSquareMeters(double kilogramsquaremeters)
         {
             return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
@@ -594,6 +615,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilogramSquareMillimeters(double kilogramsquaremillimeters)
         {
             return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
@@ -629,6 +653,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(double kilotonnesquarecentimeters)
         {
             return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
@@ -664,6 +691,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(double kilotonnesquaredecimeters)
         {
             return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
@@ -699,6 +729,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilotonneSquareMeters(double kilotonnesquaremeters)
         {
             return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
@@ -734,6 +767,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(double kilotonnesquaremilimeters)
         {
             return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
@@ -769,6 +805,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(double megatonnesquarecentimeters)
         {
             return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
@@ -804,6 +843,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(double megatonnesquaredecimeters)
         {
             return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
@@ -839,6 +881,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMegatonneSquareMeters(double megatonnesquaremeters)
         {
             return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
@@ -874,6 +919,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(double megatonnesquaremilimeters)
         {
             return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
@@ -909,6 +957,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMilligramSquareCentimeters(double milligramsquarecentimeters)
         {
             return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
@@ -944,6 +995,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMilligramSquareDecimeters(double milligramsquaredecimeters)
         {
             return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
@@ -979,6 +1033,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMilligramSquareMeters(double milligramsquaremeters)
         {
             return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
@@ -1014,6 +1071,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromMilligramSquareMillimeters(double milligramsquaremillimeters)
         {
             return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
@@ -1049,6 +1109,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromPoundSquareFeet(double poundsquarefeet)
         {
             return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
@@ -1084,6 +1147,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromPoundSquareInches(double poundsquareinches)
         {
             return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
@@ -1119,6 +1185,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromTonneSquareCentimeters(double tonnesquarecentimeters)
         {
             return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
@@ -1154,6 +1223,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromTonneSquareDecimeters(double tonnesquaredecimeters)
         {
             return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
@@ -1189,6 +1261,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromTonneSquareMeters(double tonnesquaremeters)
         {
             return new MassMomentOfInertia(tonnesquaremeters/1e-3);
@@ -1224,6 +1299,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static MassMomentOfInertia FromTonneSquareMilimeters(double tonnesquaremilimeters)
         {
             return new MassMomentOfInertia(tonnesquaremilimeters/1e3);

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _molesPerCubicMeter;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Molarity() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Molarity;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static MolarityUnit BaseUnit
         {
             get { return MolarityUnit.MolesPerCubicMeter; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new Molarity((centimolesperliter/1e-3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from CentimolesPerLiter.
         /// </summary>
         public static Molarity FromCentimolesPerLiter(int centimolesperliter)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new Molarity((centimolesperliter/1e-3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from CentimolesPerLiter.
         /// </summary>
         public static Molarity FromCentimolesPerLiter(long centimolesperliter)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new Molarity((centimolesperliter/1e-3) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from CentimolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromCentimolesPerLiter(decimal centimolesperliter)
         {
-	        return new Molarity((Convert.ToDouble(centimolesperliter)/1e-3) * 1e-2d);
+            return new Molarity((Convert.ToDouble(centimolesperliter)/1e-3) * 1e-2d);
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new Molarity((decimolesperliter/1e-3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
         public static Molarity FromDecimolesPerLiter(int decimolesperliter)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new Molarity((decimolesperliter/1e-3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
         public static Molarity FromDecimolesPerLiter(long decimolesperliter)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new Molarity((decimolesperliter/1e-3) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from DecimolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromDecimolesPerLiter(decimal decimolesperliter)
         {
-	        return new Molarity((Convert.ToDouble(decimolesperliter)/1e-3) * 1e-1d);
+            return new Molarity((Convert.ToDouble(decimolesperliter)/1e-3) * 1e-1d);
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new Molarity((micromolesperliter/1e-3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
         /// </summary>
         public static Molarity FromMicromolesPerLiter(int micromolesperliter)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new Molarity((micromolesperliter/1e-3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
         /// </summary>
         public static Molarity FromMicromolesPerLiter(long micromolesperliter)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new Molarity((micromolesperliter/1e-3) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MicromolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromMicromolesPerLiter(decimal micromolesperliter)
         {
-	        return new Molarity((Convert.ToDouble(micromolesperliter)/1e-3) * 1e-6d);
+            return new Molarity((Convert.ToDouble(micromolesperliter)/1e-3) * 1e-6d);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new Molarity((millimolesperliter/1e-3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
         public static Molarity FromMillimolesPerLiter(int millimolesperliter)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new Molarity((millimolesperliter/1e-3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
         public static Molarity FromMillimolesPerLiter(long millimolesperliter)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new Molarity((millimolesperliter/1e-3) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MillimolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromMillimolesPerLiter(decimal millimolesperliter)
         {
-	        return new Molarity((Convert.ToDouble(millimolesperliter)/1e-3) * 1e-3d);
+            return new Molarity((Convert.ToDouble(millimolesperliter)/1e-3) * 1e-3d);
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new Molarity(molespercubicmeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
         /// </summary>
         public static Molarity FromMolesPerCubicMeter(int molespercubicmeter)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new Molarity(molespercubicmeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
         /// </summary>
         public static Molarity FromMolesPerCubicMeter(long molespercubicmeter)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new Molarity(molespercubicmeter);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MolesPerCubicMeter of type decimal.
         /// </summary>
         public static Molarity FromMolesPerCubicMeter(decimal molespercubicmeter)
         {
-	        return new Molarity(Convert.ToDouble(molespercubicmeter));
+            return new Molarity(Convert.ToDouble(molespercubicmeter));
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new Molarity(molesperliter/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
         public static Molarity FromMolesPerLiter(int molesperliter)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new Molarity(molesperliter/1e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
         public static Molarity FromMolesPerLiter(long molesperliter)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new Molarity(molesperliter/1e-3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from MolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromMolesPerLiter(decimal molesperliter)
         {
-	        return new Molarity(Convert.ToDouble(molesperliter)/1e-3);
+            return new Molarity(Convert.ToDouble(molesperliter)/1e-3);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
         /// </summary>
         public static Molarity FromNanomolesPerLiter(int nanomolesperliter)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
         /// </summary>
         public static Molarity FromNanomolesPerLiter(long nanomolesperliter)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from NanomolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromNanomolesPerLiter(decimal nanomolesperliter)
         {
-	        return new Molarity((Convert.ToDouble(nanomolesperliter)/1e-3) * 1e-9d);
+            return new Molarity((Convert.ToDouble(nanomolesperliter)/1e-3) * 1e-9d);
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new Molarity((picomolesperliter/1e-3) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
         public static Molarity FromPicomolesPerLiter(int picomolesperliter)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new Molarity((picomolesperliter/1e-3) * 1e-12d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
         public static Molarity FromPicomolesPerLiter(long picomolesperliter)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new Molarity((picomolesperliter/1e-3) * 1e-12d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Molarity from PicomolesPerLiter of type decimal.
         /// </summary>
         public static Molarity FromPicomolesPerLiter(decimal picomolesperliter)
         {
-	        return new Molarity((Convert.ToDouble(picomolesperliter)/1e-3) * 1e-12d);
+            return new Molarity((Convert.ToDouble(picomolesperliter)/1e-3) * 1e-12d);
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable CentimolesPerLiter.
         /// </summary>
         public static Molarity? FromCentimolesPerLiter(int? centimolesperliter)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable CentimolesPerLiter.
         /// </summary>
         public static Molarity? FromCentimolesPerLiter(long? centimolesperliter)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from CentimolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromCentimolesPerLiter(decimal? centimolesperliter)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable DecimolesPerLiter.
         /// </summary>
         public static Molarity? FromDecimolesPerLiter(int? decimolesperliter)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable DecimolesPerLiter.
         /// </summary>
         public static Molarity? FromDecimolesPerLiter(long? decimolesperliter)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from DecimolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromDecimolesPerLiter(decimal? decimolesperliter)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MicromolesPerLiter.
         /// </summary>
         public static Molarity? FromMicromolesPerLiter(int? micromolesperliter)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MicromolesPerLiter.
         /// </summary>
         public static Molarity? FromMicromolesPerLiter(long? micromolesperliter)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from MicromolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromMicromolesPerLiter(decimal? micromolesperliter)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MillimolesPerLiter.
         /// </summary>
         public static Molarity? FromMillimolesPerLiter(int? millimolesperliter)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MillimolesPerLiter.
         /// </summary>
         public static Molarity? FromMillimolesPerLiter(long? millimolesperliter)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from MillimolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromMillimolesPerLiter(decimal? millimolesperliter)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MolesPerCubicMeter.
         /// </summary>
         public static Molarity? FromMolesPerCubicMeter(int? molespercubicmeter)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MolesPerCubicMeter.
         /// </summary>
         public static Molarity? FromMolesPerCubicMeter(long? molespercubicmeter)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from MolesPerCubicMeter of type decimal.
         /// </summary>
         public static Molarity? FromMolesPerCubicMeter(decimal? molespercubicmeter)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MolesPerLiter.
         /// </summary>
         public static Molarity? FromMolesPerLiter(int? molesperliter)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable MolesPerLiter.
         /// </summary>
         public static Molarity? FromMolesPerLiter(long? molesperliter)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from MolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromMolesPerLiter(decimal? molesperliter)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable NanomolesPerLiter.
         /// </summary>
         public static Molarity? FromNanomolesPerLiter(int? nanomolesperliter)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable NanomolesPerLiter.
         /// </summary>
         public static Molarity? FromNanomolesPerLiter(long? nanomolesperliter)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from NanomolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromNanomolesPerLiter(decimal? nanomolesperliter)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable PicomolesPerLiter.
         /// </summary>
         public static Molarity? FromPicomolesPerLiter(int? picomolesperliter)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from nullable PicomolesPerLiter.
         /// </summary>
         public static Molarity? FromPicomolesPerLiter(long? picomolesperliter)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Molarity from PicomolesPerLiter of type decimal.
         /// </summary>
         public static Molarity? FromPicomolesPerLiter(decimal? picomolesperliter)

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from CentimolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromCentimolesPerLiter(double centimolesperliter)
         {
             return new Molarity((centimolesperliter/1e-3) * 1e-2d);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromDecimolesPerLiter(double decimolesperliter)
         {
             return new Molarity((decimolesperliter/1e-3) * 1e-1d);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromMicromolesPerLiter(double micromolesperliter)
         {
             return new Molarity((micromolesperliter/1e-3) * 1e-6d);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromMillimolesPerLiter(double millimolesperliter)
         {
             return new Molarity((millimolesperliter/1e-3) * 1e-3d);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromMolesPerCubicMeter(double molespercubicmeter)
         {
             return new Molarity(molespercubicmeter);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromMolesPerLiter(double molesperliter)
         {
             return new Molarity(molesperliter/1e-3);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromNanomolesPerLiter(double nanomolesperliter)
         {
             return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Molarity FromPicomolesPerLiter(double picomolesperliter)
         {
             return new Molarity((picomolesperliter/1e-3) * 1e-12d);

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new Molarity((centimolesperliter/1e-3) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Molarity from CentimolesPerLiter.
+        /// </summary>
+        public static Molarity FromCentimolesPerLiter(int centimolesperliter)
+        {
+            return new Molarity((centimolesperliter/1e-3) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Molarity from CentimolesPerLiter.
+        /// </summary>
+        public static Molarity FromCentimolesPerLiter(long centimolesperliter)
+        {
+            return new Molarity((centimolesperliter/1e-3) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from CentimolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromCentimolesPerLiter(decimal centimolesperliter)
+        {
+	        return new Molarity((Convert.ToDouble(centimolesperliter)/1e-3) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new Molarity((decimolesperliter/1e-3) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Molarity from DecimolesPerLiter.
+        /// </summary>
+        public static Molarity FromDecimolesPerLiter(int decimolesperliter)
+        {
+            return new Molarity((decimolesperliter/1e-3) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Molarity from DecimolesPerLiter.
+        /// </summary>
+        public static Molarity FromDecimolesPerLiter(long decimolesperliter)
+        {
+            return new Molarity((decimolesperliter/1e-3) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from DecimolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromDecimolesPerLiter(decimal decimolesperliter)
+        {
+	        return new Molarity((Convert.ToDouble(decimolesperliter)/1e-3) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new Molarity((micromolesperliter/1e-3) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Molarity from MicromolesPerLiter.
+        /// </summary>
+        public static Molarity FromMicromolesPerLiter(int micromolesperliter)
+        {
+            return new Molarity((micromolesperliter/1e-3) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Molarity from MicromolesPerLiter.
+        /// </summary>
+        public static Molarity FromMicromolesPerLiter(long micromolesperliter)
+        {
+            return new Molarity((micromolesperliter/1e-3) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from MicromolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromMicromolesPerLiter(decimal micromolesperliter)
+        {
+	        return new Molarity((Convert.ToDouble(micromolesperliter)/1e-3) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new Molarity((millimolesperliter/1e-3) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Molarity from MillimolesPerLiter.
+        /// </summary>
+        public static Molarity FromMillimolesPerLiter(int millimolesperliter)
+        {
+            return new Molarity((millimolesperliter/1e-3) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Molarity from MillimolesPerLiter.
+        /// </summary>
+        public static Molarity FromMillimolesPerLiter(long millimolesperliter)
+        {
+            return new Molarity((millimolesperliter/1e-3) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from MillimolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromMillimolesPerLiter(decimal millimolesperliter)
+        {
+	        return new Molarity((Convert.ToDouble(millimolesperliter)/1e-3) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new Molarity(molespercubicmeter);
         }
 
+		/// <summary>
+        ///     Get Molarity from MolesPerCubicMeter.
+        /// </summary>
+        public static Molarity FromMolesPerCubicMeter(int molespercubicmeter)
+        {
+            return new Molarity(molespercubicmeter);
+        }
+
+		/// <summary>
+        ///     Get Molarity from MolesPerCubicMeter.
+        /// </summary>
+        public static Molarity FromMolesPerCubicMeter(long molespercubicmeter)
+        {
+            return new Molarity(molespercubicmeter);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from MolesPerCubicMeter of type decimal.
+        /// </summary>
+        public static Molarity FromMolesPerCubicMeter(decimal molespercubicmeter)
+        {
+	        return new Molarity(Convert.ToDouble(molespercubicmeter));
+        }
+#endif
+
         /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new Molarity(molesperliter/1e-3);
         }
+
+		/// <summary>
+        ///     Get Molarity from MolesPerLiter.
+        /// </summary>
+        public static Molarity FromMolesPerLiter(int molesperliter)
+        {
+            return new Molarity(molesperliter/1e-3);
+        }
+
+		/// <summary>
+        ///     Get Molarity from MolesPerLiter.
+        /// </summary>
+        public static Molarity FromMolesPerLiter(long molesperliter)
+        {
+            return new Molarity(molesperliter/1e-3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from MolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromMolesPerLiter(decimal molesperliter)
+        {
+	        return new Molarity(Convert.ToDouble(molesperliter)/1e-3);
+        }
+#endif
 
         /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Molarity from NanomolesPerLiter.
+        /// </summary>
+        public static Molarity FromNanomolesPerLiter(int nanomolesperliter)
+        {
+            return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Molarity from NanomolesPerLiter.
+        /// </summary>
+        public static Molarity FromNanomolesPerLiter(long nanomolesperliter)
+        {
+            return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from NanomolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromNanomolesPerLiter(decimal nanomolesperliter)
+        {
+	        return new Molarity((Convert.ToDouble(nanomolesperliter)/1e-3) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new Molarity((picomolesperliter/1e-3) * 1e-12d);
         }
 
+		/// <summary>
+        ///     Get Molarity from PicomolesPerLiter.
+        /// </summary>
+        public static Molarity FromPicomolesPerLiter(int picomolesperliter)
+        {
+            return new Molarity((picomolesperliter/1e-3) * 1e-12d);
+        }
+
+		/// <summary>
+        ///     Get Molarity from PicomolesPerLiter.
+        /// </summary>
+        public static Molarity FromPicomolesPerLiter(long picomolesperliter)
+        {
+            return new Molarity((picomolesperliter/1e-3) * 1e-12d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Molarity from PicomolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity FromPicomolesPerLiter(decimal picomolesperliter)
+        {
+	        return new Molarity((Convert.ToDouble(picomolesperliter)/1e-3) * 1e-12d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Molarity from nullable CentimolesPerLiter.
         /// </summary>
         public static Molarity? FromCentimolesPerLiter(double? centimolesperliter)
+        {
+            if (centimolesperliter.HasValue)
+            {
+                return FromCentimolesPerLiter(centimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable CentimolesPerLiter.
+        /// </summary>
+        public static Molarity? FromCentimolesPerLiter(int? centimolesperliter)
+        {
+            if (centimolesperliter.HasValue)
+            {
+                return FromCentimolesPerLiter(centimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable CentimolesPerLiter.
+        /// </summary>
+        public static Molarity? FromCentimolesPerLiter(long? centimolesperliter)
+        {
+            if (centimolesperliter.HasValue)
+            {
+                return FromCentimolesPerLiter(centimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from CentimolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromCentimolesPerLiter(decimal? centimolesperliter)
         {
             if (centimolesperliter.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Molarity from nullable DecimolesPerLiter.
+        /// </summary>
+        public static Molarity? FromDecimolesPerLiter(int? decimolesperliter)
+        {
+            if (decimolesperliter.HasValue)
+            {
+                return FromDecimolesPerLiter(decimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable DecimolesPerLiter.
+        /// </summary>
+        public static Molarity? FromDecimolesPerLiter(long? decimolesperliter)
+        {
+            if (decimolesperliter.HasValue)
+            {
+                return FromDecimolesPerLiter(decimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from DecimolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromDecimolesPerLiter(decimal? decimolesperliter)
+        {
+            if (decimolesperliter.HasValue)
+            {
+                return FromDecimolesPerLiter(decimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Molarity from nullable MicromolesPerLiter.
         /// </summary>
         public static Molarity? FromMicromolesPerLiter(double? micromolesperliter)
+        {
+            if (micromolesperliter.HasValue)
+            {
+                return FromMicromolesPerLiter(micromolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable MicromolesPerLiter.
+        /// </summary>
+        public static Molarity? FromMicromolesPerLiter(int? micromolesperliter)
+        {
+            if (micromolesperliter.HasValue)
+            {
+                return FromMicromolesPerLiter(micromolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable MicromolesPerLiter.
+        /// </summary>
+        public static Molarity? FromMicromolesPerLiter(long? micromolesperliter)
+        {
+            if (micromolesperliter.HasValue)
+            {
+                return FromMicromolesPerLiter(micromolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from MicromolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromMicromolesPerLiter(decimal? micromolesperliter)
         {
             if (micromolesperliter.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Molarity from nullable MillimolesPerLiter.
+        /// </summary>
+        public static Molarity? FromMillimolesPerLiter(int? millimolesperliter)
+        {
+            if (millimolesperliter.HasValue)
+            {
+                return FromMillimolesPerLiter(millimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable MillimolesPerLiter.
+        /// </summary>
+        public static Molarity? FromMillimolesPerLiter(long? millimolesperliter)
+        {
+            if (millimolesperliter.HasValue)
+            {
+                return FromMillimolesPerLiter(millimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from MillimolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromMillimolesPerLiter(decimal? millimolesperliter)
+        {
+            if (millimolesperliter.HasValue)
+            {
+                return FromMillimolesPerLiter(millimolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Molarity from nullable MolesPerCubicMeter.
         /// </summary>
         public static Molarity? FromMolesPerCubicMeter(double? molespercubicmeter)
+        {
+            if (molespercubicmeter.HasValue)
+            {
+                return FromMolesPerCubicMeter(molespercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable MolesPerCubicMeter.
+        /// </summary>
+        public static Molarity? FromMolesPerCubicMeter(int? molespercubicmeter)
+        {
+            if (molespercubicmeter.HasValue)
+            {
+                return FromMolesPerCubicMeter(molespercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable MolesPerCubicMeter.
+        /// </summary>
+        public static Molarity? FromMolesPerCubicMeter(long? molespercubicmeter)
+        {
+            if (molespercubicmeter.HasValue)
+            {
+                return FromMolesPerCubicMeter(molespercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from MolesPerCubicMeter of type decimal.
+        /// </summary>
+        public static Molarity? FromMolesPerCubicMeter(decimal? molespercubicmeter)
         {
             if (molespercubicmeter.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Molarity from nullable MolesPerLiter.
+        /// </summary>
+        public static Molarity? FromMolesPerLiter(int? molesperliter)
+        {
+            if (molesperliter.HasValue)
+            {
+                return FromMolesPerLiter(molesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable MolesPerLiter.
+        /// </summary>
+        public static Molarity? FromMolesPerLiter(long? molesperliter)
+        {
+            if (molesperliter.HasValue)
+            {
+                return FromMolesPerLiter(molesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from MolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromMolesPerLiter(decimal? molesperliter)
+        {
+            if (molesperliter.HasValue)
+            {
+                return FromMolesPerLiter(molesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Molarity from nullable NanomolesPerLiter.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Molarity from nullable NanomolesPerLiter.
+        /// </summary>
+        public static Molarity? FromNanomolesPerLiter(int? nanomolesperliter)
+        {
+            if (nanomolesperliter.HasValue)
+            {
+                return FromNanomolesPerLiter(nanomolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable NanomolesPerLiter.
+        /// </summary>
+        public static Molarity? FromNanomolesPerLiter(long? nanomolesperliter)
+        {
+            if (nanomolesperliter.HasValue)
+            {
+                return FromNanomolesPerLiter(nanomolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from NanomolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromNanomolesPerLiter(decimal? nanomolesperliter)
+        {
+            if (nanomolesperliter.HasValue)
+            {
+                return FromNanomolesPerLiter(nanomolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Molarity from nullable PicomolesPerLiter.
         /// </summary>
         public static Molarity? FromPicomolesPerLiter(double? picomolesperliter)
+        {
+            if (picomolesperliter.HasValue)
+            {
+                return FromPicomolesPerLiter(picomolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable PicomolesPerLiter.
+        /// </summary>
+        public static Molarity? FromPicomolesPerLiter(int? picomolesperliter)
+        {
+            if (picomolesperliter.HasValue)
+            {
+                return FromPicomolesPerLiter(picomolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from nullable PicomolesPerLiter.
+        /// </summary>
+        public static Molarity? FromPicomolesPerLiter(long? picomolesperliter)
+        {
+            if (picomolesperliter.HasValue)
+            {
+                return FromPicomolesPerLiter(picomolesperliter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Molarity from PicomolesPerLiter of type decimal.
+        /// </summary>
+        public static Molarity? FromPicomolesPerLiter(decimal? picomolesperliter)
         {
             if (picomolesperliter.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -290,6 +290,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
         }
 
+		/// <summary>
+        ///     Get Power from BoilerHorsepower.
+        /// </summary>
+        public static Power FromBoilerHorsepower(int boilerhorsepower)
+        {
+            return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
+        }
+
+		/// <summary>
+        ///     Get Power from BoilerHorsepower.
+        /// </summary>
+        public static Power FromBoilerHorsepower(long boilerhorsepower)
+        {
+            return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from BoilerHorsepower of type decimal.
+        /// </summary>
+        public static Power FromBoilerHorsepower(decimal boilerhorsepower)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(boilerhorsepower)*9812.5d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
@@ -297,6 +324,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
         }
+
+		/// <summary>
+        ///     Get Power from BritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power FromBritishThermalUnitsPerHour(int britishthermalunitsperhour)
+        {
+            return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
+        }
+
+		/// <summary>
+        ///     Get Power from BritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power FromBritishThermalUnitsPerHour(long britishthermalunitsperhour)
+        {
+            return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from BritishThermalUnitsPerHour of type decimal.
+        /// </summary>
+        public static Power FromBritishThermalUnitsPerHour(decimal britishthermalunitsperhour)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(britishthermalunitsperhour)*0.293071d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from ElectricalHorsepower.
@@ -306,6 +360,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(electricalhorsepower*746d));
         }
 
+		/// <summary>
+        ///     Get Power from ElectricalHorsepower.
+        /// </summary>
+        public static Power FromElectricalHorsepower(int electricalhorsepower)
+        {
+            return new Power(Convert.ToDecimal(electricalhorsepower*746d));
+        }
+
+		/// <summary>
+        ///     Get Power from ElectricalHorsepower.
+        /// </summary>
+        public static Power FromElectricalHorsepower(long electricalhorsepower)
+        {
+            return new Power(Convert.ToDecimal(electricalhorsepower*746d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from ElectricalHorsepower of type decimal.
+        /// </summary>
+        public static Power FromElectricalHorsepower(decimal electricalhorsepower)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(electricalhorsepower)*746d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
@@ -313,6 +394,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
         }
+
+		/// <summary>
+        ///     Get Power from Femtowatts.
+        /// </summary>
+        public static Power FromFemtowatts(int femtowatts)
+        {
+            return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
+        }
+
+		/// <summary>
+        ///     Get Power from Femtowatts.
+        /// </summary>
+        public static Power FromFemtowatts(long femtowatts)
+        {
+            return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Femtowatts of type decimal.
+        /// </summary>
+        public static Power FromFemtowatts(decimal femtowatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(femtowatts)) * 1e-15d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from Gigawatts.
@@ -322,6 +430,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
         }
 
+		/// <summary>
+        ///     Get Power from Gigawatts.
+        /// </summary>
+        public static Power FromGigawatts(int gigawatts)
+        {
+            return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
+        }
+
+		/// <summary>
+        ///     Get Power from Gigawatts.
+        /// </summary>
+        public static Power FromGigawatts(long gigawatts)
+        {
+            return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Gigawatts of type decimal.
+        /// </summary>
+        public static Power FromGigawatts(decimal gigawatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(gigawatts)) * 1e9d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
@@ -329,6 +464,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
         }
+
+		/// <summary>
+        ///     Get Power from HydraulicHorsepower.
+        /// </summary>
+        public static Power FromHydraulicHorsepower(int hydraulichorsepower)
+        {
+            return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
+        }
+
+		/// <summary>
+        ///     Get Power from HydraulicHorsepower.
+        /// </summary>
+        public static Power FromHydraulicHorsepower(long hydraulichorsepower)
+        {
+            return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from HydraulicHorsepower of type decimal.
+        /// </summary>
+        public static Power FromHydraulicHorsepower(decimal hydraulichorsepower)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(hydraulichorsepower)*745.69988145d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
@@ -338,6 +500,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
         }
 
+		/// <summary>
+        ///     Get Power from KilobritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power FromKilobritishThermalUnitsPerHour(int kilobritishthermalunitsperhour)
+        {
+            return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
+        }
+
+		/// <summary>
+        ///     Get Power from KilobritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power FromKilobritishThermalUnitsPerHour(long kilobritishthermalunitsperhour)
+        {
+            return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from KilobritishThermalUnitsPerHour of type decimal.
+        /// </summary>
+        public static Power FromKilobritishThermalUnitsPerHour(decimal kilobritishthermalunitsperhour)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(kilobritishthermalunitsperhour)*0.293071d) * 1e3d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
@@ -345,6 +534,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
         }
+
+		/// <summary>
+        ///     Get Power from Kilowatts.
+        /// </summary>
+        public static Power FromKilowatts(int kilowatts)
+        {
+            return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
+        }
+
+		/// <summary>
+        ///     Get Power from Kilowatts.
+        /// </summary>
+        public static Power FromKilowatts(long kilowatts)
+        {
+            return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Kilowatts of type decimal.
+        /// </summary>
+        public static Power FromKilowatts(decimal kilowatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(kilowatts)) * 1e3d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from MechanicalHorsepower.
@@ -354,6 +570,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
         }
 
+		/// <summary>
+        ///     Get Power from MechanicalHorsepower.
+        /// </summary>
+        public static Power FromMechanicalHorsepower(int mechanicalhorsepower)
+        {
+            return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
+        }
+
+		/// <summary>
+        ///     Get Power from MechanicalHorsepower.
+        /// </summary>
+        public static Power FromMechanicalHorsepower(long mechanicalhorsepower)
+        {
+            return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from MechanicalHorsepower of type decimal.
+        /// </summary>
+        public static Power FromMechanicalHorsepower(decimal mechanicalhorsepower)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(mechanicalhorsepower)*745.69d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
@@ -361,6 +604,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal((megawatts) * 1e6d));
         }
+
+		/// <summary>
+        ///     Get Power from Megawatts.
+        /// </summary>
+        public static Power FromMegawatts(int megawatts)
+        {
+            return new Power(Convert.ToDecimal((megawatts) * 1e6d));
+        }
+
+		/// <summary>
+        ///     Get Power from Megawatts.
+        /// </summary>
+        public static Power FromMegawatts(long megawatts)
+        {
+            return new Power(Convert.ToDecimal((megawatts) * 1e6d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Megawatts of type decimal.
+        /// </summary>
+        public static Power FromMegawatts(decimal megawatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(megawatts)) * 1e6d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from MetricHorsepower.
@@ -370,6 +640,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
         }
 
+		/// <summary>
+        ///     Get Power from MetricHorsepower.
+        /// </summary>
+        public static Power FromMetricHorsepower(int metrichorsepower)
+        {
+            return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
+        }
+
+		/// <summary>
+        ///     Get Power from MetricHorsepower.
+        /// </summary>
+        public static Power FromMetricHorsepower(long metrichorsepower)
+        {
+            return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from MetricHorsepower of type decimal.
+        /// </summary>
+        public static Power FromMetricHorsepower(decimal metrichorsepower)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(metrichorsepower)*735.49875d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
@@ -377,6 +674,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
         }
+
+		/// <summary>
+        ///     Get Power from Microwatts.
+        /// </summary>
+        public static Power FromMicrowatts(int microwatts)
+        {
+            return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
+        }
+
+		/// <summary>
+        ///     Get Power from Microwatts.
+        /// </summary>
+        public static Power FromMicrowatts(long microwatts)
+        {
+            return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Microwatts of type decimal.
+        /// </summary>
+        public static Power FromMicrowatts(decimal microwatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(microwatts)) * 1e-6d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from Milliwatts.
@@ -386,6 +710,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
         }
 
+		/// <summary>
+        ///     Get Power from Milliwatts.
+        /// </summary>
+        public static Power FromMilliwatts(int milliwatts)
+        {
+            return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
+        }
+
+		/// <summary>
+        ///     Get Power from Milliwatts.
+        /// </summary>
+        public static Power FromMilliwatts(long milliwatts)
+        {
+            return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Milliwatts of type decimal.
+        /// </summary>
+        public static Power FromMilliwatts(decimal milliwatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(milliwatts)) * 1e-3d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
@@ -393,6 +744,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
         }
+
+		/// <summary>
+        ///     Get Power from Nanowatts.
+        /// </summary>
+        public static Power FromNanowatts(int nanowatts)
+        {
+            return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
+        }
+
+		/// <summary>
+        ///     Get Power from Nanowatts.
+        /// </summary>
+        public static Power FromNanowatts(long nanowatts)
+        {
+            return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Nanowatts of type decimal.
+        /// </summary>
+        public static Power FromNanowatts(decimal nanowatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(nanowatts)) * 1e-9d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from Petawatts.
@@ -402,6 +780,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((petawatts) * 1e15d));
         }
 
+		/// <summary>
+        ///     Get Power from Petawatts.
+        /// </summary>
+        public static Power FromPetawatts(int petawatts)
+        {
+            return new Power(Convert.ToDecimal((petawatts) * 1e15d));
+        }
+
+		/// <summary>
+        ///     Get Power from Petawatts.
+        /// </summary>
+        public static Power FromPetawatts(long petawatts)
+        {
+            return new Power(Convert.ToDecimal((petawatts) * 1e15d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Petawatts of type decimal.
+        /// </summary>
+        public static Power FromPetawatts(decimal petawatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(petawatts)) * 1e15d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
@@ -409,6 +814,33 @@ namespace UnitsNet
         {
             return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
         }
+
+		/// <summary>
+        ///     Get Power from Picowatts.
+        /// </summary>
+        public static Power FromPicowatts(int picowatts)
+        {
+            return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
+        }
+
+		/// <summary>
+        ///     Get Power from Picowatts.
+        /// </summary>
+        public static Power FromPicowatts(long picowatts)
+        {
+            return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Picowatts of type decimal.
+        /// </summary>
+        public static Power FromPicowatts(decimal picowatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(picowatts)) * 1e-12d));
+        }
+#endif
 
         /// <summary>
         ///     Get Power from Terawatts.
@@ -418,6 +850,33 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((terawatts) * 1e12d));
         }
 
+		/// <summary>
+        ///     Get Power from Terawatts.
+        /// </summary>
+        public static Power FromTerawatts(int terawatts)
+        {
+            return new Power(Convert.ToDecimal((terawatts) * 1e12d));
+        }
+
+		/// <summary>
+        ///     Get Power from Terawatts.
+        /// </summary>
+        public static Power FromTerawatts(long terawatts)
+        {
+            return new Power(Convert.ToDecimal((terawatts) * 1e12d));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Terawatts of type decimal.
+        /// </summary>
+        public static Power FromTerawatts(decimal terawatts)
+        {
+	        return new Power(Convert.ToDecimal((Convert.ToDouble(terawatts)) * 1e12d));
+        }
+#endif
+
         /// <summary>
         ///     Get Power from Watts.
         /// </summary>
@@ -426,12 +885,84 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(watts));
         }
 
+		/// <summary>
+        ///     Get Power from Watts.
+        /// </summary>
+        public static Power FromWatts(int watts)
+        {
+            return new Power(Convert.ToDecimal(watts));
+        }
+
+		/// <summary>
+        ///     Get Power from Watts.
+        /// </summary>
+        public static Power FromWatts(long watts)
+        {
+            return new Power(Convert.ToDecimal(watts));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Power from Watts of type decimal.
+        /// </summary>
+        public static Power FromWatts(decimal watts)
+        {
+	        return new Power(Convert.ToDecimal(Convert.ToDouble(watts)));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Power from nullable BoilerHorsepower.
         /// </summary>
         public static Power? FromBoilerHorsepower(double? boilerhorsepower)
+        {
+            if (boilerhorsepower.HasValue)
+            {
+                return FromBoilerHorsepower(boilerhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable BoilerHorsepower.
+        /// </summary>
+        public static Power? FromBoilerHorsepower(int? boilerhorsepower)
+        {
+            if (boilerhorsepower.HasValue)
+            {
+                return FromBoilerHorsepower(boilerhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable BoilerHorsepower.
+        /// </summary>
+        public static Power? FromBoilerHorsepower(long? boilerhorsepower)
+        {
+            if (boilerhorsepower.HasValue)
+            {
+                return FromBoilerHorsepower(boilerhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from BoilerHorsepower of type decimal.
+        /// </summary>
+        public static Power? FromBoilerHorsepower(decimal? boilerhorsepower)
         {
             if (boilerhorsepower.HasValue)
             {
@@ -458,10 +989,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power? FromBritishThermalUnitsPerHour(int? britishthermalunitsperhour)
+        {
+            if (britishthermalunitsperhour.HasValue)
+            {
+                return FromBritishThermalUnitsPerHour(britishthermalunitsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power? FromBritishThermalUnitsPerHour(long? britishthermalunitsperhour)
+        {
+            if (britishthermalunitsperhour.HasValue)
+            {
+                return FromBritishThermalUnitsPerHour(britishthermalunitsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from BritishThermalUnitsPerHour of type decimal.
+        /// </summary>
+        public static Power? FromBritishThermalUnitsPerHour(decimal? britishthermalunitsperhour)
+        {
+            if (britishthermalunitsperhour.HasValue)
+            {
+                return FromBritishThermalUnitsPerHour(britishthermalunitsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable ElectricalHorsepower.
         /// </summary>
         public static Power? FromElectricalHorsepower(double? electricalhorsepower)
+        {
+            if (electricalhorsepower.HasValue)
+            {
+                return FromElectricalHorsepower(electricalhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable ElectricalHorsepower.
+        /// </summary>
+        public static Power? FromElectricalHorsepower(int? electricalhorsepower)
+        {
+            if (electricalhorsepower.HasValue)
+            {
+                return FromElectricalHorsepower(electricalhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable ElectricalHorsepower.
+        /// </summary>
+        public static Power? FromElectricalHorsepower(long? electricalhorsepower)
+        {
+            if (electricalhorsepower.HasValue)
+            {
+                return FromElectricalHorsepower(electricalhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from ElectricalHorsepower of type decimal.
+        /// </summary>
+        public static Power? FromElectricalHorsepower(decimal? electricalhorsepower)
         {
             if (electricalhorsepower.HasValue)
             {
@@ -488,10 +1109,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Femtowatts.
+        /// </summary>
+        public static Power? FromFemtowatts(int? femtowatts)
+        {
+            if (femtowatts.HasValue)
+            {
+                return FromFemtowatts(femtowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Femtowatts.
+        /// </summary>
+        public static Power? FromFemtowatts(long? femtowatts)
+        {
+            if (femtowatts.HasValue)
+            {
+                return FromFemtowatts(femtowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Femtowatts of type decimal.
+        /// </summary>
+        public static Power? FromFemtowatts(decimal? femtowatts)
+        {
+            if (femtowatts.HasValue)
+            {
+                return FromFemtowatts(femtowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable Gigawatts.
         /// </summary>
         public static Power? FromGigawatts(double? gigawatts)
+        {
+            if (gigawatts.HasValue)
+            {
+                return FromGigawatts(gigawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Gigawatts.
+        /// </summary>
+        public static Power? FromGigawatts(int? gigawatts)
+        {
+            if (gigawatts.HasValue)
+            {
+                return FromGigawatts(gigawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Gigawatts.
+        /// </summary>
+        public static Power? FromGigawatts(long? gigawatts)
+        {
+            if (gigawatts.HasValue)
+            {
+                return FromGigawatts(gigawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Gigawatts of type decimal.
+        /// </summary>
+        public static Power? FromGigawatts(decimal? gigawatts)
         {
             if (gigawatts.HasValue)
             {
@@ -518,10 +1229,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable HydraulicHorsepower.
+        /// </summary>
+        public static Power? FromHydraulicHorsepower(int? hydraulichorsepower)
+        {
+            if (hydraulichorsepower.HasValue)
+            {
+                return FromHydraulicHorsepower(hydraulichorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable HydraulicHorsepower.
+        /// </summary>
+        public static Power? FromHydraulicHorsepower(long? hydraulichorsepower)
+        {
+            if (hydraulichorsepower.HasValue)
+            {
+                return FromHydraulicHorsepower(hydraulichorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from HydraulicHorsepower of type decimal.
+        /// </summary>
+        public static Power? FromHydraulicHorsepower(decimal? hydraulichorsepower)
+        {
+            if (hydraulichorsepower.HasValue)
+            {
+                return FromHydraulicHorsepower(hydraulichorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
         /// </summary>
         public static Power? FromKilobritishThermalUnitsPerHour(double? kilobritishthermalunitsperhour)
+        {
+            if (kilobritishthermalunitsperhour.HasValue)
+            {
+                return FromKilobritishThermalUnitsPerHour(kilobritishthermalunitsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power? FromKilobritishThermalUnitsPerHour(int? kilobritishthermalunitsperhour)
+        {
+            if (kilobritishthermalunitsperhour.HasValue)
+            {
+                return FromKilobritishThermalUnitsPerHour(kilobritishthermalunitsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
+        /// </summary>
+        public static Power? FromKilobritishThermalUnitsPerHour(long? kilobritishthermalunitsperhour)
+        {
+            if (kilobritishthermalunitsperhour.HasValue)
+            {
+                return FromKilobritishThermalUnitsPerHour(kilobritishthermalunitsperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from KilobritishThermalUnitsPerHour of type decimal.
+        /// </summary>
+        public static Power? FromKilobritishThermalUnitsPerHour(decimal? kilobritishthermalunitsperhour)
         {
             if (kilobritishthermalunitsperhour.HasValue)
             {
@@ -548,10 +1349,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Kilowatts.
+        /// </summary>
+        public static Power? FromKilowatts(int? kilowatts)
+        {
+            if (kilowatts.HasValue)
+            {
+                return FromKilowatts(kilowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Kilowatts.
+        /// </summary>
+        public static Power? FromKilowatts(long? kilowatts)
+        {
+            if (kilowatts.HasValue)
+            {
+                return FromKilowatts(kilowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Kilowatts of type decimal.
+        /// </summary>
+        public static Power? FromKilowatts(decimal? kilowatts)
+        {
+            if (kilowatts.HasValue)
+            {
+                return FromKilowatts(kilowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable MechanicalHorsepower.
         /// </summary>
         public static Power? FromMechanicalHorsepower(double? mechanicalhorsepower)
+        {
+            if (mechanicalhorsepower.HasValue)
+            {
+                return FromMechanicalHorsepower(mechanicalhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable MechanicalHorsepower.
+        /// </summary>
+        public static Power? FromMechanicalHorsepower(int? mechanicalhorsepower)
+        {
+            if (mechanicalhorsepower.HasValue)
+            {
+                return FromMechanicalHorsepower(mechanicalhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable MechanicalHorsepower.
+        /// </summary>
+        public static Power? FromMechanicalHorsepower(long? mechanicalhorsepower)
+        {
+            if (mechanicalhorsepower.HasValue)
+            {
+                return FromMechanicalHorsepower(mechanicalhorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from MechanicalHorsepower of type decimal.
+        /// </summary>
+        public static Power? FromMechanicalHorsepower(decimal? mechanicalhorsepower)
         {
             if (mechanicalhorsepower.HasValue)
             {
@@ -578,10 +1469,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Megawatts.
+        /// </summary>
+        public static Power? FromMegawatts(int? megawatts)
+        {
+            if (megawatts.HasValue)
+            {
+                return FromMegawatts(megawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Megawatts.
+        /// </summary>
+        public static Power? FromMegawatts(long? megawatts)
+        {
+            if (megawatts.HasValue)
+            {
+                return FromMegawatts(megawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Megawatts of type decimal.
+        /// </summary>
+        public static Power? FromMegawatts(decimal? megawatts)
+        {
+            if (megawatts.HasValue)
+            {
+                return FromMegawatts(megawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable MetricHorsepower.
         /// </summary>
         public static Power? FromMetricHorsepower(double? metrichorsepower)
+        {
+            if (metrichorsepower.HasValue)
+            {
+                return FromMetricHorsepower(metrichorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable MetricHorsepower.
+        /// </summary>
+        public static Power? FromMetricHorsepower(int? metrichorsepower)
+        {
+            if (metrichorsepower.HasValue)
+            {
+                return FromMetricHorsepower(metrichorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable MetricHorsepower.
+        /// </summary>
+        public static Power? FromMetricHorsepower(long? metrichorsepower)
+        {
+            if (metrichorsepower.HasValue)
+            {
+                return FromMetricHorsepower(metrichorsepower.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from MetricHorsepower of type decimal.
+        /// </summary>
+        public static Power? FromMetricHorsepower(decimal? metrichorsepower)
         {
             if (metrichorsepower.HasValue)
             {
@@ -608,10 +1589,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Microwatts.
+        /// </summary>
+        public static Power? FromMicrowatts(int? microwatts)
+        {
+            if (microwatts.HasValue)
+            {
+                return FromMicrowatts(microwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Microwatts.
+        /// </summary>
+        public static Power? FromMicrowatts(long? microwatts)
+        {
+            if (microwatts.HasValue)
+            {
+                return FromMicrowatts(microwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Microwatts of type decimal.
+        /// </summary>
+        public static Power? FromMicrowatts(decimal? microwatts)
+        {
+            if (microwatts.HasValue)
+            {
+                return FromMicrowatts(microwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable Milliwatts.
         /// </summary>
         public static Power? FromMilliwatts(double? milliwatts)
+        {
+            if (milliwatts.HasValue)
+            {
+                return FromMilliwatts(milliwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Milliwatts.
+        /// </summary>
+        public static Power? FromMilliwatts(int? milliwatts)
+        {
+            if (milliwatts.HasValue)
+            {
+                return FromMilliwatts(milliwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Milliwatts.
+        /// </summary>
+        public static Power? FromMilliwatts(long? milliwatts)
+        {
+            if (milliwatts.HasValue)
+            {
+                return FromMilliwatts(milliwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Milliwatts of type decimal.
+        /// </summary>
+        public static Power? FromMilliwatts(decimal? milliwatts)
         {
             if (milliwatts.HasValue)
             {
@@ -638,10 +1709,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Nanowatts.
+        /// </summary>
+        public static Power? FromNanowatts(int? nanowatts)
+        {
+            if (nanowatts.HasValue)
+            {
+                return FromNanowatts(nanowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Nanowatts.
+        /// </summary>
+        public static Power? FromNanowatts(long? nanowatts)
+        {
+            if (nanowatts.HasValue)
+            {
+                return FromNanowatts(nanowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Nanowatts of type decimal.
+        /// </summary>
+        public static Power? FromNanowatts(decimal? nanowatts)
+        {
+            if (nanowatts.HasValue)
+            {
+                return FromNanowatts(nanowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable Petawatts.
         /// </summary>
         public static Power? FromPetawatts(double? petawatts)
+        {
+            if (petawatts.HasValue)
+            {
+                return FromPetawatts(petawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Petawatts.
+        /// </summary>
+        public static Power? FromPetawatts(int? petawatts)
+        {
+            if (petawatts.HasValue)
+            {
+                return FromPetawatts(petawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Petawatts.
+        /// </summary>
+        public static Power? FromPetawatts(long? petawatts)
+        {
+            if (petawatts.HasValue)
+            {
+                return FromPetawatts(petawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Petawatts of type decimal.
+        /// </summary>
+        public static Power? FromPetawatts(decimal? petawatts)
         {
             if (petawatts.HasValue)
             {
@@ -668,6 +1829,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Picowatts.
+        /// </summary>
+        public static Power? FromPicowatts(int? picowatts)
+        {
+            if (picowatts.HasValue)
+            {
+                return FromPicowatts(picowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Picowatts.
+        /// </summary>
+        public static Power? FromPicowatts(long? picowatts)
+        {
+            if (picowatts.HasValue)
+            {
+                return FromPicowatts(picowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Picowatts of type decimal.
+        /// </summary>
+        public static Power? FromPicowatts(decimal? picowatts)
+        {
+            if (picowatts.HasValue)
+            {
+                return FromPicowatts(picowatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable Terawatts.
         /// </summary>
@@ -683,10 +1889,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Power from nullable Terawatts.
+        /// </summary>
+        public static Power? FromTerawatts(int? terawatts)
+        {
+            if (terawatts.HasValue)
+            {
+                return FromTerawatts(terawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Terawatts.
+        /// </summary>
+        public static Power? FromTerawatts(long? terawatts)
+        {
+            if (terawatts.HasValue)
+            {
+                return FromTerawatts(terawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Terawatts of type decimal.
+        /// </summary>
+        public static Power? FromTerawatts(decimal? terawatts)
+        {
+            if (terawatts.HasValue)
+            {
+                return FromTerawatts(terawatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Power from nullable Watts.
         /// </summary>
         public static Power? FromWatts(double? watts)
+        {
+            if (watts.HasValue)
+            {
+                return FromWatts(watts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Watts.
+        /// </summary>
+        public static Power? FromWatts(int? watts)
+        {
+            if (watts.HasValue)
+            {
+                return FromWatts(watts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from nullable Watts.
+        /// </summary>
+        public static Power? FromWatts(long? watts)
+        {
+            if (watts.HasValue)
+            {
+                return FromWatts(watts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Power from Watts of type decimal.
+        /// </summary>
+        public static Power? FromWatts(decimal? watts)
         {
             if (watts.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly decimal _watts;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Power() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Power;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static PowerUnit BaseUnit
         {
             get { return PowerUnit.Watt; }
@@ -290,7 +290,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from BoilerHorsepower.
         /// </summary>
         public static Power FromBoilerHorsepower(int boilerhorsepower)
@@ -298,7 +298,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from BoilerHorsepower.
         /// </summary>
         public static Power FromBoilerHorsepower(long boilerhorsepower)
@@ -306,14 +306,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from BoilerHorsepower of type decimal.
         /// </summary>
         public static Power FromBoilerHorsepower(decimal boilerhorsepower)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(boilerhorsepower)*9812.5d));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(boilerhorsepower)*9812.5d));
         }
 #endif
 
@@ -325,7 +325,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
         public static Power FromBritishThermalUnitsPerHour(int britishthermalunitsperhour)
@@ -333,7 +333,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
         public static Power FromBritishThermalUnitsPerHour(long britishthermalunitsperhour)
@@ -341,14 +341,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour of type decimal.
         /// </summary>
         public static Power FromBritishThermalUnitsPerHour(decimal britishthermalunitsperhour)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(britishthermalunitsperhour)*0.293071d));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(britishthermalunitsperhour)*0.293071d));
         }
 #endif
 
@@ -360,7 +360,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(electricalhorsepower*746d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from ElectricalHorsepower.
         /// </summary>
         public static Power FromElectricalHorsepower(int electricalhorsepower)
@@ -368,7 +368,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(electricalhorsepower*746d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from ElectricalHorsepower.
         /// </summary>
         public static Power FromElectricalHorsepower(long electricalhorsepower)
@@ -376,14 +376,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(electricalhorsepower*746d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from ElectricalHorsepower of type decimal.
         /// </summary>
         public static Power FromElectricalHorsepower(decimal electricalhorsepower)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(electricalhorsepower)*746d));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(electricalhorsepower)*746d));
         }
 #endif
 
@@ -395,7 +395,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
         public static Power FromFemtowatts(int femtowatts)
@@ -403,7 +403,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
         public static Power FromFemtowatts(long femtowatts)
@@ -411,14 +411,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Femtowatts of type decimal.
         /// </summary>
         public static Power FromFemtowatts(decimal femtowatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(femtowatts)) * 1e-15d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(femtowatts)) * 1e-15d));
         }
 #endif
 
@@ -430,7 +430,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Gigawatts.
         /// </summary>
         public static Power FromGigawatts(int gigawatts)
@@ -438,7 +438,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Gigawatts.
         /// </summary>
         public static Power FromGigawatts(long gigawatts)
@@ -446,14 +446,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Gigawatts of type decimal.
         /// </summary>
         public static Power FromGigawatts(decimal gigawatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(gigawatts)) * 1e9d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(gigawatts)) * 1e9d));
         }
 #endif
 
@@ -465,7 +465,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
         public static Power FromHydraulicHorsepower(int hydraulichorsepower)
@@ -473,7 +473,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
         public static Power FromHydraulicHorsepower(long hydraulichorsepower)
@@ -481,14 +481,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from HydraulicHorsepower of type decimal.
         /// </summary>
         public static Power FromHydraulicHorsepower(decimal hydraulichorsepower)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(hydraulichorsepower)*745.69988145d));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(hydraulichorsepower)*745.69988145d));
         }
 #endif
 
@@ -500,7 +500,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
         /// </summary>
         public static Power FromKilobritishThermalUnitsPerHour(int kilobritishthermalunitsperhour)
@@ -508,7 +508,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
         /// </summary>
         public static Power FromKilobritishThermalUnitsPerHour(long kilobritishthermalunitsperhour)
@@ -516,14 +516,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour of type decimal.
         /// </summary>
         public static Power FromKilobritishThermalUnitsPerHour(decimal kilobritishthermalunitsperhour)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(kilobritishthermalunitsperhour)*0.293071d) * 1e3d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(kilobritishthermalunitsperhour)*0.293071d) * 1e3d));
         }
 #endif
 
@@ -535,7 +535,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
         public static Power FromKilowatts(int kilowatts)
@@ -543,7 +543,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
         public static Power FromKilowatts(long kilowatts)
@@ -551,14 +551,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Kilowatts of type decimal.
         /// </summary>
         public static Power FromKilowatts(decimal kilowatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(kilowatts)) * 1e3d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(kilowatts)) * 1e3d));
         }
 #endif
 
@@ -570,7 +570,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from MechanicalHorsepower.
         /// </summary>
         public static Power FromMechanicalHorsepower(int mechanicalhorsepower)
@@ -578,7 +578,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from MechanicalHorsepower.
         /// </summary>
         public static Power FromMechanicalHorsepower(long mechanicalhorsepower)
@@ -586,14 +586,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from MechanicalHorsepower of type decimal.
         /// </summary>
         public static Power FromMechanicalHorsepower(decimal mechanicalhorsepower)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(mechanicalhorsepower)*745.69d));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(mechanicalhorsepower)*745.69d));
         }
 #endif
 
@@ -605,7 +605,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((megawatts) * 1e6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
         public static Power FromMegawatts(int megawatts)
@@ -613,7 +613,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((megawatts) * 1e6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
         public static Power FromMegawatts(long megawatts)
@@ -621,14 +621,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((megawatts) * 1e6d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Megawatts of type decimal.
         /// </summary>
         public static Power FromMegawatts(decimal megawatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(megawatts)) * 1e6d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(megawatts)) * 1e6d));
         }
 #endif
 
@@ -640,7 +640,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from MetricHorsepower.
         /// </summary>
         public static Power FromMetricHorsepower(int metrichorsepower)
@@ -648,7 +648,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from MetricHorsepower.
         /// </summary>
         public static Power FromMetricHorsepower(long metrichorsepower)
@@ -656,14 +656,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from MetricHorsepower of type decimal.
         /// </summary>
         public static Power FromMetricHorsepower(decimal metrichorsepower)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(metrichorsepower)*735.49875d));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(metrichorsepower)*735.49875d));
         }
 #endif
 
@@ -675,7 +675,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
         public static Power FromMicrowatts(int microwatts)
@@ -683,7 +683,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
         public static Power FromMicrowatts(long microwatts)
@@ -691,14 +691,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Microwatts of type decimal.
         /// </summary>
         public static Power FromMicrowatts(decimal microwatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(microwatts)) * 1e-6d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(microwatts)) * 1e-6d));
         }
 #endif
 
@@ -710,7 +710,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Milliwatts.
         /// </summary>
         public static Power FromMilliwatts(int milliwatts)
@@ -718,7 +718,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Milliwatts.
         /// </summary>
         public static Power FromMilliwatts(long milliwatts)
@@ -726,14 +726,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Milliwatts of type decimal.
         /// </summary>
         public static Power FromMilliwatts(decimal milliwatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(milliwatts)) * 1e-3d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(milliwatts)) * 1e-3d));
         }
 #endif
 
@@ -745,7 +745,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
         public static Power FromNanowatts(int nanowatts)
@@ -753,7 +753,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
         public static Power FromNanowatts(long nanowatts)
@@ -761,14 +761,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Nanowatts of type decimal.
         /// </summary>
         public static Power FromNanowatts(decimal nanowatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(nanowatts)) * 1e-9d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(nanowatts)) * 1e-9d));
         }
 #endif
 
@@ -780,7 +780,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((petawatts) * 1e15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Petawatts.
         /// </summary>
         public static Power FromPetawatts(int petawatts)
@@ -788,7 +788,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((petawatts) * 1e15d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Petawatts.
         /// </summary>
         public static Power FromPetawatts(long petawatts)
@@ -796,14 +796,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((petawatts) * 1e15d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Petawatts of type decimal.
         /// </summary>
         public static Power FromPetawatts(decimal petawatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(petawatts)) * 1e15d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(petawatts)) * 1e15d));
         }
 #endif
 
@@ -815,7 +815,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
         public static Power FromPicowatts(int picowatts)
@@ -823,7 +823,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
         public static Power FromPicowatts(long picowatts)
@@ -831,14 +831,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Picowatts of type decimal.
         /// </summary>
         public static Power FromPicowatts(decimal picowatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(picowatts)) * 1e-12d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(picowatts)) * 1e-12d));
         }
 #endif
 
@@ -850,7 +850,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((terawatts) * 1e12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Terawatts.
         /// </summary>
         public static Power FromTerawatts(int terawatts)
@@ -858,7 +858,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((terawatts) * 1e12d));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Terawatts.
         /// </summary>
         public static Power FromTerawatts(long terawatts)
@@ -866,14 +866,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal((terawatts) * 1e12d));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Terawatts of type decimal.
         /// </summary>
         public static Power FromTerawatts(decimal terawatts)
         {
-	        return new Power(Convert.ToDecimal((Convert.ToDouble(terawatts)) * 1e12d));
+            return new Power(Convert.ToDecimal((Convert.ToDouble(terawatts)) * 1e12d));
         }
 #endif
 
@@ -885,7 +885,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(watts));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Watts.
         /// </summary>
         public static Power FromWatts(int watts)
@@ -893,7 +893,7 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(watts));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Power from Watts.
         /// </summary>
         public static Power FromWatts(long watts)
@@ -901,14 +901,14 @@ namespace UnitsNet
             return new Power(Convert.ToDecimal(watts));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Power from Watts of type decimal.
         /// </summary>
         public static Power FromWatts(decimal watts)
         {
-	        return new Power(Convert.ToDecimal(Convert.ToDouble(watts)));
+            return new Power(Convert.ToDecimal(Convert.ToDouble(watts)));
         }
 #endif
 
@@ -929,7 +929,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable BoilerHorsepower.
         /// </summary>
         public static Power? FromBoilerHorsepower(int? boilerhorsepower)
@@ -944,7 +944,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable BoilerHorsepower.
         /// </summary>
         public static Power? FromBoilerHorsepower(long? boilerhorsepower)
@@ -959,7 +959,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from BoilerHorsepower of type decimal.
         /// </summary>
         public static Power? FromBoilerHorsepower(decimal? boilerhorsepower)
@@ -989,7 +989,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
         /// </summary>
         public static Power? FromBritishThermalUnitsPerHour(int? britishthermalunitsperhour)
@@ -1004,7 +1004,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
         /// </summary>
         public static Power? FromBritishThermalUnitsPerHour(long? britishthermalunitsperhour)
@@ -1019,7 +1019,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from BritishThermalUnitsPerHour of type decimal.
         /// </summary>
         public static Power? FromBritishThermalUnitsPerHour(decimal? britishthermalunitsperhour)
@@ -1049,7 +1049,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable ElectricalHorsepower.
         /// </summary>
         public static Power? FromElectricalHorsepower(int? electricalhorsepower)
@@ -1064,7 +1064,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable ElectricalHorsepower.
         /// </summary>
         public static Power? FromElectricalHorsepower(long? electricalhorsepower)
@@ -1079,7 +1079,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from ElectricalHorsepower of type decimal.
         /// </summary>
         public static Power? FromElectricalHorsepower(decimal? electricalhorsepower)
@@ -1109,7 +1109,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Femtowatts.
         /// </summary>
         public static Power? FromFemtowatts(int? femtowatts)
@@ -1124,7 +1124,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Femtowatts.
         /// </summary>
         public static Power? FromFemtowatts(long? femtowatts)
@@ -1139,7 +1139,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Femtowatts of type decimal.
         /// </summary>
         public static Power? FromFemtowatts(decimal? femtowatts)
@@ -1169,7 +1169,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Gigawatts.
         /// </summary>
         public static Power? FromGigawatts(int? gigawatts)
@@ -1184,7 +1184,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Gigawatts.
         /// </summary>
         public static Power? FromGigawatts(long? gigawatts)
@@ -1199,7 +1199,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Gigawatts of type decimal.
         /// </summary>
         public static Power? FromGigawatts(decimal? gigawatts)
@@ -1229,7 +1229,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable HydraulicHorsepower.
         /// </summary>
         public static Power? FromHydraulicHorsepower(int? hydraulichorsepower)
@@ -1244,7 +1244,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable HydraulicHorsepower.
         /// </summary>
         public static Power? FromHydraulicHorsepower(long? hydraulichorsepower)
@@ -1259,7 +1259,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from HydraulicHorsepower of type decimal.
         /// </summary>
         public static Power? FromHydraulicHorsepower(decimal? hydraulichorsepower)
@@ -1289,7 +1289,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
         /// </summary>
         public static Power? FromKilobritishThermalUnitsPerHour(int? kilobritishthermalunitsperhour)
@@ -1304,7 +1304,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
         /// </summary>
         public static Power? FromKilobritishThermalUnitsPerHour(long? kilobritishthermalunitsperhour)
@@ -1319,7 +1319,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from KilobritishThermalUnitsPerHour of type decimal.
         /// </summary>
         public static Power? FromKilobritishThermalUnitsPerHour(decimal? kilobritishthermalunitsperhour)
@@ -1349,7 +1349,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Kilowatts.
         /// </summary>
         public static Power? FromKilowatts(int? kilowatts)
@@ -1364,7 +1364,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Kilowatts.
         /// </summary>
         public static Power? FromKilowatts(long? kilowatts)
@@ -1379,7 +1379,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Kilowatts of type decimal.
         /// </summary>
         public static Power? FromKilowatts(decimal? kilowatts)
@@ -1409,7 +1409,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable MechanicalHorsepower.
         /// </summary>
         public static Power? FromMechanicalHorsepower(int? mechanicalhorsepower)
@@ -1424,7 +1424,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable MechanicalHorsepower.
         /// </summary>
         public static Power? FromMechanicalHorsepower(long? mechanicalhorsepower)
@@ -1439,7 +1439,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from MechanicalHorsepower of type decimal.
         /// </summary>
         public static Power? FromMechanicalHorsepower(decimal? mechanicalhorsepower)
@@ -1469,7 +1469,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Megawatts.
         /// </summary>
         public static Power? FromMegawatts(int? megawatts)
@@ -1484,7 +1484,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Megawatts.
         /// </summary>
         public static Power? FromMegawatts(long? megawatts)
@@ -1499,7 +1499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Megawatts of type decimal.
         /// </summary>
         public static Power? FromMegawatts(decimal? megawatts)
@@ -1529,7 +1529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable MetricHorsepower.
         /// </summary>
         public static Power? FromMetricHorsepower(int? metrichorsepower)
@@ -1544,7 +1544,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable MetricHorsepower.
         /// </summary>
         public static Power? FromMetricHorsepower(long? metrichorsepower)
@@ -1559,7 +1559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from MetricHorsepower of type decimal.
         /// </summary>
         public static Power? FromMetricHorsepower(decimal? metrichorsepower)
@@ -1589,7 +1589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Microwatts.
         /// </summary>
         public static Power? FromMicrowatts(int? microwatts)
@@ -1604,7 +1604,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Microwatts.
         /// </summary>
         public static Power? FromMicrowatts(long? microwatts)
@@ -1619,7 +1619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Microwatts of type decimal.
         /// </summary>
         public static Power? FromMicrowatts(decimal? microwatts)
@@ -1649,7 +1649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Milliwatts.
         /// </summary>
         public static Power? FromMilliwatts(int? milliwatts)
@@ -1664,7 +1664,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Milliwatts.
         /// </summary>
         public static Power? FromMilliwatts(long? milliwatts)
@@ -1679,7 +1679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Milliwatts of type decimal.
         /// </summary>
         public static Power? FromMilliwatts(decimal? milliwatts)
@@ -1709,7 +1709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Nanowatts.
         /// </summary>
         public static Power? FromNanowatts(int? nanowatts)
@@ -1724,7 +1724,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Nanowatts.
         /// </summary>
         public static Power? FromNanowatts(long? nanowatts)
@@ -1739,7 +1739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Nanowatts of type decimal.
         /// </summary>
         public static Power? FromNanowatts(decimal? nanowatts)
@@ -1769,7 +1769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Petawatts.
         /// </summary>
         public static Power? FromPetawatts(int? petawatts)
@@ -1784,7 +1784,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Petawatts.
         /// </summary>
         public static Power? FromPetawatts(long? petawatts)
@@ -1799,7 +1799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Petawatts of type decimal.
         /// </summary>
         public static Power? FromPetawatts(decimal? petawatts)
@@ -1829,7 +1829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Picowatts.
         /// </summary>
         public static Power? FromPicowatts(int? picowatts)
@@ -1844,7 +1844,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Picowatts.
         /// </summary>
         public static Power? FromPicowatts(long? picowatts)
@@ -1859,7 +1859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Picowatts of type decimal.
         /// </summary>
         public static Power? FromPicowatts(decimal? picowatts)
@@ -1889,7 +1889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Terawatts.
         /// </summary>
         public static Power? FromTerawatts(int? terawatts)
@@ -1904,7 +1904,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Terawatts.
         /// </summary>
         public static Power? FromTerawatts(long? terawatts)
@@ -1919,7 +1919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Terawatts of type decimal.
         /// </summary>
         public static Power? FromTerawatts(decimal? terawatts)
@@ -1949,7 +1949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Watts.
         /// </summary>
         public static Power? FromWatts(int? watts)
@@ -1964,7 +1964,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from nullable Watts.
         /// </summary>
         public static Power? FromWatts(long? watts)
@@ -1979,7 +1979,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Power from Watts of type decimal.
         /// </summary>
         public static Power? FromWatts(decimal? watts)

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -285,6 +285,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BoilerHorsepower.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromBoilerHorsepower(double boilerhorsepower)
         {
             return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
@@ -320,6 +323,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromBritishThermalUnitsPerHour(double britishthermalunitsperhour)
         {
             return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
@@ -355,6 +361,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from ElectricalHorsepower.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromElectricalHorsepower(double electricalhorsepower)
         {
             return new Power(Convert.ToDecimal(electricalhorsepower*746d));
@@ -390,6 +399,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromFemtowatts(double femtowatts)
         {
             return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
@@ -425,6 +437,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Gigawatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromGigawatts(double gigawatts)
         {
             return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
@@ -460,6 +475,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromHydraulicHorsepower(double hydraulichorsepower)
         {
             return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
@@ -495,6 +513,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromKilobritishThermalUnitsPerHour(double kilobritishthermalunitsperhour)
         {
             return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
@@ -530,6 +551,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromKilowatts(double kilowatts)
         {
             return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
@@ -565,6 +589,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from MechanicalHorsepower.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromMechanicalHorsepower(double mechanicalhorsepower)
         {
             return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
@@ -600,6 +627,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromMegawatts(double megawatts)
         {
             return new Power(Convert.ToDecimal((megawatts) * 1e6d));
@@ -635,6 +665,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from MetricHorsepower.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromMetricHorsepower(double metrichorsepower)
         {
             return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
@@ -670,6 +703,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromMicrowatts(double microwatts)
         {
             return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
@@ -705,6 +741,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Milliwatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromMilliwatts(double milliwatts)
         {
             return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
@@ -740,6 +779,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromNanowatts(double nanowatts)
         {
             return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
@@ -775,6 +817,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Petawatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromPetawatts(double petawatts)
         {
             return new Power(Convert.ToDecimal((petawatts) * 1e15d));
@@ -810,6 +855,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromPicowatts(double picowatts)
         {
             return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
@@ -845,6 +893,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Terawatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromTerawatts(double terawatts)
         {
             return new Power(Convert.ToDecimal((terawatts) * 1e12d));
@@ -880,6 +931,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Watts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Power FromWatts(double watts)
         {
             return new Power(Convert.ToDecimal(watts));

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -157,6 +157,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static PowerRatio FromDecibelMilliwatts(double decibelmilliwatts)
         {
             return new PowerRatio(decibelmilliwatts - 30);
@@ -192,6 +195,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static PowerRatio FromDecibelWatts(double decibelwatts)
         {
             return new PowerRatio(decibelwatts);

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _decibelWatts;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public PowerRatio() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.PowerRatio;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static PowerRatioUnit BaseUnit
         {
             get { return PowerRatioUnit.DecibelWatt; }
@@ -162,7 +162,7 @@ namespace UnitsNet
             return new PowerRatio(decibelmilliwatts - 30);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts.
         /// </summary>
         public static PowerRatio FromDecibelMilliwatts(int decibelmilliwatts)
@@ -170,7 +170,7 @@ namespace UnitsNet
             return new PowerRatio(decibelmilliwatts - 30);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts.
         /// </summary>
         public static PowerRatio FromDecibelMilliwatts(long decibelmilliwatts)
@@ -178,14 +178,14 @@ namespace UnitsNet
             return new PowerRatio(decibelmilliwatts - 30);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts of type decimal.
         /// </summary>
         public static PowerRatio FromDecibelMilliwatts(decimal decibelmilliwatts)
         {
-	        return new PowerRatio(Convert.ToDouble(decibelmilliwatts) - 30);
+            return new PowerRatio(Convert.ToDouble(decibelmilliwatts) - 30);
         }
 #endif
 
@@ -197,7 +197,7 @@ namespace UnitsNet
             return new PowerRatio(decibelwatts);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
         public static PowerRatio FromDecibelWatts(int decibelwatts)
@@ -205,7 +205,7 @@ namespace UnitsNet
             return new PowerRatio(decibelwatts);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
         public static PowerRatio FromDecibelWatts(long decibelwatts)
@@ -213,14 +213,14 @@ namespace UnitsNet
             return new PowerRatio(decibelwatts);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get PowerRatio from DecibelWatts of type decimal.
         /// </summary>
         public static PowerRatio FromDecibelWatts(decimal decibelwatts)
         {
-	        return new PowerRatio(Convert.ToDouble(decibelwatts));
+            return new PowerRatio(Convert.ToDouble(decibelwatts));
         }
 #endif
 
@@ -241,7 +241,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
         /// </summary>
         public static PowerRatio? FromDecibelMilliwatts(int? decibelmilliwatts)
@@ -256,7 +256,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
         /// </summary>
         public static PowerRatio? FromDecibelMilliwatts(long? decibelmilliwatts)
@@ -271,7 +271,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PowerRatio from DecibelMilliwatts of type decimal.
         /// </summary>
         public static PowerRatio? FromDecibelMilliwatts(decimal? decibelmilliwatts)
@@ -301,7 +301,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelWatts.
         /// </summary>
         public static PowerRatio? FromDecibelWatts(int? decibelwatts)
@@ -316,7 +316,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelWatts.
         /// </summary>
         public static PowerRatio? FromDecibelWatts(long? decibelwatts)
@@ -331,7 +331,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PowerRatio from DecibelWatts of type decimal.
         /// </summary>
         public static PowerRatio? FromDecibelWatts(decimal? decibelwatts)

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -162,6 +162,33 @@ namespace UnitsNet
             return new PowerRatio(decibelmilliwatts - 30);
         }
 
+		/// <summary>
+        ///     Get PowerRatio from DecibelMilliwatts.
+        /// </summary>
+        public static PowerRatio FromDecibelMilliwatts(int decibelmilliwatts)
+        {
+            return new PowerRatio(decibelmilliwatts - 30);
+        }
+
+		/// <summary>
+        ///     Get PowerRatio from DecibelMilliwatts.
+        /// </summary>
+        public static PowerRatio FromDecibelMilliwatts(long decibelmilliwatts)
+        {
+            return new PowerRatio(decibelmilliwatts - 30);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get PowerRatio from DecibelMilliwatts of type decimal.
+        /// </summary>
+        public static PowerRatio FromDecibelMilliwatts(decimal decibelmilliwatts)
+        {
+	        return new PowerRatio(Convert.ToDouble(decibelmilliwatts) - 30);
+        }
+#endif
+
         /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
@@ -169,6 +196,33 @@ namespace UnitsNet
         {
             return new PowerRatio(decibelwatts);
         }
+
+		/// <summary>
+        ///     Get PowerRatio from DecibelWatts.
+        /// </summary>
+        public static PowerRatio FromDecibelWatts(int decibelwatts)
+        {
+            return new PowerRatio(decibelwatts);
+        }
+
+		/// <summary>
+        ///     Get PowerRatio from DecibelWatts.
+        /// </summary>
+        public static PowerRatio FromDecibelWatts(long decibelwatts)
+        {
+            return new PowerRatio(decibelwatts);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get PowerRatio from DecibelWatts of type decimal.
+        /// </summary>
+        public static PowerRatio FromDecibelWatts(decimal decibelwatts)
+        {
+	        return new PowerRatio(Convert.ToDouble(decibelwatts));
+        }
+#endif
 
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
@@ -187,10 +241,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
+        /// </summary>
+        public static PowerRatio? FromDecibelMilliwatts(int? decibelmilliwatts)
+        {
+            if (decibelmilliwatts.HasValue)
+            {
+                return FromDecibelMilliwatts(decibelmilliwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
+        /// </summary>
+        public static PowerRatio? FromDecibelMilliwatts(long? decibelmilliwatts)
+        {
+            if (decibelmilliwatts.HasValue)
+            {
+                return FromDecibelMilliwatts(decibelmilliwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PowerRatio from DecibelMilliwatts of type decimal.
+        /// </summary>
+        public static PowerRatio? FromDecibelMilliwatts(decimal? decibelmilliwatts)
+        {
+            if (decibelmilliwatts.HasValue)
+            {
+                return FromDecibelMilliwatts(decibelmilliwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelWatts.
         /// </summary>
         public static PowerRatio? FromDecibelWatts(double? decibelwatts)
+        {
+            if (decibelwatts.HasValue)
+            {
+                return FromDecibelWatts(decibelwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PowerRatio from nullable DecibelWatts.
+        /// </summary>
+        public static PowerRatio? FromDecibelWatts(int? decibelwatts)
+        {
+            if (decibelwatts.HasValue)
+            {
+                return FromDecibelWatts(decibelwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PowerRatio from nullable DecibelWatts.
+        /// </summary>
+        public static PowerRatio? FromDecibelWatts(long? decibelwatts)
+        {
+            if (decibelwatts.HasValue)
+            {
+                return FromDecibelWatts(decibelwatts.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PowerRatio from DecibelWatts of type decimal.
+        /// </summary>
+        public static PowerRatio? FromDecibelWatts(decimal? decibelwatts)
         {
             if (decibelwatts.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -443,6 +443,33 @@ namespace UnitsNet
             return new Pressure(atmospheres*1.01325*1e5);
         }
 
+		/// <summary>
+        ///     Get Pressure from Atmospheres.
+        /// </summary>
+        public static Pressure FromAtmospheres(int atmospheres)
+        {
+            return new Pressure(atmospheres*1.01325*1e5);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Atmospheres.
+        /// </summary>
+        public static Pressure FromAtmospheres(long atmospheres)
+        {
+            return new Pressure(atmospheres*1.01325*1e5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Atmospheres of type decimal.
+        /// </summary>
+        public static Pressure FromAtmospheres(decimal atmospheres)
+        {
+	        return new Pressure(Convert.ToDouble(atmospheres)*1.01325*1e5);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
@@ -450,6 +477,33 @@ namespace UnitsNet
         {
             return new Pressure(bars*1e5);
         }
+
+		/// <summary>
+        ///     Get Pressure from Bars.
+        /// </summary>
+        public static Pressure FromBars(int bars)
+        {
+            return new Pressure(bars*1e5);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Bars.
+        /// </summary>
+        public static Pressure FromBars(long bars)
+        {
+            return new Pressure(bars*1e5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Bars of type decimal.
+        /// </summary>
+        public static Pressure FromBars(decimal bars)
+        {
+	        return new Pressure(Convert.ToDouble(bars)*1e5);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Centibars.
@@ -459,6 +513,33 @@ namespace UnitsNet
             return new Pressure((centibars*1e5) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Pressure from Centibars.
+        /// </summary>
+        public static Pressure FromCentibars(int centibars)
+        {
+            return new Pressure((centibars*1e5) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Centibars.
+        /// </summary>
+        public static Pressure FromCentibars(long centibars)
+        {
+            return new Pressure((centibars*1e5) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Centibars of type decimal.
+        /// </summary>
+        public static Pressure FromCentibars(decimal centibars)
+        {
+	        return new Pressure((Convert.ToDouble(centibars)*1e5) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
@@ -466,6 +547,33 @@ namespace UnitsNet
         {
             return new Pressure((decapascals) * 1e1d);
         }
+
+		/// <summary>
+        ///     Get Pressure from Decapascals.
+        /// </summary>
+        public static Pressure FromDecapascals(int decapascals)
+        {
+            return new Pressure((decapascals) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Decapascals.
+        /// </summary>
+        public static Pressure FromDecapascals(long decapascals)
+        {
+            return new Pressure((decapascals) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Decapascals of type decimal.
+        /// </summary>
+        public static Pressure FromDecapascals(decimal decapascals)
+        {
+	        return new Pressure((Convert.ToDouble(decapascals)) * 1e1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Decibars.
@@ -475,6 +583,33 @@ namespace UnitsNet
             return new Pressure((decibars*1e5) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get Pressure from Decibars.
+        /// </summary>
+        public static Pressure FromDecibars(int decibars)
+        {
+            return new Pressure((decibars*1e5) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Decibars.
+        /// </summary>
+        public static Pressure FromDecibars(long decibars)
+        {
+            return new Pressure((decibars*1e5) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Decibars of type decimal.
+        /// </summary>
+        public static Pressure FromDecibars(decimal decibars)
+        {
+	        return new Pressure((Convert.ToDouble(decibars)*1e5) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
@@ -482,6 +617,33 @@ namespace UnitsNet
         {
             return new Pressure(feetofhead*2989.0669);
         }
+
+		/// <summary>
+        ///     Get Pressure from FeetOfHead.
+        /// </summary>
+        public static Pressure FromFeetOfHead(int feetofhead)
+        {
+            return new Pressure(feetofhead*2989.0669);
+        }
+
+		/// <summary>
+        ///     Get Pressure from FeetOfHead.
+        /// </summary>
+        public static Pressure FromFeetOfHead(long feetofhead)
+        {
+            return new Pressure(feetofhead*2989.0669);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from FeetOfHead of type decimal.
+        /// </summary>
+        public static Pressure FromFeetOfHead(decimal feetofhead)
+        {
+	        return new Pressure(Convert.ToDouble(feetofhead)*2989.0669);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Gigapascals.
@@ -491,6 +653,33 @@ namespace UnitsNet
             return new Pressure((gigapascals) * 1e9d);
         }
 
+		/// <summary>
+        ///     Get Pressure from Gigapascals.
+        /// </summary>
+        public static Pressure FromGigapascals(int gigapascals)
+        {
+            return new Pressure((gigapascals) * 1e9d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Gigapascals.
+        /// </summary>
+        public static Pressure FromGigapascals(long gigapascals)
+        {
+            return new Pressure((gigapascals) * 1e9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Gigapascals of type decimal.
+        /// </summary>
+        public static Pressure FromGigapascals(decimal gigapascals)
+        {
+	        return new Pressure((Convert.ToDouble(gigapascals)) * 1e9d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
@@ -498,6 +687,33 @@ namespace UnitsNet
         {
             return new Pressure((hectopascals) * 1e2d);
         }
+
+		/// <summary>
+        ///     Get Pressure from Hectopascals.
+        /// </summary>
+        public static Pressure FromHectopascals(int hectopascals)
+        {
+            return new Pressure((hectopascals) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Hectopascals.
+        /// </summary>
+        public static Pressure FromHectopascals(long hectopascals)
+        {
+            return new Pressure((hectopascals) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Hectopascals of type decimal.
+        /// </summary>
+        public static Pressure FromHectopascals(decimal hectopascals)
+        {
+	        return new Pressure((Convert.ToDouble(hectopascals)) * 1e2d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from InchesOfMercury.
@@ -507,6 +723,33 @@ namespace UnitsNet
             return new Pressure(inchesofmercury/2.95299830714159e-4);
         }
 
+		/// <summary>
+        ///     Get Pressure from InchesOfMercury.
+        /// </summary>
+        public static Pressure FromInchesOfMercury(int inchesofmercury)
+        {
+            return new Pressure(inchesofmercury/2.95299830714159e-4);
+        }
+
+		/// <summary>
+        ///     Get Pressure from InchesOfMercury.
+        /// </summary>
+        public static Pressure FromInchesOfMercury(long inchesofmercury)
+        {
+            return new Pressure(inchesofmercury/2.95299830714159e-4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from InchesOfMercury of type decimal.
+        /// </summary>
+        public static Pressure FromInchesOfMercury(decimal inchesofmercury)
+        {
+	        return new Pressure(Convert.ToDouble(inchesofmercury)/2.95299830714159e-4);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
@@ -514,6 +757,33 @@ namespace UnitsNet
         {
             return new Pressure((kilobars*1e5) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Pressure from Kilobars.
+        /// </summary>
+        public static Pressure FromKilobars(int kilobars)
+        {
+            return new Pressure((kilobars*1e5) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Kilobars.
+        /// </summary>
+        public static Pressure FromKilobars(long kilobars)
+        {
+            return new Pressure((kilobars*1e5) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Kilobars of type decimal.
+        /// </summary>
+        public static Pressure FromKilobars(decimal kilobars)
+        {
+	        return new Pressure((Convert.ToDouble(kilobars)*1e5) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
@@ -523,6 +793,33 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
         }
 
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareCentimeter(int kilogramsforcepersquarecentimeter)
+        {
+            return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareCentimeter(long kilogramsforcepersquarecentimeter)
+        {
+            return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareCentimeter(decimal kilogramsforcepersquarecentimeter)
+        {
+	        return new Pressure(Convert.ToDouble(kilogramsforcepersquarecentimeter)*9.80665*1e4);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
@@ -530,6 +827,33 @@ namespace UnitsNet
         {
             return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
         }
+
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareMeter.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareMeter(int kilogramsforcepersquaremeter)
+        {
+            return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareMeter.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareMeter(long kilogramsforcepersquaremeter)
+        {
+            return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareMeter(decimal kilogramsforcepersquaremeter)
+        {
+	        return new Pressure(Convert.ToDouble(kilogramsforcepersquaremeter)*9.80665019960652);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
@@ -539,6 +863,33 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
         }
 
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareMillimeter(int kilogramsforcepersquaremillimeter)
+        {
+            return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareMillimeter(long kilogramsforcepersquaremillimeter)
+        {
+            return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilogramsForcePerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure FromKilogramsForcePerSquareMillimeter(decimal kilogramsforcepersquaremillimeter)
+        {
+	        return new Pressure(Convert.ToDouble(kilogramsforcepersquaremillimeter)*9806650.19960652);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
@@ -546,6 +897,33 @@ namespace UnitsNet
         {
             return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareCentimeter(int kilonewtonspersquarecentimeter)
+        {
+            return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareCentimeter(long kilonewtonspersquarecentimeter)
+        {
+            return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareCentimeter(decimal kilonewtonspersquarecentimeter)
+        {
+	        return new Pressure((Convert.ToDouble(kilonewtonspersquarecentimeter)*1e4) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
@@ -555,6 +933,33 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremeter) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareMeter(int kilonewtonspersquaremeter)
+        {
+            return new Pressure((kilonewtonspersquaremeter) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareMeter(long kilonewtonspersquaremeter)
+        {
+            return new Pressure((kilonewtonspersquaremeter) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareMeter(decimal kilonewtonspersquaremeter)
+        {
+	        return new Pressure((Convert.ToDouble(kilonewtonspersquaremeter)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
@@ -562,6 +967,33 @@ namespace UnitsNet
         {
             return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareMillimeter(int kilonewtonspersquaremillimeter)
+        {
+            return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareMillimeter(long kilonewtonspersquaremillimeter)
+        {
+            return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilonewtonsPerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure FromKilonewtonsPerSquareMillimeter(decimal kilonewtonspersquaremillimeter)
+        {
+	        return new Pressure((Convert.ToDouble(kilonewtonspersquaremillimeter)*1e6) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Kilopascals.
@@ -571,6 +1003,33 @@ namespace UnitsNet
             return new Pressure((kilopascals) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Pressure from Kilopascals.
+        /// </summary>
+        public static Pressure FromKilopascals(int kilopascals)
+        {
+            return new Pressure((kilopascals) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Kilopascals.
+        /// </summary>
+        public static Pressure FromKilopascals(long kilopascals)
+        {
+            return new Pressure((kilopascals) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Kilopascals of type decimal.
+        /// </summary>
+        public static Pressure FromKilopascals(decimal kilopascals)
+        {
+	        return new Pressure((Convert.ToDouble(kilopascals)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
@@ -578,6 +1037,33 @@ namespace UnitsNet
         {
             return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Pressure from KilopoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure FromKilopoundsForcePerSquareFoot(int kilopoundsforcepersquarefoot)
+        {
+            return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilopoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure FromKilopoundsForcePerSquareFoot(long kilopoundsforcepersquarefoot)
+        {
+            return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilopoundsForcePerSquareFoot of type decimal.
+        /// </summary>
+        public static Pressure FromKilopoundsForcePerSquareFoot(decimal kilopoundsforcepersquarefoot)
+        {
+	        return new Pressure((Convert.ToDouble(kilopoundsforcepersquarefoot)*47.8802631216372) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
@@ -587,6 +1073,33 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Pressure from KilopoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure FromKilopoundsForcePerSquareInch(int kilopoundsforcepersquareinch)
+        {
+            return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from KilopoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure FromKilopoundsForcePerSquareInch(long kilopoundsforcepersquareinch)
+        {
+            return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from KilopoundsForcePerSquareInch of type decimal.
+        /// </summary>
+        public static Pressure FromKilopoundsForcePerSquareInch(decimal kilopoundsforcepersquareinch)
+        {
+	        return new Pressure((Convert.ToDouble(kilopoundsforcepersquareinch)*6894.75729316836) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
@@ -594,6 +1107,33 @@ namespace UnitsNet
         {
             return new Pressure((megabars*1e5) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get Pressure from Megabars.
+        /// </summary>
+        public static Pressure FromMegabars(int megabars)
+        {
+            return new Pressure((megabars*1e5) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Megabars.
+        /// </summary>
+        public static Pressure FromMegabars(long megabars)
+        {
+            return new Pressure((megabars*1e5) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Megabars of type decimal.
+        /// </summary>
+        public static Pressure FromMegabars(decimal megabars)
+        {
+	        return new Pressure((Convert.ToDouble(megabars)*1e5) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Megapascals.
@@ -603,6 +1143,33 @@ namespace UnitsNet
             return new Pressure((megapascals) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get Pressure from Megapascals.
+        /// </summary>
+        public static Pressure FromMegapascals(int megapascals)
+        {
+            return new Pressure((megapascals) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Megapascals.
+        /// </summary>
+        public static Pressure FromMegapascals(long megapascals)
+        {
+            return new Pressure((megapascals) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Megapascals of type decimal.
+        /// </summary>
+        public static Pressure FromMegapascals(decimal megapascals)
+        {
+	        return new Pressure((Convert.ToDouble(megapascals)) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
@@ -610,6 +1177,33 @@ namespace UnitsNet
         {
             return new Pressure(metersofhead*9804.139432);
         }
+
+		/// <summary>
+        ///     Get Pressure from MetersOfHead.
+        /// </summary>
+        public static Pressure FromMetersOfHead(int metersofhead)
+        {
+            return new Pressure(metersofhead*9804.139432);
+        }
+
+		/// <summary>
+        ///     Get Pressure from MetersOfHead.
+        /// </summary>
+        public static Pressure FromMetersOfHead(long metersofhead)
+        {
+            return new Pressure(metersofhead*9804.139432);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from MetersOfHead of type decimal.
+        /// </summary>
+        public static Pressure FromMetersOfHead(decimal metersofhead)
+        {
+	        return new Pressure(Convert.ToDouble(metersofhead)*9804.139432);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Micropascals.
@@ -619,6 +1213,33 @@ namespace UnitsNet
             return new Pressure((micropascals) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Pressure from Micropascals.
+        /// </summary>
+        public static Pressure FromMicropascals(int micropascals)
+        {
+            return new Pressure((micropascals) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Micropascals.
+        /// </summary>
+        public static Pressure FromMicropascals(long micropascals)
+        {
+            return new Pressure((micropascals) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Micropascals of type decimal.
+        /// </summary>
+        public static Pressure FromMicropascals(decimal micropascals)
+        {
+	        return new Pressure((Convert.ToDouble(micropascals)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
@@ -626,6 +1247,33 @@ namespace UnitsNet
         {
             return new Pressure((millibars*1e5) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Pressure from Millibars.
+        /// </summary>
+        public static Pressure FromMillibars(int millibars)
+        {
+            return new Pressure((millibars*1e5) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Millibars.
+        /// </summary>
+        public static Pressure FromMillibars(long millibars)
+        {
+            return new Pressure((millibars*1e5) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Millibars of type decimal.
+        /// </summary>
+        public static Pressure FromMillibars(decimal millibars)
+        {
+	        return new Pressure((Convert.ToDouble(millibars)*1e5) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
@@ -635,6 +1283,33 @@ namespace UnitsNet
             return new Pressure(millimetersofmercury/7.50061561302643e-3);
         }
 
+		/// <summary>
+        ///     Get Pressure from MillimetersOfMercury.
+        /// </summary>
+        public static Pressure FromMillimetersOfMercury(int millimetersofmercury)
+        {
+            return new Pressure(millimetersofmercury/7.50061561302643e-3);
+        }
+
+		/// <summary>
+        ///     Get Pressure from MillimetersOfMercury.
+        /// </summary>
+        public static Pressure FromMillimetersOfMercury(long millimetersofmercury)
+        {
+            return new Pressure(millimetersofmercury/7.50061561302643e-3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from MillimetersOfMercury of type decimal.
+        /// </summary>
+        public static Pressure FromMillimetersOfMercury(decimal millimetersofmercury)
+        {
+	        return new Pressure(Convert.ToDouble(millimetersofmercury)/7.50061561302643e-3);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
@@ -642,6 +1317,33 @@ namespace UnitsNet
         {
             return new Pressure(newtonspersquarecentimeter*1e4);
         }
+
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareCentimeter(int newtonspersquarecentimeter)
+        {
+            return new Pressure(newtonspersquarecentimeter*1e4);
+        }
+
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareCentimeter(long newtonspersquarecentimeter)
+        {
+            return new Pressure(newtonspersquarecentimeter*1e4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareCentimeter(decimal newtonspersquarecentimeter)
+        {
+	        return new Pressure(Convert.ToDouble(newtonspersquarecentimeter)*1e4);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
@@ -651,6 +1353,33 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremeter);
         }
 
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareMeter(int newtonspersquaremeter)
+        {
+            return new Pressure(newtonspersquaremeter);
+        }
+
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareMeter(long newtonspersquaremeter)
+        {
+            return new Pressure(newtonspersquaremeter);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareMeter(decimal newtonspersquaremeter)
+        {
+	        return new Pressure(Convert.ToDouble(newtonspersquaremeter));
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
@@ -658,6 +1387,33 @@ namespace UnitsNet
         {
             return new Pressure(newtonspersquaremillimeter*1e6);
         }
+
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareMillimeter(int newtonspersquaremillimeter)
+        {
+            return new Pressure(newtonspersquaremillimeter*1e6);
+        }
+
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareMillimeter(long newtonspersquaremillimeter)
+        {
+            return new Pressure(newtonspersquaremillimeter*1e6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from NewtonsPerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure FromNewtonsPerSquareMillimeter(decimal newtonspersquaremillimeter)
+        {
+	        return new Pressure(Convert.ToDouble(newtonspersquaremillimeter)*1e6);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Pascals.
@@ -667,6 +1423,33 @@ namespace UnitsNet
             return new Pressure(pascals);
         }
 
+		/// <summary>
+        ///     Get Pressure from Pascals.
+        /// </summary>
+        public static Pressure FromPascals(int pascals)
+        {
+            return new Pressure(pascals);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Pascals.
+        /// </summary>
+        public static Pressure FromPascals(long pascals)
+        {
+            return new Pressure(pascals);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Pascals of type decimal.
+        /// </summary>
+        public static Pressure FromPascals(decimal pascals)
+        {
+	        return new Pressure(Convert.ToDouble(pascals));
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
@@ -674,6 +1457,33 @@ namespace UnitsNet
         {
             return new Pressure(poundsforcepersquarefoot*47.8802631216372);
         }
+
+		/// <summary>
+        ///     Get Pressure from PoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure FromPoundsForcePerSquareFoot(int poundsforcepersquarefoot)
+        {
+            return new Pressure(poundsforcepersquarefoot*47.8802631216372);
+        }
+
+		/// <summary>
+        ///     Get Pressure from PoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure FromPoundsForcePerSquareFoot(long poundsforcepersquarefoot)
+        {
+            return new Pressure(poundsforcepersquarefoot*47.8802631216372);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from PoundsForcePerSquareFoot of type decimal.
+        /// </summary>
+        public static Pressure FromPoundsForcePerSquareFoot(decimal poundsforcepersquarefoot)
+        {
+	        return new Pressure(Convert.ToDouble(poundsforcepersquarefoot)*47.8802631216372);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
@@ -683,6 +1493,33 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquareinch*6894.75729316836);
         }
 
+		/// <summary>
+        ///     Get Pressure from PoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure FromPoundsForcePerSquareInch(int poundsforcepersquareinch)
+        {
+            return new Pressure(poundsforcepersquareinch*6894.75729316836);
+        }
+
+		/// <summary>
+        ///     Get Pressure from PoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure FromPoundsForcePerSquareInch(long poundsforcepersquareinch)
+        {
+            return new Pressure(poundsforcepersquareinch*6894.75729316836);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from PoundsForcePerSquareInch of type decimal.
+        /// </summary>
+        public static Pressure FromPoundsForcePerSquareInch(decimal poundsforcepersquareinch)
+        {
+	        return new Pressure(Convert.ToDouble(poundsforcepersquareinch)*6894.75729316836);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from Psi.
         /// </summary>
@@ -690,6 +1527,33 @@ namespace UnitsNet
         {
             return new Pressure(psi*6.89464975179*1e3);
         }
+
+		/// <summary>
+        ///     Get Pressure from Psi.
+        /// </summary>
+        public static Pressure FromPsi(int psi)
+        {
+            return new Pressure(psi*6.89464975179*1e3);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Psi.
+        /// </summary>
+        public static Pressure FromPsi(long psi)
+        {
+            return new Pressure(psi*6.89464975179*1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Psi of type decimal.
+        /// </summary>
+        public static Pressure FromPsi(decimal psi)
+        {
+	        return new Pressure(Convert.ToDouble(psi)*6.89464975179*1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
@@ -699,6 +1563,33 @@ namespace UnitsNet
             return new Pressure(technicalatmospheres*9.80680592331*1e4);
         }
 
+		/// <summary>
+        ///     Get Pressure from TechnicalAtmospheres.
+        /// </summary>
+        public static Pressure FromTechnicalAtmospheres(int technicalatmospheres)
+        {
+            return new Pressure(technicalatmospheres*9.80680592331*1e4);
+        }
+
+		/// <summary>
+        ///     Get Pressure from TechnicalAtmospheres.
+        /// </summary>
+        public static Pressure FromTechnicalAtmospheres(long technicalatmospheres)
+        {
+            return new Pressure(technicalatmospheres*9.80680592331*1e4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from TechnicalAtmospheres of type decimal.
+        /// </summary>
+        public static Pressure FromTechnicalAtmospheres(decimal technicalatmospheres)
+        {
+	        return new Pressure(Convert.ToDouble(technicalatmospheres)*9.80680592331*1e4);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
@@ -706,6 +1597,33 @@ namespace UnitsNet
         {
             return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
         }
+
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareCentimeter(int tonnesforcepersquarecentimeter)
+        {
+            return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
+        }
+
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareCentimeter(long tonnesforcepersquarecentimeter)
+        {
+            return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareCentimeter(decimal tonnesforcepersquarecentimeter)
+        {
+	        return new Pressure(Convert.ToDouble(tonnesforcepersquarecentimeter)*98066501.9960652);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
@@ -715,6 +1633,33 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
         }
 
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareMeter.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareMeter(int tonnesforcepersquaremeter)
+        {
+            return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
+        }
+
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareMeter.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareMeter(long tonnesforcepersquaremeter)
+        {
+            return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareMeter(decimal tonnesforcepersquaremeter)
+        {
+	        return new Pressure(Convert.ToDouble(tonnesforcepersquaremeter)*9806.65019960653);
+        }
+#endif
+
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
@@ -722,6 +1667,33 @@ namespace UnitsNet
         {
             return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
         }
+
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareMillimeter(int tonnesforcepersquaremillimeter)
+        {
+            return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
+        }
+
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareMillimeter(long tonnesforcepersquaremillimeter)
+        {
+            return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from TonnesForcePerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure FromTonnesForcePerSquareMillimeter(decimal tonnesforcepersquaremillimeter)
+        {
+	        return new Pressure(Convert.ToDouble(tonnesforcepersquaremillimeter)*9806650199.60653);
+        }
+#endif
 
         /// <summary>
         ///     Get Pressure from Torrs.
@@ -731,12 +1703,84 @@ namespace UnitsNet
             return new Pressure(torrs*1.3332266752*1e2);
         }
 
+		/// <summary>
+        ///     Get Pressure from Torrs.
+        /// </summary>
+        public static Pressure FromTorrs(int torrs)
+        {
+            return new Pressure(torrs*1.3332266752*1e2);
+        }
+
+		/// <summary>
+        ///     Get Pressure from Torrs.
+        /// </summary>
+        public static Pressure FromTorrs(long torrs)
+        {
+            return new Pressure(torrs*1.3332266752*1e2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Pressure from Torrs of type decimal.
+        /// </summary>
+        public static Pressure FromTorrs(decimal torrs)
+        {
+	        return new Pressure(Convert.ToDouble(torrs)*1.3332266752*1e2);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Pressure from nullable Atmospheres.
         /// </summary>
         public static Pressure? FromAtmospheres(double? atmospheres)
+        {
+            if (atmospheres.HasValue)
+            {
+                return FromAtmospheres(atmospheres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Atmospheres.
+        /// </summary>
+        public static Pressure? FromAtmospheres(int? atmospheres)
+        {
+            if (atmospheres.HasValue)
+            {
+                return FromAtmospheres(atmospheres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Atmospheres.
+        /// </summary>
+        public static Pressure? FromAtmospheres(long? atmospheres)
+        {
+            if (atmospheres.HasValue)
+            {
+                return FromAtmospheres(atmospheres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Atmospheres of type decimal.
+        /// </summary>
+        public static Pressure? FromAtmospheres(decimal? atmospheres)
         {
             if (atmospheres.HasValue)
             {
@@ -763,10 +1807,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Bars.
+        /// </summary>
+        public static Pressure? FromBars(int? bars)
+        {
+            if (bars.HasValue)
+            {
+                return FromBars(bars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Bars.
+        /// </summary>
+        public static Pressure? FromBars(long? bars)
+        {
+            if (bars.HasValue)
+            {
+                return FromBars(bars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Bars of type decimal.
+        /// </summary>
+        public static Pressure? FromBars(decimal? bars)
+        {
+            if (bars.HasValue)
+            {
+                return FromBars(bars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Centibars.
         /// </summary>
         public static Pressure? FromCentibars(double? centibars)
+        {
+            if (centibars.HasValue)
+            {
+                return FromCentibars(centibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Centibars.
+        /// </summary>
+        public static Pressure? FromCentibars(int? centibars)
+        {
+            if (centibars.HasValue)
+            {
+                return FromCentibars(centibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Centibars.
+        /// </summary>
+        public static Pressure? FromCentibars(long? centibars)
+        {
+            if (centibars.HasValue)
+            {
+                return FromCentibars(centibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Centibars of type decimal.
+        /// </summary>
+        public static Pressure? FromCentibars(decimal? centibars)
         {
             if (centibars.HasValue)
             {
@@ -793,10 +1927,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Decapascals.
+        /// </summary>
+        public static Pressure? FromDecapascals(int? decapascals)
+        {
+            if (decapascals.HasValue)
+            {
+                return FromDecapascals(decapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Decapascals.
+        /// </summary>
+        public static Pressure? FromDecapascals(long? decapascals)
+        {
+            if (decapascals.HasValue)
+            {
+                return FromDecapascals(decapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Decapascals of type decimal.
+        /// </summary>
+        public static Pressure? FromDecapascals(decimal? decapascals)
+        {
+            if (decapascals.HasValue)
+            {
+                return FromDecapascals(decapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Decibars.
         /// </summary>
         public static Pressure? FromDecibars(double? decibars)
+        {
+            if (decibars.HasValue)
+            {
+                return FromDecibars(decibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Decibars.
+        /// </summary>
+        public static Pressure? FromDecibars(int? decibars)
+        {
+            if (decibars.HasValue)
+            {
+                return FromDecibars(decibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Decibars.
+        /// </summary>
+        public static Pressure? FromDecibars(long? decibars)
+        {
+            if (decibars.HasValue)
+            {
+                return FromDecibars(decibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Decibars of type decimal.
+        /// </summary>
+        public static Pressure? FromDecibars(decimal? decibars)
         {
             if (decibars.HasValue)
             {
@@ -823,10 +2047,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable FeetOfHead.
+        /// </summary>
+        public static Pressure? FromFeetOfHead(int? feetofhead)
+        {
+            if (feetofhead.HasValue)
+            {
+                return FromFeetOfHead(feetofhead.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable FeetOfHead.
+        /// </summary>
+        public static Pressure? FromFeetOfHead(long? feetofhead)
+        {
+            if (feetofhead.HasValue)
+            {
+                return FromFeetOfHead(feetofhead.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from FeetOfHead of type decimal.
+        /// </summary>
+        public static Pressure? FromFeetOfHead(decimal? feetofhead)
+        {
+            if (feetofhead.HasValue)
+            {
+                return FromFeetOfHead(feetofhead.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Gigapascals.
         /// </summary>
         public static Pressure? FromGigapascals(double? gigapascals)
+        {
+            if (gigapascals.HasValue)
+            {
+                return FromGigapascals(gigapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Gigapascals.
+        /// </summary>
+        public static Pressure? FromGigapascals(int? gigapascals)
+        {
+            if (gigapascals.HasValue)
+            {
+                return FromGigapascals(gigapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Gigapascals.
+        /// </summary>
+        public static Pressure? FromGigapascals(long? gigapascals)
+        {
+            if (gigapascals.HasValue)
+            {
+                return FromGigapascals(gigapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Gigapascals of type decimal.
+        /// </summary>
+        public static Pressure? FromGigapascals(decimal? gigapascals)
         {
             if (gigapascals.HasValue)
             {
@@ -853,10 +2167,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Hectopascals.
+        /// </summary>
+        public static Pressure? FromHectopascals(int? hectopascals)
+        {
+            if (hectopascals.HasValue)
+            {
+                return FromHectopascals(hectopascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Hectopascals.
+        /// </summary>
+        public static Pressure? FromHectopascals(long? hectopascals)
+        {
+            if (hectopascals.HasValue)
+            {
+                return FromHectopascals(hectopascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Hectopascals of type decimal.
+        /// </summary>
+        public static Pressure? FromHectopascals(decimal? hectopascals)
+        {
+            if (hectopascals.HasValue)
+            {
+                return FromHectopascals(hectopascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable InchesOfMercury.
         /// </summary>
         public static Pressure? FromInchesOfMercury(double? inchesofmercury)
+        {
+            if (inchesofmercury.HasValue)
+            {
+                return FromInchesOfMercury(inchesofmercury.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable InchesOfMercury.
+        /// </summary>
+        public static Pressure? FromInchesOfMercury(int? inchesofmercury)
+        {
+            if (inchesofmercury.HasValue)
+            {
+                return FromInchesOfMercury(inchesofmercury.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable InchesOfMercury.
+        /// </summary>
+        public static Pressure? FromInchesOfMercury(long? inchesofmercury)
+        {
+            if (inchesofmercury.HasValue)
+            {
+                return FromInchesOfMercury(inchesofmercury.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from InchesOfMercury of type decimal.
+        /// </summary>
+        public static Pressure? FromInchesOfMercury(decimal? inchesofmercury)
         {
             if (inchesofmercury.HasValue)
             {
@@ -883,10 +2287,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Kilobars.
+        /// </summary>
+        public static Pressure? FromKilobars(int? kilobars)
+        {
+            if (kilobars.HasValue)
+            {
+                return FromKilobars(kilobars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Kilobars.
+        /// </summary>
+        public static Pressure? FromKilobars(long? kilobars)
+        {
+            if (kilobars.HasValue)
+            {
+                return FromKilobars(kilobars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Kilobars of type decimal.
+        /// </summary>
+        public static Pressure? FromKilobars(decimal? kilobars)
+        {
+            if (kilobars.HasValue)
+            {
+                return FromKilobars(kilobars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareCentimeter(double? kilogramsforcepersquarecentimeter)
+        {
+            if (kilogramsforcepersquarecentimeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareCentimeter(kilogramsforcepersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareCentimeter(int? kilogramsforcepersquarecentimeter)
+        {
+            if (kilogramsforcepersquarecentimeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareCentimeter(kilogramsforcepersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareCentimeter(long? kilogramsforcepersquarecentimeter)
+        {
+            if (kilogramsforcepersquarecentimeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareCentimeter(kilogramsforcepersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilogramsForcePerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareCentimeter(decimal? kilogramsforcepersquarecentimeter)
         {
             if (kilogramsforcepersquarecentimeter.HasValue)
             {
@@ -913,10 +2407,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareMeter(int? kilogramsforcepersquaremeter)
+        {
+            if (kilogramsforcepersquaremeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareMeter(kilogramsforcepersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareMeter(long? kilogramsforcepersquaremeter)
+        {
+            if (kilogramsforcepersquaremeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareMeter(kilogramsforcepersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilogramsForcePerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareMeter(decimal? kilogramsforcepersquaremeter)
+        {
+            if (kilogramsforcepersquaremeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareMeter(kilogramsforcepersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMillimeter(double? kilogramsforcepersquaremillimeter)
+        {
+            if (kilogramsforcepersquaremillimeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareMillimeter(kilogramsforcepersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareMillimeter(int? kilogramsforcepersquaremillimeter)
+        {
+            if (kilogramsforcepersquaremillimeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareMillimeter(kilogramsforcepersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareMillimeter(long? kilogramsforcepersquaremillimeter)
+        {
+            if (kilogramsforcepersquaremillimeter.HasValue)
+            {
+                return FromKilogramsForcePerSquareMillimeter(kilogramsforcepersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilogramsForcePerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromKilogramsForcePerSquareMillimeter(decimal? kilogramsforcepersquaremillimeter)
         {
             if (kilogramsforcepersquaremillimeter.HasValue)
             {
@@ -943,10 +2527,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareCentimeter(int? kilonewtonspersquarecentimeter)
+        {
+            if (kilonewtonspersquarecentimeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareCentimeter(kilonewtonspersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareCentimeter(long? kilonewtonspersquarecentimeter)
+        {
+            if (kilonewtonspersquarecentimeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareCentimeter(kilonewtonspersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilonewtonsPerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareCentimeter(decimal? kilonewtonspersquarecentimeter)
+        {
+            if (kilonewtonspersquarecentimeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareCentimeter(kilonewtonspersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMeter(double? kilonewtonspersquaremeter)
+        {
+            if (kilonewtonspersquaremeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareMeter(kilonewtonspersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareMeter(int? kilonewtonspersquaremeter)
+        {
+            if (kilonewtonspersquaremeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareMeter(kilonewtonspersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareMeter(long? kilonewtonspersquaremeter)
+        {
+            if (kilonewtonspersquaremeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareMeter(kilonewtonspersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilonewtonsPerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareMeter(decimal? kilonewtonspersquaremeter)
         {
             if (kilonewtonspersquaremeter.HasValue)
             {
@@ -973,10 +2647,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareMillimeter(int? kilonewtonspersquaremillimeter)
+        {
+            if (kilonewtonspersquaremillimeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareMillimeter(kilonewtonspersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareMillimeter(long? kilonewtonspersquaremillimeter)
+        {
+            if (kilonewtonspersquaremillimeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareMillimeter(kilonewtonspersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilonewtonsPerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromKilonewtonsPerSquareMillimeter(decimal? kilonewtonspersquaremillimeter)
+        {
+            if (kilonewtonspersquaremillimeter.HasValue)
+            {
+                return FromKilonewtonsPerSquareMillimeter(kilonewtonspersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Kilopascals.
         /// </summary>
         public static Pressure? FromKilopascals(double? kilopascals)
+        {
+            if (kilopascals.HasValue)
+            {
+                return FromKilopascals(kilopascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Kilopascals.
+        /// </summary>
+        public static Pressure? FromKilopascals(int? kilopascals)
+        {
+            if (kilopascals.HasValue)
+            {
+                return FromKilopascals(kilopascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Kilopascals.
+        /// </summary>
+        public static Pressure? FromKilopascals(long? kilopascals)
+        {
+            if (kilopascals.HasValue)
+            {
+                return FromKilopascals(kilopascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Kilopascals of type decimal.
+        /// </summary>
+        public static Pressure? FromKilopascals(decimal? kilopascals)
         {
             if (kilopascals.HasValue)
             {
@@ -1003,10 +2767,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure? FromKilopoundsForcePerSquareFoot(int? kilopoundsforcepersquarefoot)
+        {
+            if (kilopoundsforcepersquarefoot.HasValue)
+            {
+                return FromKilopoundsForcePerSquareFoot(kilopoundsforcepersquarefoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure? FromKilopoundsForcePerSquareFoot(long? kilopoundsforcepersquarefoot)
+        {
+            if (kilopoundsforcepersquarefoot.HasValue)
+            {
+                return FromKilopoundsForcePerSquareFoot(kilopoundsforcepersquarefoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilopoundsForcePerSquareFoot of type decimal.
+        /// </summary>
+        public static Pressure? FromKilopoundsForcePerSquareFoot(decimal? kilopoundsforcepersquarefoot)
+        {
+            if (kilopoundsforcepersquarefoot.HasValue)
+            {
+                return FromKilopoundsForcePerSquareFoot(kilopoundsforcepersquarefoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareInch(double? kilopoundsforcepersquareinch)
+        {
+            if (kilopoundsforcepersquareinch.HasValue)
+            {
+                return FromKilopoundsForcePerSquareInch(kilopoundsforcepersquareinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure? FromKilopoundsForcePerSquareInch(int? kilopoundsforcepersquareinch)
+        {
+            if (kilopoundsforcepersquareinch.HasValue)
+            {
+                return FromKilopoundsForcePerSquareInch(kilopoundsforcepersquareinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure? FromKilopoundsForcePerSquareInch(long? kilopoundsforcepersquareinch)
+        {
+            if (kilopoundsforcepersquareinch.HasValue)
+            {
+                return FromKilopoundsForcePerSquareInch(kilopoundsforcepersquareinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from KilopoundsForcePerSquareInch of type decimal.
+        /// </summary>
+        public static Pressure? FromKilopoundsForcePerSquareInch(decimal? kilopoundsforcepersquareinch)
         {
             if (kilopoundsforcepersquareinch.HasValue)
             {
@@ -1033,10 +2887,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Megabars.
+        /// </summary>
+        public static Pressure? FromMegabars(int? megabars)
+        {
+            if (megabars.HasValue)
+            {
+                return FromMegabars(megabars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Megabars.
+        /// </summary>
+        public static Pressure? FromMegabars(long? megabars)
+        {
+            if (megabars.HasValue)
+            {
+                return FromMegabars(megabars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Megabars of type decimal.
+        /// </summary>
+        public static Pressure? FromMegabars(decimal? megabars)
+        {
+            if (megabars.HasValue)
+            {
+                return FromMegabars(megabars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Megapascals.
         /// </summary>
         public static Pressure? FromMegapascals(double? megapascals)
+        {
+            if (megapascals.HasValue)
+            {
+                return FromMegapascals(megapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Megapascals.
+        /// </summary>
+        public static Pressure? FromMegapascals(int? megapascals)
+        {
+            if (megapascals.HasValue)
+            {
+                return FromMegapascals(megapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Megapascals.
+        /// </summary>
+        public static Pressure? FromMegapascals(long? megapascals)
+        {
+            if (megapascals.HasValue)
+            {
+                return FromMegapascals(megapascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Megapascals of type decimal.
+        /// </summary>
+        public static Pressure? FromMegapascals(decimal? megapascals)
         {
             if (megapascals.HasValue)
             {
@@ -1063,10 +3007,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable MetersOfHead.
+        /// </summary>
+        public static Pressure? FromMetersOfHead(int? metersofhead)
+        {
+            if (metersofhead.HasValue)
+            {
+                return FromMetersOfHead(metersofhead.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable MetersOfHead.
+        /// </summary>
+        public static Pressure? FromMetersOfHead(long? metersofhead)
+        {
+            if (metersofhead.HasValue)
+            {
+                return FromMetersOfHead(metersofhead.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from MetersOfHead of type decimal.
+        /// </summary>
+        public static Pressure? FromMetersOfHead(decimal? metersofhead)
+        {
+            if (metersofhead.HasValue)
+            {
+                return FromMetersOfHead(metersofhead.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Micropascals.
         /// </summary>
         public static Pressure? FromMicropascals(double? micropascals)
+        {
+            if (micropascals.HasValue)
+            {
+                return FromMicropascals(micropascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Micropascals.
+        /// </summary>
+        public static Pressure? FromMicropascals(int? micropascals)
+        {
+            if (micropascals.HasValue)
+            {
+                return FromMicropascals(micropascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Micropascals.
+        /// </summary>
+        public static Pressure? FromMicropascals(long? micropascals)
+        {
+            if (micropascals.HasValue)
+            {
+                return FromMicropascals(micropascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Micropascals of type decimal.
+        /// </summary>
+        public static Pressure? FromMicropascals(decimal? micropascals)
         {
             if (micropascals.HasValue)
             {
@@ -1093,10 +3127,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Millibars.
+        /// </summary>
+        public static Pressure? FromMillibars(int? millibars)
+        {
+            if (millibars.HasValue)
+            {
+                return FromMillibars(millibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Millibars.
+        /// </summary>
+        public static Pressure? FromMillibars(long? millibars)
+        {
+            if (millibars.HasValue)
+            {
+                return FromMillibars(millibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Millibars of type decimal.
+        /// </summary>
+        public static Pressure? FromMillibars(decimal? millibars)
+        {
+            if (millibars.HasValue)
+            {
+                return FromMillibars(millibars.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable MillimetersOfMercury.
         /// </summary>
         public static Pressure? FromMillimetersOfMercury(double? millimetersofmercury)
+        {
+            if (millimetersofmercury.HasValue)
+            {
+                return FromMillimetersOfMercury(millimetersofmercury.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable MillimetersOfMercury.
+        /// </summary>
+        public static Pressure? FromMillimetersOfMercury(int? millimetersofmercury)
+        {
+            if (millimetersofmercury.HasValue)
+            {
+                return FromMillimetersOfMercury(millimetersofmercury.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable MillimetersOfMercury.
+        /// </summary>
+        public static Pressure? FromMillimetersOfMercury(long? millimetersofmercury)
+        {
+            if (millimetersofmercury.HasValue)
+            {
+                return FromMillimetersOfMercury(millimetersofmercury.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from MillimetersOfMercury of type decimal.
+        /// </summary>
+        public static Pressure? FromMillimetersOfMercury(decimal? millimetersofmercury)
         {
             if (millimetersofmercury.HasValue)
             {
@@ -1123,10 +3247,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareCentimeter(int? newtonspersquarecentimeter)
+        {
+            if (newtonspersquarecentimeter.HasValue)
+            {
+                return FromNewtonsPerSquareCentimeter(newtonspersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareCentimeter(long? newtonspersquarecentimeter)
+        {
+            if (newtonspersquarecentimeter.HasValue)
+            {
+                return FromNewtonsPerSquareCentimeter(newtonspersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from NewtonsPerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareCentimeter(decimal? newtonspersquarecentimeter)
+        {
+            if (newtonspersquarecentimeter.HasValue)
+            {
+                return FromNewtonsPerSquareCentimeter(newtonspersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMeter(double? newtonspersquaremeter)
+        {
+            if (newtonspersquaremeter.HasValue)
+            {
+                return FromNewtonsPerSquareMeter(newtonspersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareMeter(int? newtonspersquaremeter)
+        {
+            if (newtonspersquaremeter.HasValue)
+            {
+                return FromNewtonsPerSquareMeter(newtonspersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareMeter(long? newtonspersquaremeter)
+        {
+            if (newtonspersquaremeter.HasValue)
+            {
+                return FromNewtonsPerSquareMeter(newtonspersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from NewtonsPerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareMeter(decimal? newtonspersquaremeter)
         {
             if (newtonspersquaremeter.HasValue)
             {
@@ -1153,10 +3367,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareMillimeter(int? newtonspersquaremillimeter)
+        {
+            if (newtonspersquaremillimeter.HasValue)
+            {
+                return FromNewtonsPerSquareMillimeter(newtonspersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareMillimeter(long? newtonspersquaremillimeter)
+        {
+            if (newtonspersquaremillimeter.HasValue)
+            {
+                return FromNewtonsPerSquareMillimeter(newtonspersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from NewtonsPerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromNewtonsPerSquareMillimeter(decimal? newtonspersquaremillimeter)
+        {
+            if (newtonspersquaremillimeter.HasValue)
+            {
+                return FromNewtonsPerSquareMillimeter(newtonspersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Pascals.
         /// </summary>
         public static Pressure? FromPascals(double? pascals)
+        {
+            if (pascals.HasValue)
+            {
+                return FromPascals(pascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Pascals.
+        /// </summary>
+        public static Pressure? FromPascals(int? pascals)
+        {
+            if (pascals.HasValue)
+            {
+                return FromPascals(pascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Pascals.
+        /// </summary>
+        public static Pressure? FromPascals(long? pascals)
+        {
+            if (pascals.HasValue)
+            {
+                return FromPascals(pascals.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Pascals of type decimal.
+        /// </summary>
+        public static Pressure? FromPascals(decimal? pascals)
         {
             if (pascals.HasValue)
             {
@@ -1183,10 +3487,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure? FromPoundsForcePerSquareFoot(int? poundsforcepersquarefoot)
+        {
+            if (poundsforcepersquarefoot.HasValue)
+            {
+                return FromPoundsForcePerSquareFoot(poundsforcepersquarefoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
+        /// </summary>
+        public static Pressure? FromPoundsForcePerSquareFoot(long? poundsforcepersquarefoot)
+        {
+            if (poundsforcepersquarefoot.HasValue)
+            {
+                return FromPoundsForcePerSquareFoot(poundsforcepersquarefoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from PoundsForcePerSquareFoot of type decimal.
+        /// </summary>
+        public static Pressure? FromPoundsForcePerSquareFoot(decimal? poundsforcepersquarefoot)
+        {
+            if (poundsforcepersquarefoot.HasValue)
+            {
+                return FromPoundsForcePerSquareFoot(poundsforcepersquarefoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareInch(double? poundsforcepersquareinch)
+        {
+            if (poundsforcepersquareinch.HasValue)
+            {
+                return FromPoundsForcePerSquareInch(poundsforcepersquareinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure? FromPoundsForcePerSquareInch(int? poundsforcepersquareinch)
+        {
+            if (poundsforcepersquareinch.HasValue)
+            {
+                return FromPoundsForcePerSquareInch(poundsforcepersquareinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
+        /// </summary>
+        public static Pressure? FromPoundsForcePerSquareInch(long? poundsforcepersquareinch)
+        {
+            if (poundsforcepersquareinch.HasValue)
+            {
+                return FromPoundsForcePerSquareInch(poundsforcepersquareinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from PoundsForcePerSquareInch of type decimal.
+        /// </summary>
+        public static Pressure? FromPoundsForcePerSquareInch(decimal? poundsforcepersquareinch)
         {
             if (poundsforcepersquareinch.HasValue)
             {
@@ -1213,10 +3607,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable Psi.
+        /// </summary>
+        public static Pressure? FromPsi(int? psi)
+        {
+            if (psi.HasValue)
+            {
+                return FromPsi(psi.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Psi.
+        /// </summary>
+        public static Pressure? FromPsi(long? psi)
+        {
+            if (psi.HasValue)
+            {
+                return FromPsi(psi.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Psi of type decimal.
+        /// </summary>
+        public static Pressure? FromPsi(decimal? psi)
+        {
+            if (psi.HasValue)
+            {
+                return FromPsi(psi.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable TechnicalAtmospheres.
         /// </summary>
         public static Pressure? FromTechnicalAtmospheres(double? technicalatmospheres)
+        {
+            if (technicalatmospheres.HasValue)
+            {
+                return FromTechnicalAtmospheres(technicalatmospheres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable TechnicalAtmospheres.
+        /// </summary>
+        public static Pressure? FromTechnicalAtmospheres(int? technicalatmospheres)
+        {
+            if (technicalatmospheres.HasValue)
+            {
+                return FromTechnicalAtmospheres(technicalatmospheres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable TechnicalAtmospheres.
+        /// </summary>
+        public static Pressure? FromTechnicalAtmospheres(long? technicalatmospheres)
+        {
+            if (technicalatmospheres.HasValue)
+            {
+                return FromTechnicalAtmospheres(technicalatmospheres.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from TechnicalAtmospheres of type decimal.
+        /// </summary>
+        public static Pressure? FromTechnicalAtmospheres(decimal? technicalatmospheres)
         {
             if (technicalatmospheres.HasValue)
             {
@@ -1243,10 +3727,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareCentimeter(int? tonnesforcepersquarecentimeter)
+        {
+            if (tonnesforcepersquarecentimeter.HasValue)
+            {
+                return FromTonnesForcePerSquareCentimeter(tonnesforcepersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareCentimeter(long? tonnesforcepersquarecentimeter)
+        {
+            if (tonnesforcepersquarecentimeter.HasValue)
+            {
+                return FromTonnesForcePerSquareCentimeter(tonnesforcepersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from TonnesForcePerSquareCentimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareCentimeter(decimal? tonnesforcepersquarecentimeter)
+        {
+            if (tonnesforcepersquarecentimeter.HasValue)
+            {
+                return FromTonnesForcePerSquareCentimeter(tonnesforcepersquarecentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMeter(double? tonnesforcepersquaremeter)
+        {
+            if (tonnesforcepersquaremeter.HasValue)
+            {
+                return FromTonnesForcePerSquareMeter(tonnesforcepersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareMeter(int? tonnesforcepersquaremeter)
+        {
+            if (tonnesforcepersquaremeter.HasValue)
+            {
+                return FromTonnesForcePerSquareMeter(tonnesforcepersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareMeter(long? tonnesforcepersquaremeter)
+        {
+            if (tonnesforcepersquaremeter.HasValue)
+            {
+                return FromTonnesForcePerSquareMeter(tonnesforcepersquaremeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from TonnesForcePerSquareMeter of type decimal.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareMeter(decimal? tonnesforcepersquaremeter)
         {
             if (tonnesforcepersquaremeter.HasValue)
             {
@@ -1273,10 +3847,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareMillimeter(int? tonnesforcepersquaremillimeter)
+        {
+            if (tonnesforcepersquaremillimeter.HasValue)
+            {
+                return FromTonnesForcePerSquareMillimeter(tonnesforcepersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareMillimeter(long? tonnesforcepersquaremillimeter)
+        {
+            if (tonnesforcepersquaremillimeter.HasValue)
+            {
+                return FromTonnesForcePerSquareMillimeter(tonnesforcepersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from TonnesForcePerSquareMillimeter of type decimal.
+        /// </summary>
+        public static Pressure? FromTonnesForcePerSquareMillimeter(decimal? tonnesforcepersquaremillimeter)
+        {
+            if (tonnesforcepersquaremillimeter.HasValue)
+            {
+                return FromTonnesForcePerSquareMillimeter(tonnesforcepersquaremillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Pressure from nullable Torrs.
         /// </summary>
         public static Pressure? FromTorrs(double? torrs)
+        {
+            if (torrs.HasValue)
+            {
+                return FromTorrs(torrs.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Torrs.
+        /// </summary>
+        public static Pressure? FromTorrs(int? torrs)
+        {
+            if (torrs.HasValue)
+            {
+                return FromTorrs(torrs.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from nullable Torrs.
+        /// </summary>
+        public static Pressure? FromTorrs(long? torrs)
+        {
+            if (torrs.HasValue)
+            {
+                return FromTorrs(torrs.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Pressure from Torrs of type decimal.
+        /// </summary>
+        public static Pressure? FromTorrs(decimal? torrs)
         {
             if (torrs.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -438,6 +438,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Atmospheres.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromAtmospheres(double atmospheres)
         {
             return new Pressure(atmospheres*1.01325*1e5);
@@ -473,6 +476,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromBars(double bars)
         {
             return new Pressure(bars*1e5);
@@ -508,6 +514,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Centibars.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromCentibars(double centibars)
         {
             return new Pressure((centibars*1e5) * 1e-2d);
@@ -543,6 +552,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromDecapascals(double decapascals)
         {
             return new Pressure((decapascals) * 1e1d);
@@ -578,6 +590,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Decibars.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromDecibars(double decibars)
         {
             return new Pressure((decibars*1e5) * 1e-1d);
@@ -613,6 +628,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromFeetOfHead(double feetofhead)
         {
             return new Pressure(feetofhead*2989.0669);
@@ -648,6 +666,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Gigapascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromGigapascals(double gigapascals)
         {
             return new Pressure((gigapascals) * 1e9d);
@@ -683,6 +704,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromHectopascals(double hectopascals)
         {
             return new Pressure((hectopascals) * 1e2d);
@@ -718,6 +742,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from InchesOfMercury.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromInchesOfMercury(double inchesofmercury)
         {
             return new Pressure(inchesofmercury/2.95299830714159e-4);
@@ -753,6 +780,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilobars(double kilobars)
         {
             return new Pressure((kilobars*1e5) * 1e3d);
@@ -788,6 +818,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilogramsForcePerSquareCentimeter(double kilogramsforcepersquarecentimeter)
         {
             return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
@@ -823,6 +856,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilogramsForcePerSquareMeter(double kilogramsforcepersquaremeter)
         {
             return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
@@ -858,6 +894,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilogramsForcePerSquareMillimeter(double kilogramsforcepersquaremillimeter)
         {
             return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
@@ -893,6 +932,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilonewtonsPerSquareCentimeter(double kilonewtonspersquarecentimeter)
         {
             return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
@@ -928,6 +970,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilonewtonsPerSquareMeter(double kilonewtonspersquaremeter)
         {
             return new Pressure((kilonewtonspersquaremeter) * 1e3d);
@@ -963,6 +1008,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilonewtonsPerSquareMillimeter(double kilonewtonspersquaremillimeter)
         {
             return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
@@ -998,6 +1046,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Kilopascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilopascals(double kilopascals)
         {
             return new Pressure((kilopascals) * 1e3d);
@@ -1033,6 +1084,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilopoundsForcePerSquareFoot(double kilopoundsforcepersquarefoot)
         {
             return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
@@ -1068,6 +1122,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromKilopoundsForcePerSquareInch(double kilopoundsforcepersquareinch)
         {
             return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
@@ -1103,6 +1160,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromMegabars(double megabars)
         {
             return new Pressure((megabars*1e5) * 1e6d);
@@ -1138,6 +1198,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Megapascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromMegapascals(double megapascals)
         {
             return new Pressure((megapascals) * 1e6d);
@@ -1173,6 +1236,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromMetersOfHead(double metersofhead)
         {
             return new Pressure(metersofhead*9804.139432);
@@ -1208,6 +1274,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Micropascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromMicropascals(double micropascals)
         {
             return new Pressure((micropascals) * 1e-6d);
@@ -1243,6 +1312,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromMillibars(double millibars)
         {
             return new Pressure((millibars*1e5) * 1e-3d);
@@ -1278,6 +1350,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromMillimetersOfMercury(double millimetersofmercury)
         {
             return new Pressure(millimetersofmercury/7.50061561302643e-3);
@@ -1313,6 +1388,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromNewtonsPerSquareCentimeter(double newtonspersquarecentimeter)
         {
             return new Pressure(newtonspersquarecentimeter*1e4);
@@ -1348,6 +1426,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromNewtonsPerSquareMeter(double newtonspersquaremeter)
         {
             return new Pressure(newtonspersquaremeter);
@@ -1383,6 +1464,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromNewtonsPerSquareMillimeter(double newtonspersquaremillimeter)
         {
             return new Pressure(newtonspersquaremillimeter*1e6);
@@ -1418,6 +1502,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Pascals.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromPascals(double pascals)
         {
             return new Pressure(pascals);
@@ -1453,6 +1540,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromPoundsForcePerSquareFoot(double poundsforcepersquarefoot)
         {
             return new Pressure(poundsforcepersquarefoot*47.8802631216372);
@@ -1488,6 +1578,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromPoundsForcePerSquareInch(double poundsforcepersquareinch)
         {
             return new Pressure(poundsforcepersquareinch*6894.75729316836);
@@ -1523,6 +1616,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Psi.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromPsi(double psi)
         {
             return new Pressure(psi*6.89464975179*1e3);
@@ -1558,6 +1654,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromTechnicalAtmospheres(double technicalatmospheres)
         {
             return new Pressure(technicalatmospheres*9.80680592331*1e4);
@@ -1593,6 +1692,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromTonnesForcePerSquareCentimeter(double tonnesforcepersquarecentimeter)
         {
             return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
@@ -1628,6 +1730,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromTonnesForcePerSquareMeter(double tonnesforcepersquaremeter)
         {
             return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
@@ -1663,6 +1768,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromTonnesForcePerSquareMillimeter(double tonnesforcepersquaremillimeter)
         {
             return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
@@ -1698,6 +1806,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Torrs.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Pressure FromTorrs(double torrs)
         {
             return new Pressure(torrs*1.3332266752*1e2);

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _pascals;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Pressure() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Pressure;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static PressureUnit BaseUnit
         {
             get { return PressureUnit.Pascal; }
@@ -443,7 +443,7 @@ namespace UnitsNet
             return new Pressure(atmospheres*1.01325*1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Atmospheres.
         /// </summary>
         public static Pressure FromAtmospheres(int atmospheres)
@@ -451,7 +451,7 @@ namespace UnitsNet
             return new Pressure(atmospheres*1.01325*1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Atmospheres.
         /// </summary>
         public static Pressure FromAtmospheres(long atmospheres)
@@ -459,14 +459,14 @@ namespace UnitsNet
             return new Pressure(atmospheres*1.01325*1e5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Atmospheres of type decimal.
         /// </summary>
         public static Pressure FromAtmospheres(decimal atmospheres)
         {
-	        return new Pressure(Convert.ToDouble(atmospheres)*1.01325*1e5);
+            return new Pressure(Convert.ToDouble(atmospheres)*1.01325*1e5);
         }
 #endif
 
@@ -478,7 +478,7 @@ namespace UnitsNet
             return new Pressure(bars*1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
         public static Pressure FromBars(int bars)
@@ -486,7 +486,7 @@ namespace UnitsNet
             return new Pressure(bars*1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
         public static Pressure FromBars(long bars)
@@ -494,14 +494,14 @@ namespace UnitsNet
             return new Pressure(bars*1e5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Bars of type decimal.
         /// </summary>
         public static Pressure FromBars(decimal bars)
         {
-	        return new Pressure(Convert.ToDouble(bars)*1e5);
+            return new Pressure(Convert.ToDouble(bars)*1e5);
         }
 #endif
 
@@ -513,7 +513,7 @@ namespace UnitsNet
             return new Pressure((centibars*1e5) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Centibars.
         /// </summary>
         public static Pressure FromCentibars(int centibars)
@@ -521,7 +521,7 @@ namespace UnitsNet
             return new Pressure((centibars*1e5) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Centibars.
         /// </summary>
         public static Pressure FromCentibars(long centibars)
@@ -529,14 +529,14 @@ namespace UnitsNet
             return new Pressure((centibars*1e5) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Centibars of type decimal.
         /// </summary>
         public static Pressure FromCentibars(decimal centibars)
         {
-	        return new Pressure((Convert.ToDouble(centibars)*1e5) * 1e-2d);
+            return new Pressure((Convert.ToDouble(centibars)*1e5) * 1e-2d);
         }
 #endif
 
@@ -548,7 +548,7 @@ namespace UnitsNet
             return new Pressure((decapascals) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
         public static Pressure FromDecapascals(int decapascals)
@@ -556,7 +556,7 @@ namespace UnitsNet
             return new Pressure((decapascals) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
         public static Pressure FromDecapascals(long decapascals)
@@ -564,14 +564,14 @@ namespace UnitsNet
             return new Pressure((decapascals) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Decapascals of type decimal.
         /// </summary>
         public static Pressure FromDecapascals(decimal decapascals)
         {
-	        return new Pressure((Convert.ToDouble(decapascals)) * 1e1d);
+            return new Pressure((Convert.ToDouble(decapascals)) * 1e1d);
         }
 #endif
 
@@ -583,7 +583,7 @@ namespace UnitsNet
             return new Pressure((decibars*1e5) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Decibars.
         /// </summary>
         public static Pressure FromDecibars(int decibars)
@@ -591,7 +591,7 @@ namespace UnitsNet
             return new Pressure((decibars*1e5) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Decibars.
         /// </summary>
         public static Pressure FromDecibars(long decibars)
@@ -599,14 +599,14 @@ namespace UnitsNet
             return new Pressure((decibars*1e5) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Decibars of type decimal.
         /// </summary>
         public static Pressure FromDecibars(decimal decibars)
         {
-	        return new Pressure((Convert.ToDouble(decibars)*1e5) * 1e-1d);
+            return new Pressure((Convert.ToDouble(decibars)*1e5) * 1e-1d);
         }
 #endif
 
@@ -618,7 +618,7 @@ namespace UnitsNet
             return new Pressure(feetofhead*2989.0669);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
         public static Pressure FromFeetOfHead(int feetofhead)
@@ -626,7 +626,7 @@ namespace UnitsNet
             return new Pressure(feetofhead*2989.0669);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
         public static Pressure FromFeetOfHead(long feetofhead)
@@ -634,14 +634,14 @@ namespace UnitsNet
             return new Pressure(feetofhead*2989.0669);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from FeetOfHead of type decimal.
         /// </summary>
         public static Pressure FromFeetOfHead(decimal feetofhead)
         {
-	        return new Pressure(Convert.ToDouble(feetofhead)*2989.0669);
+            return new Pressure(Convert.ToDouble(feetofhead)*2989.0669);
         }
 #endif
 
@@ -653,7 +653,7 @@ namespace UnitsNet
             return new Pressure((gigapascals) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Gigapascals.
         /// </summary>
         public static Pressure FromGigapascals(int gigapascals)
@@ -661,7 +661,7 @@ namespace UnitsNet
             return new Pressure((gigapascals) * 1e9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Gigapascals.
         /// </summary>
         public static Pressure FromGigapascals(long gigapascals)
@@ -669,14 +669,14 @@ namespace UnitsNet
             return new Pressure((gigapascals) * 1e9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Gigapascals of type decimal.
         /// </summary>
         public static Pressure FromGigapascals(decimal gigapascals)
         {
-	        return new Pressure((Convert.ToDouble(gigapascals)) * 1e9d);
+            return new Pressure((Convert.ToDouble(gigapascals)) * 1e9d);
         }
 #endif
 
@@ -688,7 +688,7 @@ namespace UnitsNet
             return new Pressure((hectopascals) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
         public static Pressure FromHectopascals(int hectopascals)
@@ -696,7 +696,7 @@ namespace UnitsNet
             return new Pressure((hectopascals) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
         public static Pressure FromHectopascals(long hectopascals)
@@ -704,14 +704,14 @@ namespace UnitsNet
             return new Pressure((hectopascals) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Hectopascals of type decimal.
         /// </summary>
         public static Pressure FromHectopascals(decimal hectopascals)
         {
-	        return new Pressure((Convert.ToDouble(hectopascals)) * 1e2d);
+            return new Pressure((Convert.ToDouble(hectopascals)) * 1e2d);
         }
 #endif
 
@@ -723,7 +723,7 @@ namespace UnitsNet
             return new Pressure(inchesofmercury/2.95299830714159e-4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from InchesOfMercury.
         /// </summary>
         public static Pressure FromInchesOfMercury(int inchesofmercury)
@@ -731,7 +731,7 @@ namespace UnitsNet
             return new Pressure(inchesofmercury/2.95299830714159e-4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from InchesOfMercury.
         /// </summary>
         public static Pressure FromInchesOfMercury(long inchesofmercury)
@@ -739,14 +739,14 @@ namespace UnitsNet
             return new Pressure(inchesofmercury/2.95299830714159e-4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from InchesOfMercury of type decimal.
         /// </summary>
         public static Pressure FromInchesOfMercury(decimal inchesofmercury)
         {
-	        return new Pressure(Convert.ToDouble(inchesofmercury)/2.95299830714159e-4);
+            return new Pressure(Convert.ToDouble(inchesofmercury)/2.95299830714159e-4);
         }
 #endif
 
@@ -758,7 +758,7 @@ namespace UnitsNet
             return new Pressure((kilobars*1e5) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
         public static Pressure FromKilobars(int kilobars)
@@ -766,7 +766,7 @@ namespace UnitsNet
             return new Pressure((kilobars*1e5) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
         public static Pressure FromKilobars(long kilobars)
@@ -774,14 +774,14 @@ namespace UnitsNet
             return new Pressure((kilobars*1e5) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Kilobars of type decimal.
         /// </summary>
         public static Pressure FromKilobars(decimal kilobars)
         {
-	        return new Pressure((Convert.ToDouble(kilobars)*1e5) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilobars)*1e5) * 1e3d);
         }
 #endif
 
@@ -793,7 +793,7 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareCentimeter(int kilogramsforcepersquarecentimeter)
@@ -801,7 +801,7 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareCentimeter(long kilogramsforcepersquarecentimeter)
@@ -809,14 +809,14 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareCentimeter(decimal kilogramsforcepersquarecentimeter)
         {
-	        return new Pressure(Convert.ToDouble(kilogramsforcepersquarecentimeter)*9.80665*1e4);
+            return new Pressure(Convert.ToDouble(kilogramsforcepersquarecentimeter)*9.80665*1e4);
         }
 #endif
 
@@ -828,7 +828,7 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareMeter(int kilogramsforcepersquaremeter)
@@ -836,7 +836,7 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareMeter(long kilogramsforcepersquaremeter)
@@ -844,14 +844,14 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter of type decimal.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareMeter(decimal kilogramsforcepersquaremeter)
         {
-	        return new Pressure(Convert.ToDouble(kilogramsforcepersquaremeter)*9.80665019960652);
+            return new Pressure(Convert.ToDouble(kilogramsforcepersquaremeter)*9.80665019960652);
         }
 #endif
 
@@ -863,7 +863,7 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareMillimeter(int kilogramsforcepersquaremillimeter)
@@ -871,7 +871,7 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareMillimeter(long kilogramsforcepersquaremillimeter)
@@ -879,14 +879,14 @@ namespace UnitsNet
             return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure FromKilogramsForcePerSquareMillimeter(decimal kilogramsforcepersquaremillimeter)
         {
-	        return new Pressure(Convert.ToDouble(kilogramsforcepersquaremillimeter)*9806650.19960652);
+            return new Pressure(Convert.ToDouble(kilogramsforcepersquaremillimeter)*9806650.19960652);
         }
 #endif
 
@@ -898,7 +898,7 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareCentimeter(int kilonewtonspersquarecentimeter)
@@ -906,7 +906,7 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareCentimeter(long kilonewtonspersquarecentimeter)
@@ -914,14 +914,14 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareCentimeter(decimal kilonewtonspersquarecentimeter)
         {
-	        return new Pressure((Convert.ToDouble(kilonewtonspersquarecentimeter)*1e4) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilonewtonspersquarecentimeter)*1e4) * 1e3d);
         }
 #endif
 
@@ -933,7 +933,7 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremeter) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareMeter(int kilonewtonspersquaremeter)
@@ -941,7 +941,7 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremeter) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareMeter(long kilonewtonspersquaremeter)
@@ -949,14 +949,14 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremeter) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter of type decimal.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareMeter(decimal kilonewtonspersquaremeter)
         {
-	        return new Pressure((Convert.ToDouble(kilonewtonspersquaremeter)) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilonewtonspersquaremeter)) * 1e3d);
         }
 #endif
 
@@ -968,7 +968,7 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareMillimeter(int kilonewtonspersquaremillimeter)
@@ -976,7 +976,7 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareMillimeter(long kilonewtonspersquaremillimeter)
@@ -984,14 +984,14 @@ namespace UnitsNet
             return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure FromKilonewtonsPerSquareMillimeter(decimal kilonewtonspersquaremillimeter)
         {
-	        return new Pressure((Convert.ToDouble(kilonewtonspersquaremillimeter)*1e6) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilonewtonspersquaremillimeter)*1e6) * 1e3d);
         }
 #endif
 
@@ -1003,7 +1003,7 @@ namespace UnitsNet
             return new Pressure((kilopascals) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Kilopascals.
         /// </summary>
         public static Pressure FromKilopascals(int kilopascals)
@@ -1011,7 +1011,7 @@ namespace UnitsNet
             return new Pressure((kilopascals) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Kilopascals.
         /// </summary>
         public static Pressure FromKilopascals(long kilopascals)
@@ -1019,14 +1019,14 @@ namespace UnitsNet
             return new Pressure((kilopascals) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Kilopascals of type decimal.
         /// </summary>
         public static Pressure FromKilopascals(decimal kilopascals)
         {
-	        return new Pressure((Convert.ToDouble(kilopascals)) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilopascals)) * 1e3d);
         }
 #endif
 
@@ -1038,7 +1038,7 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareFoot(int kilopoundsforcepersquarefoot)
@@ -1046,7 +1046,7 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareFoot(long kilopoundsforcepersquarefoot)
@@ -1054,14 +1054,14 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot of type decimal.
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareFoot(decimal kilopoundsforcepersquarefoot)
         {
-	        return new Pressure((Convert.ToDouble(kilopoundsforcepersquarefoot)*47.8802631216372) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilopoundsforcepersquarefoot)*47.8802631216372) * 1e3d);
         }
 #endif
 
@@ -1073,7 +1073,7 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareInch(int kilopoundsforcepersquareinch)
@@ -1081,7 +1081,7 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareInch(long kilopoundsforcepersquareinch)
@@ -1089,14 +1089,14 @@ namespace UnitsNet
             return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch of type decimal.
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareInch(decimal kilopoundsforcepersquareinch)
         {
-	        return new Pressure((Convert.ToDouble(kilopoundsforcepersquareinch)*6894.75729316836) * 1e3d);
+            return new Pressure((Convert.ToDouble(kilopoundsforcepersquareinch)*6894.75729316836) * 1e3d);
         }
 #endif
 
@@ -1108,7 +1108,7 @@ namespace UnitsNet
             return new Pressure((megabars*1e5) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
         public static Pressure FromMegabars(int megabars)
@@ -1116,7 +1116,7 @@ namespace UnitsNet
             return new Pressure((megabars*1e5) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
         public static Pressure FromMegabars(long megabars)
@@ -1124,14 +1124,14 @@ namespace UnitsNet
             return new Pressure((megabars*1e5) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Megabars of type decimal.
         /// </summary>
         public static Pressure FromMegabars(decimal megabars)
         {
-	        return new Pressure((Convert.ToDouble(megabars)*1e5) * 1e6d);
+            return new Pressure((Convert.ToDouble(megabars)*1e5) * 1e6d);
         }
 #endif
 
@@ -1143,7 +1143,7 @@ namespace UnitsNet
             return new Pressure((megapascals) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Megapascals.
         /// </summary>
         public static Pressure FromMegapascals(int megapascals)
@@ -1151,7 +1151,7 @@ namespace UnitsNet
             return new Pressure((megapascals) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Megapascals.
         /// </summary>
         public static Pressure FromMegapascals(long megapascals)
@@ -1159,14 +1159,14 @@ namespace UnitsNet
             return new Pressure((megapascals) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Megapascals of type decimal.
         /// </summary>
         public static Pressure FromMegapascals(decimal megapascals)
         {
-	        return new Pressure((Convert.ToDouble(megapascals)) * 1e6d);
+            return new Pressure((Convert.ToDouble(megapascals)) * 1e6d);
         }
 #endif
 
@@ -1178,7 +1178,7 @@ namespace UnitsNet
             return new Pressure(metersofhead*9804.139432);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
         public static Pressure FromMetersOfHead(int metersofhead)
@@ -1186,7 +1186,7 @@ namespace UnitsNet
             return new Pressure(metersofhead*9804.139432);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
         public static Pressure FromMetersOfHead(long metersofhead)
@@ -1194,14 +1194,14 @@ namespace UnitsNet
             return new Pressure(metersofhead*9804.139432);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from MetersOfHead of type decimal.
         /// </summary>
         public static Pressure FromMetersOfHead(decimal metersofhead)
         {
-	        return new Pressure(Convert.ToDouble(metersofhead)*9804.139432);
+            return new Pressure(Convert.ToDouble(metersofhead)*9804.139432);
         }
 #endif
 
@@ -1213,7 +1213,7 @@ namespace UnitsNet
             return new Pressure((micropascals) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Micropascals.
         /// </summary>
         public static Pressure FromMicropascals(int micropascals)
@@ -1221,7 +1221,7 @@ namespace UnitsNet
             return new Pressure((micropascals) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Micropascals.
         /// </summary>
         public static Pressure FromMicropascals(long micropascals)
@@ -1229,14 +1229,14 @@ namespace UnitsNet
             return new Pressure((micropascals) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Micropascals of type decimal.
         /// </summary>
         public static Pressure FromMicropascals(decimal micropascals)
         {
-	        return new Pressure((Convert.ToDouble(micropascals)) * 1e-6d);
+            return new Pressure((Convert.ToDouble(micropascals)) * 1e-6d);
         }
 #endif
 
@@ -1248,7 +1248,7 @@ namespace UnitsNet
             return new Pressure((millibars*1e5) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
         public static Pressure FromMillibars(int millibars)
@@ -1256,7 +1256,7 @@ namespace UnitsNet
             return new Pressure((millibars*1e5) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
         public static Pressure FromMillibars(long millibars)
@@ -1264,14 +1264,14 @@ namespace UnitsNet
             return new Pressure((millibars*1e5) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Millibars of type decimal.
         /// </summary>
         public static Pressure FromMillibars(decimal millibars)
         {
-	        return new Pressure((Convert.ToDouble(millibars)*1e5) * 1e-3d);
+            return new Pressure((Convert.ToDouble(millibars)*1e5) * 1e-3d);
         }
 #endif
 
@@ -1283,7 +1283,7 @@ namespace UnitsNet
             return new Pressure(millimetersofmercury/7.50061561302643e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
         /// </summary>
         public static Pressure FromMillimetersOfMercury(int millimetersofmercury)
@@ -1291,7 +1291,7 @@ namespace UnitsNet
             return new Pressure(millimetersofmercury/7.50061561302643e-3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
         /// </summary>
         public static Pressure FromMillimetersOfMercury(long millimetersofmercury)
@@ -1299,14 +1299,14 @@ namespace UnitsNet
             return new Pressure(millimetersofmercury/7.50061561302643e-3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from MillimetersOfMercury of type decimal.
         /// </summary>
         public static Pressure FromMillimetersOfMercury(decimal millimetersofmercury)
         {
-	        return new Pressure(Convert.ToDouble(millimetersofmercury)/7.50061561302643e-3);
+            return new Pressure(Convert.ToDouble(millimetersofmercury)/7.50061561302643e-3);
         }
 #endif
 
@@ -1318,7 +1318,7 @@ namespace UnitsNet
             return new Pressure(newtonspersquarecentimeter*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure FromNewtonsPerSquareCentimeter(int newtonspersquarecentimeter)
@@ -1326,7 +1326,7 @@ namespace UnitsNet
             return new Pressure(newtonspersquarecentimeter*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure FromNewtonsPerSquareCentimeter(long newtonspersquarecentimeter)
@@ -1334,14 +1334,14 @@ namespace UnitsNet
             return new Pressure(newtonspersquarecentimeter*1e4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure FromNewtonsPerSquareCentimeter(decimal newtonspersquarecentimeter)
         {
-	        return new Pressure(Convert.ToDouble(newtonspersquarecentimeter)*1e4);
+            return new Pressure(Convert.ToDouble(newtonspersquarecentimeter)*1e4);
         }
 #endif
 
@@ -1353,7 +1353,7 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
         /// </summary>
         public static Pressure FromNewtonsPerSquareMeter(int newtonspersquaremeter)
@@ -1361,7 +1361,7 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
         /// </summary>
         public static Pressure FromNewtonsPerSquareMeter(long newtonspersquaremeter)
@@ -1369,14 +1369,14 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremeter);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter of type decimal.
         /// </summary>
         public static Pressure FromNewtonsPerSquareMeter(decimal newtonspersquaremeter)
         {
-	        return new Pressure(Convert.ToDouble(newtonspersquaremeter));
+            return new Pressure(Convert.ToDouble(newtonspersquaremeter));
         }
 #endif
 
@@ -1388,7 +1388,7 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremillimeter*1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure FromNewtonsPerSquareMillimeter(int newtonspersquaremillimeter)
@@ -1396,7 +1396,7 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremillimeter*1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure FromNewtonsPerSquareMillimeter(long newtonspersquaremillimeter)
@@ -1404,14 +1404,14 @@ namespace UnitsNet
             return new Pressure(newtonspersquaremillimeter*1e6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure FromNewtonsPerSquareMillimeter(decimal newtonspersquaremillimeter)
         {
-	        return new Pressure(Convert.ToDouble(newtonspersquaremillimeter)*1e6);
+            return new Pressure(Convert.ToDouble(newtonspersquaremillimeter)*1e6);
         }
 #endif
 
@@ -1423,7 +1423,7 @@ namespace UnitsNet
             return new Pressure(pascals);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Pascals.
         /// </summary>
         public static Pressure FromPascals(int pascals)
@@ -1431,7 +1431,7 @@ namespace UnitsNet
             return new Pressure(pascals);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Pascals.
         /// </summary>
         public static Pressure FromPascals(long pascals)
@@ -1439,14 +1439,14 @@ namespace UnitsNet
             return new Pressure(pascals);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Pascals of type decimal.
         /// </summary>
         public static Pressure FromPascals(decimal pascals)
         {
-	        return new Pressure(Convert.ToDouble(pascals));
+            return new Pressure(Convert.ToDouble(pascals));
         }
 #endif
 
@@ -1458,7 +1458,7 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquarefoot*47.8802631216372);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure FromPoundsForcePerSquareFoot(int poundsforcepersquarefoot)
@@ -1466,7 +1466,7 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquarefoot*47.8802631216372);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure FromPoundsForcePerSquareFoot(long poundsforcepersquarefoot)
@@ -1474,14 +1474,14 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquarefoot*47.8802631216372);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot of type decimal.
         /// </summary>
         public static Pressure FromPoundsForcePerSquareFoot(decimal poundsforcepersquarefoot)
         {
-	        return new Pressure(Convert.ToDouble(poundsforcepersquarefoot)*47.8802631216372);
+            return new Pressure(Convert.ToDouble(poundsforcepersquarefoot)*47.8802631216372);
         }
 #endif
 
@@ -1493,7 +1493,7 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquareinch*6894.75729316836);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
         /// </summary>
         public static Pressure FromPoundsForcePerSquareInch(int poundsforcepersquareinch)
@@ -1501,7 +1501,7 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquareinch*6894.75729316836);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
         /// </summary>
         public static Pressure FromPoundsForcePerSquareInch(long poundsforcepersquareinch)
@@ -1509,14 +1509,14 @@ namespace UnitsNet
             return new Pressure(poundsforcepersquareinch*6894.75729316836);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch of type decimal.
         /// </summary>
         public static Pressure FromPoundsForcePerSquareInch(decimal poundsforcepersquareinch)
         {
-	        return new Pressure(Convert.ToDouble(poundsforcepersquareinch)*6894.75729316836);
+            return new Pressure(Convert.ToDouble(poundsforcepersquareinch)*6894.75729316836);
         }
 #endif
 
@@ -1528,7 +1528,7 @@ namespace UnitsNet
             return new Pressure(psi*6.89464975179*1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Psi.
         /// </summary>
         public static Pressure FromPsi(int psi)
@@ -1536,7 +1536,7 @@ namespace UnitsNet
             return new Pressure(psi*6.89464975179*1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Psi.
         /// </summary>
         public static Pressure FromPsi(long psi)
@@ -1544,14 +1544,14 @@ namespace UnitsNet
             return new Pressure(psi*6.89464975179*1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Psi of type decimal.
         /// </summary>
         public static Pressure FromPsi(decimal psi)
         {
-	        return new Pressure(Convert.ToDouble(psi)*6.89464975179*1e3);
+            return new Pressure(Convert.ToDouble(psi)*6.89464975179*1e3);
         }
 #endif
 
@@ -1563,7 +1563,7 @@ namespace UnitsNet
             return new Pressure(technicalatmospheres*9.80680592331*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
         /// </summary>
         public static Pressure FromTechnicalAtmospheres(int technicalatmospheres)
@@ -1571,7 +1571,7 @@ namespace UnitsNet
             return new Pressure(technicalatmospheres*9.80680592331*1e4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
         /// </summary>
         public static Pressure FromTechnicalAtmospheres(long technicalatmospheres)
@@ -1579,14 +1579,14 @@ namespace UnitsNet
             return new Pressure(technicalatmospheres*9.80680592331*1e4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TechnicalAtmospheres of type decimal.
         /// </summary>
         public static Pressure FromTechnicalAtmospheres(decimal technicalatmospheres)
         {
-	        return new Pressure(Convert.ToDouble(technicalatmospheres)*9.80680592331*1e4);
+            return new Pressure(Convert.ToDouble(technicalatmospheres)*9.80680592331*1e4);
         }
 #endif
 
@@ -1598,7 +1598,7 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareCentimeter(int tonnesforcepersquarecentimeter)
@@ -1606,7 +1606,7 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareCentimeter(long tonnesforcepersquarecentimeter)
@@ -1614,14 +1614,14 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareCentimeter(decimal tonnesforcepersquarecentimeter)
         {
-	        return new Pressure(Convert.ToDouble(tonnesforcepersquarecentimeter)*98066501.9960652);
+            return new Pressure(Convert.ToDouble(tonnesforcepersquarecentimeter)*98066501.9960652);
         }
 #endif
 
@@ -1633,7 +1633,7 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareMeter(int tonnesforcepersquaremeter)
@@ -1641,7 +1641,7 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareMeter(long tonnesforcepersquaremeter)
@@ -1649,14 +1649,14 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter of type decimal.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareMeter(decimal tonnesforcepersquaremeter)
         {
-	        return new Pressure(Convert.ToDouble(tonnesforcepersquaremeter)*9806.65019960653);
+            return new Pressure(Convert.ToDouble(tonnesforcepersquaremeter)*9806.65019960653);
         }
 #endif
 
@@ -1668,7 +1668,7 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareMillimeter(int tonnesforcepersquaremillimeter)
@@ -1676,7 +1676,7 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareMillimeter(long tonnesforcepersquaremillimeter)
@@ -1684,14 +1684,14 @@ namespace UnitsNet
             return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure FromTonnesForcePerSquareMillimeter(decimal tonnesforcepersquaremillimeter)
         {
-	        return new Pressure(Convert.ToDouble(tonnesforcepersquaremillimeter)*9806650199.60653);
+            return new Pressure(Convert.ToDouble(tonnesforcepersquaremillimeter)*9806650199.60653);
         }
 #endif
 
@@ -1703,7 +1703,7 @@ namespace UnitsNet
             return new Pressure(torrs*1.3332266752*1e2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Torrs.
         /// </summary>
         public static Pressure FromTorrs(int torrs)
@@ -1711,7 +1711,7 @@ namespace UnitsNet
             return new Pressure(torrs*1.3332266752*1e2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Torrs.
         /// </summary>
         public static Pressure FromTorrs(long torrs)
@@ -1719,14 +1719,14 @@ namespace UnitsNet
             return new Pressure(torrs*1.3332266752*1e2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Pressure from Torrs of type decimal.
         /// </summary>
         public static Pressure FromTorrs(decimal torrs)
         {
-	        return new Pressure(Convert.ToDouble(torrs)*1.3332266752*1e2);
+            return new Pressure(Convert.ToDouble(torrs)*1.3332266752*1e2);
         }
 #endif
 
@@ -1747,7 +1747,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Atmospheres.
         /// </summary>
         public static Pressure? FromAtmospheres(int? atmospheres)
@@ -1762,7 +1762,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Atmospheres.
         /// </summary>
         public static Pressure? FromAtmospheres(long? atmospheres)
@@ -1777,7 +1777,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Atmospheres of type decimal.
         /// </summary>
         public static Pressure? FromAtmospheres(decimal? atmospheres)
@@ -1807,7 +1807,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Bars.
         /// </summary>
         public static Pressure? FromBars(int? bars)
@@ -1822,7 +1822,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Bars.
         /// </summary>
         public static Pressure? FromBars(long? bars)
@@ -1837,7 +1837,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Bars of type decimal.
         /// </summary>
         public static Pressure? FromBars(decimal? bars)
@@ -1867,7 +1867,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Centibars.
         /// </summary>
         public static Pressure? FromCentibars(int? centibars)
@@ -1882,7 +1882,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Centibars.
         /// </summary>
         public static Pressure? FromCentibars(long? centibars)
@@ -1897,7 +1897,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Centibars of type decimal.
         /// </summary>
         public static Pressure? FromCentibars(decimal? centibars)
@@ -1927,7 +1927,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Decapascals.
         /// </summary>
         public static Pressure? FromDecapascals(int? decapascals)
@@ -1942,7 +1942,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Decapascals.
         /// </summary>
         public static Pressure? FromDecapascals(long? decapascals)
@@ -1957,7 +1957,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Decapascals of type decimal.
         /// </summary>
         public static Pressure? FromDecapascals(decimal? decapascals)
@@ -1987,7 +1987,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Decibars.
         /// </summary>
         public static Pressure? FromDecibars(int? decibars)
@@ -2002,7 +2002,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Decibars.
         /// </summary>
         public static Pressure? FromDecibars(long? decibars)
@@ -2017,7 +2017,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Decibars of type decimal.
         /// </summary>
         public static Pressure? FromDecibars(decimal? decibars)
@@ -2047,7 +2047,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable FeetOfHead.
         /// </summary>
         public static Pressure? FromFeetOfHead(int? feetofhead)
@@ -2062,7 +2062,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable FeetOfHead.
         /// </summary>
         public static Pressure? FromFeetOfHead(long? feetofhead)
@@ -2077,7 +2077,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from FeetOfHead of type decimal.
         /// </summary>
         public static Pressure? FromFeetOfHead(decimal? feetofhead)
@@ -2107,7 +2107,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Gigapascals.
         /// </summary>
         public static Pressure? FromGigapascals(int? gigapascals)
@@ -2122,7 +2122,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Gigapascals.
         /// </summary>
         public static Pressure? FromGigapascals(long? gigapascals)
@@ -2137,7 +2137,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Gigapascals of type decimal.
         /// </summary>
         public static Pressure? FromGigapascals(decimal? gigapascals)
@@ -2167,7 +2167,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Hectopascals.
         /// </summary>
         public static Pressure? FromHectopascals(int? hectopascals)
@@ -2182,7 +2182,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Hectopascals.
         /// </summary>
         public static Pressure? FromHectopascals(long? hectopascals)
@@ -2197,7 +2197,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Hectopascals of type decimal.
         /// </summary>
         public static Pressure? FromHectopascals(decimal? hectopascals)
@@ -2227,7 +2227,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable InchesOfMercury.
         /// </summary>
         public static Pressure? FromInchesOfMercury(int? inchesofmercury)
@@ -2242,7 +2242,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable InchesOfMercury.
         /// </summary>
         public static Pressure? FromInchesOfMercury(long? inchesofmercury)
@@ -2257,7 +2257,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from InchesOfMercury of type decimal.
         /// </summary>
         public static Pressure? FromInchesOfMercury(decimal? inchesofmercury)
@@ -2287,7 +2287,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Kilobars.
         /// </summary>
         public static Pressure? FromKilobars(int? kilobars)
@@ -2302,7 +2302,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Kilobars.
         /// </summary>
         public static Pressure? FromKilobars(long? kilobars)
@@ -2317,7 +2317,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Kilobars of type decimal.
         /// </summary>
         public static Pressure? FromKilobars(decimal? kilobars)
@@ -2347,7 +2347,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareCentimeter(int? kilogramsforcepersquarecentimeter)
@@ -2362,7 +2362,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareCentimeter(long? kilogramsforcepersquarecentimeter)
@@ -2377,7 +2377,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilogramsForcePerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareCentimeter(decimal? kilogramsforcepersquarecentimeter)
@@ -2407,7 +2407,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMeter(int? kilogramsforcepersquaremeter)
@@ -2422,7 +2422,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMeter(long? kilogramsforcepersquaremeter)
@@ -2437,7 +2437,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilogramsForcePerSquareMeter of type decimal.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMeter(decimal? kilogramsforcepersquaremeter)
@@ -2467,7 +2467,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMillimeter(int? kilogramsforcepersquaremillimeter)
@@ -2482,7 +2482,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMillimeter(long? kilogramsforcepersquaremillimeter)
@@ -2497,7 +2497,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilogramsForcePerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure? FromKilogramsForcePerSquareMillimeter(decimal? kilogramsforcepersquaremillimeter)
@@ -2527,7 +2527,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareCentimeter(int? kilonewtonspersquarecentimeter)
@@ -2542,7 +2542,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareCentimeter(long? kilonewtonspersquarecentimeter)
@@ -2557,7 +2557,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilonewtonsPerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareCentimeter(decimal? kilonewtonspersquarecentimeter)
@@ -2587,7 +2587,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMeter(int? kilonewtonspersquaremeter)
@@ -2602,7 +2602,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMeter(long? kilonewtonspersquaremeter)
@@ -2617,7 +2617,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilonewtonsPerSquareMeter of type decimal.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMeter(decimal? kilonewtonspersquaremeter)
@@ -2647,7 +2647,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMillimeter(int? kilonewtonspersquaremillimeter)
@@ -2662,7 +2662,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMillimeter(long? kilonewtonspersquaremillimeter)
@@ -2677,7 +2677,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilonewtonsPerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure? FromKilonewtonsPerSquareMillimeter(decimal? kilonewtonspersquaremillimeter)
@@ -2707,7 +2707,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Kilopascals.
         /// </summary>
         public static Pressure? FromKilopascals(int? kilopascals)
@@ -2722,7 +2722,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Kilopascals.
         /// </summary>
         public static Pressure? FromKilopascals(long? kilopascals)
@@ -2737,7 +2737,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Kilopascals of type decimal.
         /// </summary>
         public static Pressure? FromKilopascals(decimal? kilopascals)
@@ -2767,7 +2767,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareFoot(int? kilopoundsforcepersquarefoot)
@@ -2782,7 +2782,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareFoot(long? kilopoundsforcepersquarefoot)
@@ -2797,7 +2797,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilopoundsForcePerSquareFoot of type decimal.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareFoot(decimal? kilopoundsforcepersquarefoot)
@@ -2827,7 +2827,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareInch(int? kilopoundsforcepersquareinch)
@@ -2842,7 +2842,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareInch(long? kilopoundsforcepersquareinch)
@@ -2857,7 +2857,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from KilopoundsForcePerSquareInch of type decimal.
         /// </summary>
         public static Pressure? FromKilopoundsForcePerSquareInch(decimal? kilopoundsforcepersquareinch)
@@ -2887,7 +2887,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Megabars.
         /// </summary>
         public static Pressure? FromMegabars(int? megabars)
@@ -2902,7 +2902,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Megabars.
         /// </summary>
         public static Pressure? FromMegabars(long? megabars)
@@ -2917,7 +2917,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Megabars of type decimal.
         /// </summary>
         public static Pressure? FromMegabars(decimal? megabars)
@@ -2947,7 +2947,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Megapascals.
         /// </summary>
         public static Pressure? FromMegapascals(int? megapascals)
@@ -2962,7 +2962,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Megapascals.
         /// </summary>
         public static Pressure? FromMegapascals(long? megapascals)
@@ -2977,7 +2977,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Megapascals of type decimal.
         /// </summary>
         public static Pressure? FromMegapascals(decimal? megapascals)
@@ -3007,7 +3007,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable MetersOfHead.
         /// </summary>
         public static Pressure? FromMetersOfHead(int? metersofhead)
@@ -3022,7 +3022,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable MetersOfHead.
         /// </summary>
         public static Pressure? FromMetersOfHead(long? metersofhead)
@@ -3037,7 +3037,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from MetersOfHead of type decimal.
         /// </summary>
         public static Pressure? FromMetersOfHead(decimal? metersofhead)
@@ -3067,7 +3067,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Micropascals.
         /// </summary>
         public static Pressure? FromMicropascals(int? micropascals)
@@ -3082,7 +3082,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Micropascals.
         /// </summary>
         public static Pressure? FromMicropascals(long? micropascals)
@@ -3097,7 +3097,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Micropascals of type decimal.
         /// </summary>
         public static Pressure? FromMicropascals(decimal? micropascals)
@@ -3127,7 +3127,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Millibars.
         /// </summary>
         public static Pressure? FromMillibars(int? millibars)
@@ -3142,7 +3142,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Millibars.
         /// </summary>
         public static Pressure? FromMillibars(long? millibars)
@@ -3157,7 +3157,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Millibars of type decimal.
         /// </summary>
         public static Pressure? FromMillibars(decimal? millibars)
@@ -3187,7 +3187,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable MillimetersOfMercury.
         /// </summary>
         public static Pressure? FromMillimetersOfMercury(int? millimetersofmercury)
@@ -3202,7 +3202,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable MillimetersOfMercury.
         /// </summary>
         public static Pressure? FromMillimetersOfMercury(long? millimetersofmercury)
@@ -3217,7 +3217,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from MillimetersOfMercury of type decimal.
         /// </summary>
         public static Pressure? FromMillimetersOfMercury(decimal? millimetersofmercury)
@@ -3247,7 +3247,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareCentimeter(int? newtonspersquarecentimeter)
@@ -3262,7 +3262,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareCentimeter(long? newtonspersquarecentimeter)
@@ -3277,7 +3277,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from NewtonsPerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareCentimeter(decimal? newtonspersquarecentimeter)
@@ -3307,7 +3307,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMeter(int? newtonspersquaremeter)
@@ -3322,7 +3322,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMeter(long? newtonspersquaremeter)
@@ -3337,7 +3337,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from NewtonsPerSquareMeter of type decimal.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMeter(decimal? newtonspersquaremeter)
@@ -3367,7 +3367,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMillimeter(int? newtonspersquaremillimeter)
@@ -3382,7 +3382,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMillimeter(long? newtonspersquaremillimeter)
@@ -3397,7 +3397,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from NewtonsPerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure? FromNewtonsPerSquareMillimeter(decimal? newtonspersquaremillimeter)
@@ -3427,7 +3427,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Pascals.
         /// </summary>
         public static Pressure? FromPascals(int? pascals)
@@ -3442,7 +3442,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Pascals.
         /// </summary>
         public static Pressure? FromPascals(long? pascals)
@@ -3457,7 +3457,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Pascals of type decimal.
         /// </summary>
         public static Pressure? FromPascals(decimal? pascals)
@@ -3487,7 +3487,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareFoot(int? poundsforcepersquarefoot)
@@ -3502,7 +3502,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareFoot(long? poundsforcepersquarefoot)
@@ -3517,7 +3517,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from PoundsForcePerSquareFoot of type decimal.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareFoot(decimal? poundsforcepersquarefoot)
@@ -3547,7 +3547,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareInch(int? poundsforcepersquareinch)
@@ -3562,7 +3562,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareInch(long? poundsforcepersquareinch)
@@ -3577,7 +3577,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from PoundsForcePerSquareInch of type decimal.
         /// </summary>
         public static Pressure? FromPoundsForcePerSquareInch(decimal? poundsforcepersquareinch)
@@ -3607,7 +3607,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Psi.
         /// </summary>
         public static Pressure? FromPsi(int? psi)
@@ -3622,7 +3622,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Psi.
         /// </summary>
         public static Pressure? FromPsi(long? psi)
@@ -3637,7 +3637,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Psi of type decimal.
         /// </summary>
         public static Pressure? FromPsi(decimal? psi)
@@ -3667,7 +3667,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TechnicalAtmospheres.
         /// </summary>
         public static Pressure? FromTechnicalAtmospheres(int? technicalatmospheres)
@@ -3682,7 +3682,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TechnicalAtmospheres.
         /// </summary>
         public static Pressure? FromTechnicalAtmospheres(long? technicalatmospheres)
@@ -3697,7 +3697,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from TechnicalAtmospheres of type decimal.
         /// </summary>
         public static Pressure? FromTechnicalAtmospheres(decimal? technicalatmospheres)
@@ -3727,7 +3727,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareCentimeter(int? tonnesforcepersquarecentimeter)
@@ -3742,7 +3742,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareCentimeter(long? tonnesforcepersquarecentimeter)
@@ -3757,7 +3757,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from TonnesForcePerSquareCentimeter of type decimal.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareCentimeter(decimal? tonnesforcepersquarecentimeter)
@@ -3787,7 +3787,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMeter(int? tonnesforcepersquaremeter)
@@ -3802,7 +3802,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMeter(long? tonnesforcepersquaremeter)
@@ -3817,7 +3817,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from TonnesForcePerSquareMeter of type decimal.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMeter(decimal? tonnesforcepersquaremeter)
@@ -3847,7 +3847,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMillimeter(int? tonnesforcepersquaremillimeter)
@@ -3862,7 +3862,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMillimeter(long? tonnesforcepersquaremillimeter)
@@ -3877,7 +3877,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from TonnesForcePerSquareMillimeter of type decimal.
         /// </summary>
         public static Pressure? FromTonnesForcePerSquareMillimeter(decimal? tonnesforcepersquaremillimeter)
@@ -3907,7 +3907,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Torrs.
         /// </summary>
         public static Pressure? FromTorrs(int? torrs)
@@ -3922,7 +3922,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from nullable Torrs.
         /// </summary>
         public static Pressure? FromTorrs(long? torrs)
@@ -3937,7 +3937,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Pressure from Torrs of type decimal.
         /// </summary>
         public static Pressure? FromTorrs(decimal? torrs)

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _pascalsPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public PressureChangeRate() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.PressureChangeRate;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static PressureChangeRateUnit BaseUnit
         {
             get { return PressureChangeRateUnit.PascalPerSecond; }
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond.
         /// </summary>
         public static PressureChangeRate FromAtmospheresPerSecond(int atmospherespersecond)
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond.
         /// </summary>
         public static PressureChangeRate FromAtmospheresPerSecond(long atmospherespersecond)
@@ -194,14 +194,14 @@ namespace UnitsNet
             return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate FromAtmospheresPerSecond(decimal atmospherespersecond)
         {
-	        return new PressureChangeRate(Convert.ToDouble(atmospherespersecond) * 1.01325*1e5);
+            return new PressureChangeRate(Convert.ToDouble(atmospherespersecond) * 1.01325*1e5);
         }
 #endif
 
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new PressureChangeRate((kilopascalspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
         public static PressureChangeRate FromKilopascalsPerSecond(int kilopascalspersecond)
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new PressureChangeRate((kilopascalspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
         public static PressureChangeRate FromKilopascalsPerSecond(long kilopascalspersecond)
@@ -229,14 +229,14 @@ namespace UnitsNet
             return new PressureChangeRate((kilopascalspersecond) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate FromKilopascalsPerSecond(decimal kilopascalspersecond)
         {
-	        return new PressureChangeRate((Convert.ToDouble(kilopascalspersecond)) * 1e3d);
+            return new PressureChangeRate((Convert.ToDouble(kilopascalspersecond)) * 1e3d);
         }
 #endif
 
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new PressureChangeRate((megapascalspersecond) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
         /// </summary>
         public static PressureChangeRate FromMegapascalsPerSecond(int megapascalspersecond)
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new PressureChangeRate((megapascalspersecond) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
         /// </summary>
         public static PressureChangeRate FromMegapascalsPerSecond(long megapascalspersecond)
@@ -264,14 +264,14 @@ namespace UnitsNet
             return new PressureChangeRate((megapascalspersecond) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate FromMegapascalsPerSecond(decimal megapascalspersecond)
         {
-	        return new PressureChangeRate((Convert.ToDouble(megapascalspersecond)) * 1e6d);
+            return new PressureChangeRate((Convert.ToDouble(megapascalspersecond)) * 1e6d);
         }
 #endif
 
@@ -283,7 +283,7 @@ namespace UnitsNet
             return new PressureChangeRate(pascalspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
         public static PressureChangeRate FromPascalsPerSecond(int pascalspersecond)
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new PressureChangeRate(pascalspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
         public static PressureChangeRate FromPascalsPerSecond(long pascalspersecond)
@@ -299,14 +299,14 @@ namespace UnitsNet
             return new PressureChangeRate(pascalspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate FromPascalsPerSecond(decimal pascalspersecond)
         {
-	        return new PressureChangeRate(Convert.ToDouble(pascalspersecond));
+            return new PressureChangeRate(Convert.ToDouble(pascalspersecond));
         }
 #endif
 
@@ -327,7 +327,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
         /// </summary>
         public static PressureChangeRate? FromAtmospheresPerSecond(int? atmospherespersecond)
@@ -342,7 +342,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
         /// </summary>
         public static PressureChangeRate? FromAtmospheresPerSecond(long? atmospherespersecond)
@@ -357,7 +357,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from AtmospheresPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate? FromAtmospheresPerSecond(decimal? atmospherespersecond)
@@ -387,7 +387,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromKilopascalsPerSecond(int? kilopascalspersecond)
@@ -402,7 +402,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromKilopascalsPerSecond(long? kilopascalspersecond)
@@ -417,7 +417,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from KilopascalsPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate? FromKilopascalsPerSecond(decimal? kilopascalspersecond)
@@ -447,7 +447,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromMegapascalsPerSecond(int? megapascalspersecond)
@@ -462,7 +462,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromMegapascalsPerSecond(long? megapascalspersecond)
@@ -477,7 +477,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from MegapascalsPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate? FromMegapascalsPerSecond(decimal? megapascalspersecond)
@@ -507,7 +507,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromPascalsPerSecond(int? pascalspersecond)
@@ -522,7 +522,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromPascalsPerSecond(long? pascalspersecond)
@@ -537,7 +537,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable PressureChangeRate from PascalsPerSecond of type decimal.
         /// </summary>
         public static PressureChangeRate? FromPascalsPerSecond(decimal? pascalspersecond)

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -178,6 +178,33 @@ namespace UnitsNet
             return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
         }
 
+		/// <summary>
+        ///     Get PressureChangeRate from AtmospheresPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromAtmospheresPerSecond(int atmospherespersecond)
+        {
+            return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
+        }
+
+		/// <summary>
+        ///     Get PressureChangeRate from AtmospheresPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromAtmospheresPerSecond(long atmospherespersecond)
+        {
+            return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get PressureChangeRate from AtmospheresPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate FromAtmospheresPerSecond(decimal atmospherespersecond)
+        {
+	        return new PressureChangeRate(Convert.ToDouble(atmospherespersecond) * 1.01325*1e5);
+        }
+#endif
+
         /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
@@ -185,6 +212,33 @@ namespace UnitsNet
         {
             return new PressureChangeRate((kilopascalspersecond) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get PressureChangeRate from KilopascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromKilopascalsPerSecond(int kilopascalspersecond)
+        {
+            return new PressureChangeRate((kilopascalspersecond) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get PressureChangeRate from KilopascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromKilopascalsPerSecond(long kilopascalspersecond)
+        {
+            return new PressureChangeRate((kilopascalspersecond) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get PressureChangeRate from KilopascalsPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate FromKilopascalsPerSecond(decimal kilopascalspersecond)
+        {
+	        return new PressureChangeRate((Convert.ToDouble(kilopascalspersecond)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
@@ -194,6 +248,33 @@ namespace UnitsNet
             return new PressureChangeRate((megapascalspersecond) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get PressureChangeRate from MegapascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromMegapascalsPerSecond(int megapascalspersecond)
+        {
+            return new PressureChangeRate((megapascalspersecond) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get PressureChangeRate from MegapascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromMegapascalsPerSecond(long megapascalspersecond)
+        {
+            return new PressureChangeRate((megapascalspersecond) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get PressureChangeRate from MegapascalsPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate FromMegapascalsPerSecond(decimal megapascalspersecond)
+        {
+	        return new PressureChangeRate((Convert.ToDouble(megapascalspersecond)) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
@@ -202,12 +283,84 @@ namespace UnitsNet
             return new PressureChangeRate(pascalspersecond);
         }
 
+		/// <summary>
+        ///     Get PressureChangeRate from PascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromPascalsPerSecond(int pascalspersecond)
+        {
+            return new PressureChangeRate(pascalspersecond);
+        }
+
+		/// <summary>
+        ///     Get PressureChangeRate from PascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate FromPascalsPerSecond(long pascalspersecond)
+        {
+            return new PressureChangeRate(pascalspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get PressureChangeRate from PascalsPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate FromPascalsPerSecond(decimal pascalspersecond)
+        {
+	        return new PressureChangeRate(Convert.ToDouble(pascalspersecond));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
         /// </summary>
         public static PressureChangeRate? FromAtmospheresPerSecond(double? atmospherespersecond)
+        {
+            if (atmospherespersecond.HasValue)
+            {
+                return FromAtmospheresPerSecond(atmospherespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromAtmospheresPerSecond(int? atmospherespersecond)
+        {
+            if (atmospherespersecond.HasValue)
+            {
+                return FromAtmospheresPerSecond(atmospherespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromAtmospheresPerSecond(long? atmospherespersecond)
+        {
+            if (atmospherespersecond.HasValue)
+            {
+                return FromAtmospheresPerSecond(atmospherespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from AtmospheresPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate? FromAtmospheresPerSecond(decimal? atmospherespersecond)
         {
             if (atmospherespersecond.HasValue)
             {
@@ -234,6 +387,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromKilopascalsPerSecond(int? kilopascalspersecond)
+        {
+            if (kilopascalspersecond.HasValue)
+            {
+                return FromKilopascalsPerSecond(kilopascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromKilopascalsPerSecond(long? kilopascalspersecond)
+        {
+            if (kilopascalspersecond.HasValue)
+            {
+                return FromKilopascalsPerSecond(kilopascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from KilopascalsPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate? FromKilopascalsPerSecond(decimal? kilopascalspersecond)
+        {
+            if (kilopascalspersecond.HasValue)
+            {
+                return FromKilopascalsPerSecond(kilopascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
         /// </summary>
@@ -249,10 +447,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromMegapascalsPerSecond(int? megapascalspersecond)
+        {
+            if (megapascalspersecond.HasValue)
+            {
+                return FromMegapascalsPerSecond(megapascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromMegapascalsPerSecond(long? megapascalspersecond)
+        {
+            if (megapascalspersecond.HasValue)
+            {
+                return FromMegapascalsPerSecond(megapascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from MegapascalsPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate? FromMegapascalsPerSecond(decimal? megapascalspersecond)
+        {
+            if (megapascalspersecond.HasValue)
+            {
+                return FromMegapascalsPerSecond(megapascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
         /// </summary>
         public static PressureChangeRate? FromPascalsPerSecond(double? pascalspersecond)
+        {
+            if (pascalspersecond.HasValue)
+            {
+                return FromPascalsPerSecond(pascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromPascalsPerSecond(int? pascalspersecond)
+        {
+            if (pascalspersecond.HasValue)
+            {
+                return FromPascalsPerSecond(pascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
+        /// </summary>
+        public static PressureChangeRate? FromPascalsPerSecond(long? pascalspersecond)
+        {
+            if (pascalspersecond.HasValue)
+            {
+                return FromPascalsPerSecond(pascalspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable PressureChangeRate from PascalsPerSecond of type decimal.
+        /// </summary>
+        public static PressureChangeRate? FromPascalsPerSecond(decimal? pascalspersecond)
         {
             if (pascalspersecond.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -173,6 +173,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static PressureChangeRate FromAtmospheresPerSecond(double atmospherespersecond)
         {
             return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
@@ -208,6 +211,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static PressureChangeRate FromKilopascalsPerSecond(double kilopascalspersecond)
         {
             return new PressureChangeRate((kilopascalspersecond) * 1e3d);
@@ -243,6 +249,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static PressureChangeRate FromMegapascalsPerSecond(double megapascalspersecond)
         {
             return new PressureChangeRate((megapascalspersecond) * 1e6d);
@@ -278,6 +287,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static PressureChangeRate FromPascalsPerSecond(double pascalspersecond)
         {
             return new PressureChangeRate(pascalspersecond);

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -189,6 +189,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from DecimalFractions.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Ratio FromDecimalFractions(double decimalfractions)
         {
             return new Ratio(decimalfractions);
@@ -224,6 +227,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Ratio FromPartsPerBillion(double partsperbillion)
         {
             return new Ratio(partsperbillion/1e9);
@@ -259,6 +265,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerMillion.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Ratio FromPartsPerMillion(double partspermillion)
         {
             return new Ratio(partspermillion/1e6);
@@ -294,6 +303,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Ratio FromPartsPerThousand(double partsperthousand)
         {
             return new Ratio(partsperthousand/1e3);
@@ -329,6 +341,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerTrillion.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Ratio FromPartsPerTrillion(double partspertrillion)
         {
             return new Ratio(partspertrillion/1e12);
@@ -364,6 +379,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Ratio FromPercent(double percent)
         {
             return new Ratio(percent/1e2);

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _decimalFractions;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Ratio() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Ratio;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static RatioUnit BaseUnit
         {
             get { return RatioUnit.DecimalFraction; }
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new Ratio(decimalfractions);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from DecimalFractions.
         /// </summary>
         public static Ratio FromDecimalFractions(int decimalfractions)
@@ -202,7 +202,7 @@ namespace UnitsNet
             return new Ratio(decimalfractions);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from DecimalFractions.
         /// </summary>
         public static Ratio FromDecimalFractions(long decimalfractions)
@@ -210,14 +210,14 @@ namespace UnitsNet
             return new Ratio(decimalfractions);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from DecimalFractions of type decimal.
         /// </summary>
         public static Ratio FromDecimalFractions(decimal decimalfractions)
         {
-	        return new Ratio(Convert.ToDouble(decimalfractions));
+            return new Ratio(Convert.ToDouble(decimalfractions));
         }
 #endif
 
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new Ratio(partsperbillion/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
         public static Ratio FromPartsPerBillion(int partsperbillion)
@@ -237,7 +237,7 @@ namespace UnitsNet
             return new Ratio(partsperbillion/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
         public static Ratio FromPartsPerBillion(long partsperbillion)
@@ -245,14 +245,14 @@ namespace UnitsNet
             return new Ratio(partsperbillion/1e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerBillion of type decimal.
         /// </summary>
         public static Ratio FromPartsPerBillion(decimal partsperbillion)
         {
-	        return new Ratio(Convert.ToDouble(partsperbillion)/1e9);
+            return new Ratio(Convert.ToDouble(partsperbillion)/1e9);
         }
 #endif
 
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new Ratio(partspermillion/1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerMillion.
         /// </summary>
         public static Ratio FromPartsPerMillion(int partspermillion)
@@ -272,7 +272,7 @@ namespace UnitsNet
             return new Ratio(partspermillion/1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerMillion.
         /// </summary>
         public static Ratio FromPartsPerMillion(long partspermillion)
@@ -280,14 +280,14 @@ namespace UnitsNet
             return new Ratio(partspermillion/1e6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerMillion of type decimal.
         /// </summary>
         public static Ratio FromPartsPerMillion(decimal partspermillion)
         {
-	        return new Ratio(Convert.ToDouble(partspermillion)/1e6);
+            return new Ratio(Convert.ToDouble(partspermillion)/1e6);
         }
 #endif
 
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new Ratio(partsperthousand/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
         public static Ratio FromPartsPerThousand(int partsperthousand)
@@ -307,7 +307,7 @@ namespace UnitsNet
             return new Ratio(partsperthousand/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
         public static Ratio FromPartsPerThousand(long partsperthousand)
@@ -315,14 +315,14 @@ namespace UnitsNet
             return new Ratio(partsperthousand/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerThousand of type decimal.
         /// </summary>
         public static Ratio FromPartsPerThousand(decimal partsperthousand)
         {
-	        return new Ratio(Convert.ToDouble(partsperthousand)/1e3);
+            return new Ratio(Convert.ToDouble(partsperthousand)/1e3);
         }
 #endif
 
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new Ratio(partspertrillion/1e12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerTrillion.
         /// </summary>
         public static Ratio FromPartsPerTrillion(int partspertrillion)
@@ -342,7 +342,7 @@ namespace UnitsNet
             return new Ratio(partspertrillion/1e12);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerTrillion.
         /// </summary>
         public static Ratio FromPartsPerTrillion(long partspertrillion)
@@ -350,14 +350,14 @@ namespace UnitsNet
             return new Ratio(partspertrillion/1e12);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from PartsPerTrillion of type decimal.
         /// </summary>
         public static Ratio FromPartsPerTrillion(decimal partspertrillion)
         {
-	        return new Ratio(Convert.ToDouble(partspertrillion)/1e12);
+            return new Ratio(Convert.ToDouble(partspertrillion)/1e12);
         }
 #endif
 
@@ -369,7 +369,7 @@ namespace UnitsNet
             return new Ratio(percent/1e2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
         public static Ratio FromPercent(int percent)
@@ -377,7 +377,7 @@ namespace UnitsNet
             return new Ratio(percent/1e2);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
         public static Ratio FromPercent(long percent)
@@ -385,14 +385,14 @@ namespace UnitsNet
             return new Ratio(percent/1e2);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Ratio from Percent of type decimal.
         /// </summary>
         public static Ratio FromPercent(decimal percent)
         {
-	        return new Ratio(Convert.ToDouble(percent)/1e2);
+            return new Ratio(Convert.ToDouble(percent)/1e2);
         }
 #endif
 
@@ -413,7 +413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable DecimalFractions.
         /// </summary>
         public static Ratio? FromDecimalFractions(int? decimalfractions)
@@ -428,7 +428,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable DecimalFractions.
         /// </summary>
         public static Ratio? FromDecimalFractions(long? decimalfractions)
@@ -443,7 +443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from DecimalFractions of type decimal.
         /// </summary>
         public static Ratio? FromDecimalFractions(decimal? decimalfractions)
@@ -473,7 +473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerBillion.
         /// </summary>
         public static Ratio? FromPartsPerBillion(int? partsperbillion)
@@ -488,7 +488,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerBillion.
         /// </summary>
         public static Ratio? FromPartsPerBillion(long? partsperbillion)
@@ -503,7 +503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from PartsPerBillion of type decimal.
         /// </summary>
         public static Ratio? FromPartsPerBillion(decimal? partsperbillion)
@@ -533,7 +533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerMillion.
         /// </summary>
         public static Ratio? FromPartsPerMillion(int? partspermillion)
@@ -548,7 +548,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerMillion.
         /// </summary>
         public static Ratio? FromPartsPerMillion(long? partspermillion)
@@ -563,7 +563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from PartsPerMillion of type decimal.
         /// </summary>
         public static Ratio? FromPartsPerMillion(decimal? partspermillion)
@@ -593,7 +593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerThousand.
         /// </summary>
         public static Ratio? FromPartsPerThousand(int? partsperthousand)
@@ -608,7 +608,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerThousand.
         /// </summary>
         public static Ratio? FromPartsPerThousand(long? partsperthousand)
@@ -623,7 +623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from PartsPerThousand of type decimal.
         /// </summary>
         public static Ratio? FromPartsPerThousand(decimal? partsperthousand)
@@ -653,7 +653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerTrillion.
         /// </summary>
         public static Ratio? FromPartsPerTrillion(int? partspertrillion)
@@ -668,7 +668,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable PartsPerTrillion.
         /// </summary>
         public static Ratio? FromPartsPerTrillion(long? partspertrillion)
@@ -683,7 +683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from PartsPerTrillion of type decimal.
         /// </summary>
         public static Ratio? FromPartsPerTrillion(decimal? partspertrillion)
@@ -713,7 +713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable Percent.
         /// </summary>
         public static Ratio? FromPercent(int? percent)
@@ -728,7 +728,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from nullable Percent.
         /// </summary>
         public static Ratio? FromPercent(long? percent)
@@ -743,7 +743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Ratio from Percent of type decimal.
         /// </summary>
         public static Ratio? FromPercent(decimal? percent)

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -194,6 +194,33 @@ namespace UnitsNet
             return new Ratio(decimalfractions);
         }
 
+		/// <summary>
+        ///     Get Ratio from DecimalFractions.
+        /// </summary>
+        public static Ratio FromDecimalFractions(int decimalfractions)
+        {
+            return new Ratio(decimalfractions);
+        }
+
+		/// <summary>
+        ///     Get Ratio from DecimalFractions.
+        /// </summary>
+        public static Ratio FromDecimalFractions(long decimalfractions)
+        {
+            return new Ratio(decimalfractions);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Ratio from DecimalFractions of type decimal.
+        /// </summary>
+        public static Ratio FromDecimalFractions(decimal decimalfractions)
+        {
+	        return new Ratio(Convert.ToDouble(decimalfractions));
+        }
+#endif
+
         /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
@@ -201,6 +228,33 @@ namespace UnitsNet
         {
             return new Ratio(partsperbillion/1e9);
         }
+
+		/// <summary>
+        ///     Get Ratio from PartsPerBillion.
+        /// </summary>
+        public static Ratio FromPartsPerBillion(int partsperbillion)
+        {
+            return new Ratio(partsperbillion/1e9);
+        }
+
+		/// <summary>
+        ///     Get Ratio from PartsPerBillion.
+        /// </summary>
+        public static Ratio FromPartsPerBillion(long partsperbillion)
+        {
+            return new Ratio(partsperbillion/1e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Ratio from PartsPerBillion of type decimal.
+        /// </summary>
+        public static Ratio FromPartsPerBillion(decimal partsperbillion)
+        {
+	        return new Ratio(Convert.ToDouble(partsperbillion)/1e9);
+        }
+#endif
 
         /// <summary>
         ///     Get Ratio from PartsPerMillion.
@@ -210,6 +264,33 @@ namespace UnitsNet
             return new Ratio(partspermillion/1e6);
         }
 
+		/// <summary>
+        ///     Get Ratio from PartsPerMillion.
+        /// </summary>
+        public static Ratio FromPartsPerMillion(int partspermillion)
+        {
+            return new Ratio(partspermillion/1e6);
+        }
+
+		/// <summary>
+        ///     Get Ratio from PartsPerMillion.
+        /// </summary>
+        public static Ratio FromPartsPerMillion(long partspermillion)
+        {
+            return new Ratio(partspermillion/1e6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Ratio from PartsPerMillion of type decimal.
+        /// </summary>
+        public static Ratio FromPartsPerMillion(decimal partspermillion)
+        {
+	        return new Ratio(Convert.ToDouble(partspermillion)/1e6);
+        }
+#endif
+
         /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
@@ -217,6 +298,33 @@ namespace UnitsNet
         {
             return new Ratio(partsperthousand/1e3);
         }
+
+		/// <summary>
+        ///     Get Ratio from PartsPerThousand.
+        /// </summary>
+        public static Ratio FromPartsPerThousand(int partsperthousand)
+        {
+            return new Ratio(partsperthousand/1e3);
+        }
+
+		/// <summary>
+        ///     Get Ratio from PartsPerThousand.
+        /// </summary>
+        public static Ratio FromPartsPerThousand(long partsperthousand)
+        {
+            return new Ratio(partsperthousand/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Ratio from PartsPerThousand of type decimal.
+        /// </summary>
+        public static Ratio FromPartsPerThousand(decimal partsperthousand)
+        {
+	        return new Ratio(Convert.ToDouble(partsperthousand)/1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Ratio from PartsPerTrillion.
@@ -226,6 +334,33 @@ namespace UnitsNet
             return new Ratio(partspertrillion/1e12);
         }
 
+		/// <summary>
+        ///     Get Ratio from PartsPerTrillion.
+        /// </summary>
+        public static Ratio FromPartsPerTrillion(int partspertrillion)
+        {
+            return new Ratio(partspertrillion/1e12);
+        }
+
+		/// <summary>
+        ///     Get Ratio from PartsPerTrillion.
+        /// </summary>
+        public static Ratio FromPartsPerTrillion(long partspertrillion)
+        {
+            return new Ratio(partspertrillion/1e12);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Ratio from PartsPerTrillion of type decimal.
+        /// </summary>
+        public static Ratio FromPartsPerTrillion(decimal partspertrillion)
+        {
+	        return new Ratio(Convert.ToDouble(partspertrillion)/1e12);
+        }
+#endif
+
         /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
@@ -234,12 +369,84 @@ namespace UnitsNet
             return new Ratio(percent/1e2);
         }
 
+		/// <summary>
+        ///     Get Ratio from Percent.
+        /// </summary>
+        public static Ratio FromPercent(int percent)
+        {
+            return new Ratio(percent/1e2);
+        }
+
+		/// <summary>
+        ///     Get Ratio from Percent.
+        /// </summary>
+        public static Ratio FromPercent(long percent)
+        {
+            return new Ratio(percent/1e2);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Ratio from Percent of type decimal.
+        /// </summary>
+        public static Ratio FromPercent(decimal percent)
+        {
+	        return new Ratio(Convert.ToDouble(percent)/1e2);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Ratio from nullable DecimalFractions.
         /// </summary>
         public static Ratio? FromDecimalFractions(double? decimalfractions)
+        {
+            if (decimalfractions.HasValue)
+            {
+                return FromDecimalFractions(decimalfractions.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable DecimalFractions.
+        /// </summary>
+        public static Ratio? FromDecimalFractions(int? decimalfractions)
+        {
+            if (decimalfractions.HasValue)
+            {
+                return FromDecimalFractions(decimalfractions.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable DecimalFractions.
+        /// </summary>
+        public static Ratio? FromDecimalFractions(long? decimalfractions)
+        {
+            if (decimalfractions.HasValue)
+            {
+                return FromDecimalFractions(decimalfractions.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from DecimalFractions of type decimal.
+        /// </summary>
+        public static Ratio? FromDecimalFractions(decimal? decimalfractions)
         {
             if (decimalfractions.HasValue)
             {
@@ -266,10 +473,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerBillion.
+        /// </summary>
+        public static Ratio? FromPartsPerBillion(int? partsperbillion)
+        {
+            if (partsperbillion.HasValue)
+            {
+                return FromPartsPerBillion(partsperbillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerBillion.
+        /// </summary>
+        public static Ratio? FromPartsPerBillion(long? partsperbillion)
+        {
+            if (partsperbillion.HasValue)
+            {
+                return FromPartsPerBillion(partsperbillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from PartsPerBillion of type decimal.
+        /// </summary>
+        public static Ratio? FromPartsPerBillion(decimal? partsperbillion)
+        {
+            if (partsperbillion.HasValue)
+            {
+                return FromPartsPerBillion(partsperbillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Ratio from nullable PartsPerMillion.
         /// </summary>
         public static Ratio? FromPartsPerMillion(double? partspermillion)
+        {
+            if (partspermillion.HasValue)
+            {
+                return FromPartsPerMillion(partspermillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerMillion.
+        /// </summary>
+        public static Ratio? FromPartsPerMillion(int? partspermillion)
+        {
+            if (partspermillion.HasValue)
+            {
+                return FromPartsPerMillion(partspermillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerMillion.
+        /// </summary>
+        public static Ratio? FromPartsPerMillion(long? partspermillion)
+        {
+            if (partspermillion.HasValue)
+            {
+                return FromPartsPerMillion(partspermillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from PartsPerMillion of type decimal.
+        /// </summary>
+        public static Ratio? FromPartsPerMillion(decimal? partspermillion)
         {
             if (partspermillion.HasValue)
             {
@@ -296,6 +593,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerThousand.
+        /// </summary>
+        public static Ratio? FromPartsPerThousand(int? partsperthousand)
+        {
+            if (partsperthousand.HasValue)
+            {
+                return FromPartsPerThousand(partsperthousand.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerThousand.
+        /// </summary>
+        public static Ratio? FromPartsPerThousand(long? partsperthousand)
+        {
+            if (partsperthousand.HasValue)
+            {
+                return FromPartsPerThousand(partsperthousand.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from PartsPerThousand of type decimal.
+        /// </summary>
+        public static Ratio? FromPartsPerThousand(decimal? partsperthousand)
+        {
+            if (partsperthousand.HasValue)
+            {
+                return FromPartsPerThousand(partsperthousand.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Ratio from nullable PartsPerTrillion.
         /// </summary>
@@ -311,10 +653,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerTrillion.
+        /// </summary>
+        public static Ratio? FromPartsPerTrillion(int? partspertrillion)
+        {
+            if (partspertrillion.HasValue)
+            {
+                return FromPartsPerTrillion(partspertrillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable PartsPerTrillion.
+        /// </summary>
+        public static Ratio? FromPartsPerTrillion(long? partspertrillion)
+        {
+            if (partspertrillion.HasValue)
+            {
+                return FromPartsPerTrillion(partspertrillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from PartsPerTrillion of type decimal.
+        /// </summary>
+        public static Ratio? FromPartsPerTrillion(decimal? partspertrillion)
+        {
+            if (partspertrillion.HasValue)
+            {
+                return FromPartsPerTrillion(partspertrillion.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Ratio from nullable Percent.
         /// </summary>
         public static Ratio? FromPercent(double? percent)
+        {
+            if (percent.HasValue)
+            {
+                return FromPercent(percent.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable Percent.
+        /// </summary>
+        public static Ratio? FromPercent(int? percent)
+        {
+            if (percent.HasValue)
+            {
+                return FromPercent(percent.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from nullable Percent.
+        /// </summary>
+        public static Ratio? FromPercent(long? percent)
+        {
+            if (percent.HasValue)
+            {
+                return FromPercent(percent.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Ratio from Percent of type decimal.
+        /// </summary>
+        public static Ratio? FromPercent(decimal? percent)
         {
             if (percent.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _voltamperesReactive;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ReactivePower() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ReactivePower;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ReactivePowerUnit BaseUnit
         {
             get { return ReactivePowerUnit.VoltampereReactive; }
@@ -170,7 +170,7 @@ namespace UnitsNet
             return new ReactivePower((kilovoltamperesreactive) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive.
         /// </summary>
         public static ReactivePower FromKilovoltamperesReactive(int kilovoltamperesreactive)
@@ -178,7 +178,7 @@ namespace UnitsNet
             return new ReactivePower((kilovoltamperesreactive) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive.
         /// </summary>
         public static ReactivePower FromKilovoltamperesReactive(long kilovoltamperesreactive)
@@ -186,14 +186,14 @@ namespace UnitsNet
             return new ReactivePower((kilovoltamperesreactive) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive of type decimal.
         /// </summary>
         public static ReactivePower FromKilovoltamperesReactive(decimal kilovoltamperesreactive)
         {
-	        return new ReactivePower((Convert.ToDouble(kilovoltamperesreactive)) * 1e3d);
+            return new ReactivePower((Convert.ToDouble(kilovoltamperesreactive)) * 1e3d);
         }
 #endif
 
@@ -205,7 +205,7 @@ namespace UnitsNet
             return new ReactivePower((megavoltamperesreactive) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
         public static ReactivePower FromMegavoltamperesReactive(int megavoltamperesreactive)
@@ -213,7 +213,7 @@ namespace UnitsNet
             return new ReactivePower((megavoltamperesreactive) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
         public static ReactivePower FromMegavoltamperesReactive(long megavoltamperesreactive)
@@ -221,14 +221,14 @@ namespace UnitsNet
             return new ReactivePower((megavoltamperesreactive) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive of type decimal.
         /// </summary>
         public static ReactivePower FromMegavoltamperesReactive(decimal megavoltamperesreactive)
         {
-	        return new ReactivePower((Convert.ToDouble(megavoltamperesreactive)) * 1e6d);
+            return new ReactivePower((Convert.ToDouble(megavoltamperesreactive)) * 1e6d);
         }
 #endif
 
@@ -240,7 +240,7 @@ namespace UnitsNet
             return new ReactivePower(voltamperesreactive);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
         /// </summary>
         public static ReactivePower FromVoltamperesReactive(int voltamperesreactive)
@@ -248,7 +248,7 @@ namespace UnitsNet
             return new ReactivePower(voltamperesreactive);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
         /// </summary>
         public static ReactivePower FromVoltamperesReactive(long voltamperesreactive)
@@ -256,14 +256,14 @@ namespace UnitsNet
             return new ReactivePower(voltamperesreactive);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ReactivePower from VoltamperesReactive of type decimal.
         /// </summary>
         public static ReactivePower FromVoltamperesReactive(decimal voltamperesreactive)
         {
-	        return new ReactivePower(Convert.ToDouble(voltamperesreactive));
+            return new ReactivePower(Convert.ToDouble(voltamperesreactive));
         }
 #endif
 
@@ -284,7 +284,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromKilovoltamperesReactive(int? kilovoltamperesreactive)
@@ -299,7 +299,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromKilovoltamperesReactive(long? kilovoltamperesreactive)
@@ -314,7 +314,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from KilovoltamperesReactive of type decimal.
         /// </summary>
         public static ReactivePower? FromKilovoltamperesReactive(decimal? kilovoltamperesreactive)
@@ -344,7 +344,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromMegavoltamperesReactive(int? megavoltamperesreactive)
@@ -359,7 +359,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromMegavoltamperesReactive(long? megavoltamperesreactive)
@@ -374,7 +374,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from MegavoltamperesReactive of type decimal.
         /// </summary>
         public static ReactivePower? FromMegavoltamperesReactive(decimal? megavoltamperesreactive)
@@ -404,7 +404,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from nullable VoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromVoltamperesReactive(int? voltamperesreactive)
@@ -419,7 +419,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from nullable VoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromVoltamperesReactive(long? voltamperesreactive)
@@ -434,7 +434,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ReactivePower from VoltamperesReactive of type decimal.
         /// </summary>
         public static ReactivePower? FromVoltamperesReactive(decimal? voltamperesreactive)

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -170,6 +170,33 @@ namespace UnitsNet
             return new ReactivePower((kilovoltamperesreactive) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get ReactivePower from KilovoltamperesReactive.
+        /// </summary>
+        public static ReactivePower FromKilovoltamperesReactive(int kilovoltamperesreactive)
+        {
+            return new ReactivePower((kilovoltamperesreactive) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get ReactivePower from KilovoltamperesReactive.
+        /// </summary>
+        public static ReactivePower FromKilovoltamperesReactive(long kilovoltamperesreactive)
+        {
+            return new ReactivePower((kilovoltamperesreactive) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ReactivePower from KilovoltamperesReactive of type decimal.
+        /// </summary>
+        public static ReactivePower FromKilovoltamperesReactive(decimal kilovoltamperesreactive)
+        {
+	        return new ReactivePower((Convert.ToDouble(kilovoltamperesreactive)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
@@ -177,6 +204,33 @@ namespace UnitsNet
         {
             return new ReactivePower((megavoltamperesreactive) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get ReactivePower from MegavoltamperesReactive.
+        /// </summary>
+        public static ReactivePower FromMegavoltamperesReactive(int megavoltamperesreactive)
+        {
+            return new ReactivePower((megavoltamperesreactive) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get ReactivePower from MegavoltamperesReactive.
+        /// </summary>
+        public static ReactivePower FromMegavoltamperesReactive(long megavoltamperesreactive)
+        {
+            return new ReactivePower((megavoltamperesreactive) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ReactivePower from MegavoltamperesReactive of type decimal.
+        /// </summary>
+        public static ReactivePower FromMegavoltamperesReactive(decimal megavoltamperesreactive)
+        {
+	        return new ReactivePower((Convert.ToDouble(megavoltamperesreactive)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
@@ -186,12 +240,84 @@ namespace UnitsNet
             return new ReactivePower(voltamperesreactive);
         }
 
+		/// <summary>
+        ///     Get ReactivePower from VoltamperesReactive.
+        /// </summary>
+        public static ReactivePower FromVoltamperesReactive(int voltamperesreactive)
+        {
+            return new ReactivePower(voltamperesreactive);
+        }
+
+		/// <summary>
+        ///     Get ReactivePower from VoltamperesReactive.
+        /// </summary>
+        public static ReactivePower FromVoltamperesReactive(long voltamperesreactive)
+        {
+            return new ReactivePower(voltamperesreactive);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ReactivePower from VoltamperesReactive of type decimal.
+        /// </summary>
+        public static ReactivePower FromVoltamperesReactive(decimal voltamperesreactive)
+        {
+	        return new ReactivePower(Convert.ToDouble(voltamperesreactive));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromKilovoltamperesReactive(double? kilovoltamperesreactive)
+        {
+            if (kilovoltamperesreactive.HasValue)
+            {
+                return FromKilovoltamperesReactive(kilovoltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
+        /// </summary>
+        public static ReactivePower? FromKilovoltamperesReactive(int? kilovoltamperesreactive)
+        {
+            if (kilovoltamperesreactive.HasValue)
+            {
+                return FromKilovoltamperesReactive(kilovoltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
+        /// </summary>
+        public static ReactivePower? FromKilovoltamperesReactive(long? kilovoltamperesreactive)
+        {
+            if (kilovoltamperesreactive.HasValue)
+            {
+                return FromKilovoltamperesReactive(kilovoltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from KilovoltamperesReactive of type decimal.
+        /// </summary>
+        public static ReactivePower? FromKilovoltamperesReactive(decimal? kilovoltamperesreactive)
         {
             if (kilovoltamperesreactive.HasValue)
             {
@@ -218,10 +344,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
+        /// </summary>
+        public static ReactivePower? FromMegavoltamperesReactive(int? megavoltamperesreactive)
+        {
+            if (megavoltamperesreactive.HasValue)
+            {
+                return FromMegavoltamperesReactive(megavoltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
+        /// </summary>
+        public static ReactivePower? FromMegavoltamperesReactive(long? megavoltamperesreactive)
+        {
+            if (megavoltamperesreactive.HasValue)
+            {
+                return FromMegavoltamperesReactive(megavoltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from MegavoltamperesReactive of type decimal.
+        /// </summary>
+        public static ReactivePower? FromMegavoltamperesReactive(decimal? megavoltamperesreactive)
+        {
+            if (megavoltamperesreactive.HasValue)
+            {
+                return FromMegavoltamperesReactive(megavoltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ReactivePower from nullable VoltamperesReactive.
         /// </summary>
         public static ReactivePower? FromVoltamperesReactive(double? voltamperesreactive)
+        {
+            if (voltamperesreactive.HasValue)
+            {
+                return FromVoltamperesReactive(voltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from nullable VoltamperesReactive.
+        /// </summary>
+        public static ReactivePower? FromVoltamperesReactive(int? voltamperesreactive)
+        {
+            if (voltamperesreactive.HasValue)
+            {
+                return FromVoltamperesReactive(voltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from nullable VoltamperesReactive.
+        /// </summary>
+        public static ReactivePower? FromVoltamperesReactive(long? voltamperesreactive)
+        {
+            if (voltamperesreactive.HasValue)
+            {
+                return FromVoltamperesReactive(voltamperesreactive.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ReactivePower from VoltamperesReactive of type decimal.
+        /// </summary>
+        public static ReactivePower? FromVoltamperesReactive(decimal? voltamperesreactive)
         {
             if (voltamperesreactive.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -165,6 +165,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ReactivePower FromKilovoltamperesReactive(double kilovoltamperesreactive)
         {
             return new ReactivePower((kilovoltamperesreactive) * 1e3d);
@@ -200,6 +203,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ReactivePower FromMegavoltamperesReactive(double megavoltamperesreactive)
         {
             return new ReactivePower((megavoltamperesreactive) * 1e6d);
@@ -235,6 +241,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ReactivePower FromVoltamperesReactive(double voltamperesreactive)
         {
             return new ReactivePower(voltamperesreactive);

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -157,6 +157,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalAcceleration FromDegreesPerSecondSquared(double degreespersecondsquared)
         {
             return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
@@ -192,6 +195,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalAcceleration FromRadiansPerSecondSquared(double radianspersecondsquared)
         {
             return new RotationalAcceleration(radianspersecondsquared);

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -162,6 +162,33 @@ namespace UnitsNet
             return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
         }
 
+		/// <summary>
+        ///     Get RotationalAcceleration from DegreesPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration FromDegreesPerSecondSquared(int degreespersecondsquared)
+        {
+            return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
+        }
+
+		/// <summary>
+        ///     Get RotationalAcceleration from DegreesPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration FromDegreesPerSecondSquared(long degreespersecondsquared)
+        {
+            return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalAcceleration from DegreesPerSecondSquared of type decimal.
+        /// </summary>
+        public static RotationalAcceleration FromDegreesPerSecondSquared(decimal degreespersecondsquared)
+        {
+	        return new RotationalAcceleration((Math.PI/180)*Convert.ToDouble(degreespersecondsquared));
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
@@ -169,6 +196,33 @@ namespace UnitsNet
         {
             return new RotationalAcceleration(radianspersecondsquared);
         }
+
+		/// <summary>
+        ///     Get RotationalAcceleration from RadiansPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration FromRadiansPerSecondSquared(int radianspersecondsquared)
+        {
+            return new RotationalAcceleration(radianspersecondsquared);
+        }
+
+		/// <summary>
+        ///     Get RotationalAcceleration from RadiansPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration FromRadiansPerSecondSquared(long radianspersecondsquared)
+        {
+            return new RotationalAcceleration(radianspersecondsquared);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalAcceleration from RadiansPerSecondSquared of type decimal.
+        /// </summary>
+        public static RotationalAcceleration FromRadiansPerSecondSquared(decimal radianspersecondsquared)
+        {
+	        return new RotationalAcceleration(Convert.ToDouble(radianspersecondsquared));
+        }
+#endif
 
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
@@ -187,10 +241,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration? FromDegreesPerSecondSquared(int? degreespersecondsquared)
+        {
+            if (degreespersecondsquared.HasValue)
+            {
+                return FromDegreesPerSecondSquared(degreespersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration? FromDegreesPerSecondSquared(long? degreespersecondsquared)
+        {
+            if (degreespersecondsquared.HasValue)
+            {
+                return FromDegreesPerSecondSquared(degreespersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalAcceleration from DegreesPerSecondSquared of type decimal.
+        /// </summary>
+        public static RotationalAcceleration? FromDegreesPerSecondSquared(decimal? degreespersecondsquared)
+        {
+            if (degreespersecondsquared.HasValue)
+            {
+                return FromDegreesPerSecondSquared(degreespersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration? FromRadiansPerSecondSquared(double? radianspersecondsquared)
+        {
+            if (radianspersecondsquared.HasValue)
+            {
+                return FromRadiansPerSecondSquared(radianspersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration? FromRadiansPerSecondSquared(int? radianspersecondsquared)
+        {
+            if (radianspersecondsquared.HasValue)
+            {
+                return FromRadiansPerSecondSquared(radianspersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
+        /// </summary>
+        public static RotationalAcceleration? FromRadiansPerSecondSquared(long? radianspersecondsquared)
+        {
+            if (radianspersecondsquared.HasValue)
+            {
+                return FromRadiansPerSecondSquared(radianspersecondsquared.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalAcceleration from RadiansPerSecondSquared of type decimal.
+        /// </summary>
+        public static RotationalAcceleration? FromRadiansPerSecondSquared(decimal? radianspersecondsquared)
         {
             if (radianspersecondsquared.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _radiansPerSecondSquared;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public RotationalAcceleration() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.RotationalAcceleration;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static RotationalAccelerationUnit BaseUnit
         {
             get { return RotationalAccelerationUnit.RadianPerSecondSquared; }
@@ -162,7 +162,7 @@ namespace UnitsNet
             return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration FromDegreesPerSecondSquared(int degreespersecondsquared)
@@ -170,7 +170,7 @@ namespace UnitsNet
             return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration FromDegreesPerSecondSquared(long degreespersecondsquared)
@@ -178,14 +178,14 @@ namespace UnitsNet
             return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared of type decimal.
         /// </summary>
         public static RotationalAcceleration FromDegreesPerSecondSquared(decimal degreespersecondsquared)
         {
-	        return new RotationalAcceleration((Math.PI/180)*Convert.ToDouble(degreespersecondsquared));
+            return new RotationalAcceleration((Math.PI/180)*Convert.ToDouble(degreespersecondsquared));
         }
 #endif
 
@@ -197,7 +197,7 @@ namespace UnitsNet
             return new RotationalAcceleration(radianspersecondsquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration FromRadiansPerSecondSquared(int radianspersecondsquared)
@@ -205,7 +205,7 @@ namespace UnitsNet
             return new RotationalAcceleration(radianspersecondsquared);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration FromRadiansPerSecondSquared(long radianspersecondsquared)
@@ -213,14 +213,14 @@ namespace UnitsNet
             return new RotationalAcceleration(radianspersecondsquared);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared of type decimal.
         /// </summary>
         public static RotationalAcceleration FromRadiansPerSecondSquared(decimal radianspersecondsquared)
         {
-	        return new RotationalAcceleration(Convert.ToDouble(radianspersecondsquared));
+            return new RotationalAcceleration(Convert.ToDouble(radianspersecondsquared));
         }
 #endif
 
@@ -241,7 +241,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration? FromDegreesPerSecondSquared(int? degreespersecondsquared)
@@ -256,7 +256,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration? FromDegreesPerSecondSquared(long? degreespersecondsquared)
@@ -271,7 +271,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalAcceleration from DegreesPerSecondSquared of type decimal.
         /// </summary>
         public static RotationalAcceleration? FromDegreesPerSecondSquared(decimal? degreespersecondsquared)
@@ -301,7 +301,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration? FromRadiansPerSecondSquared(int? radianspersecondsquared)
@@ -316,7 +316,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
         /// </summary>
         public static RotationalAcceleration? FromRadiansPerSecondSquared(long? radianspersecondsquared)
@@ -331,7 +331,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalAcceleration from RadiansPerSecondSquared of type decimal.
         /// </summary>
         public static RotationalAcceleration? FromRadiansPerSecondSquared(decimal? radianspersecondsquared)

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -245,6 +245,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromCentiradiansPerSecond(double centiradianspersecond)
         {
             return new RotationalSpeed((centiradianspersecond) * 1e-2d);
@@ -280,6 +283,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromDeciradiansPerSecond(double deciradianspersecond)
         {
             return new RotationalSpeed((deciradianspersecond) * 1e-1d);
@@ -315,6 +321,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromDegreesPerMinute(double degreesperminute)
         {
             return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
@@ -350,6 +359,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromDegreesPerSecond(double degreespersecond)
         {
             return new RotationalSpeed((Math.PI/180)*degreespersecond);
@@ -385,6 +397,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromMicrodegreesPerSecond(double microdegreespersecond)
         {
             return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
@@ -420,6 +435,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromMicroradiansPerSecond(double microradianspersecond)
         {
             return new RotationalSpeed((microradianspersecond) * 1e-6d);
@@ -455,6 +473,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromMillidegreesPerSecond(double millidegreespersecond)
         {
             return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
@@ -490,6 +511,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromMilliradiansPerSecond(double milliradianspersecond)
         {
             return new RotationalSpeed((milliradianspersecond) * 1e-3d);
@@ -525,6 +549,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromNanodegreesPerSecond(double nanodegreespersecond)
         {
             return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
@@ -560,6 +587,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromNanoradiansPerSecond(double nanoradianspersecond)
         {
             return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
@@ -595,6 +625,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromRadiansPerSecond(double radianspersecond)
         {
             return new RotationalSpeed(radianspersecond);
@@ -630,6 +663,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromRevolutionsPerMinute(double revolutionsperminute)
         {
             return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
@@ -665,6 +701,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static RotationalSpeed FromRevolutionsPerSecond(double revolutionspersecond)
         {
             return new RotationalSpeed(revolutionspersecond*6.2831853072);

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -250,6 +250,33 @@ namespace UnitsNet
             return new RotationalSpeed((centiradianspersecond) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from CentiradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromCentiradiansPerSecond(int centiradianspersecond)
+        {
+            return new RotationalSpeed((centiradianspersecond) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from CentiradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromCentiradiansPerSecond(long centiradianspersecond)
+        {
+            return new RotationalSpeed((centiradianspersecond) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from CentiradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromCentiradiansPerSecond(decimal centiradianspersecond)
+        {
+	        return new RotationalSpeed((Convert.ToDouble(centiradianspersecond)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
@@ -257,6 +284,33 @@ namespace UnitsNet
         {
             return new RotationalSpeed((deciradianspersecond) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get RotationalSpeed from DeciradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromDeciradiansPerSecond(int deciradianspersecond)
+        {
+            return new RotationalSpeed((deciradianspersecond) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from DeciradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromDeciradiansPerSecond(long deciradianspersecond)
+        {
+            return new RotationalSpeed((deciradianspersecond) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from DeciradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromDeciradiansPerSecond(decimal deciradianspersecond)
+        {
+	        return new RotationalSpeed((Convert.ToDouble(deciradianspersecond)) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
@@ -266,6 +320,33 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from DegreesPerMinute.
+        /// </summary>
+        public static RotationalSpeed FromDegreesPerMinute(int degreesperminute)
+        {
+            return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from DegreesPerMinute.
+        /// </summary>
+        public static RotationalSpeed FromDegreesPerMinute(long degreesperminute)
+        {
+            return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from DegreesPerMinute of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromDegreesPerMinute(decimal degreesperminute)
+        {
+	        return new RotationalSpeed((Math.PI/(180*60))*Convert.ToDouble(degreesperminute));
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
@@ -273,6 +354,33 @@ namespace UnitsNet
         {
             return new RotationalSpeed((Math.PI/180)*degreespersecond);
         }
+
+		/// <summary>
+        ///     Get RotationalSpeed from DegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromDegreesPerSecond(int degreespersecond)
+        {
+            return new RotationalSpeed((Math.PI/180)*degreespersecond);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from DegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromDegreesPerSecond(long degreespersecond)
+        {
+            return new RotationalSpeed((Math.PI/180)*degreespersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from DegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromDegreesPerSecond(decimal degreespersecond)
+        {
+	        return new RotationalSpeed((Math.PI/180)*Convert.ToDouble(degreespersecond));
+        }
+#endif
 
         /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
@@ -282,6 +390,33 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from MicrodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMicrodegreesPerSecond(int microdegreespersecond)
+        {
+            return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from MicrodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMicrodegreesPerSecond(long microdegreespersecond)
+        {
+            return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from MicrodegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromMicrodegreesPerSecond(decimal microdegreespersecond)
+        {
+	        return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(microdegreespersecond)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
@@ -289,6 +424,33 @@ namespace UnitsNet
         {
             return new RotationalSpeed((microradianspersecond) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get RotationalSpeed from MicroradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMicroradiansPerSecond(int microradianspersecond)
+        {
+            return new RotationalSpeed((microradianspersecond) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from MicroradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMicroradiansPerSecond(long microradianspersecond)
+        {
+            return new RotationalSpeed((microradianspersecond) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from MicroradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromMicroradiansPerSecond(decimal microradianspersecond)
+        {
+	        return new RotationalSpeed((Convert.ToDouble(microradianspersecond)) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
@@ -298,6 +460,33 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from MillidegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMillidegreesPerSecond(int millidegreespersecond)
+        {
+            return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from MillidegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMillidegreesPerSecond(long millidegreespersecond)
+        {
+            return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from MillidegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromMillidegreesPerSecond(decimal millidegreespersecond)
+        {
+	        return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(millidegreespersecond)) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
@@ -305,6 +494,33 @@ namespace UnitsNet
         {
             return new RotationalSpeed((milliradianspersecond) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get RotationalSpeed from MilliradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMilliradiansPerSecond(int milliradianspersecond)
+        {
+            return new RotationalSpeed((milliradianspersecond) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from MilliradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromMilliradiansPerSecond(long milliradianspersecond)
+        {
+            return new RotationalSpeed((milliradianspersecond) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from MilliradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromMilliradiansPerSecond(decimal milliradianspersecond)
+        {
+	        return new RotationalSpeed((Convert.ToDouble(milliradianspersecond)) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
@@ -314,6 +530,33 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from NanodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromNanodegreesPerSecond(int nanodegreespersecond)
+        {
+            return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from NanodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromNanodegreesPerSecond(long nanodegreespersecond)
+        {
+            return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from NanodegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromNanodegreesPerSecond(decimal nanodegreespersecond)
+        {
+	        return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(nanodegreespersecond)) * 1e-9d);
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
@@ -321,6 +564,33 @@ namespace UnitsNet
         {
             return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get RotationalSpeed from NanoradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromNanoradiansPerSecond(int nanoradianspersecond)
+        {
+            return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from NanoradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromNanoradiansPerSecond(long nanoradianspersecond)
+        {
+            return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from NanoradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromNanoradiansPerSecond(decimal nanoradianspersecond)
+        {
+	        return new RotationalSpeed((Convert.ToDouble(nanoradianspersecond)) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
@@ -330,6 +600,33 @@ namespace UnitsNet
             return new RotationalSpeed(radianspersecond);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from RadiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromRadiansPerSecond(int radianspersecond)
+        {
+            return new RotationalSpeed(radianspersecond);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from RadiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromRadiansPerSecond(long radianspersecond)
+        {
+            return new RotationalSpeed(radianspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from RadiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromRadiansPerSecond(decimal radianspersecond)
+        {
+	        return new RotationalSpeed(Convert.ToDouble(radianspersecond));
+        }
+#endif
+
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
@@ -337,6 +634,33 @@ namespace UnitsNet
         {
             return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
         }
+
+		/// <summary>
+        ///     Get RotationalSpeed from RevolutionsPerMinute.
+        /// </summary>
+        public static RotationalSpeed FromRevolutionsPerMinute(int revolutionsperminute)
+        {
+            return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from RevolutionsPerMinute.
+        /// </summary>
+        public static RotationalSpeed FromRevolutionsPerMinute(long revolutionsperminute)
+        {
+            return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from RevolutionsPerMinute of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromRevolutionsPerMinute(decimal revolutionsperminute)
+        {
+	        return new RotationalSpeed((Convert.ToDouble(revolutionsperminute)*6.2831853072)/60);
+        }
+#endif
 
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
@@ -346,12 +670,84 @@ namespace UnitsNet
             return new RotationalSpeed(revolutionspersecond*6.2831853072);
         }
 
+		/// <summary>
+        ///     Get RotationalSpeed from RevolutionsPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromRevolutionsPerSecond(int revolutionspersecond)
+        {
+            return new RotationalSpeed(revolutionspersecond*6.2831853072);
+        }
+
+		/// <summary>
+        ///     Get RotationalSpeed from RevolutionsPerSecond.
+        /// </summary>
+        public static RotationalSpeed FromRevolutionsPerSecond(long revolutionspersecond)
+        {
+            return new RotationalSpeed(revolutionspersecond*6.2831853072);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get RotationalSpeed from RevolutionsPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed FromRevolutionsPerSecond(decimal revolutionspersecond)
+        {
+	        return new RotationalSpeed(Convert.ToDouble(revolutionspersecond)*6.2831853072);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromCentiradiansPerSecond(double? centiradianspersecond)
+        {
+            if (centiradianspersecond.HasValue)
+            {
+                return FromCentiradiansPerSecond(centiradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromCentiradiansPerSecond(int? centiradianspersecond)
+        {
+            if (centiradianspersecond.HasValue)
+            {
+                return FromCentiradiansPerSecond(centiradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromCentiradiansPerSecond(long? centiradianspersecond)
+        {
+            if (centiradianspersecond.HasValue)
+            {
+                return FromCentiradiansPerSecond(centiradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from CentiradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromCentiradiansPerSecond(decimal? centiradianspersecond)
         {
             if (centiradianspersecond.HasValue)
             {
@@ -378,10 +774,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromDeciradiansPerSecond(int? deciradianspersecond)
+        {
+            if (deciradianspersecond.HasValue)
+            {
+                return FromDeciradiansPerSecond(deciradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromDeciradiansPerSecond(long? deciradianspersecond)
+        {
+            if (deciradianspersecond.HasValue)
+            {
+                return FromDeciradiansPerSecond(deciradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from DeciradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromDeciradiansPerSecond(decimal? deciradianspersecond)
+        {
+            if (deciradianspersecond.HasValue)
+            {
+                return FromDeciradiansPerSecond(deciradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerMinute(double? degreesperminute)
+        {
+            if (degreesperminute.HasValue)
+            {
+                return FromDegreesPerMinute(degreesperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
+        /// </summary>
+        public static RotationalSpeed? FromDegreesPerMinute(int? degreesperminute)
+        {
+            if (degreesperminute.HasValue)
+            {
+                return FromDegreesPerMinute(degreesperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
+        /// </summary>
+        public static RotationalSpeed? FromDegreesPerMinute(long? degreesperminute)
+        {
+            if (degreesperminute.HasValue)
+            {
+                return FromDegreesPerMinute(degreesperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from DegreesPerMinute of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromDegreesPerMinute(decimal? degreesperminute)
         {
             if (degreesperminute.HasValue)
             {
@@ -408,10 +894,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromDegreesPerSecond(int? degreespersecond)
+        {
+            if (degreespersecond.HasValue)
+            {
+                return FromDegreesPerSecond(degreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromDegreesPerSecond(long? degreespersecond)
+        {
+            if (degreespersecond.HasValue)
+            {
+                return FromDegreesPerSecond(degreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from DegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromDegreesPerSecond(decimal? degreespersecond)
+        {
+            if (degreespersecond.HasValue)
+            {
+                return FromDegreesPerSecond(degreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMicrodegreesPerSecond(double? microdegreespersecond)
+        {
+            if (microdegreespersecond.HasValue)
+            {
+                return FromMicrodegreesPerSecond(microdegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMicrodegreesPerSecond(int? microdegreespersecond)
+        {
+            if (microdegreespersecond.HasValue)
+            {
+                return FromMicrodegreesPerSecond(microdegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMicrodegreesPerSecond(long? microdegreespersecond)
+        {
+            if (microdegreespersecond.HasValue)
+            {
+                return FromMicrodegreesPerSecond(microdegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from MicrodegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromMicrodegreesPerSecond(decimal? microdegreespersecond)
         {
             if (microdegreespersecond.HasValue)
             {
@@ -438,10 +1014,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMicroradiansPerSecond(int? microradianspersecond)
+        {
+            if (microradianspersecond.HasValue)
+            {
+                return FromMicroradiansPerSecond(microradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMicroradiansPerSecond(long? microradianspersecond)
+        {
+            if (microradianspersecond.HasValue)
+            {
+                return FromMicroradiansPerSecond(microradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from MicroradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromMicroradiansPerSecond(decimal? microradianspersecond)
+        {
+            if (microradianspersecond.HasValue)
+            {
+                return FromMicroradiansPerSecond(microradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMillidegreesPerSecond(double? millidegreespersecond)
+        {
+            if (millidegreespersecond.HasValue)
+            {
+                return FromMillidegreesPerSecond(millidegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMillidegreesPerSecond(int? millidegreespersecond)
+        {
+            if (millidegreespersecond.HasValue)
+            {
+                return FromMillidegreesPerSecond(millidegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMillidegreesPerSecond(long? millidegreespersecond)
+        {
+            if (millidegreespersecond.HasValue)
+            {
+                return FromMillidegreesPerSecond(millidegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from MillidegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromMillidegreesPerSecond(decimal? millidegreespersecond)
         {
             if (millidegreespersecond.HasValue)
             {
@@ -468,10 +1134,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMilliradiansPerSecond(int? milliradianspersecond)
+        {
+            if (milliradianspersecond.HasValue)
+            {
+                return FromMilliradiansPerSecond(milliradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromMilliradiansPerSecond(long? milliradianspersecond)
+        {
+            if (milliradianspersecond.HasValue)
+            {
+                return FromMilliradiansPerSecond(milliradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from MilliradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromMilliradiansPerSecond(decimal? milliradianspersecond)
+        {
+            if (milliradianspersecond.HasValue)
+            {
+                return FromMilliradiansPerSecond(milliradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromNanodegreesPerSecond(double? nanodegreespersecond)
+        {
+            if (nanodegreespersecond.HasValue)
+            {
+                return FromNanodegreesPerSecond(nanodegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromNanodegreesPerSecond(int? nanodegreespersecond)
+        {
+            if (nanodegreespersecond.HasValue)
+            {
+                return FromNanodegreesPerSecond(nanodegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromNanodegreesPerSecond(long? nanodegreespersecond)
+        {
+            if (nanodegreespersecond.HasValue)
+            {
+                return FromNanodegreesPerSecond(nanodegreespersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from NanodegreesPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromNanodegreesPerSecond(decimal? nanodegreespersecond)
         {
             if (nanodegreespersecond.HasValue)
             {
@@ -498,10 +1254,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromNanoradiansPerSecond(int? nanoradianspersecond)
+        {
+            if (nanoradianspersecond.HasValue)
+            {
+                return FromNanoradiansPerSecond(nanoradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromNanoradiansPerSecond(long? nanoradianspersecond)
+        {
+            if (nanoradianspersecond.HasValue)
+            {
+                return FromNanoradiansPerSecond(nanoradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from NanoradiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromNanoradiansPerSecond(decimal? nanoradianspersecond)
+        {
+            if (nanoradianspersecond.HasValue)
+            {
+                return FromNanoradiansPerSecond(nanoradianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromRadiansPerSecond(double? radianspersecond)
+        {
+            if (radianspersecond.HasValue)
+            {
+                return FromRadiansPerSecond(radianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromRadiansPerSecond(int? radianspersecond)
+        {
+            if (radianspersecond.HasValue)
+            {
+                return FromRadiansPerSecond(radianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromRadiansPerSecond(long? radianspersecond)
+        {
+            if (radianspersecond.HasValue)
+            {
+                return FromRadiansPerSecond(radianspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from RadiansPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromRadiansPerSecond(decimal? radianspersecond)
         {
             if (radianspersecond.HasValue)
             {
@@ -528,10 +1374,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
+        /// </summary>
+        public static RotationalSpeed? FromRevolutionsPerMinute(int? revolutionsperminute)
+        {
+            if (revolutionsperminute.HasValue)
+            {
+                return FromRevolutionsPerMinute(revolutionsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
+        /// </summary>
+        public static RotationalSpeed? FromRevolutionsPerMinute(long? revolutionsperminute)
+        {
+            if (revolutionsperminute.HasValue)
+            {
+                return FromRevolutionsPerMinute(revolutionsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from RevolutionsPerMinute of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromRevolutionsPerMinute(decimal? revolutionsperminute)
+        {
+            if (revolutionsperminute.HasValue)
+            {
+                return FromRevolutionsPerMinute(revolutionsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerSecond(double? revolutionspersecond)
+        {
+            if (revolutionspersecond.HasValue)
+            {
+                return FromRevolutionsPerSecond(revolutionspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromRevolutionsPerSecond(int? revolutionspersecond)
+        {
+            if (revolutionspersecond.HasValue)
+            {
+                return FromRevolutionsPerSecond(revolutionspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
+        /// </summary>
+        public static RotationalSpeed? FromRevolutionsPerSecond(long? revolutionspersecond)
+        {
+            if (revolutionspersecond.HasValue)
+            {
+                return FromRevolutionsPerSecond(revolutionspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable RotationalSpeed from RevolutionsPerSecond of type decimal.
+        /// </summary>
+        public static RotationalSpeed? FromRevolutionsPerSecond(decimal? revolutionspersecond)
         {
             if (revolutionspersecond.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _radiansPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public RotationalSpeed() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.RotationalSpeed;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static RotationalSpeedUnit BaseUnit
         {
             get { return RotationalSpeedUnit.RadianPerSecond; }
@@ -250,7 +250,7 @@ namespace UnitsNet
             return new RotationalSpeed((centiradianspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromCentiradiansPerSecond(int centiradianspersecond)
@@ -258,7 +258,7 @@ namespace UnitsNet
             return new RotationalSpeed((centiradianspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromCentiradiansPerSecond(long centiradianspersecond)
@@ -266,14 +266,14 @@ namespace UnitsNet
             return new RotationalSpeed((centiradianspersecond) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromCentiradiansPerSecond(decimal centiradianspersecond)
         {
-	        return new RotationalSpeed((Convert.ToDouble(centiradianspersecond)) * 1e-2d);
+            return new RotationalSpeed((Convert.ToDouble(centiradianspersecond)) * 1e-2d);
         }
 #endif
 
@@ -285,7 +285,7 @@ namespace UnitsNet
             return new RotationalSpeed((deciradianspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromDeciradiansPerSecond(int deciradianspersecond)
@@ -293,7 +293,7 @@ namespace UnitsNet
             return new RotationalSpeed((deciradianspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromDeciradiansPerSecond(long deciradianspersecond)
@@ -301,14 +301,14 @@ namespace UnitsNet
             return new RotationalSpeed((deciradianspersecond) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromDeciradiansPerSecond(decimal deciradianspersecond)
         {
-	        return new RotationalSpeed((Convert.ToDouble(deciradianspersecond)) * 1e-1d);
+            return new RotationalSpeed((Convert.ToDouble(deciradianspersecond)) * 1e-1d);
         }
 #endif
 
@@ -320,7 +320,7 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
         /// </summary>
         public static RotationalSpeed FromDegreesPerMinute(int degreesperminute)
@@ -328,7 +328,7 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
         /// </summary>
         public static RotationalSpeed FromDegreesPerMinute(long degreesperminute)
@@ -336,14 +336,14 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute of type decimal.
         /// </summary>
         public static RotationalSpeed FromDegreesPerMinute(decimal degreesperminute)
         {
-	        return new RotationalSpeed((Math.PI/(180*60))*Convert.ToDouble(degreesperminute));
+            return new RotationalSpeed((Math.PI/(180*60))*Convert.ToDouble(degreesperminute));
         }
 #endif
 
@@ -355,7 +355,7 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/180)*degreespersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromDegreesPerSecond(int degreespersecond)
@@ -363,7 +363,7 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/180)*degreespersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromDegreesPerSecond(long degreespersecond)
@@ -371,14 +371,14 @@ namespace UnitsNet
             return new RotationalSpeed((Math.PI/180)*degreespersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromDegreesPerSecond(decimal degreespersecond)
         {
-	        return new RotationalSpeed((Math.PI/180)*Convert.ToDouble(degreespersecond));
+            return new RotationalSpeed((Math.PI/180)*Convert.ToDouble(degreespersecond));
         }
 #endif
 
@@ -390,7 +390,7 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromMicrodegreesPerSecond(int microdegreespersecond)
@@ -398,7 +398,7 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromMicrodegreesPerSecond(long microdegreespersecond)
@@ -406,14 +406,14 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromMicrodegreesPerSecond(decimal microdegreespersecond)
         {
-	        return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(microdegreespersecond)) * 1e-6d);
+            return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(microdegreespersecond)) * 1e-6d);
         }
 #endif
 
@@ -425,7 +425,7 @@ namespace UnitsNet
             return new RotationalSpeed((microradianspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromMicroradiansPerSecond(int microradianspersecond)
@@ -433,7 +433,7 @@ namespace UnitsNet
             return new RotationalSpeed((microradianspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromMicroradiansPerSecond(long microradianspersecond)
@@ -441,14 +441,14 @@ namespace UnitsNet
             return new RotationalSpeed((microradianspersecond) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromMicroradiansPerSecond(decimal microradianspersecond)
         {
-	        return new RotationalSpeed((Convert.ToDouble(microradianspersecond)) * 1e-6d);
+            return new RotationalSpeed((Convert.ToDouble(microradianspersecond)) * 1e-6d);
         }
 #endif
 
@@ -460,7 +460,7 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromMillidegreesPerSecond(int millidegreespersecond)
@@ -468,7 +468,7 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromMillidegreesPerSecond(long millidegreespersecond)
@@ -476,14 +476,14 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromMillidegreesPerSecond(decimal millidegreespersecond)
         {
-	        return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(millidegreespersecond)) * 1e-3d);
+            return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(millidegreespersecond)) * 1e-3d);
         }
 #endif
 
@@ -495,7 +495,7 @@ namespace UnitsNet
             return new RotationalSpeed((milliradianspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromMilliradiansPerSecond(int milliradianspersecond)
@@ -503,7 +503,7 @@ namespace UnitsNet
             return new RotationalSpeed((milliradianspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromMilliradiansPerSecond(long milliradianspersecond)
@@ -511,14 +511,14 @@ namespace UnitsNet
             return new RotationalSpeed((milliradianspersecond) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromMilliradiansPerSecond(decimal milliradianspersecond)
         {
-	        return new RotationalSpeed((Convert.ToDouble(milliradianspersecond)) * 1e-3d);
+            return new RotationalSpeed((Convert.ToDouble(milliradianspersecond)) * 1e-3d);
         }
 #endif
 
@@ -530,7 +530,7 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromNanodegreesPerSecond(int nanodegreespersecond)
@@ -538,7 +538,7 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed FromNanodegreesPerSecond(long nanodegreespersecond)
@@ -546,14 +546,14 @@ namespace UnitsNet
             return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromNanodegreesPerSecond(decimal nanodegreespersecond)
         {
-	        return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(nanodegreespersecond)) * 1e-9d);
+            return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(nanodegreespersecond)) * 1e-9d);
         }
 #endif
 
@@ -565,7 +565,7 @@ namespace UnitsNet
             return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromNanoradiansPerSecond(int nanoradianspersecond)
@@ -573,7 +573,7 @@ namespace UnitsNet
             return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromNanoradiansPerSecond(long nanoradianspersecond)
@@ -581,14 +581,14 @@ namespace UnitsNet
             return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromNanoradiansPerSecond(decimal nanoradianspersecond)
         {
-	        return new RotationalSpeed((Convert.ToDouble(nanoradianspersecond)) * 1e-9d);
+            return new RotationalSpeed((Convert.ToDouble(nanoradianspersecond)) * 1e-9d);
         }
 #endif
 
@@ -600,7 +600,7 @@ namespace UnitsNet
             return new RotationalSpeed(radianspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromRadiansPerSecond(int radianspersecond)
@@ -608,7 +608,7 @@ namespace UnitsNet
             return new RotationalSpeed(radianspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
         /// </summary>
         public static RotationalSpeed FromRadiansPerSecond(long radianspersecond)
@@ -616,14 +616,14 @@ namespace UnitsNet
             return new RotationalSpeed(radianspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromRadiansPerSecond(decimal radianspersecond)
         {
-	        return new RotationalSpeed(Convert.ToDouble(radianspersecond));
+            return new RotationalSpeed(Convert.ToDouble(radianspersecond));
         }
 #endif
 
@@ -635,7 +635,7 @@ namespace UnitsNet
             return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
         public static RotationalSpeed FromRevolutionsPerMinute(int revolutionsperminute)
@@ -643,7 +643,7 @@ namespace UnitsNet
             return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
         public static RotationalSpeed FromRevolutionsPerMinute(long revolutionsperminute)
@@ -651,14 +651,14 @@ namespace UnitsNet
             return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute of type decimal.
         /// </summary>
         public static RotationalSpeed FromRevolutionsPerMinute(decimal revolutionsperminute)
         {
-	        return new RotationalSpeed((Convert.ToDouble(revolutionsperminute)*6.2831853072)/60);
+            return new RotationalSpeed((Convert.ToDouble(revolutionsperminute)*6.2831853072)/60);
         }
 #endif
 
@@ -670,7 +670,7 @@ namespace UnitsNet
             return new RotationalSpeed(revolutionspersecond*6.2831853072);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
         /// </summary>
         public static RotationalSpeed FromRevolutionsPerSecond(int revolutionspersecond)
@@ -678,7 +678,7 @@ namespace UnitsNet
             return new RotationalSpeed(revolutionspersecond*6.2831853072);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
         /// </summary>
         public static RotationalSpeed FromRevolutionsPerSecond(long revolutionspersecond)
@@ -686,14 +686,14 @@ namespace UnitsNet
             return new RotationalSpeed(revolutionspersecond*6.2831853072);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed FromRevolutionsPerSecond(decimal revolutionspersecond)
         {
-	        return new RotationalSpeed(Convert.ToDouble(revolutionspersecond)*6.2831853072);
+            return new RotationalSpeed(Convert.ToDouble(revolutionspersecond)*6.2831853072);
         }
 #endif
 
@@ -714,7 +714,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromCentiradiansPerSecond(int? centiradianspersecond)
@@ -729,7 +729,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromCentiradiansPerSecond(long? centiradianspersecond)
@@ -744,7 +744,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from CentiradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromCentiradiansPerSecond(decimal? centiradianspersecond)
@@ -774,7 +774,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromDeciradiansPerSecond(int? deciradianspersecond)
@@ -789,7 +789,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromDeciradiansPerSecond(long? deciradianspersecond)
@@ -804,7 +804,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from DeciradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromDeciradiansPerSecond(decimal? deciradianspersecond)
@@ -834,7 +834,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerMinute(int? degreesperminute)
@@ -849,7 +849,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerMinute(long? degreesperminute)
@@ -864,7 +864,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from DegreesPerMinute of type decimal.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerMinute(decimal? degreesperminute)
@@ -894,7 +894,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerSecond(int? degreespersecond)
@@ -909,7 +909,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerSecond(long? degreespersecond)
@@ -924,7 +924,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from DegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromDegreesPerSecond(decimal? degreespersecond)
@@ -954,7 +954,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMicrodegreesPerSecond(int? microdegreespersecond)
@@ -969,7 +969,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMicrodegreesPerSecond(long? microdegreespersecond)
@@ -984,7 +984,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from MicrodegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromMicrodegreesPerSecond(decimal? microdegreespersecond)
@@ -1014,7 +1014,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMicroradiansPerSecond(int? microradianspersecond)
@@ -1029,7 +1029,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMicroradiansPerSecond(long? microradianspersecond)
@@ -1044,7 +1044,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from MicroradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromMicroradiansPerSecond(decimal? microradianspersecond)
@@ -1074,7 +1074,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMillidegreesPerSecond(int? millidegreespersecond)
@@ -1089,7 +1089,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMillidegreesPerSecond(long? millidegreespersecond)
@@ -1104,7 +1104,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from MillidegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromMillidegreesPerSecond(decimal? millidegreespersecond)
@@ -1134,7 +1134,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMilliradiansPerSecond(int? milliradianspersecond)
@@ -1149,7 +1149,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromMilliradiansPerSecond(long? milliradianspersecond)
@@ -1164,7 +1164,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from MilliradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromMilliradiansPerSecond(decimal? milliradianspersecond)
@@ -1194,7 +1194,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromNanodegreesPerSecond(int? nanodegreespersecond)
@@ -1209,7 +1209,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
         /// </summary>
         public static RotationalSpeed? FromNanodegreesPerSecond(long? nanodegreespersecond)
@@ -1224,7 +1224,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from NanodegreesPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromNanodegreesPerSecond(decimal? nanodegreespersecond)
@@ -1254,7 +1254,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromNanoradiansPerSecond(int? nanoradianspersecond)
@@ -1269,7 +1269,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromNanoradiansPerSecond(long? nanoradianspersecond)
@@ -1284,7 +1284,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from NanoradiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromNanoradiansPerSecond(decimal? nanoradianspersecond)
@@ -1314,7 +1314,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromRadiansPerSecond(int? radianspersecond)
@@ -1329,7 +1329,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
         /// </summary>
         public static RotationalSpeed? FromRadiansPerSecond(long? radianspersecond)
@@ -1344,7 +1344,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from RadiansPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromRadiansPerSecond(decimal? radianspersecond)
@@ -1374,7 +1374,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerMinute(int? revolutionsperminute)
@@ -1389,7 +1389,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerMinute(long? revolutionsperminute)
@@ -1404,7 +1404,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from RevolutionsPerMinute of type decimal.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerMinute(decimal? revolutionsperminute)
@@ -1434,7 +1434,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerSecond(int? revolutionspersecond)
@@ -1449,7 +1449,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerSecond(long? revolutionspersecond)
@@ -1464,7 +1464,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable RotationalSpeed from RevolutionsPerSecond of type decimal.
         /// </summary>
         public static RotationalSpeed? FromRevolutionsPerSecond(decimal? revolutionspersecond)

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromCaloriesPerGram(double caloriespergram)
         {
             return new SpecificEnergy(caloriespergram*4.184e3);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromJoulesPerKilogram(double joulesperkilogram)
         {
             return new SpecificEnergy(joulesperkilogram);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromKilocaloriesPerGram(double kilocaloriespergram)
         {
             return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromKilojoulesPerKilogram(double kilojoulesperkilogram)
         {
             return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromKilowattHoursPerKilogram(double kilowatthoursperkilogram)
         {
             return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromMegajoulesPerKilogram(double megajoulesperkilogram)
         {
             return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromMegawattHoursPerKilogram(double megawatthoursperkilogram)
         {
             return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificEnergy FromWattHoursPerKilogram(double watthoursperkilogram)
         {
             return new SpecificEnergy(watthoursperkilogram*3.6e3);

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _joulesPerKilogram;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public SpecificEnergy() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.SpecificEnergy;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static SpecificEnergyUnit BaseUnit
         {
             get { return SpecificEnergyUnit.JoulePerKilogram; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new SpecificEnergy(caloriespergram*4.184e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram.
         /// </summary>
         public static SpecificEnergy FromCaloriesPerGram(int caloriespergram)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new SpecificEnergy(caloriespergram*4.184e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram.
         /// </summary>
         public static SpecificEnergy FromCaloriesPerGram(long caloriespergram)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new SpecificEnergy(caloriespergram*4.184e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram of type decimal.
         /// </summary>
         public static SpecificEnergy FromCaloriesPerGram(decimal caloriespergram)
         {
-	        return new SpecificEnergy(Convert.ToDouble(caloriespergram)*4.184e3);
+            return new SpecificEnergy(Convert.ToDouble(caloriespergram)*4.184e3);
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new SpecificEnergy(joulesperkilogram);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy FromJoulesPerKilogram(int joulesperkilogram)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new SpecificEnergy(joulesperkilogram);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy FromJoulesPerKilogram(long joulesperkilogram)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new SpecificEnergy(joulesperkilogram);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy FromJoulesPerKilogram(decimal joulesperkilogram)
         {
-	        return new SpecificEnergy(Convert.ToDouble(joulesperkilogram));
+            return new SpecificEnergy(Convert.ToDouble(joulesperkilogram));
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
         /// </summary>
         public static SpecificEnergy FromKilocaloriesPerGram(int kilocaloriespergram)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
         /// </summary>
         public static SpecificEnergy FromKilocaloriesPerGram(long kilocaloriespergram)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram of type decimal.
         /// </summary>
         public static SpecificEnergy FromKilocaloriesPerGram(decimal kilocaloriespergram)
         {
-	        return new SpecificEnergy((Convert.ToDouble(kilocaloriespergram)*4.184e3) * 1e3d);
+            return new SpecificEnergy((Convert.ToDouble(kilocaloriespergram)*4.184e3) * 1e3d);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy FromKilojoulesPerKilogram(int kilojoulesperkilogram)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy FromKilojoulesPerKilogram(long kilojoulesperkilogram)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy FromKilojoulesPerKilogram(decimal kilojoulesperkilogram)
         {
-	        return new SpecificEnergy((Convert.ToDouble(kilojoulesperkilogram)) * 1e3d);
+            return new SpecificEnergy((Convert.ToDouble(kilojoulesperkilogram)) * 1e3d);
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy FromKilowattHoursPerKilogram(int kilowatthoursperkilogram)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy FromKilowattHoursPerKilogram(long kilowatthoursperkilogram)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy FromKilowattHoursPerKilogram(decimal kilowatthoursperkilogram)
         {
-	        return new SpecificEnergy((Convert.ToDouble(kilowatthoursperkilogram)*3.6e3) * 1e3d);
+            return new SpecificEnergy((Convert.ToDouble(kilowatthoursperkilogram)*3.6e3) * 1e3d);
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy FromMegajoulesPerKilogram(int megajoulesperkilogram)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy FromMegajoulesPerKilogram(long megajoulesperkilogram)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy FromMegajoulesPerKilogram(decimal megajoulesperkilogram)
         {
-	        return new SpecificEnergy((Convert.ToDouble(megajoulesperkilogram)) * 1e6d);
+            return new SpecificEnergy((Convert.ToDouble(megajoulesperkilogram)) * 1e6d);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy FromMegawattHoursPerKilogram(int megawatthoursperkilogram)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy FromMegawattHoursPerKilogram(long megawatthoursperkilogram)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy FromMegawattHoursPerKilogram(decimal megawatthoursperkilogram)
         {
-	        return new SpecificEnergy((Convert.ToDouble(megawatthoursperkilogram)*3.6e3) * 1e6d);
+            return new SpecificEnergy((Convert.ToDouble(megawatthoursperkilogram)*3.6e3) * 1e6d);
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new SpecificEnergy(watthoursperkilogram*3.6e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy FromWattHoursPerKilogram(int watthoursperkilogram)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new SpecificEnergy(watthoursperkilogram*3.6e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy FromWattHoursPerKilogram(long watthoursperkilogram)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new SpecificEnergy(watthoursperkilogram*3.6e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy FromWattHoursPerKilogram(decimal watthoursperkilogram)
         {
-	        return new SpecificEnergy(Convert.ToDouble(watthoursperkilogram)*3.6e3);
+            return new SpecificEnergy(Convert.ToDouble(watthoursperkilogram)*3.6e3);
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
         /// </summary>
         public static SpecificEnergy? FromCaloriesPerGram(int? caloriespergram)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
         /// </summary>
         public static SpecificEnergy? FromCaloriesPerGram(long? caloriespergram)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from CaloriesPerGram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromCaloriesPerGram(decimal? caloriespergram)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromJoulesPerKilogram(int? joulesperkilogram)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromJoulesPerKilogram(long? joulesperkilogram)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from JoulesPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromJoulesPerKilogram(decimal? joulesperkilogram)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
         /// </summary>
         public static SpecificEnergy? FromKilocaloriesPerGram(int? kilocaloriespergram)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
         /// </summary>
         public static SpecificEnergy? FromKilocaloriesPerGram(long? kilocaloriespergram)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from KilocaloriesPerGram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromKilocaloriesPerGram(decimal? kilocaloriespergram)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromKilojoulesPerKilogram(int? kilojoulesperkilogram)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromKilojoulesPerKilogram(long? kilojoulesperkilogram)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from KilojoulesPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromKilojoulesPerKilogram(decimal? kilojoulesperkilogram)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromKilowattHoursPerKilogram(int? kilowatthoursperkilogram)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromKilowattHoursPerKilogram(long? kilowatthoursperkilogram)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from KilowattHoursPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromKilowattHoursPerKilogram(decimal? kilowatthoursperkilogram)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromMegajoulesPerKilogram(int? megajoulesperkilogram)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromMegajoulesPerKilogram(long? megajoulesperkilogram)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from MegajoulesPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromMegajoulesPerKilogram(decimal? megajoulesperkilogram)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromMegawattHoursPerKilogram(int? megawatthoursperkilogram)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromMegawattHoursPerKilogram(long? megawatthoursperkilogram)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from MegawattHoursPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromMegawattHoursPerKilogram(decimal? megawatthoursperkilogram)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromWattHoursPerKilogram(int? watthoursperkilogram)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromWattHoursPerKilogram(long? watthoursperkilogram)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificEnergy from WattHoursPerKilogram of type decimal.
         /// </summary>
         public static SpecificEnergy? FromWattHoursPerKilogram(decimal? watthoursperkilogram)

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new SpecificEnergy(caloriespergram*4.184e3);
         }
 
+		/// <summary>
+        ///     Get SpecificEnergy from CaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy FromCaloriesPerGram(int caloriespergram)
+        {
+            return new SpecificEnergy(caloriespergram*4.184e3);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from CaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy FromCaloriesPerGram(long caloriespergram)
+        {
+            return new SpecificEnergy(caloriespergram*4.184e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from CaloriesPerGram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromCaloriesPerGram(decimal caloriespergram)
+        {
+	        return new SpecificEnergy(Convert.ToDouble(caloriespergram)*4.184e3);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new SpecificEnergy(joulesperkilogram);
         }
+
+		/// <summary>
+        ///     Get SpecificEnergy from JoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromJoulesPerKilogram(int joulesperkilogram)
+        {
+            return new SpecificEnergy(joulesperkilogram);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from JoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromJoulesPerKilogram(long joulesperkilogram)
+        {
+            return new SpecificEnergy(joulesperkilogram);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from JoulesPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromJoulesPerKilogram(decimal joulesperkilogram)
+        {
+	        return new SpecificEnergy(Convert.ToDouble(joulesperkilogram));
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get SpecificEnergy from KilocaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy FromKilocaloriesPerGram(int kilocaloriespergram)
+        {
+            return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from KilocaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy FromKilocaloriesPerGram(long kilocaloriespergram)
+        {
+            return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from KilocaloriesPerGram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromKilocaloriesPerGram(decimal kilocaloriespergram)
+        {
+	        return new SpecificEnergy((Convert.ToDouble(kilocaloriespergram)*4.184e3) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get SpecificEnergy from KilojoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromKilojoulesPerKilogram(int kilojoulesperkilogram)
+        {
+            return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from KilojoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromKilojoulesPerKilogram(long kilojoulesperkilogram)
+        {
+            return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from KilojoulesPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromKilojoulesPerKilogram(decimal kilojoulesperkilogram)
+        {
+	        return new SpecificEnergy((Convert.ToDouble(kilojoulesperkilogram)) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get SpecificEnergy from KilowattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromKilowattHoursPerKilogram(int kilowatthoursperkilogram)
+        {
+            return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from KilowattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromKilowattHoursPerKilogram(long kilowatthoursperkilogram)
+        {
+            return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from KilowattHoursPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromKilowattHoursPerKilogram(decimal kilowatthoursperkilogram)
+        {
+	        return new SpecificEnergy((Convert.ToDouble(kilowatthoursperkilogram)*3.6e3) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get SpecificEnergy from MegajoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromMegajoulesPerKilogram(int megajoulesperkilogram)
+        {
+            return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from MegajoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromMegajoulesPerKilogram(long megajoulesperkilogram)
+        {
+            return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from MegajoulesPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromMegajoulesPerKilogram(decimal megajoulesperkilogram)
+        {
+	        return new SpecificEnergy((Convert.ToDouble(megajoulesperkilogram)) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get SpecificEnergy from MegawattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromMegawattHoursPerKilogram(int megawatthoursperkilogram)
+        {
+            return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from MegawattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromMegawattHoursPerKilogram(long megawatthoursperkilogram)
+        {
+            return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from MegawattHoursPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromMegawattHoursPerKilogram(decimal megawatthoursperkilogram)
+        {
+	        return new SpecificEnergy((Convert.ToDouble(megawatthoursperkilogram)*3.6e3) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new SpecificEnergy(watthoursperkilogram*3.6e3);
         }
 
+		/// <summary>
+        ///     Get SpecificEnergy from WattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromWattHoursPerKilogram(int watthoursperkilogram)
+        {
+            return new SpecificEnergy(watthoursperkilogram*3.6e3);
+        }
+
+		/// <summary>
+        ///     Get SpecificEnergy from WattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy FromWattHoursPerKilogram(long watthoursperkilogram)
+        {
+            return new SpecificEnergy(watthoursperkilogram*3.6e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificEnergy from WattHoursPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy FromWattHoursPerKilogram(decimal watthoursperkilogram)
+        {
+	        return new SpecificEnergy(Convert.ToDouble(watthoursperkilogram)*3.6e3);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
         /// </summary>
         public static SpecificEnergy? FromCaloriesPerGram(double? caloriespergram)
+        {
+            if (caloriespergram.HasValue)
+            {
+                return FromCaloriesPerGram(caloriespergram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy? FromCaloriesPerGram(int? caloriespergram)
+        {
+            if (caloriespergram.HasValue)
+            {
+                return FromCaloriesPerGram(caloriespergram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy? FromCaloriesPerGram(long? caloriespergram)
+        {
+            if (caloriespergram.HasValue)
+            {
+                return FromCaloriesPerGram(caloriespergram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from CaloriesPerGram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromCaloriesPerGram(decimal? caloriespergram)
         {
             if (caloriespergram.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromJoulesPerKilogram(int? joulesperkilogram)
+        {
+            if (joulesperkilogram.HasValue)
+            {
+                return FromJoulesPerKilogram(joulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromJoulesPerKilogram(long? joulesperkilogram)
+        {
+            if (joulesperkilogram.HasValue)
+            {
+                return FromJoulesPerKilogram(joulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from JoulesPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromJoulesPerKilogram(decimal? joulesperkilogram)
+        {
+            if (joulesperkilogram.HasValue)
+            {
+                return FromJoulesPerKilogram(joulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
         /// </summary>
         public static SpecificEnergy? FromKilocaloriesPerGram(double? kilocaloriespergram)
+        {
+            if (kilocaloriespergram.HasValue)
+            {
+                return FromKilocaloriesPerGram(kilocaloriespergram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy? FromKilocaloriesPerGram(int? kilocaloriespergram)
+        {
+            if (kilocaloriespergram.HasValue)
+            {
+                return FromKilocaloriesPerGram(kilocaloriespergram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
+        /// </summary>
+        public static SpecificEnergy? FromKilocaloriesPerGram(long? kilocaloriespergram)
+        {
+            if (kilocaloriespergram.HasValue)
+            {
+                return FromKilocaloriesPerGram(kilocaloriespergram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from KilocaloriesPerGram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromKilocaloriesPerGram(decimal? kilocaloriespergram)
         {
             if (kilocaloriespergram.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromKilojoulesPerKilogram(int? kilojoulesperkilogram)
+        {
+            if (kilojoulesperkilogram.HasValue)
+            {
+                return FromKilojoulesPerKilogram(kilojoulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromKilojoulesPerKilogram(long? kilojoulesperkilogram)
+        {
+            if (kilojoulesperkilogram.HasValue)
+            {
+                return FromKilojoulesPerKilogram(kilojoulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from KilojoulesPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromKilojoulesPerKilogram(decimal? kilojoulesperkilogram)
+        {
+            if (kilojoulesperkilogram.HasValue)
+            {
+                return FromKilojoulesPerKilogram(kilojoulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromKilowattHoursPerKilogram(double? kilowatthoursperkilogram)
+        {
+            if (kilowatthoursperkilogram.HasValue)
+            {
+                return FromKilowattHoursPerKilogram(kilowatthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromKilowattHoursPerKilogram(int? kilowatthoursperkilogram)
+        {
+            if (kilowatthoursperkilogram.HasValue)
+            {
+                return FromKilowattHoursPerKilogram(kilowatthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromKilowattHoursPerKilogram(long? kilowatthoursperkilogram)
+        {
+            if (kilowatthoursperkilogram.HasValue)
+            {
+                return FromKilowattHoursPerKilogram(kilowatthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from KilowattHoursPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromKilowattHoursPerKilogram(decimal? kilowatthoursperkilogram)
         {
             if (kilowatthoursperkilogram.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromMegajoulesPerKilogram(int? megajoulesperkilogram)
+        {
+            if (megajoulesperkilogram.HasValue)
+            {
+                return FromMegajoulesPerKilogram(megajoulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromMegajoulesPerKilogram(long? megajoulesperkilogram)
+        {
+            if (megajoulesperkilogram.HasValue)
+            {
+                return FromMegajoulesPerKilogram(megajoulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from MegajoulesPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromMegajoulesPerKilogram(decimal? megajoulesperkilogram)
+        {
+            if (megajoulesperkilogram.HasValue)
+            {
+                return FromMegajoulesPerKilogram(megajoulesperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromMegawattHoursPerKilogram(int? megawatthoursperkilogram)
+        {
+            if (megawatthoursperkilogram.HasValue)
+            {
+                return FromMegawattHoursPerKilogram(megawatthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromMegawattHoursPerKilogram(long? megawatthoursperkilogram)
+        {
+            if (megawatthoursperkilogram.HasValue)
+            {
+                return FromMegawattHoursPerKilogram(megawatthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from MegawattHoursPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromMegawattHoursPerKilogram(decimal? megawatthoursperkilogram)
+        {
+            if (megawatthoursperkilogram.HasValue)
+            {
+                return FromMegawattHoursPerKilogram(megawatthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
         /// </summary>
         public static SpecificEnergy? FromWattHoursPerKilogram(double? watthoursperkilogram)
+        {
+            if (watthoursperkilogram.HasValue)
+            {
+                return FromWattHoursPerKilogram(watthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromWattHoursPerKilogram(int? watthoursperkilogram)
+        {
+            if (watthoursperkilogram.HasValue)
+            {
+                return FromWattHoursPerKilogram(watthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
+        /// </summary>
+        public static SpecificEnergy? FromWattHoursPerKilogram(long? watthoursperkilogram)
+        {
+            if (watthoursperkilogram.HasValue)
+            {
+                return FromWattHoursPerKilogram(watthoursperkilogram.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificEnergy from WattHoursPerKilogram of type decimal.
+        /// </summary>
+        public static SpecificEnergy? FromWattHoursPerKilogram(decimal? watthoursperkilogram)
         {
             if (watthoursperkilogram.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -269,6 +269,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(double kilogramsforcepercubiccentimeter)
         {
             return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
@@ -304,6 +307,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilogramsForcePerCubicMeter(double kilogramsforcepercubicmeter)
         {
             return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
@@ -339,6 +345,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(double kilogramsforcepercubicmillimeter)
         {
             return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
@@ -374,6 +383,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(double kilonewtonspercubiccentimeter)
         {
             return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
@@ -409,6 +421,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilonewtonsPerCubicMeter(double kilonewtonspercubicmeter)
         {
             return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
@@ -444,6 +459,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(double kilonewtonspercubicmillimeter)
         {
             return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
@@ -479,6 +497,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(double kilopoundsforcepercubicfoot)
         {
             return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
@@ -514,6 +535,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromKilopoundsForcePerCubicInch(double kilopoundsforcepercubicinch)
         {
             return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
@@ -549,6 +573,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromNewtonsPerCubicCentimeter(double newtonspercubiccentimeter)
         {
             return new SpecificWeight(newtonspercubiccentimeter*1000000);
@@ -584,6 +611,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromNewtonsPerCubicMeter(double newtonspercubicmeter)
         {
             return new SpecificWeight(newtonspercubicmeter);
@@ -619,6 +649,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromNewtonsPerCubicMillimeter(double newtonspercubicmillimeter)
         {
             return new SpecificWeight(newtonspercubicmillimeter*1000000000);
@@ -654,6 +687,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromPoundsForcePerCubicFoot(double poundsforcepercubicfoot)
         {
             return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
@@ -689,6 +725,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromPoundsForcePerCubicInch(double poundsforcepercubicinch)
         {
             return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
@@ -724,6 +763,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(double tonnesforcepercubiccentimeter)
         {
             return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
@@ -759,6 +801,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromTonnesForcePerCubicMeter(double tonnesforcepercubicmeter)
         {
             return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
@@ -794,6 +839,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(double tonnesforcepercubicmillimeter)
         {
             return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -274,6 +274,33 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(int kilogramsforcepercubiccentimeter)
+        {
+            return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(long kilogramsforcepercubiccentimeter)
+        {
+            return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(decimal kilogramsforcepercubiccentimeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubiccentimeter)*9806650.19960652);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
@@ -281,6 +308,33 @@ namespace UnitsNet
         {
             return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicMeter(int kilogramsforcepercubicmeter)
+        {
+            return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicMeter(long kilogramsforcepercubicmeter)
+        {
+            return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicMeter(decimal kilogramsforcepercubicmeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmeter)*9.80665019960652);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
@@ -290,6 +344,33 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(int kilogramsforcepercubicmillimeter)
+        {
+            return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(long kilogramsforcepercubicmillimeter)
+        {
+            return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(decimal kilogramsforcepercubicmillimeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmillimeter)*9806650199.60653);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
@@ -297,6 +378,33 @@ namespace UnitsNet
         {
             return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(int kilonewtonspercubiccentimeter)
+        {
+            return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(long kilonewtonspercubiccentimeter)
+        {
+            return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(decimal kilonewtonspercubiccentimeter)
+        {
+	        return new SpecificWeight((Convert.ToDouble(kilonewtonspercubiccentimeter)*1000000) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
@@ -306,6 +414,33 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicMeter(int kilonewtonspercubicmeter)
+        {
+            return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicMeter(long kilonewtonspercubicmeter)
+        {
+            return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicMeter(decimal kilonewtonspercubicmeter)
+        {
+	        return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmeter)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
@@ -313,6 +448,33 @@ namespace UnitsNet
         {
             return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(int kilonewtonspercubicmillimeter)
+        {
+            return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(long kilonewtonspercubicmillimeter)
+        {
+            return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(decimal kilonewtonspercubicmillimeter)
+        {
+	        return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmillimeter)*1000000000) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
@@ -322,6 +484,33 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight FromKilopoundsForcePerCubicFoot(int kilopoundsforcepercubicfoot)
+        {
+            return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight FromKilopoundsForcePerCubicFoot(long kilopoundsforcepercubicfoot)
+        {
+            return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilopoundsForcePerCubicFoot of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilopoundsForcePerCubicFoot(decimal kilopoundsforcepercubicfoot)
+        {
+	        return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicfoot)*157.087477433193) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
@@ -329,6 +518,33 @@ namespace UnitsNet
         {
             return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight FromKilopoundsForcePerCubicInch(int kilopoundsforcepercubicinch)
+        {
+            return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight FromKilopoundsForcePerCubicInch(long kilopoundsforcepercubicinch)
+        {
+            return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from KilopoundsForcePerCubicInch of type decimal.
+        /// </summary>
+        public static SpecificWeight FromKilopoundsForcePerCubicInch(decimal kilopoundsforcepercubicinch)
+        {
+	        return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicinch)*271447.161004558) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
@@ -338,6 +554,33 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubiccentimeter*1000000);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicCentimeter(int newtonspercubiccentimeter)
+        {
+            return new SpecificWeight(newtonspercubiccentimeter*1000000);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicCentimeter(long newtonspercubiccentimeter)
+        {
+            return new SpecificWeight(newtonspercubiccentimeter*1000000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicCentimeter(decimal newtonspercubiccentimeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(newtonspercubiccentimeter)*1000000);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
@@ -345,6 +588,33 @@ namespace UnitsNet
         {
             return new SpecificWeight(newtonspercubicmeter);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicMeter(int newtonspercubicmeter)
+        {
+            return new SpecificWeight(newtonspercubicmeter);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicMeter(long newtonspercubicmeter)
+        {
+            return new SpecificWeight(newtonspercubicmeter);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicMeter(decimal newtonspercubicmeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(newtonspercubicmeter));
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
@@ -354,6 +624,33 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmillimeter*1000000000);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicMillimeter(int newtonspercubicmillimeter)
+        {
+            return new SpecificWeight(newtonspercubicmillimeter*1000000000);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicMillimeter(long newtonspercubicmillimeter)
+        {
+            return new SpecificWeight(newtonspercubicmillimeter*1000000000);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from NewtonsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromNewtonsPerCubicMillimeter(decimal newtonspercubicmillimeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(newtonspercubicmillimeter)*1000000000);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
@@ -361,6 +658,33 @@ namespace UnitsNet
         {
             return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from PoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight FromPoundsForcePerCubicFoot(int poundsforcepercubicfoot)
+        {
+            return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from PoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight FromPoundsForcePerCubicFoot(long poundsforcepercubicfoot)
+        {
+            return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from PoundsForcePerCubicFoot of type decimal.
+        /// </summary>
+        public static SpecificWeight FromPoundsForcePerCubicFoot(decimal poundsforcepercubicfoot)
+        {
+	        return new SpecificWeight(Convert.ToDouble(poundsforcepercubicfoot)*157.087477433193);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
@@ -370,6 +694,33 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from PoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight FromPoundsForcePerCubicInch(int poundsforcepercubicinch)
+        {
+            return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from PoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight FromPoundsForcePerCubicInch(long poundsforcepercubicinch)
+        {
+            return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from PoundsForcePerCubicInch of type decimal.
+        /// </summary>
+        public static SpecificWeight FromPoundsForcePerCubicInch(decimal poundsforcepercubicinch)
+        {
+	        return new SpecificWeight(Convert.ToDouble(poundsforcepercubicinch)*271447.161004558);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
@@ -377,6 +728,33 @@ namespace UnitsNet
         {
             return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
         }
+
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicCentimeter(int tonnesforcepercubiccentimeter)
+        {
+            return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicCentimeter(long tonnesforcepercubiccentimeter)
+        {
+            return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicCentimeter(decimal tonnesforcepercubiccentimeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(tonnesforcepercubiccentimeter)*9806650199.60653);
+        }
+#endif
 
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
@@ -386,6 +764,33 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicMeter(int tonnesforcepercubicmeter)
+        {
+            return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicMeter(long tonnesforcepercubicmeter)
+        {
+            return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicMeter(decimal tonnesforcepercubicmeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmeter)*9806.65019960653);
+        }
+#endif
+
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
@@ -394,12 +799,84 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
         }
 
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicMillimeter(int tonnesforcepercubicmillimeter)
+        {
+            return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
+        }
+
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicMillimeter(long tonnesforcepercubicmillimeter)
+        {
+            return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get SpecificWeight from TonnesForcePerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight FromTonnesForcePerCubicMillimeter(decimal tonnesforcepercubicmillimeter)
+        {
+	        return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmillimeter)*9806650199606.53);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(double? kilogramsforcepercubiccentimeter)
+        {
+            if (kilogramsforcepercubiccentimeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicCentimeter(kilogramsforcepercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(int? kilogramsforcepercubiccentimeter)
+        {
+            if (kilogramsforcepercubiccentimeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicCentimeter(kilogramsforcepercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(long? kilogramsforcepercubiccentimeter)
+        {
+            if (kilogramsforcepercubiccentimeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicCentimeter(kilogramsforcepercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilogramsForcePerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(decimal? kilogramsforcepercubiccentimeter)
         {
             if (kilogramsforcepercubiccentimeter.HasValue)
             {
@@ -426,10 +903,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicMeter(int? kilogramsforcepercubicmeter)
+        {
+            if (kilogramsforcepercubicmeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicMeter(kilogramsforcepercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicMeter(long? kilogramsforcepercubicmeter)
+        {
+            if (kilogramsforcepercubicmeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicMeter(kilogramsforcepercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilogramsForcePerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicMeter(decimal? kilogramsforcepercubicmeter)
+        {
+            if (kilogramsforcepercubicmeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicMeter(kilogramsforcepercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(double? kilogramsforcepercubicmillimeter)
+        {
+            if (kilogramsforcepercubicmillimeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicMillimeter(kilogramsforcepercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(int? kilogramsforcepercubicmillimeter)
+        {
+            if (kilogramsforcepercubicmillimeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicMillimeter(kilogramsforcepercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(long? kilogramsforcepercubicmillimeter)
+        {
+            if (kilogramsforcepercubicmillimeter.HasValue)
+            {
+                return FromKilogramsForcePerCubicMillimeter(kilogramsforcepercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilogramsForcePerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(decimal? kilogramsforcepercubicmillimeter)
         {
             if (kilogramsforcepercubicmillimeter.HasValue)
             {
@@ -456,10 +1023,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(int? kilonewtonspercubiccentimeter)
+        {
+            if (kilonewtonspercubiccentimeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicCentimeter(kilonewtonspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(long? kilonewtonspercubiccentimeter)
+        {
+            if (kilonewtonspercubiccentimeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicCentimeter(kilonewtonspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilonewtonsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(decimal? kilonewtonspercubiccentimeter)
+        {
+            if (kilonewtonspercubiccentimeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicCentimeter(kilonewtonspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMeter(double? kilonewtonspercubicmeter)
+        {
+            if (kilonewtonspercubicmeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicMeter(kilonewtonspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicMeter(int? kilonewtonspercubicmeter)
+        {
+            if (kilonewtonspercubicmeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicMeter(kilonewtonspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicMeter(long? kilonewtonspercubicmeter)
+        {
+            if (kilonewtonspercubicmeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicMeter(kilonewtonspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilonewtonsPerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicMeter(decimal? kilonewtonspercubicmeter)
         {
             if (kilonewtonspercubicmeter.HasValue)
             {
@@ -486,10 +1143,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(int? kilonewtonspercubicmillimeter)
+        {
+            if (kilonewtonspercubicmillimeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicMillimeter(kilonewtonspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(long? kilonewtonspercubicmillimeter)
+        {
+            if (kilonewtonspercubicmillimeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicMillimeter(kilonewtonspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilonewtonsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(decimal? kilonewtonspercubicmillimeter)
+        {
+            if (kilonewtonspercubicmillimeter.HasValue)
+            {
+                return FromKilonewtonsPerCubicMillimeter(kilonewtonspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicFoot(double? kilopoundsforcepercubicfoot)
+        {
+            if (kilopoundsforcepercubicfoot.HasValue)
+            {
+                return FromKilopoundsForcePerCubicFoot(kilopoundsforcepercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(int? kilopoundsforcepercubicfoot)
+        {
+            if (kilopoundsforcepercubicfoot.HasValue)
+            {
+                return FromKilopoundsForcePerCubicFoot(kilopoundsforcepercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(long? kilopoundsforcepercubicfoot)
+        {
+            if (kilopoundsforcepercubicfoot.HasValue)
+            {
+                return FromKilopoundsForcePerCubicFoot(kilopoundsforcepercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilopoundsForcePerCubicFoot of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(decimal? kilopoundsforcepercubicfoot)
         {
             if (kilopoundsforcepercubicfoot.HasValue)
             {
@@ -516,10 +1263,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight? FromKilopoundsForcePerCubicInch(int? kilopoundsforcepercubicinch)
+        {
+            if (kilopoundsforcepercubicinch.HasValue)
+            {
+                return FromKilopoundsForcePerCubicInch(kilopoundsforcepercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight? FromKilopoundsForcePerCubicInch(long? kilopoundsforcepercubicinch)
+        {
+            if (kilopoundsforcepercubicinch.HasValue)
+            {
+                return FromKilopoundsForcePerCubicInch(kilopoundsforcepercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from KilopoundsForcePerCubicInch of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromKilopoundsForcePerCubicInch(decimal? kilopoundsforcepercubicinch)
+        {
+            if (kilopoundsforcepercubicinch.HasValue)
+            {
+                return FromKilopoundsForcePerCubicInch(kilopoundsforcepercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicCentimeter(double? newtonspercubiccentimeter)
+        {
+            if (newtonspercubiccentimeter.HasValue)
+            {
+                return FromNewtonsPerCubicCentimeter(newtonspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicCentimeter(int? newtonspercubiccentimeter)
+        {
+            if (newtonspercubiccentimeter.HasValue)
+            {
+                return FromNewtonsPerCubicCentimeter(newtonspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicCentimeter(long? newtonspercubiccentimeter)
+        {
+            if (newtonspercubiccentimeter.HasValue)
+            {
+                return FromNewtonsPerCubicCentimeter(newtonspercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from NewtonsPerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicCentimeter(decimal? newtonspercubiccentimeter)
         {
             if (newtonspercubiccentimeter.HasValue)
             {
@@ -546,10 +1383,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicMeter(int? newtonspercubicmeter)
+        {
+            if (newtonspercubicmeter.HasValue)
+            {
+                return FromNewtonsPerCubicMeter(newtonspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicMeter(long? newtonspercubicmeter)
+        {
+            if (newtonspercubicmeter.HasValue)
+            {
+                return FromNewtonsPerCubicMeter(newtonspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from NewtonsPerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicMeter(decimal? newtonspercubicmeter)
+        {
+            if (newtonspercubicmeter.HasValue)
+            {
+                return FromNewtonsPerCubicMeter(newtonspercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMillimeter(double? newtonspercubicmillimeter)
+        {
+            if (newtonspercubicmillimeter.HasValue)
+            {
+                return FromNewtonsPerCubicMillimeter(newtonspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicMillimeter(int? newtonspercubicmillimeter)
+        {
+            if (newtonspercubicmillimeter.HasValue)
+            {
+                return FromNewtonsPerCubicMillimeter(newtonspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicMillimeter(long? newtonspercubicmillimeter)
+        {
+            if (newtonspercubicmillimeter.HasValue)
+            {
+                return FromNewtonsPerCubicMillimeter(newtonspercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from NewtonsPerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromNewtonsPerCubicMillimeter(decimal? newtonspercubicmillimeter)
         {
             if (newtonspercubicmillimeter.HasValue)
             {
@@ -576,10 +1503,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight? FromPoundsForcePerCubicFoot(int? poundsforcepercubicfoot)
+        {
+            if (poundsforcepercubicfoot.HasValue)
+            {
+                return FromPoundsForcePerCubicFoot(poundsforcepercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
+        /// </summary>
+        public static SpecificWeight? FromPoundsForcePerCubicFoot(long? poundsforcepercubicfoot)
+        {
+            if (poundsforcepercubicfoot.HasValue)
+            {
+                return FromPoundsForcePerCubicFoot(poundsforcepercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from PoundsForcePerCubicFoot of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromPoundsForcePerCubicFoot(decimal? poundsforcepercubicfoot)
+        {
+            if (poundsforcepercubicfoot.HasValue)
+            {
+                return FromPoundsForcePerCubicFoot(poundsforcepercubicfoot.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicInch(double? poundsforcepercubicinch)
+        {
+            if (poundsforcepercubicinch.HasValue)
+            {
+                return FromPoundsForcePerCubicInch(poundsforcepercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight? FromPoundsForcePerCubicInch(int? poundsforcepercubicinch)
+        {
+            if (poundsforcepercubicinch.HasValue)
+            {
+                return FromPoundsForcePerCubicInch(poundsforcepercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
+        /// </summary>
+        public static SpecificWeight? FromPoundsForcePerCubicInch(long? poundsforcepercubicinch)
+        {
+            if (poundsforcepercubicinch.HasValue)
+            {
+                return FromPoundsForcePerCubicInch(poundsforcepercubicinch.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from PoundsForcePerCubicInch of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromPoundsForcePerCubicInch(decimal? poundsforcepercubicinch)
         {
             if (poundsforcepercubicinch.HasValue)
             {
@@ -606,6 +1623,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(int? tonnesforcepercubiccentimeter)
+        {
+            if (tonnesforcepercubiccentimeter.HasValue)
+            {
+                return FromTonnesForcePerCubicCentimeter(tonnesforcepercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(long? tonnesforcepercubiccentimeter)
+        {
+            if (tonnesforcepercubiccentimeter.HasValue)
+            {
+                return FromTonnesForcePerCubicCentimeter(tonnesforcepercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from TonnesForcePerCubicCentimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(decimal? tonnesforcepercubiccentimeter)
+        {
+            if (tonnesforcepercubiccentimeter.HasValue)
+            {
+                return FromTonnesForcePerCubicCentimeter(tonnesforcepercubiccentimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
         /// </summary>
@@ -621,10 +1683,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicMeter(int? tonnesforcepercubicmeter)
+        {
+            if (tonnesforcepercubicmeter.HasValue)
+            {
+                return FromTonnesForcePerCubicMeter(tonnesforcepercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicMeter(long? tonnesforcepercubicmeter)
+        {
+            if (tonnesforcepercubicmeter.HasValue)
+            {
+                return FromTonnesForcePerCubicMeter(tonnesforcepercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from TonnesForcePerCubicMeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicMeter(decimal? tonnesforcepercubicmeter)
+        {
+            if (tonnesforcepercubicmeter.HasValue)
+            {
+                return FromTonnesForcePerCubicMeter(tonnesforcepercubicmeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMillimeter(double? tonnesforcepercubicmillimeter)
+        {
+            if (tonnesforcepercubicmillimeter.HasValue)
+            {
+                return FromTonnesForcePerCubicMillimeter(tonnesforcepercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(int? tonnesforcepercubicmillimeter)
+        {
+            if (tonnesforcepercubicmillimeter.HasValue)
+            {
+                return FromTonnesForcePerCubicMillimeter(tonnesforcepercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(long? tonnesforcepercubicmillimeter)
+        {
+            if (tonnesforcepercubicmillimeter.HasValue)
+            {
+                return FromTonnesForcePerCubicMillimeter(tonnesforcepercubicmillimeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable SpecificWeight from TonnesForcePerCubicMillimeter of type decimal.
+        /// </summary>
+        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(decimal? tonnesforcepercubicmillimeter)
         {
             if (tonnesforcepercubicmillimeter.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _newtonsPerCubicMeter;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public SpecificWeight() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.SpecificWeight;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static SpecificWeightUnit BaseUnit
         {
             get { return SpecificWeightUnit.NewtonPerCubicMeter; }
@@ -274,7 +274,7 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(int kilogramsforcepercubiccentimeter)
@@ -282,7 +282,7 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(long kilogramsforcepercubiccentimeter)
@@ -290,14 +290,14 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(decimal kilogramsforcepercubiccentimeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubiccentimeter)*9806650.19960652);
+            return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubiccentimeter)*9806650.19960652);
         }
 #endif
 
@@ -309,7 +309,7 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicMeter(int kilogramsforcepercubicmeter)
@@ -317,7 +317,7 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicMeter(long kilogramsforcepercubicmeter)
@@ -325,14 +325,14 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicMeter(decimal kilogramsforcepercubicmeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmeter)*9.80665019960652);
+            return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmeter)*9.80665019960652);
         }
 #endif
 
@@ -344,7 +344,7 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(int kilogramsforcepercubicmillimeter)
@@ -352,7 +352,7 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(long kilogramsforcepercubicmillimeter)
@@ -360,14 +360,14 @@ namespace UnitsNet
             return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(decimal kilogramsforcepercubicmillimeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmillimeter)*9806650199.60653);
+            return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmillimeter)*9806650199.60653);
         }
 #endif
 
@@ -379,7 +379,7 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(int kilonewtonspercubiccentimeter)
@@ -387,7 +387,7 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(long kilonewtonspercubiccentimeter)
@@ -395,14 +395,14 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(decimal kilonewtonspercubiccentimeter)
         {
-	        return new SpecificWeight((Convert.ToDouble(kilonewtonspercubiccentimeter)*1000000) * 1e3d);
+            return new SpecificWeight((Convert.ToDouble(kilonewtonspercubiccentimeter)*1000000) * 1e3d);
         }
 #endif
 
@@ -414,7 +414,7 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicMeter(int kilonewtonspercubicmeter)
@@ -422,7 +422,7 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicMeter(long kilonewtonspercubicmeter)
@@ -430,14 +430,14 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicMeter(decimal kilonewtonspercubicmeter)
         {
-	        return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmeter)) * 1e3d);
+            return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmeter)) * 1e3d);
         }
 #endif
 
@@ -449,7 +449,7 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(int kilonewtonspercubicmillimeter)
@@ -457,7 +457,7 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(long kilonewtonspercubicmillimeter)
@@ -465,14 +465,14 @@ namespace UnitsNet
             return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(decimal kilonewtonspercubicmillimeter)
         {
-	        return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmillimeter)*1000000000) * 1e3d);
+            return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmillimeter)*1000000000) * 1e3d);
         }
 #endif
 
@@ -484,7 +484,7 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(int kilopoundsforcepercubicfoot)
@@ -492,7 +492,7 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(long kilopoundsforcepercubicfoot)
@@ -500,14 +500,14 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot of type decimal.
         /// </summary>
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(decimal kilopoundsforcepercubicfoot)
         {
-	        return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicfoot)*157.087477433193) * 1e3d);
+            return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicfoot)*157.087477433193) * 1e3d);
         }
 #endif
 
@@ -519,7 +519,7 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight FromKilopoundsForcePerCubicInch(int kilopoundsforcepercubicinch)
@@ -527,7 +527,7 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight FromKilopoundsForcePerCubicInch(long kilopoundsforcepercubicinch)
@@ -535,14 +535,14 @@ namespace UnitsNet
             return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch of type decimal.
         /// </summary>
         public static SpecificWeight FromKilopoundsForcePerCubicInch(decimal kilopoundsforcepercubicinch)
         {
-	        return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicinch)*271447.161004558) * 1e3d);
+            return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicinch)*271447.161004558) * 1e3d);
         }
 #endif
 
@@ -554,7 +554,7 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubiccentimeter*1000000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicCentimeter(int newtonspercubiccentimeter)
@@ -562,7 +562,7 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubiccentimeter*1000000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicCentimeter(long newtonspercubiccentimeter)
@@ -570,14 +570,14 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubiccentimeter*1000000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicCentimeter(decimal newtonspercubiccentimeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(newtonspercubiccentimeter)*1000000);
+            return new SpecificWeight(Convert.ToDouble(newtonspercubiccentimeter)*1000000);
         }
 #endif
 
@@ -589,7 +589,7 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicMeter(int newtonspercubicmeter)
@@ -597,7 +597,7 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmeter);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicMeter(long newtonspercubicmeter)
@@ -605,14 +605,14 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmeter);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicMeter(decimal newtonspercubicmeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(newtonspercubicmeter));
+            return new SpecificWeight(Convert.ToDouble(newtonspercubicmeter));
         }
 #endif
 
@@ -624,7 +624,7 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmillimeter*1000000000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicMillimeter(int newtonspercubicmillimeter)
@@ -632,7 +632,7 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmillimeter*1000000000);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicMillimeter(long newtonspercubicmillimeter)
@@ -640,14 +640,14 @@ namespace UnitsNet
             return new SpecificWeight(newtonspercubicmillimeter*1000000000);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromNewtonsPerCubicMillimeter(decimal newtonspercubicmillimeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(newtonspercubicmillimeter)*1000000000);
+            return new SpecificWeight(Convert.ToDouble(newtonspercubicmillimeter)*1000000000);
         }
 #endif
 
@@ -659,7 +659,7 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight FromPoundsForcePerCubicFoot(int poundsforcepercubicfoot)
@@ -667,7 +667,7 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight FromPoundsForcePerCubicFoot(long poundsforcepercubicfoot)
@@ -675,14 +675,14 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot of type decimal.
         /// </summary>
         public static SpecificWeight FromPoundsForcePerCubicFoot(decimal poundsforcepercubicfoot)
         {
-	        return new SpecificWeight(Convert.ToDouble(poundsforcepercubicfoot)*157.087477433193);
+            return new SpecificWeight(Convert.ToDouble(poundsforcepercubicfoot)*157.087477433193);
         }
 #endif
 
@@ -694,7 +694,7 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight FromPoundsForcePerCubicInch(int poundsforcepercubicinch)
@@ -702,7 +702,7 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight FromPoundsForcePerCubicInch(long poundsforcepercubicinch)
@@ -710,14 +710,14 @@ namespace UnitsNet
             return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch of type decimal.
         /// </summary>
         public static SpecificWeight FromPoundsForcePerCubicInch(decimal poundsforcepercubicinch)
         {
-	        return new SpecificWeight(Convert.ToDouble(poundsforcepercubicinch)*271447.161004558);
+            return new SpecificWeight(Convert.ToDouble(poundsforcepercubicinch)*271447.161004558);
         }
 #endif
 
@@ -729,7 +729,7 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(int tonnesforcepercubiccentimeter)
@@ -737,7 +737,7 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(long tonnesforcepercubiccentimeter)
@@ -745,14 +745,14 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(decimal tonnesforcepercubiccentimeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(tonnesforcepercubiccentimeter)*9806650199.60653);
+            return new SpecificWeight(Convert.ToDouble(tonnesforcepercubiccentimeter)*9806650199.60653);
         }
 #endif
 
@@ -764,7 +764,7 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicMeter(int tonnesforcepercubicmeter)
@@ -772,7 +772,7 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicMeter(long tonnesforcepercubicmeter)
@@ -780,14 +780,14 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicMeter(decimal tonnesforcepercubicmeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmeter)*9806.65019960653);
+            return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmeter)*9806.65019960653);
         }
 #endif
 
@@ -799,7 +799,7 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(int tonnesforcepercubicmillimeter)
@@ -807,7 +807,7 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(long tonnesforcepercubicmillimeter)
@@ -815,14 +815,14 @@ namespace UnitsNet
             return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(decimal tonnesforcepercubicmillimeter)
         {
-	        return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmillimeter)*9806650199606.53);
+            return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmillimeter)*9806650199606.53);
         }
 #endif
 
@@ -843,7 +843,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(int? kilogramsforcepercubiccentimeter)
@@ -858,7 +858,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(long? kilogramsforcepercubiccentimeter)
@@ -873,7 +873,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilogramsForcePerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(decimal? kilogramsforcepercubiccentimeter)
@@ -903,7 +903,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMeter(int? kilogramsforcepercubicmeter)
@@ -918,7 +918,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMeter(long? kilogramsforcepercubicmeter)
@@ -933,7 +933,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilogramsForcePerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMeter(decimal? kilogramsforcepercubicmeter)
@@ -963,7 +963,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(int? kilogramsforcepercubicmillimeter)
@@ -978,7 +978,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(long? kilogramsforcepercubicmillimeter)
@@ -993,7 +993,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilogramsForcePerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(decimal? kilogramsforcepercubicmillimeter)
@@ -1023,7 +1023,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(int? kilonewtonspercubiccentimeter)
@@ -1038,7 +1038,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(long? kilonewtonspercubiccentimeter)
@@ -1053,7 +1053,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilonewtonsPerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(decimal? kilonewtonspercubiccentimeter)
@@ -1083,7 +1083,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMeter(int? kilonewtonspercubicmeter)
@@ -1098,7 +1098,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMeter(long? kilonewtonspercubicmeter)
@@ -1113,7 +1113,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilonewtonsPerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMeter(decimal? kilonewtonspercubicmeter)
@@ -1143,7 +1143,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(int? kilonewtonspercubicmillimeter)
@@ -1158,7 +1158,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(long? kilonewtonspercubicmillimeter)
@@ -1173,7 +1173,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilonewtonsPerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(decimal? kilonewtonspercubicmillimeter)
@@ -1203,7 +1203,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicFoot(int? kilopoundsforcepercubicfoot)
@@ -1218,7 +1218,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicFoot(long? kilopoundsforcepercubicfoot)
@@ -1233,7 +1233,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilopoundsForcePerCubicFoot of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicFoot(decimal? kilopoundsforcepercubicfoot)
@@ -1263,7 +1263,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicInch(int? kilopoundsforcepercubicinch)
@@ -1278,7 +1278,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicInch(long? kilopoundsforcepercubicinch)
@@ -1293,7 +1293,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from KilopoundsForcePerCubicInch of type decimal.
         /// </summary>
         public static SpecificWeight? FromKilopoundsForcePerCubicInch(decimal? kilopoundsforcepercubicinch)
@@ -1323,7 +1323,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicCentimeter(int? newtonspercubiccentimeter)
@@ -1338,7 +1338,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicCentimeter(long? newtonspercubiccentimeter)
@@ -1353,7 +1353,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from NewtonsPerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicCentimeter(decimal? newtonspercubiccentimeter)
@@ -1383,7 +1383,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMeter(int? newtonspercubicmeter)
@@ -1398,7 +1398,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMeter(long? newtonspercubicmeter)
@@ -1413,7 +1413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from NewtonsPerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMeter(decimal? newtonspercubicmeter)
@@ -1443,7 +1443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMillimeter(int? newtonspercubicmillimeter)
@@ -1458,7 +1458,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMillimeter(long? newtonspercubicmillimeter)
@@ -1473,7 +1473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from NewtonsPerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromNewtonsPerCubicMillimeter(decimal? newtonspercubicmillimeter)
@@ -1503,7 +1503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicFoot(int? poundsforcepercubicfoot)
@@ -1518,7 +1518,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicFoot(long? poundsforcepercubicfoot)
@@ -1533,7 +1533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from PoundsForcePerCubicFoot of type decimal.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicFoot(decimal? poundsforcepercubicfoot)
@@ -1563,7 +1563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicInch(int? poundsforcepercubicinch)
@@ -1578,7 +1578,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicInch(long? poundsforcepercubicinch)
@@ -1593,7 +1593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from PoundsForcePerCubicInch of type decimal.
         /// </summary>
         public static SpecificWeight? FromPoundsForcePerCubicInch(decimal? poundsforcepercubicinch)
@@ -1623,7 +1623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicCentimeter(int? tonnesforcepercubiccentimeter)
@@ -1638,7 +1638,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicCentimeter(long? tonnesforcepercubiccentimeter)
@@ -1653,7 +1653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from TonnesForcePerCubicCentimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicCentimeter(decimal? tonnesforcepercubiccentimeter)
@@ -1683,7 +1683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMeter(int? tonnesforcepercubicmeter)
@@ -1698,7 +1698,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMeter(long? tonnesforcepercubicmeter)
@@ -1713,7 +1713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from TonnesForcePerCubicMeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMeter(decimal? tonnesforcepercubicmeter)
@@ -1743,7 +1743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMillimeter(int? tonnesforcepercubicmillimeter)
@@ -1758,7 +1758,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMillimeter(long? tonnesforcepercubicmillimeter)
@@ -1773,7 +1773,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable SpecificWeight from TonnesForcePerCubicMillimeter of type decimal.
         /// </summary>
         public static SpecificWeight? FromTonnesForcePerCubicMillimeter(decimal? tonnesforcepercubicmillimeter)

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -309,6 +309,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromCentimetersPerHour(double centimetersperhour)
         {
             return new Speed((centimetersperhour/3600) * 1e-2d);
@@ -344,6 +347,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromCentimetersPerMinutes(double centimetersperminutes)
         {
             return new Speed((centimetersperminutes/60) * 1e-2d);
@@ -379,6 +385,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromCentimetersPerSecond(double centimeterspersecond)
         {
             return new Speed((centimeterspersecond) * 1e-2d);
@@ -414,6 +423,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromDecimetersPerMinutes(double decimetersperminutes)
         {
             return new Speed((decimetersperminutes/60) * 1e-1d);
@@ -449,6 +461,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from DecimetersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromDecimetersPerSecond(double decimeterspersecond)
         {
             return new Speed((decimeterspersecond) * 1e-1d);
@@ -484,6 +499,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromFeetPerSecond(double feetpersecond)
         {
             return new Speed(feetpersecond*0.3048);
@@ -519,6 +537,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromKilometersPerHour(double kilometersperhour)
         {
             return new Speed((kilometersperhour/3600) * 1e3d);
@@ -554,6 +575,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromKilometersPerMinutes(double kilometersperminutes)
         {
             return new Speed((kilometersperminutes/60) * 1e3d);
@@ -589,6 +613,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromKilometersPerSecond(double kilometerspersecond)
         {
             return new Speed((kilometerspersecond) * 1e3d);
@@ -624,6 +651,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromKnots(double knots)
         {
             return new Speed(knots*0.514444);
@@ -659,6 +689,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMetersPerHour(double metersperhour)
         {
             return new Speed(metersperhour/3600);
@@ -694,6 +727,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMetersPerMinutes(double metersperminutes)
         {
             return new Speed(metersperminutes/60);
@@ -729,6 +765,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMetersPerSecond(double meterspersecond)
         {
             return new Speed(meterspersecond);
@@ -764,6 +803,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMicrometersPerMinutes(double micrometersperminutes)
         {
             return new Speed((micrometersperminutes/60) * 1e-6d);
@@ -799,6 +841,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MicrometersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMicrometersPerSecond(double micrometerspersecond)
         {
             return new Speed((micrometerspersecond) * 1e-6d);
@@ -834,6 +879,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMilesPerHour(double milesperhour)
         {
             return new Speed(milesperhour*0.44704);
@@ -869,6 +917,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerHour.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMillimetersPerHour(double millimetersperhour)
         {
             return new Speed((millimetersperhour/3600) * 1e-3d);
@@ -904,6 +955,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMillimetersPerMinutes(double millimetersperminutes)
         {
             return new Speed((millimetersperminutes/60) * 1e-3d);
@@ -939,6 +993,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromMillimetersPerSecond(double millimeterspersecond)
         {
             return new Speed((millimeterspersecond) * 1e-3d);
@@ -974,6 +1031,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromNanometersPerMinutes(double nanometersperminutes)
         {
             return new Speed((nanometersperminutes/60) * 1e-9d);
@@ -1009,6 +1069,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from NanometersPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Speed FromNanometersPerSecond(double nanometerspersecond)
         {
             return new Speed((nanometerspersecond) * 1e-9d);

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -314,6 +314,33 @@ namespace UnitsNet
             return new Speed((centimetersperhour/3600) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Speed from CentimetersPerHour.
+        /// </summary>
+        public static Speed FromCentimetersPerHour(int centimetersperhour)
+        {
+            return new Speed((centimetersperhour/3600) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Speed from CentimetersPerHour.
+        /// </summary>
+        public static Speed FromCentimetersPerHour(long centimetersperhour)
+        {
+            return new Speed((centimetersperhour/3600) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from CentimetersPerHour of type decimal.
+        /// </summary>
+        public static Speed FromCentimetersPerHour(decimal centimetersperhour)
+        {
+	        return new Speed((Convert.ToDouble(centimetersperhour)/3600) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
@@ -321,6 +348,33 @@ namespace UnitsNet
         {
             return new Speed((centimetersperminutes/60) * 1e-2d);
         }
+
+		/// <summary>
+        ///     Get Speed from CentimetersPerMinutes.
+        /// </summary>
+        public static Speed FromCentimetersPerMinutes(int centimetersperminutes)
+        {
+            return new Speed((centimetersperminutes/60) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Speed from CentimetersPerMinutes.
+        /// </summary>
+        public static Speed FromCentimetersPerMinutes(long centimetersperminutes)
+        {
+            return new Speed((centimetersperminutes/60) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from CentimetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromCentimetersPerMinutes(decimal centimetersperminutes)
+        {
+	        return new Speed((Convert.ToDouble(centimetersperminutes)/60) * 1e-2d);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from CentimetersPerSecond.
@@ -330,6 +384,33 @@ namespace UnitsNet
             return new Speed((centimeterspersecond) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get Speed from CentimetersPerSecond.
+        /// </summary>
+        public static Speed FromCentimetersPerSecond(int centimeterspersecond)
+        {
+            return new Speed((centimeterspersecond) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Speed from CentimetersPerSecond.
+        /// </summary>
+        public static Speed FromCentimetersPerSecond(long centimeterspersecond)
+        {
+            return new Speed((centimeterspersecond) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from CentimetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromCentimetersPerSecond(decimal centimeterspersecond)
+        {
+	        return new Speed((Convert.ToDouble(centimeterspersecond)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
@@ -337,6 +418,33 @@ namespace UnitsNet
         {
             return new Speed((decimetersperminutes/60) * 1e-1d);
         }
+
+		/// <summary>
+        ///     Get Speed from DecimetersPerMinutes.
+        /// </summary>
+        public static Speed FromDecimetersPerMinutes(int decimetersperminutes)
+        {
+            return new Speed((decimetersperminutes/60) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Speed from DecimetersPerMinutes.
+        /// </summary>
+        public static Speed FromDecimetersPerMinutes(long decimetersperminutes)
+        {
+            return new Speed((decimetersperminutes/60) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from DecimetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromDecimetersPerMinutes(decimal decimetersperminutes)
+        {
+	        return new Speed((Convert.ToDouble(decimetersperminutes)/60) * 1e-1d);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from DecimetersPerSecond.
@@ -346,6 +454,33 @@ namespace UnitsNet
             return new Speed((decimeterspersecond) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get Speed from DecimetersPerSecond.
+        /// </summary>
+        public static Speed FromDecimetersPerSecond(int decimeterspersecond)
+        {
+            return new Speed((decimeterspersecond) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Speed from DecimetersPerSecond.
+        /// </summary>
+        public static Speed FromDecimetersPerSecond(long decimeterspersecond)
+        {
+            return new Speed((decimeterspersecond) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from DecimetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromDecimetersPerSecond(decimal decimeterspersecond)
+        {
+	        return new Speed((Convert.ToDouble(decimeterspersecond)) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
@@ -353,6 +488,33 @@ namespace UnitsNet
         {
             return new Speed(feetpersecond*0.3048);
         }
+
+		/// <summary>
+        ///     Get Speed from FeetPerSecond.
+        /// </summary>
+        public static Speed FromFeetPerSecond(int feetpersecond)
+        {
+            return new Speed(feetpersecond*0.3048);
+        }
+
+		/// <summary>
+        ///     Get Speed from FeetPerSecond.
+        /// </summary>
+        public static Speed FromFeetPerSecond(long feetpersecond)
+        {
+            return new Speed(feetpersecond*0.3048);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from FeetPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromFeetPerSecond(decimal feetpersecond)
+        {
+	        return new Speed(Convert.ToDouble(feetpersecond)*0.3048);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from KilometersPerHour.
@@ -362,6 +524,33 @@ namespace UnitsNet
             return new Speed((kilometersperhour/3600) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Speed from KilometersPerHour.
+        /// </summary>
+        public static Speed FromKilometersPerHour(int kilometersperhour)
+        {
+            return new Speed((kilometersperhour/3600) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Speed from KilometersPerHour.
+        /// </summary>
+        public static Speed FromKilometersPerHour(long kilometersperhour)
+        {
+            return new Speed((kilometersperhour/3600) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from KilometersPerHour of type decimal.
+        /// </summary>
+        public static Speed FromKilometersPerHour(decimal kilometersperhour)
+        {
+	        return new Speed((Convert.ToDouble(kilometersperhour)/3600) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
@@ -369,6 +558,33 @@ namespace UnitsNet
         {
             return new Speed((kilometersperminutes/60) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Speed from KilometersPerMinutes.
+        /// </summary>
+        public static Speed FromKilometersPerMinutes(int kilometersperminutes)
+        {
+            return new Speed((kilometersperminutes/60) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Speed from KilometersPerMinutes.
+        /// </summary>
+        public static Speed FromKilometersPerMinutes(long kilometersperminutes)
+        {
+            return new Speed((kilometersperminutes/60) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from KilometersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromKilometersPerMinutes(decimal kilometersperminutes)
+        {
+	        return new Speed((Convert.ToDouble(kilometersperminutes)/60) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from KilometersPerSecond.
@@ -378,6 +594,33 @@ namespace UnitsNet
             return new Speed((kilometerspersecond) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Speed from KilometersPerSecond.
+        /// </summary>
+        public static Speed FromKilometersPerSecond(int kilometerspersecond)
+        {
+            return new Speed((kilometerspersecond) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Speed from KilometersPerSecond.
+        /// </summary>
+        public static Speed FromKilometersPerSecond(long kilometerspersecond)
+        {
+            return new Speed((kilometerspersecond) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from KilometersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromKilometersPerSecond(decimal kilometerspersecond)
+        {
+	        return new Speed((Convert.ToDouble(kilometerspersecond)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
@@ -385,6 +628,33 @@ namespace UnitsNet
         {
             return new Speed(knots*0.514444);
         }
+
+		/// <summary>
+        ///     Get Speed from Knots.
+        /// </summary>
+        public static Speed FromKnots(int knots)
+        {
+            return new Speed(knots*0.514444);
+        }
+
+		/// <summary>
+        ///     Get Speed from Knots.
+        /// </summary>
+        public static Speed FromKnots(long knots)
+        {
+            return new Speed(knots*0.514444);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from Knots of type decimal.
+        /// </summary>
+        public static Speed FromKnots(decimal knots)
+        {
+	        return new Speed(Convert.ToDouble(knots)*0.514444);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from MetersPerHour.
@@ -394,6 +664,33 @@ namespace UnitsNet
             return new Speed(metersperhour/3600);
         }
 
+		/// <summary>
+        ///     Get Speed from MetersPerHour.
+        /// </summary>
+        public static Speed FromMetersPerHour(int metersperhour)
+        {
+            return new Speed(metersperhour/3600);
+        }
+
+		/// <summary>
+        ///     Get Speed from MetersPerHour.
+        /// </summary>
+        public static Speed FromMetersPerHour(long metersperhour)
+        {
+            return new Speed(metersperhour/3600);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MetersPerHour of type decimal.
+        /// </summary>
+        public static Speed FromMetersPerHour(decimal metersperhour)
+        {
+	        return new Speed(Convert.ToDouble(metersperhour)/3600);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
@@ -401,6 +698,33 @@ namespace UnitsNet
         {
             return new Speed(metersperminutes/60);
         }
+
+		/// <summary>
+        ///     Get Speed from MetersPerMinutes.
+        /// </summary>
+        public static Speed FromMetersPerMinutes(int metersperminutes)
+        {
+            return new Speed(metersperminutes/60);
+        }
+
+		/// <summary>
+        ///     Get Speed from MetersPerMinutes.
+        /// </summary>
+        public static Speed FromMetersPerMinutes(long metersperminutes)
+        {
+            return new Speed(metersperminutes/60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromMetersPerMinutes(decimal metersperminutes)
+        {
+	        return new Speed(Convert.ToDouble(metersperminutes)/60);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from MetersPerSecond.
@@ -410,6 +734,33 @@ namespace UnitsNet
             return new Speed(meterspersecond);
         }
 
+		/// <summary>
+        ///     Get Speed from MetersPerSecond.
+        /// </summary>
+        public static Speed FromMetersPerSecond(int meterspersecond)
+        {
+            return new Speed(meterspersecond);
+        }
+
+		/// <summary>
+        ///     Get Speed from MetersPerSecond.
+        /// </summary>
+        public static Speed FromMetersPerSecond(long meterspersecond)
+        {
+            return new Speed(meterspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromMetersPerSecond(decimal meterspersecond)
+        {
+	        return new Speed(Convert.ToDouble(meterspersecond));
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
@@ -417,6 +768,33 @@ namespace UnitsNet
         {
             return new Speed((micrometersperminutes/60) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get Speed from MicrometersPerMinutes.
+        /// </summary>
+        public static Speed FromMicrometersPerMinutes(int micrometersperminutes)
+        {
+            return new Speed((micrometersperminutes/60) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Speed from MicrometersPerMinutes.
+        /// </summary>
+        public static Speed FromMicrometersPerMinutes(long micrometersperminutes)
+        {
+            return new Speed((micrometersperminutes/60) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MicrometersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromMicrometersPerMinutes(decimal micrometersperminutes)
+        {
+	        return new Speed((Convert.ToDouble(micrometersperminutes)/60) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from MicrometersPerSecond.
@@ -426,6 +804,33 @@ namespace UnitsNet
             return new Speed((micrometerspersecond) * 1e-6d);
         }
 
+		/// <summary>
+        ///     Get Speed from MicrometersPerSecond.
+        /// </summary>
+        public static Speed FromMicrometersPerSecond(int micrometerspersecond)
+        {
+            return new Speed((micrometerspersecond) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Speed from MicrometersPerSecond.
+        /// </summary>
+        public static Speed FromMicrometersPerSecond(long micrometerspersecond)
+        {
+            return new Speed((micrometerspersecond) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MicrometersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromMicrometersPerSecond(decimal micrometerspersecond)
+        {
+	        return new Speed((Convert.ToDouble(micrometerspersecond)) * 1e-6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
@@ -433,6 +838,33 @@ namespace UnitsNet
         {
             return new Speed(milesperhour*0.44704);
         }
+
+		/// <summary>
+        ///     Get Speed from MilesPerHour.
+        /// </summary>
+        public static Speed FromMilesPerHour(int milesperhour)
+        {
+            return new Speed(milesperhour*0.44704);
+        }
+
+		/// <summary>
+        ///     Get Speed from MilesPerHour.
+        /// </summary>
+        public static Speed FromMilesPerHour(long milesperhour)
+        {
+            return new Speed(milesperhour*0.44704);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MilesPerHour of type decimal.
+        /// </summary>
+        public static Speed FromMilesPerHour(decimal milesperhour)
+        {
+	        return new Speed(Convert.ToDouble(milesperhour)*0.44704);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from MillimetersPerHour.
@@ -442,6 +874,33 @@ namespace UnitsNet
             return new Speed((millimetersperhour/3600) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Speed from MillimetersPerHour.
+        /// </summary>
+        public static Speed FromMillimetersPerHour(int millimetersperhour)
+        {
+            return new Speed((millimetersperhour/3600) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Speed from MillimetersPerHour.
+        /// </summary>
+        public static Speed FromMillimetersPerHour(long millimetersperhour)
+        {
+            return new Speed((millimetersperhour/3600) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MillimetersPerHour of type decimal.
+        /// </summary>
+        public static Speed FromMillimetersPerHour(decimal millimetersperhour)
+        {
+	        return new Speed((Convert.ToDouble(millimetersperhour)/3600) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
@@ -449,6 +908,33 @@ namespace UnitsNet
         {
             return new Speed((millimetersperminutes/60) * 1e-3d);
         }
+
+		/// <summary>
+        ///     Get Speed from MillimetersPerMinutes.
+        /// </summary>
+        public static Speed FromMillimetersPerMinutes(int millimetersperminutes)
+        {
+            return new Speed((millimetersperminutes/60) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Speed from MillimetersPerMinutes.
+        /// </summary>
+        public static Speed FromMillimetersPerMinutes(long millimetersperminutes)
+        {
+            return new Speed((millimetersperminutes/60) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MillimetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromMillimetersPerMinutes(decimal millimetersperminutes)
+        {
+	        return new Speed((Convert.ToDouble(millimetersperminutes)/60) * 1e-3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from MillimetersPerSecond.
@@ -458,6 +944,33 @@ namespace UnitsNet
             return new Speed((millimeterspersecond) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Speed from MillimetersPerSecond.
+        /// </summary>
+        public static Speed FromMillimetersPerSecond(int millimeterspersecond)
+        {
+            return new Speed((millimeterspersecond) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Speed from MillimetersPerSecond.
+        /// </summary>
+        public static Speed FromMillimetersPerSecond(long millimeterspersecond)
+        {
+            return new Speed((millimeterspersecond) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from MillimetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromMillimetersPerSecond(decimal millimeterspersecond)
+        {
+	        return new Speed((Convert.ToDouble(millimeterspersecond)) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
@@ -465,6 +978,33 @@ namespace UnitsNet
         {
             return new Speed((nanometersperminutes/60) * 1e-9d);
         }
+
+		/// <summary>
+        ///     Get Speed from NanometersPerMinutes.
+        /// </summary>
+        public static Speed FromNanometersPerMinutes(int nanometersperminutes)
+        {
+            return new Speed((nanometersperminutes/60) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Speed from NanometersPerMinutes.
+        /// </summary>
+        public static Speed FromNanometersPerMinutes(long nanometersperminutes)
+        {
+            return new Speed((nanometersperminutes/60) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from NanometersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed FromNanometersPerMinutes(decimal nanometersperminutes)
+        {
+	        return new Speed((Convert.ToDouble(nanometersperminutes)/60) * 1e-9d);
+        }
+#endif
 
         /// <summary>
         ///     Get Speed from NanometersPerSecond.
@@ -474,12 +1014,84 @@ namespace UnitsNet
             return new Speed((nanometerspersecond) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get Speed from NanometersPerSecond.
+        /// </summary>
+        public static Speed FromNanometersPerSecond(int nanometerspersecond)
+        {
+            return new Speed((nanometerspersecond) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get Speed from NanometersPerSecond.
+        /// </summary>
+        public static Speed FromNanometersPerSecond(long nanometerspersecond)
+        {
+            return new Speed((nanometerspersecond) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Speed from NanometersPerSecond of type decimal.
+        /// </summary>
+        public static Speed FromNanometersPerSecond(decimal nanometerspersecond)
+        {
+	        return new Speed((Convert.ToDouble(nanometerspersecond)) * 1e-9d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerHour.
         /// </summary>
         public static Speed? FromCentimetersPerHour(double? centimetersperhour)
+        {
+            if (centimetersperhour.HasValue)
+            {
+                return FromCentimetersPerHour(centimetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable CentimetersPerHour.
+        /// </summary>
+        public static Speed? FromCentimetersPerHour(int? centimetersperhour)
+        {
+            if (centimetersperhour.HasValue)
+            {
+                return FromCentimetersPerHour(centimetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable CentimetersPerHour.
+        /// </summary>
+        public static Speed? FromCentimetersPerHour(long? centimetersperhour)
+        {
+            if (centimetersperhour.HasValue)
+            {
+                return FromCentimetersPerHour(centimetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from CentimetersPerHour of type decimal.
+        /// </summary>
+        public static Speed? FromCentimetersPerHour(decimal? centimetersperhour)
         {
             if (centimetersperhour.HasValue)
             {
@@ -506,10 +1118,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable CentimetersPerMinutes.
+        /// </summary>
+        public static Speed? FromCentimetersPerMinutes(int? centimetersperminutes)
+        {
+            if (centimetersperminutes.HasValue)
+            {
+                return FromCentimetersPerMinutes(centimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable CentimetersPerMinutes.
+        /// </summary>
+        public static Speed? FromCentimetersPerMinutes(long? centimetersperminutes)
+        {
+            if (centimetersperminutes.HasValue)
+            {
+                return FromCentimetersPerMinutes(centimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from CentimetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromCentimetersPerMinutes(decimal? centimetersperminutes)
+        {
+            if (centimetersperminutes.HasValue)
+            {
+                return FromCentimetersPerMinutes(centimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerSecond.
         /// </summary>
         public static Speed? FromCentimetersPerSecond(double? centimeterspersecond)
+        {
+            if (centimeterspersecond.HasValue)
+            {
+                return FromCentimetersPerSecond(centimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable CentimetersPerSecond.
+        /// </summary>
+        public static Speed? FromCentimetersPerSecond(int? centimeterspersecond)
+        {
+            if (centimeterspersecond.HasValue)
+            {
+                return FromCentimetersPerSecond(centimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable CentimetersPerSecond.
+        /// </summary>
+        public static Speed? FromCentimetersPerSecond(long? centimeterspersecond)
+        {
+            if (centimeterspersecond.HasValue)
+            {
+                return FromCentimetersPerSecond(centimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from CentimetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromCentimetersPerSecond(decimal? centimeterspersecond)
         {
             if (centimeterspersecond.HasValue)
             {
@@ -536,10 +1238,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable DecimetersPerMinutes.
+        /// </summary>
+        public static Speed? FromDecimetersPerMinutes(int? decimetersperminutes)
+        {
+            if (decimetersperminutes.HasValue)
+            {
+                return FromDecimetersPerMinutes(decimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable DecimetersPerMinutes.
+        /// </summary>
+        public static Speed? FromDecimetersPerMinutes(long? decimetersperminutes)
+        {
+            if (decimetersperminutes.HasValue)
+            {
+                return FromDecimetersPerMinutes(decimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from DecimetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromDecimetersPerMinutes(decimal? decimetersperminutes)
+        {
+            if (decimetersperminutes.HasValue)
+            {
+                return FromDecimetersPerMinutes(decimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerSecond.
         /// </summary>
         public static Speed? FromDecimetersPerSecond(double? decimeterspersecond)
+        {
+            if (decimeterspersecond.HasValue)
+            {
+                return FromDecimetersPerSecond(decimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable DecimetersPerSecond.
+        /// </summary>
+        public static Speed? FromDecimetersPerSecond(int? decimeterspersecond)
+        {
+            if (decimeterspersecond.HasValue)
+            {
+                return FromDecimetersPerSecond(decimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable DecimetersPerSecond.
+        /// </summary>
+        public static Speed? FromDecimetersPerSecond(long? decimeterspersecond)
+        {
+            if (decimeterspersecond.HasValue)
+            {
+                return FromDecimetersPerSecond(decimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from DecimetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromDecimetersPerSecond(decimal? decimeterspersecond)
         {
             if (decimeterspersecond.HasValue)
             {
@@ -566,10 +1358,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable FeetPerSecond.
+        /// </summary>
+        public static Speed? FromFeetPerSecond(int? feetpersecond)
+        {
+            if (feetpersecond.HasValue)
+            {
+                return FromFeetPerSecond(feetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable FeetPerSecond.
+        /// </summary>
+        public static Speed? FromFeetPerSecond(long? feetpersecond)
+        {
+            if (feetpersecond.HasValue)
+            {
+                return FromFeetPerSecond(feetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from FeetPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromFeetPerSecond(decimal? feetpersecond)
+        {
+            if (feetpersecond.HasValue)
+            {
+                return FromFeetPerSecond(feetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable KilometersPerHour.
         /// </summary>
         public static Speed? FromKilometersPerHour(double? kilometersperhour)
+        {
+            if (kilometersperhour.HasValue)
+            {
+                return FromKilometersPerHour(kilometersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable KilometersPerHour.
+        /// </summary>
+        public static Speed? FromKilometersPerHour(int? kilometersperhour)
+        {
+            if (kilometersperhour.HasValue)
+            {
+                return FromKilometersPerHour(kilometersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable KilometersPerHour.
+        /// </summary>
+        public static Speed? FromKilometersPerHour(long? kilometersperhour)
+        {
+            if (kilometersperhour.HasValue)
+            {
+                return FromKilometersPerHour(kilometersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from KilometersPerHour of type decimal.
+        /// </summary>
+        public static Speed? FromKilometersPerHour(decimal? kilometersperhour)
         {
             if (kilometersperhour.HasValue)
             {
@@ -596,10 +1478,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable KilometersPerMinutes.
+        /// </summary>
+        public static Speed? FromKilometersPerMinutes(int? kilometersperminutes)
+        {
+            if (kilometersperminutes.HasValue)
+            {
+                return FromKilometersPerMinutes(kilometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable KilometersPerMinutes.
+        /// </summary>
+        public static Speed? FromKilometersPerMinutes(long? kilometersperminutes)
+        {
+            if (kilometersperminutes.HasValue)
+            {
+                return FromKilometersPerMinutes(kilometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from KilometersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromKilometersPerMinutes(decimal? kilometersperminutes)
+        {
+            if (kilometersperminutes.HasValue)
+            {
+                return FromKilometersPerMinutes(kilometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable KilometersPerSecond.
         /// </summary>
         public static Speed? FromKilometersPerSecond(double? kilometerspersecond)
+        {
+            if (kilometerspersecond.HasValue)
+            {
+                return FromKilometersPerSecond(kilometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable KilometersPerSecond.
+        /// </summary>
+        public static Speed? FromKilometersPerSecond(int? kilometerspersecond)
+        {
+            if (kilometerspersecond.HasValue)
+            {
+                return FromKilometersPerSecond(kilometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable KilometersPerSecond.
+        /// </summary>
+        public static Speed? FromKilometersPerSecond(long? kilometerspersecond)
+        {
+            if (kilometerspersecond.HasValue)
+            {
+                return FromKilometersPerSecond(kilometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from KilometersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromKilometersPerSecond(decimal? kilometerspersecond)
         {
             if (kilometerspersecond.HasValue)
             {
@@ -626,10 +1598,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable Knots.
+        /// </summary>
+        public static Speed? FromKnots(int? knots)
+        {
+            if (knots.HasValue)
+            {
+                return FromKnots(knots.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable Knots.
+        /// </summary>
+        public static Speed? FromKnots(long? knots)
+        {
+            if (knots.HasValue)
+            {
+                return FromKnots(knots.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from Knots of type decimal.
+        /// </summary>
+        public static Speed? FromKnots(decimal? knots)
+        {
+            if (knots.HasValue)
+            {
+                return FromKnots(knots.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable MetersPerHour.
         /// </summary>
         public static Speed? FromMetersPerHour(double? metersperhour)
+        {
+            if (metersperhour.HasValue)
+            {
+                return FromMetersPerHour(metersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MetersPerHour.
+        /// </summary>
+        public static Speed? FromMetersPerHour(int? metersperhour)
+        {
+            if (metersperhour.HasValue)
+            {
+                return FromMetersPerHour(metersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MetersPerHour.
+        /// </summary>
+        public static Speed? FromMetersPerHour(long? metersperhour)
+        {
+            if (metersperhour.HasValue)
+            {
+                return FromMetersPerHour(metersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MetersPerHour of type decimal.
+        /// </summary>
+        public static Speed? FromMetersPerHour(decimal? metersperhour)
         {
             if (metersperhour.HasValue)
             {
@@ -656,10 +1718,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable MetersPerMinutes.
+        /// </summary>
+        public static Speed? FromMetersPerMinutes(int? metersperminutes)
+        {
+            if (metersperminutes.HasValue)
+            {
+                return FromMetersPerMinutes(metersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MetersPerMinutes.
+        /// </summary>
+        public static Speed? FromMetersPerMinutes(long? metersperminutes)
+        {
+            if (metersperminutes.HasValue)
+            {
+                return FromMetersPerMinutes(metersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromMetersPerMinutes(decimal? metersperminutes)
+        {
+            if (metersperminutes.HasValue)
+            {
+                return FromMetersPerMinutes(metersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable MetersPerSecond.
         /// </summary>
         public static Speed? FromMetersPerSecond(double? meterspersecond)
+        {
+            if (meterspersecond.HasValue)
+            {
+                return FromMetersPerSecond(meterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MetersPerSecond.
+        /// </summary>
+        public static Speed? FromMetersPerSecond(int? meterspersecond)
+        {
+            if (meterspersecond.HasValue)
+            {
+                return FromMetersPerSecond(meterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MetersPerSecond.
+        /// </summary>
+        public static Speed? FromMetersPerSecond(long? meterspersecond)
+        {
+            if (meterspersecond.HasValue)
+            {
+                return FromMetersPerSecond(meterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromMetersPerSecond(decimal? meterspersecond)
         {
             if (meterspersecond.HasValue)
             {
@@ -686,10 +1838,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable MicrometersPerMinutes.
+        /// </summary>
+        public static Speed? FromMicrometersPerMinutes(int? micrometersperminutes)
+        {
+            if (micrometersperminutes.HasValue)
+            {
+                return FromMicrometersPerMinutes(micrometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MicrometersPerMinutes.
+        /// </summary>
+        public static Speed? FromMicrometersPerMinutes(long? micrometersperminutes)
+        {
+            if (micrometersperminutes.HasValue)
+            {
+                return FromMicrometersPerMinutes(micrometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MicrometersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromMicrometersPerMinutes(decimal? micrometersperminutes)
+        {
+            if (micrometersperminutes.HasValue)
+            {
+                return FromMicrometersPerMinutes(micrometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerSecond.
         /// </summary>
         public static Speed? FromMicrometersPerSecond(double? micrometerspersecond)
+        {
+            if (micrometerspersecond.HasValue)
+            {
+                return FromMicrometersPerSecond(micrometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MicrometersPerSecond.
+        /// </summary>
+        public static Speed? FromMicrometersPerSecond(int? micrometerspersecond)
+        {
+            if (micrometerspersecond.HasValue)
+            {
+                return FromMicrometersPerSecond(micrometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MicrometersPerSecond.
+        /// </summary>
+        public static Speed? FromMicrometersPerSecond(long? micrometerspersecond)
+        {
+            if (micrometerspersecond.HasValue)
+            {
+                return FromMicrometersPerSecond(micrometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MicrometersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromMicrometersPerSecond(decimal? micrometerspersecond)
         {
             if (micrometerspersecond.HasValue)
             {
@@ -716,10 +1958,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable MilesPerHour.
+        /// </summary>
+        public static Speed? FromMilesPerHour(int? milesperhour)
+        {
+            if (milesperhour.HasValue)
+            {
+                return FromMilesPerHour(milesperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MilesPerHour.
+        /// </summary>
+        public static Speed? FromMilesPerHour(long? milesperhour)
+        {
+            if (milesperhour.HasValue)
+            {
+                return FromMilesPerHour(milesperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MilesPerHour of type decimal.
+        /// </summary>
+        public static Speed? FromMilesPerHour(decimal? milesperhour)
+        {
+            if (milesperhour.HasValue)
+            {
+                return FromMilesPerHour(milesperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerHour.
         /// </summary>
         public static Speed? FromMillimetersPerHour(double? millimetersperhour)
+        {
+            if (millimetersperhour.HasValue)
+            {
+                return FromMillimetersPerHour(millimetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MillimetersPerHour.
+        /// </summary>
+        public static Speed? FromMillimetersPerHour(int? millimetersperhour)
+        {
+            if (millimetersperhour.HasValue)
+            {
+                return FromMillimetersPerHour(millimetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MillimetersPerHour.
+        /// </summary>
+        public static Speed? FromMillimetersPerHour(long? millimetersperhour)
+        {
+            if (millimetersperhour.HasValue)
+            {
+                return FromMillimetersPerHour(millimetersperhour.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MillimetersPerHour of type decimal.
+        /// </summary>
+        public static Speed? FromMillimetersPerHour(decimal? millimetersperhour)
         {
             if (millimetersperhour.HasValue)
             {
@@ -746,10 +2078,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable MillimetersPerMinutes.
+        /// </summary>
+        public static Speed? FromMillimetersPerMinutes(int? millimetersperminutes)
+        {
+            if (millimetersperminutes.HasValue)
+            {
+                return FromMillimetersPerMinutes(millimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MillimetersPerMinutes.
+        /// </summary>
+        public static Speed? FromMillimetersPerMinutes(long? millimetersperminutes)
+        {
+            if (millimetersperminutes.HasValue)
+            {
+                return FromMillimetersPerMinutes(millimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MillimetersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromMillimetersPerMinutes(decimal? millimetersperminutes)
+        {
+            if (millimetersperminutes.HasValue)
+            {
+                return FromMillimetersPerMinutes(millimetersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerSecond.
         /// </summary>
         public static Speed? FromMillimetersPerSecond(double? millimeterspersecond)
+        {
+            if (millimeterspersecond.HasValue)
+            {
+                return FromMillimetersPerSecond(millimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MillimetersPerSecond.
+        /// </summary>
+        public static Speed? FromMillimetersPerSecond(int? millimeterspersecond)
+        {
+            if (millimeterspersecond.HasValue)
+            {
+                return FromMillimetersPerSecond(millimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable MillimetersPerSecond.
+        /// </summary>
+        public static Speed? FromMillimetersPerSecond(long? millimeterspersecond)
+        {
+            if (millimeterspersecond.HasValue)
+            {
+                return FromMillimetersPerSecond(millimeterspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from MillimetersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromMillimetersPerSecond(decimal? millimeterspersecond)
         {
             if (millimeterspersecond.HasValue)
             {
@@ -776,10 +2198,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Speed from nullable NanometersPerMinutes.
+        /// </summary>
+        public static Speed? FromNanometersPerMinutes(int? nanometersperminutes)
+        {
+            if (nanometersperminutes.HasValue)
+            {
+                return FromNanometersPerMinutes(nanometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable NanometersPerMinutes.
+        /// </summary>
+        public static Speed? FromNanometersPerMinutes(long? nanometersperminutes)
+        {
+            if (nanometersperminutes.HasValue)
+            {
+                return FromNanometersPerMinutes(nanometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from NanometersPerMinutes of type decimal.
+        /// </summary>
+        public static Speed? FromNanometersPerMinutes(decimal? nanometersperminutes)
+        {
+            if (nanometersperminutes.HasValue)
+            {
+                return FromNanometersPerMinutes(nanometersperminutes.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Speed from nullable NanometersPerSecond.
         /// </summary>
         public static Speed? FromNanometersPerSecond(double? nanometerspersecond)
+        {
+            if (nanometerspersecond.HasValue)
+            {
+                return FromNanometersPerSecond(nanometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable NanometersPerSecond.
+        /// </summary>
+        public static Speed? FromNanometersPerSecond(int? nanometerspersecond)
+        {
+            if (nanometerspersecond.HasValue)
+            {
+                return FromNanometersPerSecond(nanometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from nullable NanometersPerSecond.
+        /// </summary>
+        public static Speed? FromNanometersPerSecond(long? nanometerspersecond)
+        {
+            if (nanometerspersecond.HasValue)
+            {
+                return FromNanometersPerSecond(nanometerspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Speed from NanometersPerSecond of type decimal.
+        /// </summary>
+        public static Speed? FromNanometersPerSecond(decimal? nanometerspersecond)
         {
             if (nanometerspersecond.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _metersPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Speed() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Speed;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static SpeedUnit BaseUnit
         {
             get { return SpeedUnit.MeterPerSecond; }
@@ -314,7 +314,7 @@ namespace UnitsNet
             return new Speed((centimetersperhour/3600) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerHour.
         /// </summary>
         public static Speed FromCentimetersPerHour(int centimetersperhour)
@@ -322,7 +322,7 @@ namespace UnitsNet
             return new Speed((centimetersperhour/3600) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerHour.
         /// </summary>
         public static Speed FromCentimetersPerHour(long centimetersperhour)
@@ -330,14 +330,14 @@ namespace UnitsNet
             return new Speed((centimetersperhour/3600) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerHour of type decimal.
         /// </summary>
         public static Speed FromCentimetersPerHour(decimal centimetersperhour)
         {
-	        return new Speed((Convert.ToDouble(centimetersperhour)/3600) * 1e-2d);
+            return new Speed((Convert.ToDouble(centimetersperhour)/3600) * 1e-2d);
         }
 #endif
 
@@ -349,7 +349,7 @@ namespace UnitsNet
             return new Speed((centimetersperminutes/60) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
         public static Speed FromCentimetersPerMinutes(int centimetersperminutes)
@@ -357,7 +357,7 @@ namespace UnitsNet
             return new Speed((centimetersperminutes/60) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
         public static Speed FromCentimetersPerMinutes(long centimetersperminutes)
@@ -365,14 +365,14 @@ namespace UnitsNet
             return new Speed((centimetersperminutes/60) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromCentimetersPerMinutes(decimal centimetersperminutes)
         {
-	        return new Speed((Convert.ToDouble(centimetersperminutes)/60) * 1e-2d);
+            return new Speed((Convert.ToDouble(centimetersperminutes)/60) * 1e-2d);
         }
 #endif
 
@@ -384,7 +384,7 @@ namespace UnitsNet
             return new Speed((centimeterspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerSecond.
         /// </summary>
         public static Speed FromCentimetersPerSecond(int centimeterspersecond)
@@ -392,7 +392,7 @@ namespace UnitsNet
             return new Speed((centimeterspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerSecond.
         /// </summary>
         public static Speed FromCentimetersPerSecond(long centimeterspersecond)
@@ -400,14 +400,14 @@ namespace UnitsNet
             return new Speed((centimeterspersecond) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from CentimetersPerSecond of type decimal.
         /// </summary>
         public static Speed FromCentimetersPerSecond(decimal centimeterspersecond)
         {
-	        return new Speed((Convert.ToDouble(centimeterspersecond)) * 1e-2d);
+            return new Speed((Convert.ToDouble(centimeterspersecond)) * 1e-2d);
         }
 #endif
 
@@ -419,7 +419,7 @@ namespace UnitsNet
             return new Speed((decimetersperminutes/60) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
         public static Speed FromDecimetersPerMinutes(int decimetersperminutes)
@@ -427,7 +427,7 @@ namespace UnitsNet
             return new Speed((decimetersperminutes/60) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
         public static Speed FromDecimetersPerMinutes(long decimetersperminutes)
@@ -435,14 +435,14 @@ namespace UnitsNet
             return new Speed((decimetersperminutes/60) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from DecimetersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromDecimetersPerMinutes(decimal decimetersperminutes)
         {
-	        return new Speed((Convert.ToDouble(decimetersperminutes)/60) * 1e-1d);
+            return new Speed((Convert.ToDouble(decimetersperminutes)/60) * 1e-1d);
         }
 #endif
 
@@ -454,7 +454,7 @@ namespace UnitsNet
             return new Speed((decimeterspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from DecimetersPerSecond.
         /// </summary>
         public static Speed FromDecimetersPerSecond(int decimeterspersecond)
@@ -462,7 +462,7 @@ namespace UnitsNet
             return new Speed((decimeterspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from DecimetersPerSecond.
         /// </summary>
         public static Speed FromDecimetersPerSecond(long decimeterspersecond)
@@ -470,14 +470,14 @@ namespace UnitsNet
             return new Speed((decimeterspersecond) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from DecimetersPerSecond of type decimal.
         /// </summary>
         public static Speed FromDecimetersPerSecond(decimal decimeterspersecond)
         {
-	        return new Speed((Convert.ToDouble(decimeterspersecond)) * 1e-1d);
+            return new Speed((Convert.ToDouble(decimeterspersecond)) * 1e-1d);
         }
 #endif
 
@@ -489,7 +489,7 @@ namespace UnitsNet
             return new Speed(feetpersecond*0.3048);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
         public static Speed FromFeetPerSecond(int feetpersecond)
@@ -497,7 +497,7 @@ namespace UnitsNet
             return new Speed(feetpersecond*0.3048);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
         public static Speed FromFeetPerSecond(long feetpersecond)
@@ -505,14 +505,14 @@ namespace UnitsNet
             return new Speed(feetpersecond*0.3048);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from FeetPerSecond of type decimal.
         /// </summary>
         public static Speed FromFeetPerSecond(decimal feetpersecond)
         {
-	        return new Speed(Convert.ToDouble(feetpersecond)*0.3048);
+            return new Speed(Convert.ToDouble(feetpersecond)*0.3048);
         }
 #endif
 
@@ -524,7 +524,7 @@ namespace UnitsNet
             return new Speed((kilometersperhour/3600) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerHour.
         /// </summary>
         public static Speed FromKilometersPerHour(int kilometersperhour)
@@ -532,7 +532,7 @@ namespace UnitsNet
             return new Speed((kilometersperhour/3600) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerHour.
         /// </summary>
         public static Speed FromKilometersPerHour(long kilometersperhour)
@@ -540,14 +540,14 @@ namespace UnitsNet
             return new Speed((kilometersperhour/3600) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerHour of type decimal.
         /// </summary>
         public static Speed FromKilometersPerHour(decimal kilometersperhour)
         {
-	        return new Speed((Convert.ToDouble(kilometersperhour)/3600) * 1e3d);
+            return new Speed((Convert.ToDouble(kilometersperhour)/3600) * 1e3d);
         }
 #endif
 
@@ -559,7 +559,7 @@ namespace UnitsNet
             return new Speed((kilometersperminutes/60) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
         public static Speed FromKilometersPerMinutes(int kilometersperminutes)
@@ -567,7 +567,7 @@ namespace UnitsNet
             return new Speed((kilometersperminutes/60) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
         public static Speed FromKilometersPerMinutes(long kilometersperminutes)
@@ -575,14 +575,14 @@ namespace UnitsNet
             return new Speed((kilometersperminutes/60) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromKilometersPerMinutes(decimal kilometersperminutes)
         {
-	        return new Speed((Convert.ToDouble(kilometersperminutes)/60) * 1e3d);
+            return new Speed((Convert.ToDouble(kilometersperminutes)/60) * 1e3d);
         }
 #endif
 
@@ -594,7 +594,7 @@ namespace UnitsNet
             return new Speed((kilometerspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerSecond.
         /// </summary>
         public static Speed FromKilometersPerSecond(int kilometerspersecond)
@@ -602,7 +602,7 @@ namespace UnitsNet
             return new Speed((kilometerspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerSecond.
         /// </summary>
         public static Speed FromKilometersPerSecond(long kilometerspersecond)
@@ -610,14 +610,14 @@ namespace UnitsNet
             return new Speed((kilometerspersecond) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from KilometersPerSecond of type decimal.
         /// </summary>
         public static Speed FromKilometersPerSecond(decimal kilometerspersecond)
         {
-	        return new Speed((Convert.ToDouble(kilometerspersecond)) * 1e3d);
+            return new Speed((Convert.ToDouble(kilometerspersecond)) * 1e3d);
         }
 #endif
 
@@ -629,7 +629,7 @@ namespace UnitsNet
             return new Speed(knots*0.514444);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
         public static Speed FromKnots(int knots)
@@ -637,7 +637,7 @@ namespace UnitsNet
             return new Speed(knots*0.514444);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
         public static Speed FromKnots(long knots)
@@ -645,14 +645,14 @@ namespace UnitsNet
             return new Speed(knots*0.514444);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from Knots of type decimal.
         /// </summary>
         public static Speed FromKnots(decimal knots)
         {
-	        return new Speed(Convert.ToDouble(knots)*0.514444);
+            return new Speed(Convert.ToDouble(knots)*0.514444);
         }
 #endif
 
@@ -664,7 +664,7 @@ namespace UnitsNet
             return new Speed(metersperhour/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerHour.
         /// </summary>
         public static Speed FromMetersPerHour(int metersperhour)
@@ -672,7 +672,7 @@ namespace UnitsNet
             return new Speed(metersperhour/3600);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerHour.
         /// </summary>
         public static Speed FromMetersPerHour(long metersperhour)
@@ -680,14 +680,14 @@ namespace UnitsNet
             return new Speed(metersperhour/3600);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerHour of type decimal.
         /// </summary>
         public static Speed FromMetersPerHour(decimal metersperhour)
         {
-	        return new Speed(Convert.ToDouble(metersperhour)/3600);
+            return new Speed(Convert.ToDouble(metersperhour)/3600);
         }
 #endif
 
@@ -699,7 +699,7 @@ namespace UnitsNet
             return new Speed(metersperminutes/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
         public static Speed FromMetersPerMinutes(int metersperminutes)
@@ -707,7 +707,7 @@ namespace UnitsNet
             return new Speed(metersperminutes/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
         public static Speed FromMetersPerMinutes(long metersperminutes)
@@ -715,14 +715,14 @@ namespace UnitsNet
             return new Speed(metersperminutes/60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromMetersPerMinutes(decimal metersperminutes)
         {
-	        return new Speed(Convert.ToDouble(metersperminutes)/60);
+            return new Speed(Convert.ToDouble(metersperminutes)/60);
         }
 #endif
 
@@ -734,7 +734,7 @@ namespace UnitsNet
             return new Speed(meterspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerSecond.
         /// </summary>
         public static Speed FromMetersPerSecond(int meterspersecond)
@@ -742,7 +742,7 @@ namespace UnitsNet
             return new Speed(meterspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerSecond.
         /// </summary>
         public static Speed FromMetersPerSecond(long meterspersecond)
@@ -750,14 +750,14 @@ namespace UnitsNet
             return new Speed(meterspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MetersPerSecond of type decimal.
         /// </summary>
         public static Speed FromMetersPerSecond(decimal meterspersecond)
         {
-	        return new Speed(Convert.ToDouble(meterspersecond));
+            return new Speed(Convert.ToDouble(meterspersecond));
         }
 #endif
 
@@ -769,7 +769,7 @@ namespace UnitsNet
             return new Speed((micrometersperminutes/60) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
         public static Speed FromMicrometersPerMinutes(int micrometersperminutes)
@@ -777,7 +777,7 @@ namespace UnitsNet
             return new Speed((micrometersperminutes/60) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
         public static Speed FromMicrometersPerMinutes(long micrometersperminutes)
@@ -785,14 +785,14 @@ namespace UnitsNet
             return new Speed((micrometersperminutes/60) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MicrometersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromMicrometersPerMinutes(decimal micrometersperminutes)
         {
-	        return new Speed((Convert.ToDouble(micrometersperminutes)/60) * 1e-6d);
+            return new Speed((Convert.ToDouble(micrometersperminutes)/60) * 1e-6d);
         }
 #endif
 
@@ -804,7 +804,7 @@ namespace UnitsNet
             return new Speed((micrometerspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MicrometersPerSecond.
         /// </summary>
         public static Speed FromMicrometersPerSecond(int micrometerspersecond)
@@ -812,7 +812,7 @@ namespace UnitsNet
             return new Speed((micrometerspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MicrometersPerSecond.
         /// </summary>
         public static Speed FromMicrometersPerSecond(long micrometerspersecond)
@@ -820,14 +820,14 @@ namespace UnitsNet
             return new Speed((micrometerspersecond) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MicrometersPerSecond of type decimal.
         /// </summary>
         public static Speed FromMicrometersPerSecond(decimal micrometerspersecond)
         {
-	        return new Speed((Convert.ToDouble(micrometerspersecond)) * 1e-6d);
+            return new Speed((Convert.ToDouble(micrometerspersecond)) * 1e-6d);
         }
 #endif
 
@@ -839,7 +839,7 @@ namespace UnitsNet
             return new Speed(milesperhour*0.44704);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
         public static Speed FromMilesPerHour(int milesperhour)
@@ -847,7 +847,7 @@ namespace UnitsNet
             return new Speed(milesperhour*0.44704);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
         public static Speed FromMilesPerHour(long milesperhour)
@@ -855,14 +855,14 @@ namespace UnitsNet
             return new Speed(milesperhour*0.44704);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MilesPerHour of type decimal.
         /// </summary>
         public static Speed FromMilesPerHour(decimal milesperhour)
         {
-	        return new Speed(Convert.ToDouble(milesperhour)*0.44704);
+            return new Speed(Convert.ToDouble(milesperhour)*0.44704);
         }
 #endif
 
@@ -874,7 +874,7 @@ namespace UnitsNet
             return new Speed((millimetersperhour/3600) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerHour.
         /// </summary>
         public static Speed FromMillimetersPerHour(int millimetersperhour)
@@ -882,7 +882,7 @@ namespace UnitsNet
             return new Speed((millimetersperhour/3600) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerHour.
         /// </summary>
         public static Speed FromMillimetersPerHour(long millimetersperhour)
@@ -890,14 +890,14 @@ namespace UnitsNet
             return new Speed((millimetersperhour/3600) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerHour of type decimal.
         /// </summary>
         public static Speed FromMillimetersPerHour(decimal millimetersperhour)
         {
-	        return new Speed((Convert.ToDouble(millimetersperhour)/3600) * 1e-3d);
+            return new Speed((Convert.ToDouble(millimetersperhour)/3600) * 1e-3d);
         }
 #endif
 
@@ -909,7 +909,7 @@ namespace UnitsNet
             return new Speed((millimetersperminutes/60) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
         public static Speed FromMillimetersPerMinutes(int millimetersperminutes)
@@ -917,7 +917,7 @@ namespace UnitsNet
             return new Speed((millimetersperminutes/60) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
         public static Speed FromMillimetersPerMinutes(long millimetersperminutes)
@@ -925,14 +925,14 @@ namespace UnitsNet
             return new Speed((millimetersperminutes/60) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromMillimetersPerMinutes(decimal millimetersperminutes)
         {
-	        return new Speed((Convert.ToDouble(millimetersperminutes)/60) * 1e-3d);
+            return new Speed((Convert.ToDouble(millimetersperminutes)/60) * 1e-3d);
         }
 #endif
 
@@ -944,7 +944,7 @@ namespace UnitsNet
             return new Speed((millimeterspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerSecond.
         /// </summary>
         public static Speed FromMillimetersPerSecond(int millimeterspersecond)
@@ -952,7 +952,7 @@ namespace UnitsNet
             return new Speed((millimeterspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerSecond.
         /// </summary>
         public static Speed FromMillimetersPerSecond(long millimeterspersecond)
@@ -960,14 +960,14 @@ namespace UnitsNet
             return new Speed((millimeterspersecond) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from MillimetersPerSecond of type decimal.
         /// </summary>
         public static Speed FromMillimetersPerSecond(decimal millimeterspersecond)
         {
-	        return new Speed((Convert.ToDouble(millimeterspersecond)) * 1e-3d);
+            return new Speed((Convert.ToDouble(millimeterspersecond)) * 1e-3d);
         }
 #endif
 
@@ -979,7 +979,7 @@ namespace UnitsNet
             return new Speed((nanometersperminutes/60) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
         public static Speed FromNanometersPerMinutes(int nanometersperminutes)
@@ -987,7 +987,7 @@ namespace UnitsNet
             return new Speed((nanometersperminutes/60) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
         public static Speed FromNanometersPerMinutes(long nanometersperminutes)
@@ -995,14 +995,14 @@ namespace UnitsNet
             return new Speed((nanometersperminutes/60) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from NanometersPerMinutes of type decimal.
         /// </summary>
         public static Speed FromNanometersPerMinutes(decimal nanometersperminutes)
         {
-	        return new Speed((Convert.ToDouble(nanometersperminutes)/60) * 1e-9d);
+            return new Speed((Convert.ToDouble(nanometersperminutes)/60) * 1e-9d);
         }
 #endif
 
@@ -1014,7 +1014,7 @@ namespace UnitsNet
             return new Speed((nanometerspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from NanometersPerSecond.
         /// </summary>
         public static Speed FromNanometersPerSecond(int nanometerspersecond)
@@ -1022,7 +1022,7 @@ namespace UnitsNet
             return new Speed((nanometerspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Speed from NanometersPerSecond.
         /// </summary>
         public static Speed FromNanometersPerSecond(long nanometerspersecond)
@@ -1030,14 +1030,14 @@ namespace UnitsNet
             return new Speed((nanometerspersecond) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Speed from NanometersPerSecond of type decimal.
         /// </summary>
         public static Speed FromNanometersPerSecond(decimal nanometerspersecond)
         {
-	        return new Speed((Convert.ToDouble(nanometerspersecond)) * 1e-9d);
+            return new Speed((Convert.ToDouble(nanometerspersecond)) * 1e-9d);
         }
 #endif
 
@@ -1058,7 +1058,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerHour.
         /// </summary>
         public static Speed? FromCentimetersPerHour(int? centimetersperhour)
@@ -1073,7 +1073,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerHour.
         /// </summary>
         public static Speed? FromCentimetersPerHour(long? centimetersperhour)
@@ -1088,7 +1088,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from CentimetersPerHour of type decimal.
         /// </summary>
         public static Speed? FromCentimetersPerHour(decimal? centimetersperhour)
@@ -1118,7 +1118,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerMinutes.
         /// </summary>
         public static Speed? FromCentimetersPerMinutes(int? centimetersperminutes)
@@ -1133,7 +1133,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerMinutes.
         /// </summary>
         public static Speed? FromCentimetersPerMinutes(long? centimetersperminutes)
@@ -1148,7 +1148,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from CentimetersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromCentimetersPerMinutes(decimal? centimetersperminutes)
@@ -1178,7 +1178,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerSecond.
         /// </summary>
         public static Speed? FromCentimetersPerSecond(int? centimeterspersecond)
@@ -1193,7 +1193,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerSecond.
         /// </summary>
         public static Speed? FromCentimetersPerSecond(long? centimeterspersecond)
@@ -1208,7 +1208,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from CentimetersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromCentimetersPerSecond(decimal? centimeterspersecond)
@@ -1238,7 +1238,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerMinutes.
         /// </summary>
         public static Speed? FromDecimetersPerMinutes(int? decimetersperminutes)
@@ -1253,7 +1253,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerMinutes.
         /// </summary>
         public static Speed? FromDecimetersPerMinutes(long? decimetersperminutes)
@@ -1268,7 +1268,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from DecimetersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromDecimetersPerMinutes(decimal? decimetersperminutes)
@@ -1298,7 +1298,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerSecond.
         /// </summary>
         public static Speed? FromDecimetersPerSecond(int? decimeterspersecond)
@@ -1313,7 +1313,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerSecond.
         /// </summary>
         public static Speed? FromDecimetersPerSecond(long? decimeterspersecond)
@@ -1328,7 +1328,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from DecimetersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromDecimetersPerSecond(decimal? decimeterspersecond)
@@ -1358,7 +1358,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable FeetPerSecond.
         /// </summary>
         public static Speed? FromFeetPerSecond(int? feetpersecond)
@@ -1373,7 +1373,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable FeetPerSecond.
         /// </summary>
         public static Speed? FromFeetPerSecond(long? feetpersecond)
@@ -1388,7 +1388,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from FeetPerSecond of type decimal.
         /// </summary>
         public static Speed? FromFeetPerSecond(decimal? feetpersecond)
@@ -1418,7 +1418,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable KilometersPerHour.
         /// </summary>
         public static Speed? FromKilometersPerHour(int? kilometersperhour)
@@ -1433,7 +1433,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable KilometersPerHour.
         /// </summary>
         public static Speed? FromKilometersPerHour(long? kilometersperhour)
@@ -1448,7 +1448,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from KilometersPerHour of type decimal.
         /// </summary>
         public static Speed? FromKilometersPerHour(decimal? kilometersperhour)
@@ -1478,7 +1478,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable KilometersPerMinutes.
         /// </summary>
         public static Speed? FromKilometersPerMinutes(int? kilometersperminutes)
@@ -1493,7 +1493,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable KilometersPerMinutes.
         /// </summary>
         public static Speed? FromKilometersPerMinutes(long? kilometersperminutes)
@@ -1508,7 +1508,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from KilometersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromKilometersPerMinutes(decimal? kilometersperminutes)
@@ -1538,7 +1538,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable KilometersPerSecond.
         /// </summary>
         public static Speed? FromKilometersPerSecond(int? kilometerspersecond)
@@ -1553,7 +1553,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable KilometersPerSecond.
         /// </summary>
         public static Speed? FromKilometersPerSecond(long? kilometerspersecond)
@@ -1568,7 +1568,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from KilometersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromKilometersPerSecond(decimal? kilometerspersecond)
@@ -1598,7 +1598,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable Knots.
         /// </summary>
         public static Speed? FromKnots(int? knots)
@@ -1613,7 +1613,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable Knots.
         /// </summary>
         public static Speed? FromKnots(long? knots)
@@ -1628,7 +1628,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from Knots of type decimal.
         /// </summary>
         public static Speed? FromKnots(decimal? knots)
@@ -1658,7 +1658,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MetersPerHour.
         /// </summary>
         public static Speed? FromMetersPerHour(int? metersperhour)
@@ -1673,7 +1673,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MetersPerHour.
         /// </summary>
         public static Speed? FromMetersPerHour(long? metersperhour)
@@ -1688,7 +1688,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MetersPerHour of type decimal.
         /// </summary>
         public static Speed? FromMetersPerHour(decimal? metersperhour)
@@ -1718,7 +1718,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MetersPerMinutes.
         /// </summary>
         public static Speed? FromMetersPerMinutes(int? metersperminutes)
@@ -1733,7 +1733,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MetersPerMinutes.
         /// </summary>
         public static Speed? FromMetersPerMinutes(long? metersperminutes)
@@ -1748,7 +1748,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MetersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromMetersPerMinutes(decimal? metersperminutes)
@@ -1778,7 +1778,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MetersPerSecond.
         /// </summary>
         public static Speed? FromMetersPerSecond(int? meterspersecond)
@@ -1793,7 +1793,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MetersPerSecond.
         /// </summary>
         public static Speed? FromMetersPerSecond(long? meterspersecond)
@@ -1808,7 +1808,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MetersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromMetersPerSecond(decimal? meterspersecond)
@@ -1838,7 +1838,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerMinutes.
         /// </summary>
         public static Speed? FromMicrometersPerMinutes(int? micrometersperminutes)
@@ -1853,7 +1853,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerMinutes.
         /// </summary>
         public static Speed? FromMicrometersPerMinutes(long? micrometersperminutes)
@@ -1868,7 +1868,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MicrometersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromMicrometersPerMinutes(decimal? micrometersperminutes)
@@ -1898,7 +1898,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerSecond.
         /// </summary>
         public static Speed? FromMicrometersPerSecond(int? micrometerspersecond)
@@ -1913,7 +1913,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerSecond.
         /// </summary>
         public static Speed? FromMicrometersPerSecond(long? micrometerspersecond)
@@ -1928,7 +1928,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MicrometersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromMicrometersPerSecond(decimal? micrometerspersecond)
@@ -1958,7 +1958,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MilesPerHour.
         /// </summary>
         public static Speed? FromMilesPerHour(int? milesperhour)
@@ -1973,7 +1973,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MilesPerHour.
         /// </summary>
         public static Speed? FromMilesPerHour(long? milesperhour)
@@ -1988,7 +1988,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MilesPerHour of type decimal.
         /// </summary>
         public static Speed? FromMilesPerHour(decimal? milesperhour)
@@ -2018,7 +2018,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerHour.
         /// </summary>
         public static Speed? FromMillimetersPerHour(int? millimetersperhour)
@@ -2033,7 +2033,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerHour.
         /// </summary>
         public static Speed? FromMillimetersPerHour(long? millimetersperhour)
@@ -2048,7 +2048,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MillimetersPerHour of type decimal.
         /// </summary>
         public static Speed? FromMillimetersPerHour(decimal? millimetersperhour)
@@ -2078,7 +2078,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerMinutes.
         /// </summary>
         public static Speed? FromMillimetersPerMinutes(int? millimetersperminutes)
@@ -2093,7 +2093,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerMinutes.
         /// </summary>
         public static Speed? FromMillimetersPerMinutes(long? millimetersperminutes)
@@ -2108,7 +2108,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MillimetersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromMillimetersPerMinutes(decimal? millimetersperminutes)
@@ -2138,7 +2138,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerSecond.
         /// </summary>
         public static Speed? FromMillimetersPerSecond(int? millimeterspersecond)
@@ -2153,7 +2153,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerSecond.
         /// </summary>
         public static Speed? FromMillimetersPerSecond(long? millimeterspersecond)
@@ -2168,7 +2168,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from MillimetersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromMillimetersPerSecond(decimal? millimeterspersecond)
@@ -2198,7 +2198,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable NanometersPerMinutes.
         /// </summary>
         public static Speed? FromNanometersPerMinutes(int? nanometersperminutes)
@@ -2213,7 +2213,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable NanometersPerMinutes.
         /// </summary>
         public static Speed? FromNanometersPerMinutes(long? nanometersperminutes)
@@ -2228,7 +2228,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from NanometersPerMinutes of type decimal.
         /// </summary>
         public static Speed? FromNanometersPerMinutes(decimal? nanometersperminutes)
@@ -2258,7 +2258,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable NanometersPerSecond.
         /// </summary>
         public static Speed? FromNanometersPerSecond(int? nanometerspersecond)
@@ -2273,7 +2273,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from nullable NanometersPerSecond.
         /// </summary>
         public static Speed? FromNanometersPerSecond(long? nanometerspersecond)
@@ -2288,7 +2288,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Speed from NanometersPerSecond of type decimal.
         /// </summary>
         public static Speed? FromNanometersPerSecond(decimal? nanometerspersecond)

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _kelvins;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Temperature() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Temperature;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static TemperatureUnit BaseUnit
         {
             get { return TemperatureUnit.Kelvin; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new Temperature(degreescelsius + 273.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesCelsius.
         /// </summary>
         public static Temperature FromDegreesCelsius(int degreescelsius)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new Temperature(degreescelsius + 273.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesCelsius.
         /// </summary>
         public static Temperature FromDegreesCelsius(long degreescelsius)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new Temperature(degreescelsius + 273.15);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesCelsius of type decimal.
         /// </summary>
         public static Temperature FromDegreesCelsius(decimal degreescelsius)
         {
-	        return new Temperature(Convert.ToDouble(degreescelsius) + 273.15);
+            return new Temperature(Convert.ToDouble(degreescelsius) + 273.15);
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new Temperature(degreesdelisle*-2/3 + 373.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
         public static Temperature FromDegreesDelisle(int degreesdelisle)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new Temperature(degreesdelisle*-2/3 + 373.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
         public static Temperature FromDegreesDelisle(long degreesdelisle)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new Temperature(degreesdelisle*-2/3 + 373.15);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesDelisle of type decimal.
         /// </summary>
         public static Temperature FromDegreesDelisle(decimal degreesdelisle)
         {
-	        return new Temperature(Convert.ToDouble(degreesdelisle)*-2/3 + 373.15);
+            return new Temperature(Convert.ToDouble(degreesdelisle)*-2/3 + 373.15);
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
         /// </summary>
         public static Temperature FromDegreesFahrenheit(int degreesfahrenheit)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
         /// </summary>
         public static Temperature FromDegreesFahrenheit(long degreesfahrenheit)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesFahrenheit of type decimal.
         /// </summary>
         public static Temperature FromDegreesFahrenheit(decimal degreesfahrenheit)
         {
-	        return new Temperature(Convert.ToDouble(degreesfahrenheit)*5/9 + 459.67*5/9);
+            return new Temperature(Convert.ToDouble(degreesfahrenheit)*5/9 + 459.67*5/9);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new Temperature(degreesnewton*100/33 + 273.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
         public static Temperature FromDegreesNewton(int degreesnewton)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new Temperature(degreesnewton*100/33 + 273.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
         public static Temperature FromDegreesNewton(long degreesnewton)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new Temperature(degreesnewton*100/33 + 273.15);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesNewton of type decimal.
         /// </summary>
         public static Temperature FromDegreesNewton(decimal degreesnewton)
         {
-	        return new Temperature(Convert.ToDouble(degreesnewton)*100/33 + 273.15);
+            return new Temperature(Convert.ToDouble(degreesnewton)*100/33 + 273.15);
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new Temperature(degreesrankine*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesRankine.
         /// </summary>
         public static Temperature FromDegreesRankine(int degreesrankine)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new Temperature(degreesrankine*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesRankine.
         /// </summary>
         public static Temperature FromDegreesRankine(long degreesrankine)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new Temperature(degreesrankine*5/9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesRankine of type decimal.
         /// </summary>
         public static Temperature FromDegreesRankine(decimal degreesrankine)
         {
-	        return new Temperature(Convert.ToDouble(degreesrankine)*5/9);
+            return new Temperature(Convert.ToDouble(degreesrankine)*5/9);
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new Temperature(degreesreaumur*5/4 + 273.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
         public static Temperature FromDegreesReaumur(int degreesreaumur)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new Temperature(degreesreaumur*5/4 + 273.15);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
         public static Temperature FromDegreesReaumur(long degreesreaumur)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new Temperature(degreesreaumur*5/4 + 273.15);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesReaumur of type decimal.
         /// </summary>
         public static Temperature FromDegreesReaumur(decimal degreesreaumur)
         {
-	        return new Temperature(Convert.ToDouble(degreesreaumur)*5/4 + 273.15);
+            return new Temperature(Convert.ToDouble(degreesreaumur)*5/4 + 273.15);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesRoemer.
         /// </summary>
         public static Temperature FromDegreesRoemer(int degreesroemer)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesRoemer.
         /// </summary>
         public static Temperature FromDegreesRoemer(long degreesroemer)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from DegreesRoemer of type decimal.
         /// </summary>
         public static Temperature FromDegreesRoemer(decimal degreesroemer)
         {
-	        return new Temperature(Convert.ToDouble(degreesroemer)*40/21 + 273.15 - 7.5*40d/21);
+            return new Temperature(Convert.ToDouble(degreesroemer)*40/21 + 273.15 - 7.5*40d/21);
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new Temperature(kelvins);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
         public static Temperature FromKelvins(int kelvins)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new Temperature(kelvins);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
         public static Temperature FromKelvins(long kelvins)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new Temperature(kelvins);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Temperature from Kelvins of type decimal.
         /// </summary>
         public static Temperature FromKelvins(decimal kelvins)
         {
-	        return new Temperature(Convert.ToDouble(kelvins));
+            return new Temperature(Convert.ToDouble(kelvins));
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesCelsius.
         /// </summary>
         public static Temperature? FromDegreesCelsius(int? degreescelsius)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesCelsius.
         /// </summary>
         public static Temperature? FromDegreesCelsius(long? degreescelsius)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesCelsius of type decimal.
         /// </summary>
         public static Temperature? FromDegreesCelsius(decimal? degreescelsius)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesDelisle.
         /// </summary>
         public static Temperature? FromDegreesDelisle(int? degreesdelisle)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesDelisle.
         /// </summary>
         public static Temperature? FromDegreesDelisle(long? degreesdelisle)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesDelisle of type decimal.
         /// </summary>
         public static Temperature? FromDegreesDelisle(decimal? degreesdelisle)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesFahrenheit.
         /// </summary>
         public static Temperature? FromDegreesFahrenheit(int? degreesfahrenheit)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesFahrenheit.
         /// </summary>
         public static Temperature? FromDegreesFahrenheit(long? degreesfahrenheit)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesFahrenheit of type decimal.
         /// </summary>
         public static Temperature? FromDegreesFahrenheit(decimal? degreesfahrenheit)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesNewton.
         /// </summary>
         public static Temperature? FromDegreesNewton(int? degreesnewton)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesNewton.
         /// </summary>
         public static Temperature? FromDegreesNewton(long? degreesnewton)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesNewton of type decimal.
         /// </summary>
         public static Temperature? FromDegreesNewton(decimal? degreesnewton)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesRankine.
         /// </summary>
         public static Temperature? FromDegreesRankine(int? degreesrankine)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesRankine.
         /// </summary>
         public static Temperature? FromDegreesRankine(long? degreesrankine)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesRankine of type decimal.
         /// </summary>
         public static Temperature? FromDegreesRankine(decimal? degreesrankine)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesReaumur.
         /// </summary>
         public static Temperature? FromDegreesReaumur(int? degreesreaumur)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesReaumur.
         /// </summary>
         public static Temperature? FromDegreesReaumur(long? degreesreaumur)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesReaumur of type decimal.
         /// </summary>
         public static Temperature? FromDegreesReaumur(decimal? degreesreaumur)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesRoemer.
         /// </summary>
         public static Temperature? FromDegreesRoemer(int? degreesroemer)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable DegreesRoemer.
         /// </summary>
         public static Temperature? FromDegreesRoemer(long? degreesroemer)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from DegreesRoemer of type decimal.
         /// </summary>
         public static Temperature? FromDegreesRoemer(decimal? degreesroemer)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable Kelvins.
         /// </summary>
         public static Temperature? FromKelvins(int? kelvins)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from nullable Kelvins.
         /// </summary>
         public static Temperature? FromKelvins(long? kelvins)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Temperature from Kelvins of type decimal.
         /// </summary>
         public static Temperature? FromKelvins(decimal? kelvins)

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesCelsius.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesCelsius(double degreescelsius)
         {
             return new Temperature(degreescelsius + 273.15);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesDelisle(double degreesdelisle)
         {
             return new Temperature(degreesdelisle*-2/3 + 373.15);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesFahrenheit(double degreesfahrenheit)
         {
             return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesNewton(double degreesnewton)
         {
             return new Temperature(degreesnewton*100/33 + 273.15);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesRankine.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesRankine(double degreesrankine)
         {
             return new Temperature(degreesrankine*5/9);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesReaumur(double degreesreaumur)
         {
             return new Temperature(degreesreaumur*5/4 + 273.15);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesRoemer.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromDegreesRoemer(double degreesroemer)
         {
             return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Temperature FromKelvins(double kelvins)
         {
             return new Temperature(kelvins);

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new Temperature(degreescelsius + 273.15);
         }
 
+		/// <summary>
+        ///     Get Temperature from DegreesCelsius.
+        /// </summary>
+        public static Temperature FromDegreesCelsius(int degreescelsius)
+        {
+            return new Temperature(degreescelsius + 273.15);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesCelsius.
+        /// </summary>
+        public static Temperature FromDegreesCelsius(long degreescelsius)
+        {
+            return new Temperature(degreescelsius + 273.15);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesCelsius of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesCelsius(decimal degreescelsius)
+        {
+	        return new Temperature(Convert.ToDouble(degreescelsius) + 273.15);
+        }
+#endif
+
         /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new Temperature(degreesdelisle*-2/3 + 373.15);
         }
+
+		/// <summary>
+        ///     Get Temperature from DegreesDelisle.
+        /// </summary>
+        public static Temperature FromDegreesDelisle(int degreesdelisle)
+        {
+            return new Temperature(degreesdelisle*-2/3 + 373.15);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesDelisle.
+        /// </summary>
+        public static Temperature FromDegreesDelisle(long degreesdelisle)
+        {
+            return new Temperature(degreesdelisle*-2/3 + 373.15);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesDelisle of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesDelisle(decimal degreesdelisle)
+        {
+	        return new Temperature(Convert.ToDouble(degreesdelisle)*-2/3 + 373.15);
+        }
+#endif
 
         /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
         }
 
+		/// <summary>
+        ///     Get Temperature from DegreesFahrenheit.
+        /// </summary>
+        public static Temperature FromDegreesFahrenheit(int degreesfahrenheit)
+        {
+            return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesFahrenheit.
+        /// </summary>
+        public static Temperature FromDegreesFahrenheit(long degreesfahrenheit)
+        {
+            return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesFahrenheit of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesFahrenheit(decimal degreesfahrenheit)
+        {
+	        return new Temperature(Convert.ToDouble(degreesfahrenheit)*5/9 + 459.67*5/9);
+        }
+#endif
+
         /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new Temperature(degreesnewton*100/33 + 273.15);
         }
+
+		/// <summary>
+        ///     Get Temperature from DegreesNewton.
+        /// </summary>
+        public static Temperature FromDegreesNewton(int degreesnewton)
+        {
+            return new Temperature(degreesnewton*100/33 + 273.15);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesNewton.
+        /// </summary>
+        public static Temperature FromDegreesNewton(long degreesnewton)
+        {
+            return new Temperature(degreesnewton*100/33 + 273.15);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesNewton of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesNewton(decimal degreesnewton)
+        {
+	        return new Temperature(Convert.ToDouble(degreesnewton)*100/33 + 273.15);
+        }
+#endif
 
         /// <summary>
         ///     Get Temperature from DegreesRankine.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new Temperature(degreesrankine*5/9);
         }
 
+		/// <summary>
+        ///     Get Temperature from DegreesRankine.
+        /// </summary>
+        public static Temperature FromDegreesRankine(int degreesrankine)
+        {
+            return new Temperature(degreesrankine*5/9);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesRankine.
+        /// </summary>
+        public static Temperature FromDegreesRankine(long degreesrankine)
+        {
+            return new Temperature(degreesrankine*5/9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesRankine of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesRankine(decimal degreesrankine)
+        {
+	        return new Temperature(Convert.ToDouble(degreesrankine)*5/9);
+        }
+#endif
+
         /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new Temperature(degreesreaumur*5/4 + 273.15);
         }
+
+		/// <summary>
+        ///     Get Temperature from DegreesReaumur.
+        /// </summary>
+        public static Temperature FromDegreesReaumur(int degreesreaumur)
+        {
+            return new Temperature(degreesreaumur*5/4 + 273.15);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesReaumur.
+        /// </summary>
+        public static Temperature FromDegreesReaumur(long degreesreaumur)
+        {
+            return new Temperature(degreesreaumur*5/4 + 273.15);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesReaumur of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesReaumur(decimal degreesreaumur)
+        {
+	        return new Temperature(Convert.ToDouble(degreesreaumur)*5/4 + 273.15);
+        }
+#endif
 
         /// <summary>
         ///     Get Temperature from DegreesRoemer.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
         }
 
+		/// <summary>
+        ///     Get Temperature from DegreesRoemer.
+        /// </summary>
+        public static Temperature FromDegreesRoemer(int degreesroemer)
+        {
+            return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
+        }
+
+		/// <summary>
+        ///     Get Temperature from DegreesRoemer.
+        /// </summary>
+        public static Temperature FromDegreesRoemer(long degreesroemer)
+        {
+            return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from DegreesRoemer of type decimal.
+        /// </summary>
+        public static Temperature FromDegreesRoemer(decimal degreesroemer)
+        {
+	        return new Temperature(Convert.ToDouble(degreesroemer)*40/21 + 273.15 - 7.5*40d/21);
+        }
+#endif
+
         /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new Temperature(kelvins);
         }
 
+		/// <summary>
+        ///     Get Temperature from Kelvins.
+        /// </summary>
+        public static Temperature FromKelvins(int kelvins)
+        {
+            return new Temperature(kelvins);
+        }
+
+		/// <summary>
+        ///     Get Temperature from Kelvins.
+        /// </summary>
+        public static Temperature FromKelvins(long kelvins)
+        {
+            return new Temperature(kelvins);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Temperature from Kelvins of type decimal.
+        /// </summary>
+        public static Temperature FromKelvins(decimal kelvins)
+        {
+	        return new Temperature(Convert.ToDouble(kelvins));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesCelsius.
         /// </summary>
         public static Temperature? FromDegreesCelsius(double? degreescelsius)
+        {
+            if (degreescelsius.HasValue)
+            {
+                return FromDegreesCelsius(degreescelsius.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesCelsius.
+        /// </summary>
+        public static Temperature? FromDegreesCelsius(int? degreescelsius)
+        {
+            if (degreescelsius.HasValue)
+            {
+                return FromDegreesCelsius(degreescelsius.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesCelsius.
+        /// </summary>
+        public static Temperature? FromDegreesCelsius(long? degreescelsius)
+        {
+            if (degreescelsius.HasValue)
+            {
+                return FromDegreesCelsius(degreescelsius.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesCelsius of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesCelsius(decimal? degreescelsius)
         {
             if (degreescelsius.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesDelisle.
+        /// </summary>
+        public static Temperature? FromDegreesDelisle(int? degreesdelisle)
+        {
+            if (degreesdelisle.HasValue)
+            {
+                return FromDegreesDelisle(degreesdelisle.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesDelisle.
+        /// </summary>
+        public static Temperature? FromDegreesDelisle(long? degreesdelisle)
+        {
+            if (degreesdelisle.HasValue)
+            {
+                return FromDegreesDelisle(degreesdelisle.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesDelisle of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesDelisle(decimal? degreesdelisle)
+        {
+            if (degreesdelisle.HasValue)
+            {
+                return FromDegreesDelisle(degreesdelisle.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesFahrenheit.
         /// </summary>
         public static Temperature? FromDegreesFahrenheit(double? degreesfahrenheit)
+        {
+            if (degreesfahrenheit.HasValue)
+            {
+                return FromDegreesFahrenheit(degreesfahrenheit.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesFahrenheit.
+        /// </summary>
+        public static Temperature? FromDegreesFahrenheit(int? degreesfahrenheit)
+        {
+            if (degreesfahrenheit.HasValue)
+            {
+                return FromDegreesFahrenheit(degreesfahrenheit.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesFahrenheit.
+        /// </summary>
+        public static Temperature? FromDegreesFahrenheit(long? degreesfahrenheit)
+        {
+            if (degreesfahrenheit.HasValue)
+            {
+                return FromDegreesFahrenheit(degreesfahrenheit.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesFahrenheit of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesFahrenheit(decimal? degreesfahrenheit)
         {
             if (degreesfahrenheit.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesNewton.
+        /// </summary>
+        public static Temperature? FromDegreesNewton(int? degreesnewton)
+        {
+            if (degreesnewton.HasValue)
+            {
+                return FromDegreesNewton(degreesnewton.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesNewton.
+        /// </summary>
+        public static Temperature? FromDegreesNewton(long? degreesnewton)
+        {
+            if (degreesnewton.HasValue)
+            {
+                return FromDegreesNewton(degreesnewton.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesNewton of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesNewton(decimal? degreesnewton)
+        {
+            if (degreesnewton.HasValue)
+            {
+                return FromDegreesNewton(degreesnewton.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesRankine.
         /// </summary>
         public static Temperature? FromDegreesRankine(double? degreesrankine)
+        {
+            if (degreesrankine.HasValue)
+            {
+                return FromDegreesRankine(degreesrankine.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesRankine.
+        /// </summary>
+        public static Temperature? FromDegreesRankine(int? degreesrankine)
+        {
+            if (degreesrankine.HasValue)
+            {
+                return FromDegreesRankine(degreesrankine.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesRankine.
+        /// </summary>
+        public static Temperature? FromDegreesRankine(long? degreesrankine)
+        {
+            if (degreesrankine.HasValue)
+            {
+                return FromDegreesRankine(degreesrankine.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesRankine of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesRankine(decimal? degreesrankine)
         {
             if (degreesrankine.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesReaumur.
+        /// </summary>
+        public static Temperature? FromDegreesReaumur(int? degreesreaumur)
+        {
+            if (degreesreaumur.HasValue)
+            {
+                return FromDegreesReaumur(degreesreaumur.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesReaumur.
+        /// </summary>
+        public static Temperature? FromDegreesReaumur(long? degreesreaumur)
+        {
+            if (degreesreaumur.HasValue)
+            {
+                return FromDegreesReaumur(degreesreaumur.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesReaumur of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesReaumur(decimal? degreesreaumur)
+        {
+            if (degreesreaumur.HasValue)
+            {
+                return FromDegreesReaumur(degreesreaumur.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesRoemer.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesRoemer.
+        /// </summary>
+        public static Temperature? FromDegreesRoemer(int? degreesroemer)
+        {
+            if (degreesroemer.HasValue)
+            {
+                return FromDegreesRoemer(degreesroemer.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable DegreesRoemer.
+        /// </summary>
+        public static Temperature? FromDegreesRoemer(long? degreesroemer)
+        {
+            if (degreesroemer.HasValue)
+            {
+                return FromDegreesRoemer(degreesroemer.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from DegreesRoemer of type decimal.
+        /// </summary>
+        public static Temperature? FromDegreesRoemer(decimal? degreesroemer)
+        {
+            if (degreesroemer.HasValue)
+            {
+                return FromDegreesRoemer(degreesroemer.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Temperature from nullable Kelvins.
         /// </summary>
         public static Temperature? FromKelvins(double? kelvins)
+        {
+            if (kelvins.HasValue)
+            {
+                return FromKelvins(kelvins.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable Kelvins.
+        /// </summary>
+        public static Temperature? FromKelvins(int? kelvins)
+        {
+            if (kelvins.HasValue)
+            {
+                return FromKelvins(kelvins.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from nullable Kelvins.
+        /// </summary>
+        public static Temperature? FromKelvins(long? kelvins)
+        {
+            if (kelvins.HasValue)
+            {
+                return FromKelvins(kelvins.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Temperature from Kelvins of type decimal.
+        /// </summary>
+        public static Temperature? FromKelvins(decimal? kelvins)
         {
             if (kelvins.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _degreesCelsiusPerSecond;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public TemperatureChangeRate() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.TemperatureChangeRate;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static TemperatureChangeRateUnit BaseUnit
         {
             get { return TemperatureChangeRateUnit.DegreeCelsiusPerSecond; }
@@ -226,7 +226,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(int centidegreescelsiuspersecond)
@@ -234,7 +234,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(long centidegreescelsiuspersecond)
@@ -242,14 +242,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(decimal centidegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(centidegreescelsiuspersecond)) * 1e-2d);
+            return new TemperatureChangeRate((Convert.ToDouble(centidegreescelsiuspersecond)) * 1e-2d);
         }
 #endif
 
@@ -261,7 +261,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(int decadegreescelsiuspersecond)
@@ -269,7 +269,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(long decadegreescelsiuspersecond)
@@ -277,14 +277,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(decimal decadegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(decadegreescelsiuspersecond)) * 1e1d);
+            return new TemperatureChangeRate((Convert.ToDouble(decadegreescelsiuspersecond)) * 1e1d);
         }
 #endif
 
@@ -296,7 +296,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(int decidegreescelsiuspersecond)
@@ -304,7 +304,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(long decidegreescelsiuspersecond)
@@ -312,14 +312,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(decimal decidegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(decidegreescelsiuspersecond)) * 1e-1d);
+            return new TemperatureChangeRate((Convert.ToDouble(decidegreescelsiuspersecond)) * 1e-1d);
         }
 #endif
 
@@ -331,7 +331,7 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiusperminute/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(int degreescelsiusperminute)
@@ -339,7 +339,7 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiusperminute/60);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(long degreescelsiusperminute)
@@ -347,14 +347,14 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiusperminute/60);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(decimal degreescelsiusperminute)
         {
-	        return new TemperatureChangeRate(Convert.ToDouble(degreescelsiusperminute)/60);
+            return new TemperatureChangeRate(Convert.ToDouble(degreescelsiusperminute)/60);
         }
 #endif
 
@@ -366,7 +366,7 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiuspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(int degreescelsiuspersecond)
@@ -374,7 +374,7 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiuspersecond);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(long degreescelsiuspersecond)
@@ -382,14 +382,14 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiuspersecond);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(decimal degreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate(Convert.ToDouble(degreescelsiuspersecond));
+            return new TemperatureChangeRate(Convert.ToDouble(degreescelsiuspersecond));
         }
 #endif
 
@@ -401,7 +401,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(int hectodegreescelsiuspersecond)
@@ -409,7 +409,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(long hectodegreescelsiuspersecond)
@@ -417,14 +417,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(decimal hectodegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(hectodegreescelsiuspersecond)) * 1e2d);
+            return new TemperatureChangeRate((Convert.ToDouble(hectodegreescelsiuspersecond)) * 1e2d);
         }
 #endif
 
@@ -436,7 +436,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(int kilodegreescelsiuspersecond)
@@ -444,7 +444,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(long kilodegreescelsiuspersecond)
@@ -452,14 +452,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(decimal kilodegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(kilodegreescelsiuspersecond)) * 1e3d);
+            return new TemperatureChangeRate((Convert.ToDouble(kilodegreescelsiuspersecond)) * 1e3d);
         }
 #endif
 
@@ -471,7 +471,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(int microdegreescelsiuspersecond)
@@ -479,7 +479,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(long microdegreescelsiuspersecond)
@@ -487,14 +487,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(decimal microdegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(microdegreescelsiuspersecond)) * 1e-6d);
+            return new TemperatureChangeRate((Convert.ToDouble(microdegreescelsiuspersecond)) * 1e-6d);
         }
 #endif
 
@@ -506,7 +506,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(int millidegreescelsiuspersecond)
@@ -514,7 +514,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(long millidegreescelsiuspersecond)
@@ -522,14 +522,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(decimal millidegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(millidegreescelsiuspersecond)) * 1e-3d);
+            return new TemperatureChangeRate((Convert.ToDouble(millidegreescelsiuspersecond)) * 1e-3d);
         }
 #endif
 
@@ -541,7 +541,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(int nanodegreescelsiuspersecond)
@@ -549,7 +549,7 @@ namespace UnitsNet
             return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(long nanodegreescelsiuspersecond)
@@ -557,14 +557,14 @@ namespace UnitsNet
             return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(decimal nanodegreescelsiuspersecond)
         {
-	        return new TemperatureChangeRate((Convert.ToDouble(nanodegreescelsiuspersecond)) * 1e-9d);
+            return new TemperatureChangeRate((Convert.ToDouble(nanodegreescelsiuspersecond)) * 1e-9d);
         }
 #endif
 
@@ -585,7 +585,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(int? centidegreescelsiuspersecond)
@@ -600,7 +600,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(long? centidegreescelsiuspersecond)
@@ -615,7 +615,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from CentidegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(decimal? centidegreescelsiuspersecond)
@@ -645,7 +645,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(int? decadegreescelsiuspersecond)
@@ -660,7 +660,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(long? decadegreescelsiuspersecond)
@@ -675,7 +675,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from DecadegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(decimal? decadegreescelsiuspersecond)
@@ -705,7 +705,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(int? decidegreescelsiuspersecond)
@@ -720,7 +720,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(long? decidegreescelsiuspersecond)
@@ -735,7 +735,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from DecidegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(decimal? decidegreescelsiuspersecond)
@@ -765,7 +765,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(int? degreescelsiusperminute)
@@ -780,7 +780,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(long? degreescelsiusperminute)
@@ -795,7 +795,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from DegreesCelsiusPerMinute of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(decimal? degreescelsiusperminute)
@@ -825,7 +825,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(int? degreescelsiuspersecond)
@@ -840,7 +840,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(long? degreescelsiuspersecond)
@@ -855,7 +855,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from DegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(decimal? degreescelsiuspersecond)
@@ -885,7 +885,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(int? hectodegreescelsiuspersecond)
@@ -900,7 +900,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(long? hectodegreescelsiuspersecond)
@@ -915,7 +915,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from HectodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(decimal? hectodegreescelsiuspersecond)
@@ -945,7 +945,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(int? kilodegreescelsiuspersecond)
@@ -960,7 +960,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(long? kilodegreescelsiuspersecond)
@@ -975,7 +975,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from KilodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(decimal? kilodegreescelsiuspersecond)
@@ -1005,7 +1005,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(int? microdegreescelsiuspersecond)
@@ -1020,7 +1020,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(long? microdegreescelsiuspersecond)
@@ -1035,7 +1035,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from MicrodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(decimal? microdegreescelsiuspersecond)
@@ -1065,7 +1065,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(int? millidegreescelsiuspersecond)
@@ -1080,7 +1080,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(long? millidegreescelsiuspersecond)
@@ -1095,7 +1095,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from MillidegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(decimal? millidegreescelsiuspersecond)
@@ -1125,7 +1125,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(int? nanodegreescelsiuspersecond)
@@ -1140,7 +1140,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(long? nanodegreescelsiuspersecond)
@@ -1155,7 +1155,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureChangeRate from NanodegreesCelsiusPerSecond of type decimal.
         /// </summary>
         public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(decimal? nanodegreescelsiuspersecond)

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -226,6 +226,33 @@ namespace UnitsNet
             return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
         }
 
+		/// <summary>
+        ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(int centidegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(long centidegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(decimal centidegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(centidegreescelsiuspersecond)) * 1e-2d);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
@@ -233,6 +260,33 @@ namespace UnitsNet
         {
             return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
         }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(int decadegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(long decadegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(decimal decadegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(decadegreescelsiuspersecond)) * 1e1d);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
@@ -242,6 +296,33 @@ namespace UnitsNet
             return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(int decidegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(long decidegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(decimal decidegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(decidegreescelsiuspersecond)) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
@@ -249,6 +330,33 @@ namespace UnitsNet
         {
             return new TemperatureChangeRate(degreescelsiusperminute/60);
         }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
+        /// </summary>
+        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(int degreescelsiusperminute)
+        {
+            return new TemperatureChangeRate(degreescelsiusperminute/60);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
+        /// </summary>
+        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(long degreescelsiusperminute)
+        {
+            return new TemperatureChangeRate(degreescelsiusperminute/60);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(decimal degreescelsiusperminute)
+        {
+	        return new TemperatureChangeRate(Convert.ToDouble(degreescelsiusperminute)/60);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
@@ -258,6 +366,33 @@ namespace UnitsNet
             return new TemperatureChangeRate(degreescelsiuspersecond);
         }
 
+		/// <summary>
+        ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(int degreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate(degreescelsiuspersecond);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(long degreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate(degreescelsiuspersecond);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(decimal degreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate(Convert.ToDouble(degreescelsiuspersecond));
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
@@ -265,6 +400,33 @@ namespace UnitsNet
         {
             return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
         }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(int hectodegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(long hectodegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(decimal hectodegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(hectodegreescelsiuspersecond)) * 1e2d);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
@@ -274,6 +436,33 @@ namespace UnitsNet
             return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(int kilodegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(long kilodegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(decimal kilodegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(kilodegreescelsiuspersecond)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
@@ -281,6 +470,33 @@ namespace UnitsNet
         {
             return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(int microdegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(long microdegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(decimal microdegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(microdegreescelsiuspersecond)) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
@@ -290,6 +506,33 @@ namespace UnitsNet
             return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(int millidegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(long millidegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(decimal millidegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(millidegreescelsiuspersecond)) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
@@ -298,12 +541,84 @@ namespace UnitsNet
             return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
         }
 
+		/// <summary>
+        ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(int nanodegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
+        }
+
+		/// <summary>
+        ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(long nanodegreescelsiuspersecond)
+        {
+            return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(decimal nanodegreescelsiuspersecond)
+        {
+	        return new TemperatureChangeRate((Convert.ToDouble(nanodegreescelsiuspersecond)) * 1e-9d);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(double? centidegreescelsiuspersecond)
+        {
+            if (centidegreescelsiuspersecond.HasValue)
+            {
+                return FromCentidegreesCelsiusPerSecond(centidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(int? centidegreescelsiuspersecond)
+        {
+            if (centidegreescelsiuspersecond.HasValue)
+            {
+                return FromCentidegreesCelsiusPerSecond(centidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(long? centidegreescelsiuspersecond)
+        {
+            if (centidegreescelsiuspersecond.HasValue)
+            {
+                return FromCentidegreesCelsiusPerSecond(centidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from CentidegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(decimal? centidegreescelsiuspersecond)
         {
             if (centidegreescelsiuspersecond.HasValue)
             {
@@ -330,10 +645,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(int? decadegreescelsiuspersecond)
+        {
+            if (decadegreescelsiuspersecond.HasValue)
+            {
+                return FromDecadegreesCelsiusPerSecond(decadegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(long? decadegreescelsiuspersecond)
+        {
+            if (decadegreescelsiuspersecond.HasValue)
+            {
+                return FromDecadegreesCelsiusPerSecond(decadegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from DecadegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(decimal? decadegreescelsiuspersecond)
+        {
+            if (decadegreescelsiuspersecond.HasValue)
+            {
+                return FromDecadegreesCelsiusPerSecond(decadegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(double? decidegreescelsiuspersecond)
+        {
+            if (decidegreescelsiuspersecond.HasValue)
+            {
+                return FromDecidegreesCelsiusPerSecond(decidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(int? decidegreescelsiuspersecond)
+        {
+            if (decidegreescelsiuspersecond.HasValue)
+            {
+                return FromDecidegreesCelsiusPerSecond(decidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(long? decidegreescelsiuspersecond)
+        {
+            if (decidegreescelsiuspersecond.HasValue)
+            {
+                return FromDecidegreesCelsiusPerSecond(decidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from DecidegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(decimal? decidegreescelsiuspersecond)
         {
             if (decidegreescelsiuspersecond.HasValue)
             {
@@ -360,10 +765,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
+        /// </summary>
+        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(int? degreescelsiusperminute)
+        {
+            if (degreescelsiusperminute.HasValue)
+            {
+                return FromDegreesCelsiusPerMinute(degreescelsiusperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
+        /// </summary>
+        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(long? degreescelsiusperminute)
+        {
+            if (degreescelsiusperminute.HasValue)
+            {
+                return FromDegreesCelsiusPerMinute(degreescelsiusperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from DegreesCelsiusPerMinute of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(decimal? degreescelsiusperminute)
+        {
+            if (degreescelsiusperminute.HasValue)
+            {
+                return FromDegreesCelsiusPerMinute(degreescelsiusperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(double? degreescelsiuspersecond)
+        {
+            if (degreescelsiuspersecond.HasValue)
+            {
+                return FromDegreesCelsiusPerSecond(degreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(int? degreescelsiuspersecond)
+        {
+            if (degreescelsiuspersecond.HasValue)
+            {
+                return FromDegreesCelsiusPerSecond(degreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(long? degreescelsiuspersecond)
+        {
+            if (degreescelsiuspersecond.HasValue)
+            {
+                return FromDegreesCelsiusPerSecond(degreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from DegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(decimal? degreescelsiuspersecond)
         {
             if (degreescelsiuspersecond.HasValue)
             {
@@ -390,10 +885,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(int? hectodegreescelsiuspersecond)
+        {
+            if (hectodegreescelsiuspersecond.HasValue)
+            {
+                return FromHectodegreesCelsiusPerSecond(hectodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(long? hectodegreescelsiuspersecond)
+        {
+            if (hectodegreescelsiuspersecond.HasValue)
+            {
+                return FromHectodegreesCelsiusPerSecond(hectodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from HectodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(decimal? hectodegreescelsiuspersecond)
+        {
+            if (hectodegreescelsiuspersecond.HasValue)
+            {
+                return FromHectodegreesCelsiusPerSecond(hectodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(double? kilodegreescelsiuspersecond)
+        {
+            if (kilodegreescelsiuspersecond.HasValue)
+            {
+                return FromKilodegreesCelsiusPerSecond(kilodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(int? kilodegreescelsiuspersecond)
+        {
+            if (kilodegreescelsiuspersecond.HasValue)
+            {
+                return FromKilodegreesCelsiusPerSecond(kilodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(long? kilodegreescelsiuspersecond)
+        {
+            if (kilodegreescelsiuspersecond.HasValue)
+            {
+                return FromKilodegreesCelsiusPerSecond(kilodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from KilodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(decimal? kilodegreescelsiuspersecond)
         {
             if (kilodegreescelsiuspersecond.HasValue)
             {
@@ -420,6 +1005,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(int? microdegreescelsiuspersecond)
+        {
+            if (microdegreescelsiuspersecond.HasValue)
+            {
+                return FromMicrodegreesCelsiusPerSecond(microdegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(long? microdegreescelsiuspersecond)
+        {
+            if (microdegreescelsiuspersecond.HasValue)
+            {
+                return FromMicrodegreesCelsiusPerSecond(microdegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from MicrodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(decimal? microdegreescelsiuspersecond)
+        {
+            if (microdegreescelsiuspersecond.HasValue)
+            {
+                return FromMicrodegreesCelsiusPerSecond(microdegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
         /// </summary>
@@ -435,10 +1065,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(int? millidegreescelsiuspersecond)
+        {
+            if (millidegreescelsiuspersecond.HasValue)
+            {
+                return FromMillidegreesCelsiusPerSecond(millidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(long? millidegreescelsiuspersecond)
+        {
+            if (millidegreescelsiuspersecond.HasValue)
+            {
+                return FromMillidegreesCelsiusPerSecond(millidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from MillidegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(decimal? millidegreescelsiuspersecond)
+        {
+            if (millidegreescelsiuspersecond.HasValue)
+            {
+                return FromMillidegreesCelsiusPerSecond(millidegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
         /// </summary>
         public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(double? nanodegreescelsiuspersecond)
+        {
+            if (nanodegreescelsiuspersecond.HasValue)
+            {
+                return FromNanodegreesCelsiusPerSecond(nanodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(int? nanodegreescelsiuspersecond)
+        {
+            if (nanodegreescelsiuspersecond.HasValue)
+            {
+                return FromNanodegreesCelsiusPerSecond(nanodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
+        /// </summary>
+        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(long? nanodegreescelsiuspersecond)
+        {
+            if (nanodegreescelsiuspersecond.HasValue)
+            {
+                return FromNanodegreesCelsiusPerSecond(nanodegreescelsiuspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureChangeRate from NanodegreesCelsiusPerSecond of type decimal.
+        /// </summary>
+        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(decimal? nanodegreescelsiuspersecond)
         {
             if (nanodegreescelsiuspersecond.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -221,6 +221,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(double centidegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
@@ -256,6 +259,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(double decadegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
@@ -291,6 +297,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(double decidegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
@@ -326,6 +335,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(double degreescelsiusperminute)
         {
             return new TemperatureChangeRate(degreescelsiusperminute/60);
@@ -361,6 +373,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(double degreescelsiuspersecond)
         {
             return new TemperatureChangeRate(degreescelsiuspersecond);
@@ -396,6 +411,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(double hectodegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
@@ -431,6 +449,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(double kilodegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
@@ -466,6 +487,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(double microdegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
@@ -501,6 +525,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(double millidegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
@@ -536,6 +563,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(double nanodegreescelsiuspersecond)
         {
             return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -205,6 +205,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesCelsiusDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesCelsiusDelta(double degreescelsiusdelta)
         {
             return new TemperatureDelta(degreescelsiusdelta);
@@ -240,6 +243,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesDelisleDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesDelisleDelta(double degreesdelisledelta)
         {
             return new TemperatureDelta(degreesdelisledelta*-2/3);
@@ -275,6 +281,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheitDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesFahrenheitDelta(double degreesfahrenheitdelta)
         {
             return new TemperatureDelta(degreesfahrenheitdelta*5/9);
@@ -310,6 +319,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesNewtonDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesNewtonDelta(double degreesnewtondelta)
         {
             return new TemperatureDelta(degreesnewtondelta*100/33);
@@ -345,6 +357,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesRankineDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesRankineDelta(double degreesrankinedelta)
         {
             return new TemperatureDelta(degreesrankinedelta*5/9);
@@ -380,6 +395,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesReaumurDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesReaumurDelta(double degreesreaumurdelta)
         {
             return new TemperatureDelta(degreesreaumurdelta*5/4);
@@ -415,6 +433,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesRoemerDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromDegreesRoemerDelta(double degreesroemerdelta)
         {
             return new TemperatureDelta(degreesroemerdelta*40/21);
@@ -450,6 +471,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from KelvinsDelta.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static TemperatureDelta FromKelvinsDelta(double kelvinsdelta)
         {
             return new TemperatureDelta(kelvinsdelta);

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _kelvinsDelta;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public TemperatureDelta() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.TemperatureDelta;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static TemperatureDeltaUnit BaseUnit
         {
             get { return TemperatureDeltaUnit.KelvinDelta; }
@@ -210,7 +210,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreescelsiusdelta);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesCelsiusDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesCelsiusDelta(int degreescelsiusdelta)
@@ -218,7 +218,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreescelsiusdelta);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesCelsiusDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesCelsiusDelta(long degreescelsiusdelta)
@@ -226,14 +226,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreescelsiusdelta);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesCelsiusDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesCelsiusDelta(decimal degreescelsiusdelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreescelsiusdelta));
+            return new TemperatureDelta(Convert.ToDouble(degreescelsiusdelta));
         }
 #endif
 
@@ -245,7 +245,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesdelisledelta*-2/3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesDelisleDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesDelisleDelta(int degreesdelisledelta)
@@ -253,7 +253,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesdelisledelta*-2/3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesDelisleDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesDelisleDelta(long degreesdelisledelta)
@@ -261,14 +261,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreesdelisledelta*-2/3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesDelisleDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesDelisleDelta(decimal degreesdelisledelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreesdelisledelta)*-2/3);
+            return new TemperatureDelta(Convert.ToDouble(degreesdelisledelta)*-2/3);
         }
 #endif
 
@@ -280,7 +280,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesfahrenheitdelta*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheitDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesFahrenheitDelta(int degreesfahrenheitdelta)
@@ -288,7 +288,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesfahrenheitdelta*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheitDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesFahrenheitDelta(long degreesfahrenheitdelta)
@@ -296,14 +296,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreesfahrenheitdelta*5/9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheitDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesFahrenheitDelta(decimal degreesfahrenheitdelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreesfahrenheitdelta)*5/9);
+            return new TemperatureDelta(Convert.ToDouble(degreesfahrenheitdelta)*5/9);
         }
 #endif
 
@@ -315,7 +315,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesnewtondelta*100/33);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesNewtonDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesNewtonDelta(int degreesnewtondelta)
@@ -323,7 +323,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesnewtondelta*100/33);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesNewtonDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesNewtonDelta(long degreesnewtondelta)
@@ -331,14 +331,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreesnewtondelta*100/33);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesNewtonDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesNewtonDelta(decimal degreesnewtondelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreesnewtondelta)*100/33);
+            return new TemperatureDelta(Convert.ToDouble(degreesnewtondelta)*100/33);
         }
 #endif
 
@@ -350,7 +350,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesrankinedelta*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesRankineDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesRankineDelta(int degreesrankinedelta)
@@ -358,7 +358,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesrankinedelta*5/9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesRankineDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesRankineDelta(long degreesrankinedelta)
@@ -366,14 +366,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreesrankinedelta*5/9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesRankineDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesRankineDelta(decimal degreesrankinedelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreesrankinedelta)*5/9);
+            return new TemperatureDelta(Convert.ToDouble(degreesrankinedelta)*5/9);
         }
 #endif
 
@@ -385,7 +385,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesreaumurdelta*5/4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesReaumurDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesReaumurDelta(int degreesreaumurdelta)
@@ -393,7 +393,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesreaumurdelta*5/4);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesReaumurDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesReaumurDelta(long degreesreaumurdelta)
@@ -401,14 +401,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreesreaumurdelta*5/4);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesReaumurDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesReaumurDelta(decimal degreesreaumurdelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreesreaumurdelta)*5/4);
+            return new TemperatureDelta(Convert.ToDouble(degreesreaumurdelta)*5/4);
         }
 #endif
 
@@ -420,7 +420,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesroemerdelta*40/21);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesRoemerDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesRoemerDelta(int degreesroemerdelta)
@@ -428,7 +428,7 @@ namespace UnitsNet
             return new TemperatureDelta(degreesroemerdelta*40/21);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesRoemerDelta.
         /// </summary>
         public static TemperatureDelta FromDegreesRoemerDelta(long degreesroemerdelta)
@@ -436,14 +436,14 @@ namespace UnitsNet
             return new TemperatureDelta(degreesroemerdelta*40/21);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from DegreesRoemerDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromDegreesRoemerDelta(decimal degreesroemerdelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(degreesroemerdelta)*40/21);
+            return new TemperatureDelta(Convert.ToDouble(degreesroemerdelta)*40/21);
         }
 #endif
 
@@ -455,7 +455,7 @@ namespace UnitsNet
             return new TemperatureDelta(kelvinsdelta);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from KelvinsDelta.
         /// </summary>
         public static TemperatureDelta FromKelvinsDelta(int kelvinsdelta)
@@ -463,7 +463,7 @@ namespace UnitsNet
             return new TemperatureDelta(kelvinsdelta);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from KelvinsDelta.
         /// </summary>
         public static TemperatureDelta FromKelvinsDelta(long kelvinsdelta)
@@ -471,14 +471,14 @@ namespace UnitsNet
             return new TemperatureDelta(kelvinsdelta);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get TemperatureDelta from KelvinsDelta of type decimal.
         /// </summary>
         public static TemperatureDelta FromKelvinsDelta(decimal kelvinsdelta)
         {
-	        return new TemperatureDelta(Convert.ToDouble(kelvinsdelta));
+            return new TemperatureDelta(Convert.ToDouble(kelvinsdelta));
         }
 #endif
 
@@ -499,7 +499,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesCelsiusDelta(int? degreescelsiusdelta)
@@ -514,7 +514,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesCelsiusDelta(long? degreescelsiusdelta)
@@ -529,7 +529,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesCelsiusDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesCelsiusDelta(decimal? degreescelsiusdelta)
@@ -559,7 +559,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesDelisleDelta(int? degreesdelisledelta)
@@ -574,7 +574,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesDelisleDelta(long? degreesdelisledelta)
@@ -589,7 +589,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesDelisleDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesDelisleDelta(decimal? degreesdelisledelta)
@@ -619,7 +619,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesFahrenheitDelta(int? degreesfahrenheitdelta)
@@ -634,7 +634,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesFahrenheitDelta(long? degreesfahrenheitdelta)
@@ -649,7 +649,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesFahrenheitDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesFahrenheitDelta(decimal? degreesfahrenheitdelta)
@@ -679,7 +679,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesNewtonDelta(int? degreesnewtondelta)
@@ -694,7 +694,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesNewtonDelta(long? degreesnewtondelta)
@@ -709,7 +709,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesNewtonDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesNewtonDelta(decimal? degreesnewtondelta)
@@ -739,7 +739,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesRankineDelta(int? degreesrankinedelta)
@@ -754,7 +754,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesRankineDelta(long? degreesrankinedelta)
@@ -769,7 +769,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesRankineDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesRankineDelta(decimal? degreesrankinedelta)
@@ -799,7 +799,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesReaumurDelta(int? degreesreaumurdelta)
@@ -814,7 +814,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesReaumurDelta(long? degreesreaumurdelta)
@@ -829,7 +829,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesReaumurDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesReaumurDelta(decimal? degreesreaumurdelta)
@@ -859,7 +859,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesRoemerDelta(int? degreesroemerdelta)
@@ -874,7 +874,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesRoemerDelta(long? degreesroemerdelta)
@@ -889,7 +889,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from DegreesRoemerDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromDegreesRoemerDelta(decimal? degreesroemerdelta)
@@ -919,7 +919,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
         /// </summary>
         public static TemperatureDelta? FromKelvinsDelta(int? kelvinsdelta)
@@ -934,7 +934,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
         /// </summary>
         public static TemperatureDelta? FromKelvinsDelta(long? kelvinsdelta)
@@ -949,7 +949,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable TemperatureDelta from KelvinsDelta of type decimal.
         /// </summary>
         public static TemperatureDelta? FromKelvinsDelta(decimal? kelvinsdelta)

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -210,6 +210,33 @@ namespace UnitsNet
             return new TemperatureDelta(degreescelsiusdelta);
         }
 
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesCelsiusDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesCelsiusDelta(int degreescelsiusdelta)
+        {
+            return new TemperatureDelta(degreescelsiusdelta);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesCelsiusDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesCelsiusDelta(long degreescelsiusdelta)
+        {
+            return new TemperatureDelta(degreescelsiusdelta);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesCelsiusDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesCelsiusDelta(decimal degreescelsiusdelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreescelsiusdelta));
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureDelta from DegreesDelisleDelta.
         /// </summary>
@@ -217,6 +244,33 @@ namespace UnitsNet
         {
             return new TemperatureDelta(degreesdelisledelta*-2/3);
         }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesDelisleDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesDelisleDelta(int degreesdelisledelta)
+        {
+            return new TemperatureDelta(degreesdelisledelta*-2/3);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesDelisleDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesDelisleDelta(long degreesdelisledelta)
+        {
+            return new TemperatureDelta(degreesdelisledelta*-2/3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesDelisleDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesDelisleDelta(decimal degreesdelisledelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreesdelisledelta)*-2/3);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheitDelta.
@@ -226,6 +280,33 @@ namespace UnitsNet
             return new TemperatureDelta(degreesfahrenheitdelta*5/9);
         }
 
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesFahrenheitDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesFahrenheitDelta(int degreesfahrenheitdelta)
+        {
+            return new TemperatureDelta(degreesfahrenheitdelta*5/9);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesFahrenheitDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesFahrenheitDelta(long degreesfahrenheitdelta)
+        {
+            return new TemperatureDelta(degreesfahrenheitdelta*5/9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesFahrenheitDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesFahrenheitDelta(decimal degreesfahrenheitdelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreesfahrenheitdelta)*5/9);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureDelta from DegreesNewtonDelta.
         /// </summary>
@@ -233,6 +314,33 @@ namespace UnitsNet
         {
             return new TemperatureDelta(degreesnewtondelta*100/33);
         }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesNewtonDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesNewtonDelta(int degreesnewtondelta)
+        {
+            return new TemperatureDelta(degreesnewtondelta*100/33);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesNewtonDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesNewtonDelta(long degreesnewtondelta)
+        {
+            return new TemperatureDelta(degreesnewtondelta*100/33);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesNewtonDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesNewtonDelta(decimal degreesnewtondelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreesnewtondelta)*100/33);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesRankineDelta.
@@ -242,6 +350,33 @@ namespace UnitsNet
             return new TemperatureDelta(degreesrankinedelta*5/9);
         }
 
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesRankineDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesRankineDelta(int degreesrankinedelta)
+        {
+            return new TemperatureDelta(degreesrankinedelta*5/9);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesRankineDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesRankineDelta(long degreesrankinedelta)
+        {
+            return new TemperatureDelta(degreesrankinedelta*5/9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesRankineDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesRankineDelta(decimal degreesrankinedelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreesrankinedelta)*5/9);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureDelta from DegreesReaumurDelta.
         /// </summary>
@@ -249,6 +384,33 @@ namespace UnitsNet
         {
             return new TemperatureDelta(degreesreaumurdelta*5/4);
         }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesReaumurDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesReaumurDelta(int degreesreaumurdelta)
+        {
+            return new TemperatureDelta(degreesreaumurdelta*5/4);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesReaumurDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesReaumurDelta(long degreesreaumurdelta)
+        {
+            return new TemperatureDelta(degreesreaumurdelta*5/4);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesReaumurDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesReaumurDelta(decimal degreesreaumurdelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreesreaumurdelta)*5/4);
+        }
+#endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesRoemerDelta.
@@ -258,6 +420,33 @@ namespace UnitsNet
             return new TemperatureDelta(degreesroemerdelta*40/21);
         }
 
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesRoemerDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesRoemerDelta(int degreesroemerdelta)
+        {
+            return new TemperatureDelta(degreesroemerdelta*40/21);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesRoemerDelta.
+        /// </summary>
+        public static TemperatureDelta FromDegreesRoemerDelta(long degreesroemerdelta)
+        {
+            return new TemperatureDelta(degreesroemerdelta*40/21);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from DegreesRoemerDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromDegreesRoemerDelta(decimal degreesroemerdelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(degreesroemerdelta)*40/21);
+        }
+#endif
+
         /// <summary>
         ///     Get TemperatureDelta from KelvinsDelta.
         /// </summary>
@@ -266,12 +455,84 @@ namespace UnitsNet
             return new TemperatureDelta(kelvinsdelta);
         }
 
+		/// <summary>
+        ///     Get TemperatureDelta from KelvinsDelta.
+        /// </summary>
+        public static TemperatureDelta FromKelvinsDelta(int kelvinsdelta)
+        {
+            return new TemperatureDelta(kelvinsdelta);
+        }
+
+		/// <summary>
+        ///     Get TemperatureDelta from KelvinsDelta.
+        /// </summary>
+        public static TemperatureDelta FromKelvinsDelta(long kelvinsdelta)
+        {
+            return new TemperatureDelta(kelvinsdelta);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get TemperatureDelta from KelvinsDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta FromKelvinsDelta(decimal kelvinsdelta)
+        {
+	        return new TemperatureDelta(Convert.ToDouble(kelvinsdelta));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesCelsiusDelta(double? degreescelsiusdelta)
+        {
+            if (degreescelsiusdelta.HasValue)
+            {
+                return FromDegreesCelsiusDelta(degreescelsiusdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesCelsiusDelta(int? degreescelsiusdelta)
+        {
+            if (degreescelsiusdelta.HasValue)
+            {
+                return FromDegreesCelsiusDelta(degreescelsiusdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesCelsiusDelta(long? degreescelsiusdelta)
+        {
+            if (degreescelsiusdelta.HasValue)
+            {
+                return FromDegreesCelsiusDelta(degreescelsiusdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesCelsiusDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesCelsiusDelta(decimal? degreescelsiusdelta)
         {
             if (degreescelsiusdelta.HasValue)
             {
@@ -298,10 +559,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesDelisleDelta(int? degreesdelisledelta)
+        {
+            if (degreesdelisledelta.HasValue)
+            {
+                return FromDegreesDelisleDelta(degreesdelisledelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesDelisleDelta(long? degreesdelisledelta)
+        {
+            if (degreesdelisledelta.HasValue)
+            {
+                return FromDegreesDelisleDelta(degreesdelisledelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesDelisleDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesDelisleDelta(decimal? degreesdelisledelta)
+        {
+            if (degreesdelisledelta.HasValue)
+            {
+                return FromDegreesDelisleDelta(degreesdelisledelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesFahrenheitDelta(double? degreesfahrenheitdelta)
+        {
+            if (degreesfahrenheitdelta.HasValue)
+            {
+                return FromDegreesFahrenheitDelta(degreesfahrenheitdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesFahrenheitDelta(int? degreesfahrenheitdelta)
+        {
+            if (degreesfahrenheitdelta.HasValue)
+            {
+                return FromDegreesFahrenheitDelta(degreesfahrenheitdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesFahrenheitDelta(long? degreesfahrenheitdelta)
+        {
+            if (degreesfahrenheitdelta.HasValue)
+            {
+                return FromDegreesFahrenheitDelta(degreesfahrenheitdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesFahrenheitDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesFahrenheitDelta(decimal? degreesfahrenheitdelta)
         {
             if (degreesfahrenheitdelta.HasValue)
             {
@@ -328,10 +679,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesNewtonDelta(int? degreesnewtondelta)
+        {
+            if (degreesnewtondelta.HasValue)
+            {
+                return FromDegreesNewtonDelta(degreesnewtondelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesNewtonDelta(long? degreesnewtondelta)
+        {
+            if (degreesnewtondelta.HasValue)
+            {
+                return FromDegreesNewtonDelta(degreesnewtondelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesNewtonDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesNewtonDelta(decimal? degreesnewtondelta)
+        {
+            if (degreesnewtondelta.HasValue)
+            {
+                return FromDegreesNewtonDelta(degreesnewtondelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
         /// </summary>
         public static TemperatureDelta? FromDegreesRankineDelta(double? degreesrankinedelta)
+        {
+            if (degreesrankinedelta.HasValue)
+            {
+                return FromDegreesRankineDelta(degreesrankinedelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesRankineDelta(int? degreesrankinedelta)
+        {
+            if (degreesrankinedelta.HasValue)
+            {
+                return FromDegreesRankineDelta(degreesrankinedelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesRankineDelta(long? degreesrankinedelta)
+        {
+            if (degreesrankinedelta.HasValue)
+            {
+                return FromDegreesRankineDelta(degreesrankinedelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesRankineDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesRankineDelta(decimal? degreesrankinedelta)
         {
             if (degreesrankinedelta.HasValue)
             {
@@ -358,6 +799,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesReaumurDelta(int? degreesreaumurdelta)
+        {
+            if (degreesreaumurdelta.HasValue)
+            {
+                return FromDegreesReaumurDelta(degreesreaumurdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesReaumurDelta(long? degreesreaumurdelta)
+        {
+            if (degreesreaumurdelta.HasValue)
+            {
+                return FromDegreesReaumurDelta(degreesreaumurdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesReaumurDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesReaumurDelta(decimal? degreesreaumurdelta)
+        {
+            if (degreesreaumurdelta.HasValue)
+            {
+                return FromDegreesReaumurDelta(degreesreaumurdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
         /// </summary>
@@ -373,10 +859,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesRoemerDelta(int? degreesroemerdelta)
+        {
+            if (degreesroemerdelta.HasValue)
+            {
+                return FromDegreesRoemerDelta(degreesroemerdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesRoemerDelta(long? degreesroemerdelta)
+        {
+            if (degreesroemerdelta.HasValue)
+            {
+                return FromDegreesRoemerDelta(degreesroemerdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from DegreesRoemerDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromDegreesRoemerDelta(decimal? degreesroemerdelta)
+        {
+            if (degreesroemerdelta.HasValue)
+            {
+                return FromDegreesRoemerDelta(degreesroemerdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
         /// </summary>
         public static TemperatureDelta? FromKelvinsDelta(double? kelvinsdelta)
+        {
+            if (kelvinsdelta.HasValue)
+            {
+                return FromKelvinsDelta(kelvinsdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
+        /// </summary>
+        public static TemperatureDelta? FromKelvinsDelta(int? kelvinsdelta)
+        {
+            if (kelvinsdelta.HasValue)
+            {
+                return FromKelvinsDelta(kelvinsdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
+        /// </summary>
+        public static TemperatureDelta? FromKelvinsDelta(long? kelvinsdelta)
+        {
+            if (kelvinsdelta.HasValue)
+            {
+                return FromKelvinsDelta(kelvinsdelta.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable TemperatureDelta from KelvinsDelta of type decimal.
+        /// </summary>
+        public static TemperatureDelta? FromKelvinsDelta(decimal? kelvinsdelta)
         {
             if (kelvinsdelta.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -186,6 +186,33 @@ namespace UnitsNet
             return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
         }
 
+		/// <summary>
+        ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
+        /// </summary>
+        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(int hoursquarefeetdegreesfahrenheitperbtu)
+        {
+            return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
+        }
+
+		/// <summary>
+        ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
+        /// </summary>
+        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(long hoursquarefeetdegreesfahrenheitperbtu)
+        {
+            return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu of type decimal.
+        /// </summary>
+        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(decimal hoursquarefeetdegreesfahrenheitperbtu)
+        {
+	        return new ThermalResistance(Convert.ToDouble(hoursquarefeetdegreesfahrenheitperbtu)*176.1121482159839);
+        }
+#endif
+
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
@@ -193,6 +220,33 @@ namespace UnitsNet
         {
             return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
         }
+
+		/// <summary>
+        ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
+        /// </summary>
+        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(int squarecentimeterhourdegreescelsiusperkilocalorie)
+        {
+            return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
+        }
+
+		/// <summary>
+        ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
+        /// </summary>
+        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(long squarecentimeterhourdegreescelsiusperkilocalorie)
+        {
+            return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie of type decimal.
+        /// </summary>
+        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(decimal squarecentimeterhourdegreescelsiusperkilocalorie)
+        {
+	        return new ThermalResistance(Convert.ToDouble(squarecentimeterhourdegreescelsiusperkilocalorie)*0.0859779507590433);
+        }
+#endif
 
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
@@ -202,6 +256,33 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
         }
 
+		/// <summary>
+        ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
+        /// </summary>
+        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(int squarecentimeterkelvinsperwatt)
+        {
+            return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
+        }
+
+		/// <summary>
+        ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
+        /// </summary>
+        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(long squarecentimeterkelvinsperwatt)
+        {
+            return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt of type decimal.
+        /// </summary>
+        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(decimal squarecentimeterkelvinsperwatt)
+        {
+	        return new ThermalResistance(Convert.ToDouble(squarecentimeterkelvinsperwatt)*0.0999964777570357);
+        }
+#endif
+
         /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
@@ -209,6 +290,33 @@ namespace UnitsNet
         {
             return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
         }
+
+		/// <summary>
+        ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
+        /// </summary>
+        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(int squaremeterdegreescelsiusperwatt)
+        {
+            return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
+        }
+
+		/// <summary>
+        ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
+        /// </summary>
+        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(long squaremeterdegreescelsiusperwatt)
+        {
+            return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt of type decimal.
+        /// </summary>
+        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(decimal squaremeterdegreescelsiusperwatt)
+        {
+	        return new ThermalResistance(Convert.ToDouble(squaremeterdegreescelsiusperwatt)*1000.088056074108);
+        }
+#endif
 
         /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
@@ -218,12 +326,84 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterkelvinsperkilowatt);
         }
 
+		/// <summary>
+        ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
+        /// </summary>
+        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(int squaremeterkelvinsperkilowatt)
+        {
+            return new ThermalResistance(squaremeterkelvinsperkilowatt);
+        }
+
+		/// <summary>
+        ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
+        /// </summary>
+        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(long squaremeterkelvinsperkilowatt)
+        {
+            return new ThermalResistance(squaremeterkelvinsperkilowatt);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt of type decimal.
+        /// </summary>
+        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(decimal squaremeterkelvinsperkilowatt)
+        {
+	        return new ThermalResistance(Convert.ToDouble(squaremeterkelvinsperkilowatt));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
         public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(double? hoursquarefeetdegreesfahrenheitperbtu)
+        {
+            if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
+            {
+                return FromHourSquareFeetDegreesFahrenheitPerBtu(hoursquarefeetdegreesfahrenheitperbtu.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
+        /// </summary>
+        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(int? hoursquarefeetdegreesfahrenheitperbtu)
+        {
+            if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
+            {
+                return FromHourSquareFeetDegreesFahrenheitPerBtu(hoursquarefeetdegreesfahrenheitperbtu.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
+        /// </summary>
+        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(long? hoursquarefeetdegreesfahrenheitperbtu)
+        {
+            if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
+            {
+                return FromHourSquareFeetDegreesFahrenheitPerBtu(hoursquarefeetdegreesfahrenheitperbtu.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu of type decimal.
+        /// </summary>
+        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(decimal? hoursquarefeetdegreesfahrenheitperbtu)
         {
             if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
             {
@@ -250,10 +430,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
+        /// </summary>
+        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(int? squarecentimeterhourdegreescelsiusperkilocalorie)
+        {
+            if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
+            {
+                return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(squarecentimeterhourdegreescelsiusperkilocalorie.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
+        /// </summary>
+        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(long? squarecentimeterhourdegreescelsiusperkilocalorie)
+        {
+            if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
+            {
+                return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(squarecentimeterhourdegreescelsiusperkilocalorie.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie of type decimal.
+        /// </summary>
+        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(decimal? squarecentimeterhourdegreescelsiusperkilocalorie)
+        {
+            if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
+            {
+                return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(squarecentimeterhourdegreescelsiusperkilocalorie.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(double? squarecentimeterkelvinsperwatt)
+        {
+            if (squarecentimeterkelvinsperwatt.HasValue)
+            {
+                return FromSquareCentimeterKelvinsPerWatt(squarecentimeterkelvinsperwatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
+        /// </summary>
+        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(int? squarecentimeterkelvinsperwatt)
+        {
+            if (squarecentimeterkelvinsperwatt.HasValue)
+            {
+                return FromSquareCentimeterKelvinsPerWatt(squarecentimeterkelvinsperwatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
+        /// </summary>
+        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(long? squarecentimeterkelvinsperwatt)
+        {
+            if (squarecentimeterkelvinsperwatt.HasValue)
+            {
+                return FromSquareCentimeterKelvinsPerWatt(squarecentimeterkelvinsperwatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from SquareCentimeterKelvinsPerWatt of type decimal.
+        /// </summary>
+        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(decimal? squarecentimeterkelvinsperwatt)
         {
             if (squarecentimeterkelvinsperwatt.HasValue)
             {
@@ -280,10 +550,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
+        /// </summary>
+        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(int? squaremeterdegreescelsiusperwatt)
+        {
+            if (squaremeterdegreescelsiusperwatt.HasValue)
+            {
+                return FromSquareMeterDegreesCelsiusPerWatt(squaremeterdegreescelsiusperwatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
+        /// </summary>
+        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(long? squaremeterdegreescelsiusperwatt)
+        {
+            if (squaremeterdegreescelsiusperwatt.HasValue)
+            {
+                return FromSquareMeterDegreesCelsiusPerWatt(squaremeterdegreescelsiusperwatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from SquareMeterDegreesCelsiusPerWatt of type decimal.
+        /// </summary>
+        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(decimal? squaremeterdegreescelsiusperwatt)
+        {
+            if (squaremeterdegreescelsiusperwatt.HasValue)
+            {
+                return FromSquareMeterDegreesCelsiusPerWatt(squaremeterdegreescelsiusperwatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
         /// </summary>
         public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(double? squaremeterkelvinsperkilowatt)
+        {
+            if (squaremeterkelvinsperkilowatt.HasValue)
+            {
+                return FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinsperkilowatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
+        /// </summary>
+        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(int? squaremeterkelvinsperkilowatt)
+        {
+            if (squaremeterkelvinsperkilowatt.HasValue)
+            {
+                return FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinsperkilowatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
+        /// </summary>
+        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(long? squaremeterkelvinsperkilowatt)
+        {
+            if (squaremeterkelvinsperkilowatt.HasValue)
+            {
+                return FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinsperkilowatt.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable ThermalResistance from SquareMeterKelvinsPerKilowatt of type decimal.
+        /// </summary>
+        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(decimal? squaremeterkelvinsperkilowatt)
         {
             if (squaremeterkelvinsperkilowatt.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _squareMeterKelvinsPerKilowatt;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public ThermalResistance() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.ThermalResistance;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static ThermalResistanceUnit BaseUnit
         {
             get { return ThermalResistanceUnit.SquareMeterKelvinPerKilowatt; }
@@ -186,7 +186,7 @@ namespace UnitsNet
             return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(int hoursquarefeetdegreesfahrenheitperbtu)
@@ -194,7 +194,7 @@ namespace UnitsNet
             return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(long hoursquarefeetdegreesfahrenheitperbtu)
@@ -202,14 +202,14 @@ namespace UnitsNet
             return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu of type decimal.
         /// </summary>
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(decimal hoursquarefeetdegreesfahrenheitperbtu)
         {
-	        return new ThermalResistance(Convert.ToDouble(hoursquarefeetdegreesfahrenheitperbtu)*176.1121482159839);
+            return new ThermalResistance(Convert.ToDouble(hoursquarefeetdegreesfahrenheitperbtu)*176.1121482159839);
         }
 #endif
 
@@ -221,7 +221,7 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(int squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -229,7 +229,7 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(long squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -237,14 +237,14 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie of type decimal.
         /// </summary>
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(decimal squarecentimeterhourdegreescelsiusperkilocalorie)
         {
-	        return new ThermalResistance(Convert.ToDouble(squarecentimeterhourdegreescelsiusperkilocalorie)*0.0859779507590433);
+            return new ThermalResistance(Convert.ToDouble(squarecentimeterhourdegreescelsiusperkilocalorie)*0.0859779507590433);
         }
 #endif
 
@@ -256,7 +256,7 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
         /// </summary>
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(int squarecentimeterkelvinsperwatt)
@@ -264,7 +264,7 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
         /// </summary>
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(long squarecentimeterkelvinsperwatt)
@@ -272,14 +272,14 @@ namespace UnitsNet
             return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt of type decimal.
         /// </summary>
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(decimal squarecentimeterkelvinsperwatt)
         {
-	        return new ThermalResistance(Convert.ToDouble(squarecentimeterkelvinsperwatt)*0.0999964777570357);
+            return new ThermalResistance(Convert.ToDouble(squarecentimeterkelvinsperwatt)*0.0999964777570357);
         }
 #endif
 
@@ -291,7 +291,7 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(int squaremeterdegreescelsiusperwatt)
@@ -299,7 +299,7 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(long squaremeterdegreescelsiusperwatt)
@@ -307,14 +307,14 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt of type decimal.
         /// </summary>
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(decimal squaremeterdegreescelsiusperwatt)
         {
-	        return new ThermalResistance(Convert.ToDouble(squaremeterdegreescelsiusperwatt)*1000.088056074108);
+            return new ThermalResistance(Convert.ToDouble(squaremeterdegreescelsiusperwatt)*1000.088056074108);
         }
 #endif
 
@@ -326,7 +326,7 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterkelvinsperkilowatt);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
         /// </summary>
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(int squaremeterkelvinsperkilowatt)
@@ -334,7 +334,7 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterkelvinsperkilowatt);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
         /// </summary>
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(long squaremeterkelvinsperkilowatt)
@@ -342,14 +342,14 @@ namespace UnitsNet
             return new ThermalResistance(squaremeterkelvinsperkilowatt);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt of type decimal.
         /// </summary>
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(decimal squaremeterkelvinsperkilowatt)
         {
-	        return new ThermalResistance(Convert.ToDouble(squaremeterkelvinsperkilowatt));
+            return new ThermalResistance(Convert.ToDouble(squaremeterkelvinsperkilowatt));
         }
 #endif
 
@@ -370,7 +370,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
         public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(int? hoursquarefeetdegreesfahrenheitperbtu)
@@ -385,7 +385,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
         public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(long? hoursquarefeetdegreesfahrenheitperbtu)
@@ -400,7 +400,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu of type decimal.
         /// </summary>
         public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(decimal? hoursquarefeetdegreesfahrenheitperbtu)
@@ -430,7 +430,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(int? squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -445,7 +445,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(long? squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -460,7 +460,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie of type decimal.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(decimal? squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -490,7 +490,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(int? squarecentimeterkelvinsperwatt)
@@ -505,7 +505,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(long? squarecentimeterkelvinsperwatt)
@@ -520,7 +520,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from SquareCentimeterKelvinsPerWatt of type decimal.
         /// </summary>
         public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(decimal? squarecentimeterkelvinsperwatt)
@@ -550,7 +550,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
         public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(int? squaremeterdegreescelsiusperwatt)
@@ -565,7 +565,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
         public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(long? squaremeterdegreescelsiusperwatt)
@@ -580,7 +580,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from SquareMeterDegreesCelsiusPerWatt of type decimal.
         /// </summary>
         public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(decimal? squaremeterdegreescelsiusperwatt)
@@ -610,7 +610,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
         /// </summary>
         public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(int? squaremeterkelvinsperkilowatt)
@@ -625,7 +625,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
         /// </summary>
         public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(long? squaremeterkelvinsperkilowatt)
@@ -640,7 +640,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable ThermalResistance from SquareMeterKelvinsPerKilowatt of type decimal.
         /// </summary>
         public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(decimal? squaremeterkelvinsperkilowatt)

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -181,6 +181,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(double hoursquarefeetdegreesfahrenheitperbtu)
         {
             return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
@@ -216,6 +219,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(double squarecentimeterhourdegreescelsiusperkilocalorie)
         {
             return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
@@ -251,6 +257,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(double squarecentimeterkelvinsperwatt)
         {
             return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
@@ -286,6 +295,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(double squaremeterdegreescelsiusperwatt)
         {
             return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
@@ -321,6 +333,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(double squaremeterkelvinsperkilowatt)
         {
             return new ThermalResistance(squaremeterkelvinsperkilowatt);

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -274,6 +274,33 @@ namespace UnitsNet
             return new Torque(kilogramforcecentimeters*0.0980665019960652);
         }
 
+		/// <summary>
+        ///     Get Torque from KilogramForceCentimeters.
+        /// </summary>
+        public static Torque FromKilogramForceCentimeters(int kilogramforcecentimeters)
+        {
+            return new Torque(kilogramforcecentimeters*0.0980665019960652);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilogramForceCentimeters.
+        /// </summary>
+        public static Torque FromKilogramForceCentimeters(long kilogramforcecentimeters)
+        {
+            return new Torque(kilogramforcecentimeters*0.0980665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilogramForceCentimeters of type decimal.
+        /// </summary>
+        public static Torque FromKilogramForceCentimeters(decimal kilogramforcecentimeters)
+        {
+	        return new Torque(Convert.ToDouble(kilogramforcecentimeters)*0.0980665019960652);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
@@ -281,6 +308,33 @@ namespace UnitsNet
         {
             return new Torque(kilogramforcemeters*9.80665019960652);
         }
+
+		/// <summary>
+        ///     Get Torque from KilogramForceMeters.
+        /// </summary>
+        public static Torque FromKilogramForceMeters(int kilogramforcemeters)
+        {
+            return new Torque(kilogramforcemeters*9.80665019960652);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilogramForceMeters.
+        /// </summary>
+        public static Torque FromKilogramForceMeters(long kilogramforcemeters)
+        {
+            return new Torque(kilogramforcemeters*9.80665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilogramForceMeters of type decimal.
+        /// </summary>
+        public static Torque FromKilogramForceMeters(decimal kilogramforcemeters)
+        {
+	        return new Torque(Convert.ToDouble(kilogramforcemeters)*9.80665019960652);
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
@@ -290,6 +344,33 @@ namespace UnitsNet
             return new Torque(kilogramforcemillimeters*0.00980665019960652);
         }
 
+		/// <summary>
+        ///     Get Torque from KilogramForceMillimeters.
+        /// </summary>
+        public static Torque FromKilogramForceMillimeters(int kilogramforcemillimeters)
+        {
+            return new Torque(kilogramforcemillimeters*0.00980665019960652);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilogramForceMillimeters.
+        /// </summary>
+        public static Torque FromKilogramForceMillimeters(long kilogramforcemillimeters)
+        {
+            return new Torque(kilogramforcemillimeters*0.00980665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilogramForceMillimeters of type decimal.
+        /// </summary>
+        public static Torque FromKilogramForceMillimeters(decimal kilogramforcemillimeters)
+        {
+	        return new Torque(Convert.ToDouble(kilogramforcemillimeters)*0.00980665019960652);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
@@ -297,6 +378,33 @@ namespace UnitsNet
         {
             return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Torque from KilonewtonCentimeters.
+        /// </summary>
+        public static Torque FromKilonewtonCentimeters(int kilonewtoncentimeters)
+        {
+            return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilonewtonCentimeters.
+        /// </summary>
+        public static Torque FromKilonewtonCentimeters(long kilonewtoncentimeters)
+        {
+            return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilonewtonCentimeters of type decimal.
+        /// </summary>
+        public static Torque FromKilonewtonCentimeters(decimal kilonewtoncentimeters)
+        {
+	        return new Torque((Convert.ToDouble(kilonewtoncentimeters)*0.01) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from KilonewtonMeters.
@@ -306,6 +414,33 @@ namespace UnitsNet
             return new Torque((kilonewtonmeters) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Torque from KilonewtonMeters.
+        /// </summary>
+        public static Torque FromKilonewtonMeters(int kilonewtonmeters)
+        {
+            return new Torque((kilonewtonmeters) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilonewtonMeters.
+        /// </summary>
+        public static Torque FromKilonewtonMeters(long kilonewtonmeters)
+        {
+            return new Torque((kilonewtonmeters) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilonewtonMeters of type decimal.
+        /// </summary>
+        public static Torque FromKilonewtonMeters(decimal kilonewtonmeters)
+        {
+	        return new Torque((Convert.ToDouble(kilonewtonmeters)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
@@ -313,6 +448,33 @@ namespace UnitsNet
         {
             return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Torque from KilonewtonMillimeters.
+        /// </summary>
+        public static Torque FromKilonewtonMillimeters(int kilonewtonmillimeters)
+        {
+            return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilonewtonMillimeters.
+        /// </summary>
+        public static Torque FromKilonewtonMillimeters(long kilonewtonmillimeters)
+        {
+            return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilonewtonMillimeters of type decimal.
+        /// </summary>
+        public static Torque FromKilonewtonMillimeters(decimal kilonewtonmillimeters)
+        {
+	        return new Torque((Convert.ToDouble(kilonewtonmillimeters)*0.001) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from KilopoundForceFeet.
@@ -322,6 +484,33 @@ namespace UnitsNet
             return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Torque from KilopoundForceFeet.
+        /// </summary>
+        public static Torque FromKilopoundForceFeet(int kilopoundforcefeet)
+        {
+            return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilopoundForceFeet.
+        /// </summary>
+        public static Torque FromKilopoundForceFeet(long kilopoundforcefeet)
+        {
+            return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilopoundForceFeet of type decimal.
+        /// </summary>
+        public static Torque FromKilopoundForceFeet(decimal kilopoundforcefeet)
+        {
+	        return new Torque((Convert.ToDouble(kilopoundforcefeet)*1.3558180656) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
@@ -329,6 +518,33 @@ namespace UnitsNet
         {
             return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Torque from KilopoundForceInches.
+        /// </summary>
+        public static Torque FromKilopoundForceInches(int kilopoundforceinches)
+        {
+            return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Torque from KilopoundForceInches.
+        /// </summary>
+        public static Torque FromKilopoundForceInches(long kilopoundforceinches)
+        {
+            return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from KilopoundForceInches of type decimal.
+        /// </summary>
+        public static Torque FromKilopoundForceInches(decimal kilopoundforceinches)
+        {
+	        return new Torque((Convert.ToDouble(kilopoundforceinches)*0.1129848388) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from NewtonCentimeters.
@@ -338,6 +554,33 @@ namespace UnitsNet
             return new Torque(newtoncentimeters*0.01);
         }
 
+		/// <summary>
+        ///     Get Torque from NewtonCentimeters.
+        /// </summary>
+        public static Torque FromNewtonCentimeters(int newtoncentimeters)
+        {
+            return new Torque(newtoncentimeters*0.01);
+        }
+
+		/// <summary>
+        ///     Get Torque from NewtonCentimeters.
+        /// </summary>
+        public static Torque FromNewtonCentimeters(long newtoncentimeters)
+        {
+            return new Torque(newtoncentimeters*0.01);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from NewtonCentimeters of type decimal.
+        /// </summary>
+        public static Torque FromNewtonCentimeters(decimal newtoncentimeters)
+        {
+	        return new Torque(Convert.ToDouble(newtoncentimeters)*0.01);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
@@ -345,6 +588,33 @@ namespace UnitsNet
         {
             return new Torque(newtonmeters);
         }
+
+		/// <summary>
+        ///     Get Torque from NewtonMeters.
+        /// </summary>
+        public static Torque FromNewtonMeters(int newtonmeters)
+        {
+            return new Torque(newtonmeters);
+        }
+
+		/// <summary>
+        ///     Get Torque from NewtonMeters.
+        /// </summary>
+        public static Torque FromNewtonMeters(long newtonmeters)
+        {
+            return new Torque(newtonmeters);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from NewtonMeters of type decimal.
+        /// </summary>
+        public static Torque FromNewtonMeters(decimal newtonmeters)
+        {
+	        return new Torque(Convert.ToDouble(newtonmeters));
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from NewtonMillimeters.
@@ -354,6 +624,33 @@ namespace UnitsNet
             return new Torque(newtonmillimeters*0.001);
         }
 
+		/// <summary>
+        ///     Get Torque from NewtonMillimeters.
+        /// </summary>
+        public static Torque FromNewtonMillimeters(int newtonmillimeters)
+        {
+            return new Torque(newtonmillimeters*0.001);
+        }
+
+		/// <summary>
+        ///     Get Torque from NewtonMillimeters.
+        /// </summary>
+        public static Torque FromNewtonMillimeters(long newtonmillimeters)
+        {
+            return new Torque(newtonmillimeters*0.001);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from NewtonMillimeters of type decimal.
+        /// </summary>
+        public static Torque FromNewtonMillimeters(decimal newtonmillimeters)
+        {
+	        return new Torque(Convert.ToDouble(newtonmillimeters)*0.001);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
@@ -361,6 +658,33 @@ namespace UnitsNet
         {
             return new Torque(poundforcefeet*1.3558180656);
         }
+
+		/// <summary>
+        ///     Get Torque from PoundForceFeet.
+        /// </summary>
+        public static Torque FromPoundForceFeet(int poundforcefeet)
+        {
+            return new Torque(poundforcefeet*1.3558180656);
+        }
+
+		/// <summary>
+        ///     Get Torque from PoundForceFeet.
+        /// </summary>
+        public static Torque FromPoundForceFeet(long poundforcefeet)
+        {
+            return new Torque(poundforcefeet*1.3558180656);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from PoundForceFeet of type decimal.
+        /// </summary>
+        public static Torque FromPoundForceFeet(decimal poundforcefeet)
+        {
+	        return new Torque(Convert.ToDouble(poundforcefeet)*1.3558180656);
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from PoundForceInches.
@@ -370,6 +694,33 @@ namespace UnitsNet
             return new Torque(poundforceinches*0.1129848388);
         }
 
+		/// <summary>
+        ///     Get Torque from PoundForceInches.
+        /// </summary>
+        public static Torque FromPoundForceInches(int poundforceinches)
+        {
+            return new Torque(poundforceinches*0.1129848388);
+        }
+
+		/// <summary>
+        ///     Get Torque from PoundForceInches.
+        /// </summary>
+        public static Torque FromPoundForceInches(long poundforceinches)
+        {
+            return new Torque(poundforceinches*0.1129848388);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from PoundForceInches of type decimal.
+        /// </summary>
+        public static Torque FromPoundForceInches(decimal poundforceinches)
+        {
+	        return new Torque(Convert.ToDouble(poundforceinches)*0.1129848388);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
@@ -377,6 +728,33 @@ namespace UnitsNet
         {
             return new Torque(tonneforcecentimeters*98.0665019960652);
         }
+
+		/// <summary>
+        ///     Get Torque from TonneForceCentimeters.
+        /// </summary>
+        public static Torque FromTonneForceCentimeters(int tonneforcecentimeters)
+        {
+            return new Torque(tonneforcecentimeters*98.0665019960652);
+        }
+
+		/// <summary>
+        ///     Get Torque from TonneForceCentimeters.
+        /// </summary>
+        public static Torque FromTonneForceCentimeters(long tonneforcecentimeters)
+        {
+            return new Torque(tonneforcecentimeters*98.0665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from TonneForceCentimeters of type decimal.
+        /// </summary>
+        public static Torque FromTonneForceCentimeters(decimal tonneforcecentimeters)
+        {
+	        return new Torque(Convert.ToDouble(tonneforcecentimeters)*98.0665019960652);
+        }
+#endif
 
         /// <summary>
         ///     Get Torque from TonneForceMeters.
@@ -386,6 +764,33 @@ namespace UnitsNet
             return new Torque(tonneforcemeters*9806.65019960653);
         }
 
+		/// <summary>
+        ///     Get Torque from TonneForceMeters.
+        /// </summary>
+        public static Torque FromTonneForceMeters(int tonneforcemeters)
+        {
+            return new Torque(tonneforcemeters*9806.65019960653);
+        }
+
+		/// <summary>
+        ///     Get Torque from TonneForceMeters.
+        /// </summary>
+        public static Torque FromTonneForceMeters(long tonneforcemeters)
+        {
+            return new Torque(tonneforcemeters*9806.65019960653);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from TonneForceMeters of type decimal.
+        /// </summary>
+        public static Torque FromTonneForceMeters(decimal tonneforcemeters)
+        {
+	        return new Torque(Convert.ToDouble(tonneforcemeters)*9806.65019960653);
+        }
+#endif
+
         /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
@@ -394,12 +799,84 @@ namespace UnitsNet
             return new Torque(tonneforcemillimeters*9.80665019960652);
         }
 
+		/// <summary>
+        ///     Get Torque from TonneForceMillimeters.
+        /// </summary>
+        public static Torque FromTonneForceMillimeters(int tonneforcemillimeters)
+        {
+            return new Torque(tonneforcemillimeters*9.80665019960652);
+        }
+
+		/// <summary>
+        ///     Get Torque from TonneForceMillimeters.
+        /// </summary>
+        public static Torque FromTonneForceMillimeters(long tonneforcemillimeters)
+        {
+            return new Torque(tonneforcemillimeters*9.80665019960652);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Torque from TonneForceMillimeters of type decimal.
+        /// </summary>
+        public static Torque FromTonneForceMillimeters(decimal tonneforcemillimeters)
+        {
+	        return new Torque(Convert.ToDouble(tonneforcemillimeters)*9.80665019960652);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Torque from nullable KilogramForceCentimeters.
         /// </summary>
         public static Torque? FromKilogramForceCentimeters(double? kilogramforcecentimeters)
+        {
+            if (kilogramforcecentimeters.HasValue)
+            {
+                return FromKilogramForceCentimeters(kilogramforcecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilogramForceCentimeters.
+        /// </summary>
+        public static Torque? FromKilogramForceCentimeters(int? kilogramforcecentimeters)
+        {
+            if (kilogramforcecentimeters.HasValue)
+            {
+                return FromKilogramForceCentimeters(kilogramforcecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilogramForceCentimeters.
+        /// </summary>
+        public static Torque? FromKilogramForceCentimeters(long? kilogramforcecentimeters)
+        {
+            if (kilogramforcecentimeters.HasValue)
+            {
+                return FromKilogramForceCentimeters(kilogramforcecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilogramForceCentimeters of type decimal.
+        /// </summary>
+        public static Torque? FromKilogramForceCentimeters(decimal? kilogramforcecentimeters)
         {
             if (kilogramforcecentimeters.HasValue)
             {
@@ -426,10 +903,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable KilogramForceMeters.
+        /// </summary>
+        public static Torque? FromKilogramForceMeters(int? kilogramforcemeters)
+        {
+            if (kilogramforcemeters.HasValue)
+            {
+                return FromKilogramForceMeters(kilogramforcemeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilogramForceMeters.
+        /// </summary>
+        public static Torque? FromKilogramForceMeters(long? kilogramforcemeters)
+        {
+            if (kilogramforcemeters.HasValue)
+            {
+                return FromKilogramForceMeters(kilogramforcemeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilogramForceMeters of type decimal.
+        /// </summary>
+        public static Torque? FromKilogramForceMeters(decimal? kilogramforcemeters)
+        {
+            if (kilogramforcemeters.HasValue)
+            {
+                return FromKilogramForceMeters(kilogramforcemeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMillimeters.
         /// </summary>
         public static Torque? FromKilogramForceMillimeters(double? kilogramforcemillimeters)
+        {
+            if (kilogramforcemillimeters.HasValue)
+            {
+                return FromKilogramForceMillimeters(kilogramforcemillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilogramForceMillimeters.
+        /// </summary>
+        public static Torque? FromKilogramForceMillimeters(int? kilogramforcemillimeters)
+        {
+            if (kilogramforcemillimeters.HasValue)
+            {
+                return FromKilogramForceMillimeters(kilogramforcemillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilogramForceMillimeters.
+        /// </summary>
+        public static Torque? FromKilogramForceMillimeters(long? kilogramforcemillimeters)
+        {
+            if (kilogramforcemillimeters.HasValue)
+            {
+                return FromKilogramForceMillimeters(kilogramforcemillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilogramForceMillimeters of type decimal.
+        /// </summary>
+        public static Torque? FromKilogramForceMillimeters(decimal? kilogramforcemillimeters)
         {
             if (kilogramforcemillimeters.HasValue)
             {
@@ -456,10 +1023,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable KilonewtonCentimeters.
+        /// </summary>
+        public static Torque? FromKilonewtonCentimeters(int? kilonewtoncentimeters)
+        {
+            if (kilonewtoncentimeters.HasValue)
+            {
+                return FromKilonewtonCentimeters(kilonewtoncentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilonewtonCentimeters.
+        /// </summary>
+        public static Torque? FromKilonewtonCentimeters(long? kilonewtoncentimeters)
+        {
+            if (kilonewtoncentimeters.HasValue)
+            {
+                return FromKilonewtonCentimeters(kilonewtoncentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilonewtonCentimeters of type decimal.
+        /// </summary>
+        public static Torque? FromKilonewtonCentimeters(decimal? kilonewtoncentimeters)
+        {
+            if (kilonewtoncentimeters.HasValue)
+            {
+                return FromKilonewtonCentimeters(kilonewtoncentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMeters.
         /// </summary>
         public static Torque? FromKilonewtonMeters(double? kilonewtonmeters)
+        {
+            if (kilonewtonmeters.HasValue)
+            {
+                return FromKilonewtonMeters(kilonewtonmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilonewtonMeters.
+        /// </summary>
+        public static Torque? FromKilonewtonMeters(int? kilonewtonmeters)
+        {
+            if (kilonewtonmeters.HasValue)
+            {
+                return FromKilonewtonMeters(kilonewtonmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilonewtonMeters.
+        /// </summary>
+        public static Torque? FromKilonewtonMeters(long? kilonewtonmeters)
+        {
+            if (kilonewtonmeters.HasValue)
+            {
+                return FromKilonewtonMeters(kilonewtonmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilonewtonMeters of type decimal.
+        /// </summary>
+        public static Torque? FromKilonewtonMeters(decimal? kilonewtonmeters)
         {
             if (kilonewtonmeters.HasValue)
             {
@@ -486,10 +1143,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable KilonewtonMillimeters.
+        /// </summary>
+        public static Torque? FromKilonewtonMillimeters(int? kilonewtonmillimeters)
+        {
+            if (kilonewtonmillimeters.HasValue)
+            {
+                return FromKilonewtonMillimeters(kilonewtonmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilonewtonMillimeters.
+        /// </summary>
+        public static Torque? FromKilonewtonMillimeters(long? kilonewtonmillimeters)
+        {
+            if (kilonewtonmillimeters.HasValue)
+            {
+                return FromKilonewtonMillimeters(kilonewtonmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilonewtonMillimeters of type decimal.
+        /// </summary>
+        public static Torque? FromKilonewtonMillimeters(decimal? kilonewtonmillimeters)
+        {
+            if (kilonewtonmillimeters.HasValue)
+            {
+                return FromKilonewtonMillimeters(kilonewtonmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceFeet.
         /// </summary>
         public static Torque? FromKilopoundForceFeet(double? kilopoundforcefeet)
+        {
+            if (kilopoundforcefeet.HasValue)
+            {
+                return FromKilopoundForceFeet(kilopoundforcefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilopoundForceFeet.
+        /// </summary>
+        public static Torque? FromKilopoundForceFeet(int? kilopoundforcefeet)
+        {
+            if (kilopoundforcefeet.HasValue)
+            {
+                return FromKilopoundForceFeet(kilopoundforcefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilopoundForceFeet.
+        /// </summary>
+        public static Torque? FromKilopoundForceFeet(long? kilopoundforcefeet)
+        {
+            if (kilopoundforcefeet.HasValue)
+            {
+                return FromKilopoundForceFeet(kilopoundforcefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilopoundForceFeet of type decimal.
+        /// </summary>
+        public static Torque? FromKilopoundForceFeet(decimal? kilopoundforcefeet)
         {
             if (kilopoundforcefeet.HasValue)
             {
@@ -516,10 +1263,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable KilopoundForceInches.
+        /// </summary>
+        public static Torque? FromKilopoundForceInches(int? kilopoundforceinches)
+        {
+            if (kilopoundforceinches.HasValue)
+            {
+                return FromKilopoundForceInches(kilopoundforceinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable KilopoundForceInches.
+        /// </summary>
+        public static Torque? FromKilopoundForceInches(long? kilopoundforceinches)
+        {
+            if (kilopoundforceinches.HasValue)
+            {
+                return FromKilopoundForceInches(kilopoundforceinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from KilopoundForceInches of type decimal.
+        /// </summary>
+        public static Torque? FromKilopoundForceInches(decimal? kilopoundforceinches)
+        {
+            if (kilopoundforceinches.HasValue)
+            {
+                return FromKilopoundForceInches(kilopoundforceinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable NewtonCentimeters.
         /// </summary>
         public static Torque? FromNewtonCentimeters(double? newtoncentimeters)
+        {
+            if (newtoncentimeters.HasValue)
+            {
+                return FromNewtonCentimeters(newtoncentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable NewtonCentimeters.
+        /// </summary>
+        public static Torque? FromNewtonCentimeters(int? newtoncentimeters)
+        {
+            if (newtoncentimeters.HasValue)
+            {
+                return FromNewtonCentimeters(newtoncentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable NewtonCentimeters.
+        /// </summary>
+        public static Torque? FromNewtonCentimeters(long? newtoncentimeters)
+        {
+            if (newtoncentimeters.HasValue)
+            {
+                return FromNewtonCentimeters(newtoncentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from NewtonCentimeters of type decimal.
+        /// </summary>
+        public static Torque? FromNewtonCentimeters(decimal? newtoncentimeters)
         {
             if (newtoncentimeters.HasValue)
             {
@@ -546,10 +1383,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable NewtonMeters.
+        /// </summary>
+        public static Torque? FromNewtonMeters(int? newtonmeters)
+        {
+            if (newtonmeters.HasValue)
+            {
+                return FromNewtonMeters(newtonmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable NewtonMeters.
+        /// </summary>
+        public static Torque? FromNewtonMeters(long? newtonmeters)
+        {
+            if (newtonmeters.HasValue)
+            {
+                return FromNewtonMeters(newtonmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from NewtonMeters of type decimal.
+        /// </summary>
+        public static Torque? FromNewtonMeters(decimal? newtonmeters)
+        {
+            if (newtonmeters.HasValue)
+            {
+                return FromNewtonMeters(newtonmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable NewtonMillimeters.
         /// </summary>
         public static Torque? FromNewtonMillimeters(double? newtonmillimeters)
+        {
+            if (newtonmillimeters.HasValue)
+            {
+                return FromNewtonMillimeters(newtonmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable NewtonMillimeters.
+        /// </summary>
+        public static Torque? FromNewtonMillimeters(int? newtonmillimeters)
+        {
+            if (newtonmillimeters.HasValue)
+            {
+                return FromNewtonMillimeters(newtonmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable NewtonMillimeters.
+        /// </summary>
+        public static Torque? FromNewtonMillimeters(long? newtonmillimeters)
+        {
+            if (newtonmillimeters.HasValue)
+            {
+                return FromNewtonMillimeters(newtonmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from NewtonMillimeters of type decimal.
+        /// </summary>
+        public static Torque? FromNewtonMillimeters(decimal? newtonmillimeters)
         {
             if (newtonmillimeters.HasValue)
             {
@@ -576,10 +1503,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable PoundForceFeet.
+        /// </summary>
+        public static Torque? FromPoundForceFeet(int? poundforcefeet)
+        {
+            if (poundforcefeet.HasValue)
+            {
+                return FromPoundForceFeet(poundforcefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable PoundForceFeet.
+        /// </summary>
+        public static Torque? FromPoundForceFeet(long? poundforcefeet)
+        {
+            if (poundforcefeet.HasValue)
+            {
+                return FromPoundForceFeet(poundforcefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from PoundForceFeet of type decimal.
+        /// </summary>
+        public static Torque? FromPoundForceFeet(decimal? poundforcefeet)
+        {
+            if (poundforcefeet.HasValue)
+            {
+                return FromPoundForceFeet(poundforcefeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable PoundForceInches.
         /// </summary>
         public static Torque? FromPoundForceInches(double? poundforceinches)
+        {
+            if (poundforceinches.HasValue)
+            {
+                return FromPoundForceInches(poundforceinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable PoundForceInches.
+        /// </summary>
+        public static Torque? FromPoundForceInches(int? poundforceinches)
+        {
+            if (poundforceinches.HasValue)
+            {
+                return FromPoundForceInches(poundforceinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable PoundForceInches.
+        /// </summary>
+        public static Torque? FromPoundForceInches(long? poundforceinches)
+        {
+            if (poundforceinches.HasValue)
+            {
+                return FromPoundForceInches(poundforceinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from PoundForceInches of type decimal.
+        /// </summary>
+        public static Torque? FromPoundForceInches(decimal? poundforceinches)
         {
             if (poundforceinches.HasValue)
             {
@@ -606,6 +1623,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable TonneForceCentimeters.
+        /// </summary>
+        public static Torque? FromTonneForceCentimeters(int? tonneforcecentimeters)
+        {
+            if (tonneforcecentimeters.HasValue)
+            {
+                return FromTonneForceCentimeters(tonneforcecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable TonneForceCentimeters.
+        /// </summary>
+        public static Torque? FromTonneForceCentimeters(long? tonneforcecentimeters)
+        {
+            if (tonneforcecentimeters.HasValue)
+            {
+                return FromTonneForceCentimeters(tonneforcecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from TonneForceCentimeters of type decimal.
+        /// </summary>
+        public static Torque? FromTonneForceCentimeters(decimal? tonneforcecentimeters)
+        {
+            if (tonneforcecentimeters.HasValue)
+            {
+                return FromTonneForceCentimeters(tonneforcecentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable TonneForceMeters.
         /// </summary>
@@ -621,10 +1683,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Torque from nullable TonneForceMeters.
+        /// </summary>
+        public static Torque? FromTonneForceMeters(int? tonneforcemeters)
+        {
+            if (tonneforcemeters.HasValue)
+            {
+                return FromTonneForceMeters(tonneforcemeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable TonneForceMeters.
+        /// </summary>
+        public static Torque? FromTonneForceMeters(long? tonneforcemeters)
+        {
+            if (tonneforcemeters.HasValue)
+            {
+                return FromTonneForceMeters(tonneforcemeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from TonneForceMeters of type decimal.
+        /// </summary>
+        public static Torque? FromTonneForceMeters(decimal? tonneforcemeters)
+        {
+            if (tonneforcemeters.HasValue)
+            {
+                return FromTonneForceMeters(tonneforcemeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Torque from nullable TonneForceMillimeters.
         /// </summary>
         public static Torque? FromTonneForceMillimeters(double? tonneforcemillimeters)
+        {
+            if (tonneforcemillimeters.HasValue)
+            {
+                return FromTonneForceMillimeters(tonneforcemillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable TonneForceMillimeters.
+        /// </summary>
+        public static Torque? FromTonneForceMillimeters(int? tonneforcemillimeters)
+        {
+            if (tonneforcemillimeters.HasValue)
+            {
+                return FromTonneForceMillimeters(tonneforcemillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from nullable TonneForceMillimeters.
+        /// </summary>
+        public static Torque? FromTonneForceMillimeters(long? tonneforcemillimeters)
+        {
+            if (tonneforcemillimeters.HasValue)
+            {
+                return FromTonneForceMillimeters(tonneforcemillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Torque from TonneForceMillimeters of type decimal.
+        /// </summary>
+        public static Torque? FromTonneForceMillimeters(decimal? tonneforcemillimeters)
         {
             if (tonneforcemillimeters.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _newtonMeters;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Torque() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Torque;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static TorqueUnit BaseUnit
         {
             get { return TorqueUnit.NewtonMeter; }
@@ -274,7 +274,7 @@ namespace UnitsNet
             return new Torque(kilogramforcecentimeters*0.0980665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceCentimeters.
         /// </summary>
         public static Torque FromKilogramForceCentimeters(int kilogramforcecentimeters)
@@ -282,7 +282,7 @@ namespace UnitsNet
             return new Torque(kilogramforcecentimeters*0.0980665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceCentimeters.
         /// </summary>
         public static Torque FromKilogramForceCentimeters(long kilogramforcecentimeters)
@@ -290,14 +290,14 @@ namespace UnitsNet
             return new Torque(kilogramforcecentimeters*0.0980665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceCentimeters of type decimal.
         /// </summary>
         public static Torque FromKilogramForceCentimeters(decimal kilogramforcecentimeters)
         {
-	        return new Torque(Convert.ToDouble(kilogramforcecentimeters)*0.0980665019960652);
+            return new Torque(Convert.ToDouble(kilogramforcecentimeters)*0.0980665019960652);
         }
 #endif
 
@@ -309,7 +309,7 @@ namespace UnitsNet
             return new Torque(kilogramforcemeters*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
         public static Torque FromKilogramForceMeters(int kilogramforcemeters)
@@ -317,7 +317,7 @@ namespace UnitsNet
             return new Torque(kilogramforcemeters*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
         public static Torque FromKilogramForceMeters(long kilogramforcemeters)
@@ -325,14 +325,14 @@ namespace UnitsNet
             return new Torque(kilogramforcemeters*9.80665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceMeters of type decimal.
         /// </summary>
         public static Torque FromKilogramForceMeters(decimal kilogramforcemeters)
         {
-	        return new Torque(Convert.ToDouble(kilogramforcemeters)*9.80665019960652);
+            return new Torque(Convert.ToDouble(kilogramforcemeters)*9.80665019960652);
         }
 #endif
 
@@ -344,7 +344,7 @@ namespace UnitsNet
             return new Torque(kilogramforcemillimeters*0.00980665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
         /// </summary>
         public static Torque FromKilogramForceMillimeters(int kilogramforcemillimeters)
@@ -352,7 +352,7 @@ namespace UnitsNet
             return new Torque(kilogramforcemillimeters*0.00980665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
         /// </summary>
         public static Torque FromKilogramForceMillimeters(long kilogramforcemillimeters)
@@ -360,14 +360,14 @@ namespace UnitsNet
             return new Torque(kilogramforcemillimeters*0.00980665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilogramForceMillimeters of type decimal.
         /// </summary>
         public static Torque FromKilogramForceMillimeters(decimal kilogramforcemillimeters)
         {
-	        return new Torque(Convert.ToDouble(kilogramforcemillimeters)*0.00980665019960652);
+            return new Torque(Convert.ToDouble(kilogramforcemillimeters)*0.00980665019960652);
         }
 #endif
 
@@ -379,7 +379,7 @@ namespace UnitsNet
             return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
         public static Torque FromKilonewtonCentimeters(int kilonewtoncentimeters)
@@ -387,7 +387,7 @@ namespace UnitsNet
             return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
         public static Torque FromKilonewtonCentimeters(long kilonewtoncentimeters)
@@ -395,14 +395,14 @@ namespace UnitsNet
             return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonCentimeters of type decimal.
         /// </summary>
         public static Torque FromKilonewtonCentimeters(decimal kilonewtoncentimeters)
         {
-	        return new Torque((Convert.ToDouble(kilonewtoncentimeters)*0.01) * 1e3d);
+            return new Torque((Convert.ToDouble(kilonewtoncentimeters)*0.01) * 1e3d);
         }
 #endif
 
@@ -414,7 +414,7 @@ namespace UnitsNet
             return new Torque((kilonewtonmeters) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonMeters.
         /// </summary>
         public static Torque FromKilonewtonMeters(int kilonewtonmeters)
@@ -422,7 +422,7 @@ namespace UnitsNet
             return new Torque((kilonewtonmeters) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonMeters.
         /// </summary>
         public static Torque FromKilonewtonMeters(long kilonewtonmeters)
@@ -430,14 +430,14 @@ namespace UnitsNet
             return new Torque((kilonewtonmeters) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonMeters of type decimal.
         /// </summary>
         public static Torque FromKilonewtonMeters(decimal kilonewtonmeters)
         {
-	        return new Torque((Convert.ToDouble(kilonewtonmeters)) * 1e3d);
+            return new Torque((Convert.ToDouble(kilonewtonmeters)) * 1e3d);
         }
 #endif
 
@@ -449,7 +449,7 @@ namespace UnitsNet
             return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
         public static Torque FromKilonewtonMillimeters(int kilonewtonmillimeters)
@@ -457,7 +457,7 @@ namespace UnitsNet
             return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
         public static Torque FromKilonewtonMillimeters(long kilonewtonmillimeters)
@@ -465,14 +465,14 @@ namespace UnitsNet
             return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilonewtonMillimeters of type decimal.
         /// </summary>
         public static Torque FromKilonewtonMillimeters(decimal kilonewtonmillimeters)
         {
-	        return new Torque((Convert.ToDouble(kilonewtonmillimeters)*0.001) * 1e3d);
+            return new Torque((Convert.ToDouble(kilonewtonmillimeters)*0.001) * 1e3d);
         }
 #endif
 
@@ -484,7 +484,7 @@ namespace UnitsNet
             return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilopoundForceFeet.
         /// </summary>
         public static Torque FromKilopoundForceFeet(int kilopoundforcefeet)
@@ -492,7 +492,7 @@ namespace UnitsNet
             return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilopoundForceFeet.
         /// </summary>
         public static Torque FromKilopoundForceFeet(long kilopoundforcefeet)
@@ -500,14 +500,14 @@ namespace UnitsNet
             return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilopoundForceFeet of type decimal.
         /// </summary>
         public static Torque FromKilopoundForceFeet(decimal kilopoundforcefeet)
         {
-	        return new Torque((Convert.ToDouble(kilopoundforcefeet)*1.3558180656) * 1e3d);
+            return new Torque((Convert.ToDouble(kilopoundforcefeet)*1.3558180656) * 1e3d);
         }
 #endif
 
@@ -519,7 +519,7 @@ namespace UnitsNet
             return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
         public static Torque FromKilopoundForceInches(int kilopoundforceinches)
@@ -527,7 +527,7 @@ namespace UnitsNet
             return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
         public static Torque FromKilopoundForceInches(long kilopoundforceinches)
@@ -535,14 +535,14 @@ namespace UnitsNet
             return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from KilopoundForceInches of type decimal.
         /// </summary>
         public static Torque FromKilopoundForceInches(decimal kilopoundforceinches)
         {
-	        return new Torque((Convert.ToDouble(kilopoundforceinches)*0.1129848388) * 1e3d);
+            return new Torque((Convert.ToDouble(kilopoundforceinches)*0.1129848388) * 1e3d);
         }
 #endif
 
@@ -554,7 +554,7 @@ namespace UnitsNet
             return new Torque(newtoncentimeters*0.01);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonCentimeters.
         /// </summary>
         public static Torque FromNewtonCentimeters(int newtoncentimeters)
@@ -562,7 +562,7 @@ namespace UnitsNet
             return new Torque(newtoncentimeters*0.01);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonCentimeters.
         /// </summary>
         public static Torque FromNewtonCentimeters(long newtoncentimeters)
@@ -570,14 +570,14 @@ namespace UnitsNet
             return new Torque(newtoncentimeters*0.01);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonCentimeters of type decimal.
         /// </summary>
         public static Torque FromNewtonCentimeters(decimal newtoncentimeters)
         {
-	        return new Torque(Convert.ToDouble(newtoncentimeters)*0.01);
+            return new Torque(Convert.ToDouble(newtoncentimeters)*0.01);
         }
 #endif
 
@@ -589,7 +589,7 @@ namespace UnitsNet
             return new Torque(newtonmeters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
         public static Torque FromNewtonMeters(int newtonmeters)
@@ -597,7 +597,7 @@ namespace UnitsNet
             return new Torque(newtonmeters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
         public static Torque FromNewtonMeters(long newtonmeters)
@@ -605,14 +605,14 @@ namespace UnitsNet
             return new Torque(newtonmeters);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonMeters of type decimal.
         /// </summary>
         public static Torque FromNewtonMeters(decimal newtonmeters)
         {
-	        return new Torque(Convert.ToDouble(newtonmeters));
+            return new Torque(Convert.ToDouble(newtonmeters));
         }
 #endif
 
@@ -624,7 +624,7 @@ namespace UnitsNet
             return new Torque(newtonmillimeters*0.001);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonMillimeters.
         /// </summary>
         public static Torque FromNewtonMillimeters(int newtonmillimeters)
@@ -632,7 +632,7 @@ namespace UnitsNet
             return new Torque(newtonmillimeters*0.001);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonMillimeters.
         /// </summary>
         public static Torque FromNewtonMillimeters(long newtonmillimeters)
@@ -640,14 +640,14 @@ namespace UnitsNet
             return new Torque(newtonmillimeters*0.001);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from NewtonMillimeters of type decimal.
         /// </summary>
         public static Torque FromNewtonMillimeters(decimal newtonmillimeters)
         {
-	        return new Torque(Convert.ToDouble(newtonmillimeters)*0.001);
+            return new Torque(Convert.ToDouble(newtonmillimeters)*0.001);
         }
 #endif
 
@@ -659,7 +659,7 @@ namespace UnitsNet
             return new Torque(poundforcefeet*1.3558180656);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
         public static Torque FromPoundForceFeet(int poundforcefeet)
@@ -667,7 +667,7 @@ namespace UnitsNet
             return new Torque(poundforcefeet*1.3558180656);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
         public static Torque FromPoundForceFeet(long poundforcefeet)
@@ -675,14 +675,14 @@ namespace UnitsNet
             return new Torque(poundforcefeet*1.3558180656);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from PoundForceFeet of type decimal.
         /// </summary>
         public static Torque FromPoundForceFeet(decimal poundforcefeet)
         {
-	        return new Torque(Convert.ToDouble(poundforcefeet)*1.3558180656);
+            return new Torque(Convert.ToDouble(poundforcefeet)*1.3558180656);
         }
 #endif
 
@@ -694,7 +694,7 @@ namespace UnitsNet
             return new Torque(poundforceinches*0.1129848388);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from PoundForceInches.
         /// </summary>
         public static Torque FromPoundForceInches(int poundforceinches)
@@ -702,7 +702,7 @@ namespace UnitsNet
             return new Torque(poundforceinches*0.1129848388);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from PoundForceInches.
         /// </summary>
         public static Torque FromPoundForceInches(long poundforceinches)
@@ -710,14 +710,14 @@ namespace UnitsNet
             return new Torque(poundforceinches*0.1129848388);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from PoundForceInches of type decimal.
         /// </summary>
         public static Torque FromPoundForceInches(decimal poundforceinches)
         {
-	        return new Torque(Convert.ToDouble(poundforceinches)*0.1129848388);
+            return new Torque(Convert.ToDouble(poundforceinches)*0.1129848388);
         }
 #endif
 
@@ -729,7 +729,7 @@ namespace UnitsNet
             return new Torque(tonneforcecentimeters*98.0665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
         public static Torque FromTonneForceCentimeters(int tonneforcecentimeters)
@@ -737,7 +737,7 @@ namespace UnitsNet
             return new Torque(tonneforcecentimeters*98.0665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
         public static Torque FromTonneForceCentimeters(long tonneforcecentimeters)
@@ -745,14 +745,14 @@ namespace UnitsNet
             return new Torque(tonneforcecentimeters*98.0665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceCentimeters of type decimal.
         /// </summary>
         public static Torque FromTonneForceCentimeters(decimal tonneforcecentimeters)
         {
-	        return new Torque(Convert.ToDouble(tonneforcecentimeters)*98.0665019960652);
+            return new Torque(Convert.ToDouble(tonneforcecentimeters)*98.0665019960652);
         }
 #endif
 
@@ -764,7 +764,7 @@ namespace UnitsNet
             return new Torque(tonneforcemeters*9806.65019960653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceMeters.
         /// </summary>
         public static Torque FromTonneForceMeters(int tonneforcemeters)
@@ -772,7 +772,7 @@ namespace UnitsNet
             return new Torque(tonneforcemeters*9806.65019960653);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceMeters.
         /// </summary>
         public static Torque FromTonneForceMeters(long tonneforcemeters)
@@ -780,14 +780,14 @@ namespace UnitsNet
             return new Torque(tonneforcemeters*9806.65019960653);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceMeters of type decimal.
         /// </summary>
         public static Torque FromTonneForceMeters(decimal tonneforcemeters)
         {
-	        return new Torque(Convert.ToDouble(tonneforcemeters)*9806.65019960653);
+            return new Torque(Convert.ToDouble(tonneforcemeters)*9806.65019960653);
         }
 #endif
 
@@ -799,7 +799,7 @@ namespace UnitsNet
             return new Torque(tonneforcemillimeters*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
         public static Torque FromTonneForceMillimeters(int tonneforcemillimeters)
@@ -807,7 +807,7 @@ namespace UnitsNet
             return new Torque(tonneforcemillimeters*9.80665019960652);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
         public static Torque FromTonneForceMillimeters(long tonneforcemillimeters)
@@ -815,14 +815,14 @@ namespace UnitsNet
             return new Torque(tonneforcemillimeters*9.80665019960652);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Torque from TonneForceMillimeters of type decimal.
         /// </summary>
         public static Torque FromTonneForceMillimeters(decimal tonneforcemillimeters)
         {
-	        return new Torque(Convert.ToDouble(tonneforcemillimeters)*9.80665019960652);
+            return new Torque(Convert.ToDouble(tonneforcemillimeters)*9.80665019960652);
         }
 #endif
 
@@ -843,7 +843,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilogramForceCentimeters.
         /// </summary>
         public static Torque? FromKilogramForceCentimeters(int? kilogramforcecentimeters)
@@ -858,7 +858,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilogramForceCentimeters.
         /// </summary>
         public static Torque? FromKilogramForceCentimeters(long? kilogramforcecentimeters)
@@ -873,7 +873,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilogramForceCentimeters of type decimal.
         /// </summary>
         public static Torque? FromKilogramForceCentimeters(decimal? kilogramforcecentimeters)
@@ -903,7 +903,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMeters.
         /// </summary>
         public static Torque? FromKilogramForceMeters(int? kilogramforcemeters)
@@ -918,7 +918,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMeters.
         /// </summary>
         public static Torque? FromKilogramForceMeters(long? kilogramforcemeters)
@@ -933,7 +933,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilogramForceMeters of type decimal.
         /// </summary>
         public static Torque? FromKilogramForceMeters(decimal? kilogramforcemeters)
@@ -963,7 +963,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMillimeters.
         /// </summary>
         public static Torque? FromKilogramForceMillimeters(int? kilogramforcemillimeters)
@@ -978,7 +978,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMillimeters.
         /// </summary>
         public static Torque? FromKilogramForceMillimeters(long? kilogramforcemillimeters)
@@ -993,7 +993,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilogramForceMillimeters of type decimal.
         /// </summary>
         public static Torque? FromKilogramForceMillimeters(decimal? kilogramforcemillimeters)
@@ -1023,7 +1023,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilonewtonCentimeters.
         /// </summary>
         public static Torque? FromKilonewtonCentimeters(int? kilonewtoncentimeters)
@@ -1038,7 +1038,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilonewtonCentimeters.
         /// </summary>
         public static Torque? FromKilonewtonCentimeters(long? kilonewtoncentimeters)
@@ -1053,7 +1053,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilonewtonCentimeters of type decimal.
         /// </summary>
         public static Torque? FromKilonewtonCentimeters(decimal? kilonewtoncentimeters)
@@ -1083,7 +1083,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMeters.
         /// </summary>
         public static Torque? FromKilonewtonMeters(int? kilonewtonmeters)
@@ -1098,7 +1098,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMeters.
         /// </summary>
         public static Torque? FromKilonewtonMeters(long? kilonewtonmeters)
@@ -1113,7 +1113,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilonewtonMeters of type decimal.
         /// </summary>
         public static Torque? FromKilonewtonMeters(decimal? kilonewtonmeters)
@@ -1143,7 +1143,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMillimeters.
         /// </summary>
         public static Torque? FromKilonewtonMillimeters(int? kilonewtonmillimeters)
@@ -1158,7 +1158,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMillimeters.
         /// </summary>
         public static Torque? FromKilonewtonMillimeters(long? kilonewtonmillimeters)
@@ -1173,7 +1173,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilonewtonMillimeters of type decimal.
         /// </summary>
         public static Torque? FromKilonewtonMillimeters(decimal? kilonewtonmillimeters)
@@ -1203,7 +1203,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceFeet.
         /// </summary>
         public static Torque? FromKilopoundForceFeet(int? kilopoundforcefeet)
@@ -1218,7 +1218,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceFeet.
         /// </summary>
         public static Torque? FromKilopoundForceFeet(long? kilopoundforcefeet)
@@ -1233,7 +1233,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilopoundForceFeet of type decimal.
         /// </summary>
         public static Torque? FromKilopoundForceFeet(decimal? kilopoundforcefeet)
@@ -1263,7 +1263,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceInches.
         /// </summary>
         public static Torque? FromKilopoundForceInches(int? kilopoundforceinches)
@@ -1278,7 +1278,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceInches.
         /// </summary>
         public static Torque? FromKilopoundForceInches(long? kilopoundforceinches)
@@ -1293,7 +1293,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from KilopoundForceInches of type decimal.
         /// </summary>
         public static Torque? FromKilopoundForceInches(decimal? kilopoundforceinches)
@@ -1323,7 +1323,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable NewtonCentimeters.
         /// </summary>
         public static Torque? FromNewtonCentimeters(int? newtoncentimeters)
@@ -1338,7 +1338,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable NewtonCentimeters.
         /// </summary>
         public static Torque? FromNewtonCentimeters(long? newtoncentimeters)
@@ -1353,7 +1353,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from NewtonCentimeters of type decimal.
         /// </summary>
         public static Torque? FromNewtonCentimeters(decimal? newtoncentimeters)
@@ -1383,7 +1383,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable NewtonMeters.
         /// </summary>
         public static Torque? FromNewtonMeters(int? newtonmeters)
@@ -1398,7 +1398,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable NewtonMeters.
         /// </summary>
         public static Torque? FromNewtonMeters(long? newtonmeters)
@@ -1413,7 +1413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from NewtonMeters of type decimal.
         /// </summary>
         public static Torque? FromNewtonMeters(decimal? newtonmeters)
@@ -1443,7 +1443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable NewtonMillimeters.
         /// </summary>
         public static Torque? FromNewtonMillimeters(int? newtonmillimeters)
@@ -1458,7 +1458,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable NewtonMillimeters.
         /// </summary>
         public static Torque? FromNewtonMillimeters(long? newtonmillimeters)
@@ -1473,7 +1473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from NewtonMillimeters of type decimal.
         /// </summary>
         public static Torque? FromNewtonMillimeters(decimal? newtonmillimeters)
@@ -1503,7 +1503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable PoundForceFeet.
         /// </summary>
         public static Torque? FromPoundForceFeet(int? poundforcefeet)
@@ -1518,7 +1518,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable PoundForceFeet.
         /// </summary>
         public static Torque? FromPoundForceFeet(long? poundforcefeet)
@@ -1533,7 +1533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from PoundForceFeet of type decimal.
         /// </summary>
         public static Torque? FromPoundForceFeet(decimal? poundforcefeet)
@@ -1563,7 +1563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable PoundForceInches.
         /// </summary>
         public static Torque? FromPoundForceInches(int? poundforceinches)
@@ -1578,7 +1578,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable PoundForceInches.
         /// </summary>
         public static Torque? FromPoundForceInches(long? poundforceinches)
@@ -1593,7 +1593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from PoundForceInches of type decimal.
         /// </summary>
         public static Torque? FromPoundForceInches(decimal? poundforceinches)
@@ -1623,7 +1623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable TonneForceCentimeters.
         /// </summary>
         public static Torque? FromTonneForceCentimeters(int? tonneforcecentimeters)
@@ -1638,7 +1638,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable TonneForceCentimeters.
         /// </summary>
         public static Torque? FromTonneForceCentimeters(long? tonneforcecentimeters)
@@ -1653,7 +1653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from TonneForceCentimeters of type decimal.
         /// </summary>
         public static Torque? FromTonneForceCentimeters(decimal? tonneforcecentimeters)
@@ -1683,7 +1683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable TonneForceMeters.
         /// </summary>
         public static Torque? FromTonneForceMeters(int? tonneforcemeters)
@@ -1698,7 +1698,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable TonneForceMeters.
         /// </summary>
         public static Torque? FromTonneForceMeters(long? tonneforcemeters)
@@ -1713,7 +1713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from TonneForceMeters of type decimal.
         /// </summary>
         public static Torque? FromTonneForceMeters(decimal? tonneforcemeters)
@@ -1743,7 +1743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable TonneForceMillimeters.
         /// </summary>
         public static Torque? FromTonneForceMillimeters(int? tonneforcemillimeters)
@@ -1758,7 +1758,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from nullable TonneForceMillimeters.
         /// </summary>
         public static Torque? FromTonneForceMillimeters(long? tonneforcemillimeters)
@@ -1773,7 +1773,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Torque from TonneForceMillimeters of type decimal.
         /// </summary>
         public static Torque? FromTonneForceMillimeters(decimal? tonneforcemillimeters)

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -269,6 +269,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilogramForceCentimeters(double kilogramforcecentimeters)
         {
             return new Torque(kilogramforcecentimeters*0.0980665019960652);
@@ -304,6 +307,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilogramForceMeters(double kilogramforcemeters)
         {
             return new Torque(kilogramforcemeters*9.80665019960652);
@@ -339,6 +345,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilogramForceMillimeters(double kilogramforcemillimeters)
         {
             return new Torque(kilogramforcemillimeters*0.00980665019960652);
@@ -374,6 +383,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilonewtonCentimeters(double kilonewtoncentimeters)
         {
             return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
@@ -409,6 +421,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilonewtonMeters(double kilonewtonmeters)
         {
             return new Torque((kilonewtonmeters) * 1e3d);
@@ -444,6 +459,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilonewtonMillimeters(double kilonewtonmillimeters)
         {
             return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
@@ -479,6 +497,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilopoundForceFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilopoundForceFeet(double kilopoundforcefeet)
         {
             return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
@@ -514,6 +535,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromKilopoundForceInches(double kilopoundforceinches)
         {
             return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
@@ -549,6 +573,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromNewtonCentimeters(double newtoncentimeters)
         {
             return new Torque(newtoncentimeters*0.01);
@@ -584,6 +611,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromNewtonMeters(double newtonmeters)
         {
             return new Torque(newtonmeters);
@@ -619,6 +649,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromNewtonMillimeters(double newtonmillimeters)
         {
             return new Torque(newtonmillimeters*0.001);
@@ -654,6 +687,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromPoundForceFeet(double poundforcefeet)
         {
             return new Torque(poundforcefeet*1.3558180656);
@@ -689,6 +725,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from PoundForceInches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromPoundForceInches(double poundforceinches)
         {
             return new Torque(poundforceinches*0.1129848388);
@@ -724,6 +763,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromTonneForceCentimeters(double tonneforcecentimeters)
         {
             return new Torque(tonneforcecentimeters*98.0665019960652);
@@ -759,6 +801,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromTonneForceMeters(double tonneforcemeters)
         {
             return new Torque(tonneforcemeters*9806.65019960653);
@@ -794,6 +839,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Torque FromTonneForceMillimeters(double tonneforcemillimeters)
         {
             return new Torque(tonneforcemillimeters*9.80665019960652);

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -149,6 +149,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get VitaminA from InternationalUnits.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static VitaminA FromInternationalUnits(double internationalunits)
         {
             return new VitaminA(internationalunits);

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _internationalUnits;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public VitaminA() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.VitaminA;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static VitaminAUnit BaseUnit
         {
             get { return VitaminAUnit.InternationalUnit; }
@@ -154,7 +154,7 @@ namespace UnitsNet
             return new VitaminA(internationalunits);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get VitaminA from InternationalUnits.
         /// </summary>
         public static VitaminA FromInternationalUnits(int internationalunits)
@@ -162,7 +162,7 @@ namespace UnitsNet
             return new VitaminA(internationalunits);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get VitaminA from InternationalUnits.
         /// </summary>
         public static VitaminA FromInternationalUnits(long internationalunits)
@@ -170,14 +170,14 @@ namespace UnitsNet
             return new VitaminA(internationalunits);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get VitaminA from InternationalUnits of type decimal.
         /// </summary>
         public static VitaminA FromInternationalUnits(decimal internationalunits)
         {
-	        return new VitaminA(Convert.ToDouble(internationalunits));
+            return new VitaminA(Convert.ToDouble(internationalunits));
         }
 #endif
 
@@ -198,7 +198,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable VitaminA from nullable InternationalUnits.
         /// </summary>
         public static VitaminA? FromInternationalUnits(int? internationalunits)
@@ -213,7 +213,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable VitaminA from nullable InternationalUnits.
         /// </summary>
         public static VitaminA? FromInternationalUnits(long? internationalunits)
@@ -228,7 +228,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable VitaminA from InternationalUnits of type decimal.
         /// </summary>
         public static VitaminA? FromInternationalUnits(decimal? internationalunits)

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -154,12 +154,84 @@ namespace UnitsNet
             return new VitaminA(internationalunits);
         }
 
+		/// <summary>
+        ///     Get VitaminA from InternationalUnits.
+        /// </summary>
+        public static VitaminA FromInternationalUnits(int internationalunits)
+        {
+            return new VitaminA(internationalunits);
+        }
+
+		/// <summary>
+        ///     Get VitaminA from InternationalUnits.
+        /// </summary>
+        public static VitaminA FromInternationalUnits(long internationalunits)
+        {
+            return new VitaminA(internationalunits);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get VitaminA from InternationalUnits of type decimal.
+        /// </summary>
+        public static VitaminA FromInternationalUnits(decimal internationalunits)
+        {
+	        return new VitaminA(Convert.ToDouble(internationalunits));
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable VitaminA from nullable InternationalUnits.
         /// </summary>
         public static VitaminA? FromInternationalUnits(double? internationalunits)
+        {
+            if (internationalunits.HasValue)
+            {
+                return FromInternationalUnits(internationalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable VitaminA from nullable InternationalUnits.
+        /// </summary>
+        public static VitaminA? FromInternationalUnits(int? internationalunits)
+        {
+            if (internationalunits.HasValue)
+            {
+                return FromInternationalUnits(internationalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable VitaminA from nullable InternationalUnits.
+        /// </summary>
+        public static VitaminA? FromInternationalUnits(long? internationalunits)
+        {
+            if (internationalunits.HasValue)
+            {
+                return FromInternationalUnits(internationalunits.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable VitaminA from InternationalUnits of type decimal.
+        /// </summary>
+        public static VitaminA? FromInternationalUnits(decimal? internationalunits)
         {
             if (internationalunits.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -74,7 +74,7 @@ namespace UnitsNet
         /// </summary>
         private readonly double _cubicMeters;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public Volume() : this(0)
         {
@@ -111,14 +111,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.Volume;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static VolumeUnit BaseUnit
         {
             get { return VolumeUnit.CubicMeter; }
@@ -484,7 +484,7 @@ namespace UnitsNet
             return new Volume(autablespoons*2e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from AuTablespoons.
         /// </summary>
         public static Volume FromAuTablespoons(int autablespoons)
@@ -492,7 +492,7 @@ namespace UnitsNet
             return new Volume(autablespoons*2e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from AuTablespoons.
         /// </summary>
         public static Volume FromAuTablespoons(long autablespoons)
@@ -500,14 +500,14 @@ namespace UnitsNet
             return new Volume(autablespoons*2e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from AuTablespoons of type decimal.
         /// </summary>
         public static Volume FromAuTablespoons(decimal autablespoons)
         {
-	        return new Volume(Convert.ToDouble(autablespoons)*2e-5);
+            return new Volume(Convert.ToDouble(autablespoons)*2e-5);
         }
 #endif
 
@@ -519,7 +519,7 @@ namespace UnitsNet
             return new Volume((centiliters/1e3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
         public static Volume FromCentiliters(int centiliters)
@@ -527,7 +527,7 @@ namespace UnitsNet
             return new Volume((centiliters/1e3) * 1e-2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
         public static Volume FromCentiliters(long centiliters)
@@ -535,14 +535,14 @@ namespace UnitsNet
             return new Volume((centiliters/1e3) * 1e-2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Centiliters of type decimal.
         /// </summary>
         public static Volume FromCentiliters(decimal centiliters)
         {
-	        return new Volume((Convert.ToDouble(centiliters)/1e3) * 1e-2d);
+            return new Volume((Convert.ToDouble(centiliters)/1e3) * 1e-2d);
         }
 #endif
 
@@ -554,7 +554,7 @@ namespace UnitsNet
             return new Volume(cubiccentimeters/1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicCentimeters.
         /// </summary>
         public static Volume FromCubicCentimeters(int cubiccentimeters)
@@ -562,7 +562,7 @@ namespace UnitsNet
             return new Volume(cubiccentimeters/1e6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicCentimeters.
         /// </summary>
         public static Volume FromCubicCentimeters(long cubiccentimeters)
@@ -570,14 +570,14 @@ namespace UnitsNet
             return new Volume(cubiccentimeters/1e6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicCentimeters of type decimal.
         /// </summary>
         public static Volume FromCubicCentimeters(decimal cubiccentimeters)
         {
-	        return new Volume(Convert.ToDouble(cubiccentimeters)/1e6);
+            return new Volume(Convert.ToDouble(cubiccentimeters)/1e6);
         }
 #endif
 
@@ -589,7 +589,7 @@ namespace UnitsNet
             return new Volume(cubicdecimeters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
         public static Volume FromCubicDecimeters(int cubicdecimeters)
@@ -597,7 +597,7 @@ namespace UnitsNet
             return new Volume(cubicdecimeters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
         public static Volume FromCubicDecimeters(long cubicdecimeters)
@@ -605,14 +605,14 @@ namespace UnitsNet
             return new Volume(cubicdecimeters/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicDecimeters of type decimal.
         /// </summary>
         public static Volume FromCubicDecimeters(decimal cubicdecimeters)
         {
-	        return new Volume(Convert.ToDouble(cubicdecimeters)/1e3);
+            return new Volume(Convert.ToDouble(cubicdecimeters)/1e3);
         }
 #endif
 
@@ -624,7 +624,7 @@ namespace UnitsNet
             return new Volume(cubicfeet*0.0283168);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicFeet.
         /// </summary>
         public static Volume FromCubicFeet(int cubicfeet)
@@ -632,7 +632,7 @@ namespace UnitsNet
             return new Volume(cubicfeet*0.0283168);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicFeet.
         /// </summary>
         public static Volume FromCubicFeet(long cubicfeet)
@@ -640,14 +640,14 @@ namespace UnitsNet
             return new Volume(cubicfeet*0.0283168);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicFeet of type decimal.
         /// </summary>
         public static Volume FromCubicFeet(decimal cubicfeet)
         {
-	        return new Volume(Convert.ToDouble(cubicfeet)*0.0283168);
+            return new Volume(Convert.ToDouble(cubicfeet)*0.0283168);
         }
 #endif
 
@@ -659,7 +659,7 @@ namespace UnitsNet
             return new Volume(cubicinches*1.6387*1e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
         public static Volume FromCubicInches(int cubicinches)
@@ -667,7 +667,7 @@ namespace UnitsNet
             return new Volume(cubicinches*1.6387*1e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
         public static Volume FromCubicInches(long cubicinches)
@@ -675,14 +675,14 @@ namespace UnitsNet
             return new Volume(cubicinches*1.6387*1e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicInches of type decimal.
         /// </summary>
         public static Volume FromCubicInches(decimal cubicinches)
         {
-	        return new Volume(Convert.ToDouble(cubicinches)*1.6387*1e-5);
+            return new Volume(Convert.ToDouble(cubicinches)*1.6387*1e-5);
         }
 #endif
 
@@ -694,7 +694,7 @@ namespace UnitsNet
             return new Volume(cubickilometers*1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicKilometers.
         /// </summary>
         public static Volume FromCubicKilometers(int cubickilometers)
@@ -702,7 +702,7 @@ namespace UnitsNet
             return new Volume(cubickilometers*1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicKilometers.
         /// </summary>
         public static Volume FromCubicKilometers(long cubickilometers)
@@ -710,14 +710,14 @@ namespace UnitsNet
             return new Volume(cubickilometers*1e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicKilometers of type decimal.
         /// </summary>
         public static Volume FromCubicKilometers(decimal cubickilometers)
         {
-	        return new Volume(Convert.ToDouble(cubickilometers)*1e9);
+            return new Volume(Convert.ToDouble(cubickilometers)*1e9);
         }
 #endif
 
@@ -729,7 +729,7 @@ namespace UnitsNet
             return new Volume(cubicmeters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
         public static Volume FromCubicMeters(int cubicmeters)
@@ -737,7 +737,7 @@ namespace UnitsNet
             return new Volume(cubicmeters);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
         public static Volume FromCubicMeters(long cubicmeters)
@@ -745,14 +745,14 @@ namespace UnitsNet
             return new Volume(cubicmeters);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMeters of type decimal.
         /// </summary>
         public static Volume FromCubicMeters(decimal cubicmeters)
         {
-	        return new Volume(Convert.ToDouble(cubicmeters));
+            return new Volume(Convert.ToDouble(cubicmeters));
         }
 #endif
 
@@ -764,7 +764,7 @@ namespace UnitsNet
             return new Volume(cubicmicrometers/1e18);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMicrometers.
         /// </summary>
         public static Volume FromCubicMicrometers(int cubicmicrometers)
@@ -772,7 +772,7 @@ namespace UnitsNet
             return new Volume(cubicmicrometers/1e18);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMicrometers.
         /// </summary>
         public static Volume FromCubicMicrometers(long cubicmicrometers)
@@ -780,14 +780,14 @@ namespace UnitsNet
             return new Volume(cubicmicrometers/1e18);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMicrometers of type decimal.
         /// </summary>
         public static Volume FromCubicMicrometers(decimal cubicmicrometers)
         {
-	        return new Volume(Convert.ToDouble(cubicmicrometers)/1e18);
+            return new Volume(Convert.ToDouble(cubicmicrometers)/1e18);
         }
 #endif
 
@@ -799,7 +799,7 @@ namespace UnitsNet
             return new Volume(cubicmiles*4.16818183*1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
         public static Volume FromCubicMiles(int cubicmiles)
@@ -807,7 +807,7 @@ namespace UnitsNet
             return new Volume(cubicmiles*4.16818183*1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
         public static Volume FromCubicMiles(long cubicmiles)
@@ -815,14 +815,14 @@ namespace UnitsNet
             return new Volume(cubicmiles*4.16818183*1e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMiles of type decimal.
         /// </summary>
         public static Volume FromCubicMiles(decimal cubicmiles)
         {
-	        return new Volume(Convert.ToDouble(cubicmiles)*4.16818183*1e9);
+            return new Volume(Convert.ToDouble(cubicmiles)*4.16818183*1e9);
         }
 #endif
 
@@ -834,7 +834,7 @@ namespace UnitsNet
             return new Volume(cubicmillimeters/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMillimeters.
         /// </summary>
         public static Volume FromCubicMillimeters(int cubicmillimeters)
@@ -842,7 +842,7 @@ namespace UnitsNet
             return new Volume(cubicmillimeters/1e9);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMillimeters.
         /// </summary>
         public static Volume FromCubicMillimeters(long cubicmillimeters)
@@ -850,14 +850,14 @@ namespace UnitsNet
             return new Volume(cubicmillimeters/1e9);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicMillimeters of type decimal.
         /// </summary>
         public static Volume FromCubicMillimeters(decimal cubicmillimeters)
         {
-	        return new Volume(Convert.ToDouble(cubicmillimeters)/1e9);
+            return new Volume(Convert.ToDouble(cubicmillimeters)/1e9);
         }
 #endif
 
@@ -869,7 +869,7 @@ namespace UnitsNet
             return new Volume(cubicyards*0.764554858);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
         public static Volume FromCubicYards(int cubicyards)
@@ -877,7 +877,7 @@ namespace UnitsNet
             return new Volume(cubicyards*0.764554858);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
         public static Volume FromCubicYards(long cubicyards)
@@ -885,14 +885,14 @@ namespace UnitsNet
             return new Volume(cubicyards*0.764554858);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from CubicYards of type decimal.
         /// </summary>
         public static Volume FromCubicYards(decimal cubicyards)
         {
-	        return new Volume(Convert.ToDouble(cubicyards)*0.764554858);
+            return new Volume(Convert.ToDouble(cubicyards)*0.764554858);
         }
 #endif
 
@@ -904,7 +904,7 @@ namespace UnitsNet
             return new Volume((deciliters/1e3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Deciliters.
         /// </summary>
         public static Volume FromDeciliters(int deciliters)
@@ -912,7 +912,7 @@ namespace UnitsNet
             return new Volume((deciliters/1e3) * 1e-1d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Deciliters.
         /// </summary>
         public static Volume FromDeciliters(long deciliters)
@@ -920,14 +920,14 @@ namespace UnitsNet
             return new Volume((deciliters/1e3) * 1e-1d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Deciliters of type decimal.
         /// </summary>
         public static Volume FromDeciliters(decimal deciliters)
         {
-	        return new Volume((Convert.ToDouble(deciliters)/1e3) * 1e-1d);
+            return new Volume((Convert.ToDouble(deciliters)/1e3) * 1e-1d);
         }
 #endif
 
@@ -939,7 +939,7 @@ namespace UnitsNet
             return new Volume((hectocubicfeet*0.0283168) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
         public static Volume FromHectocubicFeet(int hectocubicfeet)
@@ -947,7 +947,7 @@ namespace UnitsNet
             return new Volume((hectocubicfeet*0.0283168) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
         public static Volume FromHectocubicFeet(long hectocubicfeet)
@@ -955,14 +955,14 @@ namespace UnitsNet
             return new Volume((hectocubicfeet*0.0283168) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from HectocubicFeet of type decimal.
         /// </summary>
         public static Volume FromHectocubicFeet(decimal hectocubicfeet)
         {
-	        return new Volume((Convert.ToDouble(hectocubicfeet)*0.0283168) * 1e2d);
+            return new Volume((Convert.ToDouble(hectocubicfeet)*0.0283168) * 1e2d);
         }
 #endif
 
@@ -974,7 +974,7 @@ namespace UnitsNet
             return new Volume((hectocubicmeters) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from HectocubicMeters.
         /// </summary>
         public static Volume FromHectocubicMeters(int hectocubicmeters)
@@ -982,7 +982,7 @@ namespace UnitsNet
             return new Volume((hectocubicmeters) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from HectocubicMeters.
         /// </summary>
         public static Volume FromHectocubicMeters(long hectocubicmeters)
@@ -990,14 +990,14 @@ namespace UnitsNet
             return new Volume((hectocubicmeters) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from HectocubicMeters of type decimal.
         /// </summary>
         public static Volume FromHectocubicMeters(decimal hectocubicmeters)
         {
-	        return new Volume((Convert.ToDouble(hectocubicmeters)) * 1e2d);
+            return new Volume((Convert.ToDouble(hectocubicmeters)) * 1e2d);
         }
 #endif
 
@@ -1009,7 +1009,7 @@ namespace UnitsNet
             return new Volume((hectoliters/1e3) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
         public static Volume FromHectoliters(int hectoliters)
@@ -1017,7 +1017,7 @@ namespace UnitsNet
             return new Volume((hectoliters/1e3) * 1e2d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
         public static Volume FromHectoliters(long hectoliters)
@@ -1025,14 +1025,14 @@ namespace UnitsNet
             return new Volume((hectoliters/1e3) * 1e2d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Hectoliters of type decimal.
         /// </summary>
         public static Volume FromHectoliters(decimal hectoliters)
         {
-	        return new Volume((Convert.ToDouble(hectoliters)/1e3) * 1e2d);
+            return new Volume((Convert.ToDouble(hectoliters)/1e3) * 1e2d);
         }
 #endif
 
@@ -1044,7 +1044,7 @@ namespace UnitsNet
             return new Volume(imperialbeerbarrels*0.16365924);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
         public static Volume FromImperialBeerBarrels(int imperialbeerbarrels)
@@ -1052,7 +1052,7 @@ namespace UnitsNet
             return new Volume(imperialbeerbarrels*0.16365924);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
         public static Volume FromImperialBeerBarrels(long imperialbeerbarrels)
@@ -1060,14 +1060,14 @@ namespace UnitsNet
             return new Volume(imperialbeerbarrels*0.16365924);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialBeerBarrels of type decimal.
         /// </summary>
         public static Volume FromImperialBeerBarrels(decimal imperialbeerbarrels)
         {
-	        return new Volume(Convert.ToDouble(imperialbeerbarrels)*0.16365924);
+            return new Volume(Convert.ToDouble(imperialbeerbarrels)*0.16365924);
         }
 #endif
 
@@ -1079,7 +1079,7 @@ namespace UnitsNet
             return new Volume(imperialgallons*0.00454609000000181429905810072407);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
         public static Volume FromImperialGallons(int imperialgallons)
@@ -1087,7 +1087,7 @@ namespace UnitsNet
             return new Volume(imperialgallons*0.00454609000000181429905810072407);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
         public static Volume FromImperialGallons(long imperialgallons)
@@ -1095,14 +1095,14 @@ namespace UnitsNet
             return new Volume(imperialgallons*0.00454609000000181429905810072407);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialGallons of type decimal.
         /// </summary>
         public static Volume FromImperialGallons(decimal imperialgallons)
         {
-	        return new Volume(Convert.ToDouble(imperialgallons)*0.00454609000000181429905810072407);
+            return new Volume(Convert.ToDouble(imperialgallons)*0.00454609000000181429905810072407);
         }
 #endif
 
@@ -1114,7 +1114,7 @@ namespace UnitsNet
             return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialOunces.
         /// </summary>
         public static Volume FromImperialOunces(int imperialounces)
@@ -1122,7 +1122,7 @@ namespace UnitsNet
             return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialOunces.
         /// </summary>
         public static Volume FromImperialOunces(long imperialounces)
@@ -1130,14 +1130,14 @@ namespace UnitsNet
             return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from ImperialOunces of type decimal.
         /// </summary>
         public static Volume FromImperialOunces(decimal imperialounces)
         {
-	        return new Volume(Convert.ToDouble(imperialounces)*2.8413062499962901241875439064617e-5);
+            return new Volume(Convert.ToDouble(imperialounces)*2.8413062499962901241875439064617e-5);
         }
 #endif
 
@@ -1149,7 +1149,7 @@ namespace UnitsNet
             return new Volume((kilocubicfeet*0.0283168) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
         public static Volume FromKilocubicFeet(int kilocubicfeet)
@@ -1157,7 +1157,7 @@ namespace UnitsNet
             return new Volume((kilocubicfeet*0.0283168) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
         public static Volume FromKilocubicFeet(long kilocubicfeet)
@@ -1165,14 +1165,14 @@ namespace UnitsNet
             return new Volume((kilocubicfeet*0.0283168) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilocubicFeet of type decimal.
         /// </summary>
         public static Volume FromKilocubicFeet(decimal kilocubicfeet)
         {
-	        return new Volume((Convert.ToDouble(kilocubicfeet)*0.0283168) * 1e3d);
+            return new Volume((Convert.ToDouble(kilocubicfeet)*0.0283168) * 1e3d);
         }
 #endif
 
@@ -1184,7 +1184,7 @@ namespace UnitsNet
             return new Volume((kilocubicmeters) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilocubicMeters.
         /// </summary>
         public static Volume FromKilocubicMeters(int kilocubicmeters)
@@ -1192,7 +1192,7 @@ namespace UnitsNet
             return new Volume((kilocubicmeters) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilocubicMeters.
         /// </summary>
         public static Volume FromKilocubicMeters(long kilocubicmeters)
@@ -1200,14 +1200,14 @@ namespace UnitsNet
             return new Volume((kilocubicmeters) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilocubicMeters of type decimal.
         /// </summary>
         public static Volume FromKilocubicMeters(decimal kilocubicmeters)
         {
-	        return new Volume((Convert.ToDouble(kilocubicmeters)) * 1e3d);
+            return new Volume((Convert.ToDouble(kilocubicmeters)) * 1e3d);
         }
 #endif
 
@@ -1219,7 +1219,7 @@ namespace UnitsNet
             return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
         public static Volume FromKiloimperialGallons(int kiloimperialgallons)
@@ -1227,7 +1227,7 @@ namespace UnitsNet
             return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
         public static Volume FromKiloimperialGallons(long kiloimperialgallons)
@@ -1235,14 +1235,14 @@ namespace UnitsNet
             return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KiloimperialGallons of type decimal.
         /// </summary>
         public static Volume FromKiloimperialGallons(decimal kiloimperialgallons)
         {
-	        return new Volume((Convert.ToDouble(kiloimperialgallons)*0.00454609000000181429905810072407) * 1e3d);
+            return new Volume((Convert.ToDouble(kiloimperialgallons)*0.00454609000000181429905810072407) * 1e3d);
         }
 #endif
 
@@ -1254,7 +1254,7 @@ namespace UnitsNet
             return new Volume((kilousgallons*0.00378541) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilousGallons.
         /// </summary>
         public static Volume FromKilousGallons(int kilousgallons)
@@ -1262,7 +1262,7 @@ namespace UnitsNet
             return new Volume((kilousgallons*0.00378541) * 1e3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilousGallons.
         /// </summary>
         public static Volume FromKilousGallons(long kilousgallons)
@@ -1270,14 +1270,14 @@ namespace UnitsNet
             return new Volume((kilousgallons*0.00378541) * 1e3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from KilousGallons of type decimal.
         /// </summary>
         public static Volume FromKilousGallons(decimal kilousgallons)
         {
-	        return new Volume((Convert.ToDouble(kilousgallons)*0.00378541) * 1e3d);
+            return new Volume((Convert.ToDouble(kilousgallons)*0.00378541) * 1e3d);
         }
 #endif
 
@@ -1289,7 +1289,7 @@ namespace UnitsNet
             return new Volume(liters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
         public static Volume FromLiters(int liters)
@@ -1297,7 +1297,7 @@ namespace UnitsNet
             return new Volume(liters/1e3);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
         public static Volume FromLiters(long liters)
@@ -1305,14 +1305,14 @@ namespace UnitsNet
             return new Volume(liters/1e3);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Liters of type decimal.
         /// </summary>
         public static Volume FromLiters(decimal liters)
         {
-	        return new Volume(Convert.ToDouble(liters)/1e3);
+            return new Volume(Convert.ToDouble(liters)/1e3);
         }
 #endif
 
@@ -1324,7 +1324,7 @@ namespace UnitsNet
             return new Volume((megacubicfeet*0.0283168) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegacubicFeet.
         /// </summary>
         public static Volume FromMegacubicFeet(int megacubicfeet)
@@ -1332,7 +1332,7 @@ namespace UnitsNet
             return new Volume((megacubicfeet*0.0283168) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegacubicFeet.
         /// </summary>
         public static Volume FromMegacubicFeet(long megacubicfeet)
@@ -1340,14 +1340,14 @@ namespace UnitsNet
             return new Volume((megacubicfeet*0.0283168) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegacubicFeet of type decimal.
         /// </summary>
         public static Volume FromMegacubicFeet(decimal megacubicfeet)
         {
-	        return new Volume((Convert.ToDouble(megacubicfeet)*0.0283168) * 1e6d);
+            return new Volume((Convert.ToDouble(megacubicfeet)*0.0283168) * 1e6d);
         }
 #endif
 
@@ -1359,7 +1359,7 @@ namespace UnitsNet
             return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
         public static Volume FromMegaimperialGallons(int megaimperialgallons)
@@ -1367,7 +1367,7 @@ namespace UnitsNet
             return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
         public static Volume FromMegaimperialGallons(long megaimperialgallons)
@@ -1375,14 +1375,14 @@ namespace UnitsNet
             return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegaimperialGallons of type decimal.
         /// </summary>
         public static Volume FromMegaimperialGallons(decimal megaimperialgallons)
         {
-	        return new Volume((Convert.ToDouble(megaimperialgallons)*0.00454609000000181429905810072407) * 1e6d);
+            return new Volume((Convert.ToDouble(megaimperialgallons)*0.00454609000000181429905810072407) * 1e6d);
         }
 #endif
 
@@ -1394,7 +1394,7 @@ namespace UnitsNet
             return new Volume((megausgallons*0.00378541) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegausGallons.
         /// </summary>
         public static Volume FromMegausGallons(int megausgallons)
@@ -1402,7 +1402,7 @@ namespace UnitsNet
             return new Volume((megausgallons*0.00378541) * 1e6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegausGallons.
         /// </summary>
         public static Volume FromMegausGallons(long megausgallons)
@@ -1410,14 +1410,14 @@ namespace UnitsNet
             return new Volume((megausgallons*0.00378541) * 1e6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MegausGallons of type decimal.
         /// </summary>
         public static Volume FromMegausGallons(decimal megausgallons)
         {
-	        return new Volume((Convert.ToDouble(megausgallons)*0.00378541) * 1e6d);
+            return new Volume((Convert.ToDouble(megausgallons)*0.00378541) * 1e6d);
         }
 #endif
 
@@ -1429,7 +1429,7 @@ namespace UnitsNet
             return new Volume(metriccups*0.00025);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
         public static Volume FromMetricCups(int metriccups)
@@ -1437,7 +1437,7 @@ namespace UnitsNet
             return new Volume(metriccups*0.00025);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
         public static Volume FromMetricCups(long metriccups)
@@ -1445,14 +1445,14 @@ namespace UnitsNet
             return new Volume(metriccups*0.00025);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MetricCups of type decimal.
         /// </summary>
         public static Volume FromMetricCups(decimal metriccups)
         {
-	        return new Volume(Convert.ToDouble(metriccups)*0.00025);
+            return new Volume(Convert.ToDouble(metriccups)*0.00025);
         }
 #endif
 
@@ -1464,7 +1464,7 @@ namespace UnitsNet
             return new Volume(metricteaspoons*0.5e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MetricTeaspoons.
         /// </summary>
         public static Volume FromMetricTeaspoons(int metricteaspoons)
@@ -1472,7 +1472,7 @@ namespace UnitsNet
             return new Volume(metricteaspoons*0.5e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MetricTeaspoons.
         /// </summary>
         public static Volume FromMetricTeaspoons(long metricteaspoons)
@@ -1480,14 +1480,14 @@ namespace UnitsNet
             return new Volume(metricteaspoons*0.5e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from MetricTeaspoons of type decimal.
         /// </summary>
         public static Volume FromMetricTeaspoons(decimal metricteaspoons)
         {
-	        return new Volume(Convert.ToDouble(metricteaspoons)*0.5e-5);
+            return new Volume(Convert.ToDouble(metricteaspoons)*0.5e-5);
         }
 #endif
 
@@ -1499,7 +1499,7 @@ namespace UnitsNet
             return new Volume((microliters/1e3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
         public static Volume FromMicroliters(int microliters)
@@ -1507,7 +1507,7 @@ namespace UnitsNet
             return new Volume((microliters/1e3) * 1e-6d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
         public static Volume FromMicroliters(long microliters)
@@ -1515,14 +1515,14 @@ namespace UnitsNet
             return new Volume((microliters/1e3) * 1e-6d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Microliters of type decimal.
         /// </summary>
         public static Volume FromMicroliters(decimal microliters)
         {
-	        return new Volume((Convert.ToDouble(microliters)/1e3) * 1e-6d);
+            return new Volume((Convert.ToDouble(microliters)/1e3) * 1e-6d);
         }
 #endif
 
@@ -1534,7 +1534,7 @@ namespace UnitsNet
             return new Volume((milliliters/1e3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
         public static Volume FromMilliliters(int milliliters)
@@ -1542,7 +1542,7 @@ namespace UnitsNet
             return new Volume((milliliters/1e3) * 1e-3d);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
         public static Volume FromMilliliters(long milliliters)
@@ -1550,14 +1550,14 @@ namespace UnitsNet
             return new Volume((milliliters/1e3) * 1e-3d);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Milliliters of type decimal.
         /// </summary>
         public static Volume FromMilliliters(decimal milliliters)
         {
-	        return new Volume((Convert.ToDouble(milliliters)/1e3) * 1e-3d);
+            return new Volume((Convert.ToDouble(milliliters)/1e3) * 1e-3d);
         }
 #endif
 
@@ -1569,7 +1569,7 @@ namespace UnitsNet
             return new Volume(oilbarrels*0.158987294928);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
         public static Volume FromOilBarrels(int oilbarrels)
@@ -1577,7 +1577,7 @@ namespace UnitsNet
             return new Volume(oilbarrels*0.158987294928);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
         public static Volume FromOilBarrels(long oilbarrels)
@@ -1585,14 +1585,14 @@ namespace UnitsNet
             return new Volume(oilbarrels*0.158987294928);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from OilBarrels of type decimal.
         /// </summary>
         public static Volume FromOilBarrels(decimal oilbarrels)
         {
-	        return new Volume(Convert.ToDouble(oilbarrels)*0.158987294928);
+            return new Volume(Convert.ToDouble(oilbarrels)*0.158987294928);
         }
 #endif
 
@@ -1604,7 +1604,7 @@ namespace UnitsNet
             return new Volume(tablespoons*1.478676478125e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Tablespoons.
         /// </summary>
         public static Volume FromTablespoons(int tablespoons)
@@ -1612,7 +1612,7 @@ namespace UnitsNet
             return new Volume(tablespoons*1.478676478125e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Tablespoons.
         /// </summary>
         public static Volume FromTablespoons(long tablespoons)
@@ -1620,14 +1620,14 @@ namespace UnitsNet
             return new Volume(tablespoons*1.478676478125e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Tablespoons of type decimal.
         /// </summary>
         public static Volume FromTablespoons(decimal tablespoons)
         {
-	        return new Volume(Convert.ToDouble(tablespoons)*1.478676478125e-5);
+            return new Volume(Convert.ToDouble(tablespoons)*1.478676478125e-5);
         }
 #endif
 
@@ -1639,7 +1639,7 @@ namespace UnitsNet
             return new Volume(teaspoons*4.92892159375e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Teaspoons.
         /// </summary>
         public static Volume FromTeaspoons(int teaspoons)
@@ -1647,7 +1647,7 @@ namespace UnitsNet
             return new Volume(teaspoons*4.92892159375e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Teaspoons.
         /// </summary>
         public static Volume FromTeaspoons(long teaspoons)
@@ -1655,14 +1655,14 @@ namespace UnitsNet
             return new Volume(teaspoons*4.92892159375e-6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from Teaspoons of type decimal.
         /// </summary>
         public static Volume FromTeaspoons(decimal teaspoons)
         {
-	        return new Volume(Convert.ToDouble(teaspoons)*4.92892159375e-6);
+            return new Volume(Convert.ToDouble(teaspoons)*4.92892159375e-6);
         }
 #endif
 
@@ -1674,7 +1674,7 @@ namespace UnitsNet
             return new Volume(uktablespoons*1.5e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
         public static Volume FromUkTablespoons(int uktablespoons)
@@ -1682,7 +1682,7 @@ namespace UnitsNet
             return new Volume(uktablespoons*1.5e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
         public static Volume FromUkTablespoons(long uktablespoons)
@@ -1690,14 +1690,14 @@ namespace UnitsNet
             return new Volume(uktablespoons*1.5e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UkTablespoons of type decimal.
         /// </summary>
         public static Volume FromUkTablespoons(decimal uktablespoons)
         {
-	        return new Volume(Convert.ToDouble(uktablespoons)*1.5e-5);
+            return new Volume(Convert.ToDouble(uktablespoons)*1.5e-5);
         }
 #endif
 
@@ -1709,7 +1709,7 @@ namespace UnitsNet
             return new Volume(usbeerbarrels*0.1173477658);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
         public static Volume FromUsBeerBarrels(int usbeerbarrels)
@@ -1717,7 +1717,7 @@ namespace UnitsNet
             return new Volume(usbeerbarrels*0.1173477658);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
         public static Volume FromUsBeerBarrels(long usbeerbarrels)
@@ -1725,14 +1725,14 @@ namespace UnitsNet
             return new Volume(usbeerbarrels*0.1173477658);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsBeerBarrels of type decimal.
         /// </summary>
         public static Volume FromUsBeerBarrels(decimal usbeerbarrels)
         {
-	        return new Volume(Convert.ToDouble(usbeerbarrels)*0.1173477658);
+            return new Volume(Convert.ToDouble(usbeerbarrels)*0.1173477658);
         }
 #endif
 
@@ -1744,7 +1744,7 @@ namespace UnitsNet
             return new Volume(uscustomarycups*0.0002365882365);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsCustomaryCups.
         /// </summary>
         public static Volume FromUsCustomaryCups(int uscustomarycups)
@@ -1752,7 +1752,7 @@ namespace UnitsNet
             return new Volume(uscustomarycups*0.0002365882365);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsCustomaryCups.
         /// </summary>
         public static Volume FromUsCustomaryCups(long uscustomarycups)
@@ -1760,14 +1760,14 @@ namespace UnitsNet
             return new Volume(uscustomarycups*0.0002365882365);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsCustomaryCups of type decimal.
         /// </summary>
         public static Volume FromUsCustomaryCups(decimal uscustomarycups)
         {
-	        return new Volume(Convert.ToDouble(uscustomarycups)*0.0002365882365);
+            return new Volume(Convert.ToDouble(uscustomarycups)*0.0002365882365);
         }
 #endif
 
@@ -1779,7 +1779,7 @@ namespace UnitsNet
             return new Volume(usgallons*0.00378541);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
         public static Volume FromUsGallons(int usgallons)
@@ -1787,7 +1787,7 @@ namespace UnitsNet
             return new Volume(usgallons*0.00378541);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
         public static Volume FromUsGallons(long usgallons)
@@ -1795,14 +1795,14 @@ namespace UnitsNet
             return new Volume(usgallons*0.00378541);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsGallons of type decimal.
         /// </summary>
         public static Volume FromUsGallons(decimal usgallons)
         {
-	        return new Volume(Convert.ToDouble(usgallons)*0.00378541);
+            return new Volume(Convert.ToDouble(usgallons)*0.00378541);
         }
 #endif
 
@@ -1814,7 +1814,7 @@ namespace UnitsNet
             return new Volume(uslegalcups*0.00024);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsLegalCups.
         /// </summary>
         public static Volume FromUsLegalCups(int uslegalcups)
@@ -1822,7 +1822,7 @@ namespace UnitsNet
             return new Volume(uslegalcups*0.00024);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsLegalCups.
         /// </summary>
         public static Volume FromUsLegalCups(long uslegalcups)
@@ -1830,14 +1830,14 @@ namespace UnitsNet
             return new Volume(uslegalcups*0.00024);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsLegalCups of type decimal.
         /// </summary>
         public static Volume FromUsLegalCups(decimal uslegalcups)
         {
-	        return new Volume(Convert.ToDouble(uslegalcups)*0.00024);
+            return new Volume(Convert.ToDouble(uslegalcups)*0.00024);
         }
 #endif
 
@@ -1849,7 +1849,7 @@ namespace UnitsNet
             return new Volume(usounces*2.957352956253760505068307980135e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
         public static Volume FromUsOunces(int usounces)
@@ -1857,7 +1857,7 @@ namespace UnitsNet
             return new Volume(usounces*2.957352956253760505068307980135e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
         public static Volume FromUsOunces(long usounces)
@@ -1865,14 +1865,14 @@ namespace UnitsNet
             return new Volume(usounces*2.957352956253760505068307980135e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsOunces of type decimal.
         /// </summary>
         public static Volume FromUsOunces(decimal usounces)
         {
-	        return new Volume(Convert.ToDouble(usounces)*2.957352956253760505068307980135e-5);
+            return new Volume(Convert.ToDouble(usounces)*2.957352956253760505068307980135e-5);
         }
 #endif
 
@@ -1884,7 +1884,7 @@ namespace UnitsNet
             return new Volume(ustablespoons*1.478676478125e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsTablespoons.
         /// </summary>
         public static Volume FromUsTablespoons(int ustablespoons)
@@ -1892,7 +1892,7 @@ namespace UnitsNet
             return new Volume(ustablespoons*1.478676478125e-5);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsTablespoons.
         /// </summary>
         public static Volume FromUsTablespoons(long ustablespoons)
@@ -1900,14 +1900,14 @@ namespace UnitsNet
             return new Volume(ustablespoons*1.478676478125e-5);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsTablespoons of type decimal.
         /// </summary>
         public static Volume FromUsTablespoons(decimal ustablespoons)
         {
-	        return new Volume(Convert.ToDouble(ustablespoons)*1.478676478125e-5);
+            return new Volume(Convert.ToDouble(ustablespoons)*1.478676478125e-5);
         }
 #endif
 
@@ -1919,7 +1919,7 @@ namespace UnitsNet
             return new Volume(usteaspoons*4.92892159375e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
         public static Volume FromUsTeaspoons(int usteaspoons)
@@ -1927,7 +1927,7 @@ namespace UnitsNet
             return new Volume(usteaspoons*4.92892159375e-6);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
         public static Volume FromUsTeaspoons(long usteaspoons)
@@ -1935,14 +1935,14 @@ namespace UnitsNet
             return new Volume(usteaspoons*4.92892159375e-6);
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get Volume from UsTeaspoons of type decimal.
         /// </summary>
         public static Volume FromUsTeaspoons(decimal usteaspoons)
         {
-	        return new Volume(Convert.ToDouble(usteaspoons)*4.92892159375e-6);
+            return new Volume(Convert.ToDouble(usteaspoons)*4.92892159375e-6);
         }
 #endif
 
@@ -1963,7 +1963,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable AuTablespoons.
         /// </summary>
         public static Volume? FromAuTablespoons(int? autablespoons)
@@ -1978,7 +1978,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable AuTablespoons.
         /// </summary>
         public static Volume? FromAuTablespoons(long? autablespoons)
@@ -1993,7 +1993,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from AuTablespoons of type decimal.
         /// </summary>
         public static Volume? FromAuTablespoons(decimal? autablespoons)
@@ -2023,7 +2023,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Centiliters.
         /// </summary>
         public static Volume? FromCentiliters(int? centiliters)
@@ -2038,7 +2038,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Centiliters.
         /// </summary>
         public static Volume? FromCentiliters(long? centiliters)
@@ -2053,7 +2053,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Centiliters of type decimal.
         /// </summary>
         public static Volume? FromCentiliters(decimal? centiliters)
@@ -2083,7 +2083,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicCentimeters.
         /// </summary>
         public static Volume? FromCubicCentimeters(int? cubiccentimeters)
@@ -2098,7 +2098,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicCentimeters.
         /// </summary>
         public static Volume? FromCubicCentimeters(long? cubiccentimeters)
@@ -2113,7 +2113,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicCentimeters of type decimal.
         /// </summary>
         public static Volume? FromCubicCentimeters(decimal? cubiccentimeters)
@@ -2143,7 +2143,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicDecimeters.
         /// </summary>
         public static Volume? FromCubicDecimeters(int? cubicdecimeters)
@@ -2158,7 +2158,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicDecimeters.
         /// </summary>
         public static Volume? FromCubicDecimeters(long? cubicdecimeters)
@@ -2173,7 +2173,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicDecimeters of type decimal.
         /// </summary>
         public static Volume? FromCubicDecimeters(decimal? cubicdecimeters)
@@ -2203,7 +2203,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicFeet.
         /// </summary>
         public static Volume? FromCubicFeet(int? cubicfeet)
@@ -2218,7 +2218,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicFeet.
         /// </summary>
         public static Volume? FromCubicFeet(long? cubicfeet)
@@ -2233,7 +2233,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicFeet of type decimal.
         /// </summary>
         public static Volume? FromCubicFeet(decimal? cubicfeet)
@@ -2263,7 +2263,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicInches.
         /// </summary>
         public static Volume? FromCubicInches(int? cubicinches)
@@ -2278,7 +2278,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicInches.
         /// </summary>
         public static Volume? FromCubicInches(long? cubicinches)
@@ -2293,7 +2293,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicInches of type decimal.
         /// </summary>
         public static Volume? FromCubicInches(decimal? cubicinches)
@@ -2323,7 +2323,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicKilometers.
         /// </summary>
         public static Volume? FromCubicKilometers(int? cubickilometers)
@@ -2338,7 +2338,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicKilometers.
         /// </summary>
         public static Volume? FromCubicKilometers(long? cubickilometers)
@@ -2353,7 +2353,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicKilometers of type decimal.
         /// </summary>
         public static Volume? FromCubicKilometers(decimal? cubickilometers)
@@ -2383,7 +2383,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMeters.
         /// </summary>
         public static Volume? FromCubicMeters(int? cubicmeters)
@@ -2398,7 +2398,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMeters.
         /// </summary>
         public static Volume? FromCubicMeters(long? cubicmeters)
@@ -2413,7 +2413,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicMeters of type decimal.
         /// </summary>
         public static Volume? FromCubicMeters(decimal? cubicmeters)
@@ -2443,7 +2443,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMicrometers.
         /// </summary>
         public static Volume? FromCubicMicrometers(int? cubicmicrometers)
@@ -2458,7 +2458,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMicrometers.
         /// </summary>
         public static Volume? FromCubicMicrometers(long? cubicmicrometers)
@@ -2473,7 +2473,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicMicrometers of type decimal.
         /// </summary>
         public static Volume? FromCubicMicrometers(decimal? cubicmicrometers)
@@ -2503,7 +2503,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMiles.
         /// </summary>
         public static Volume? FromCubicMiles(int? cubicmiles)
@@ -2518,7 +2518,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMiles.
         /// </summary>
         public static Volume? FromCubicMiles(long? cubicmiles)
@@ -2533,7 +2533,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicMiles of type decimal.
         /// </summary>
         public static Volume? FromCubicMiles(decimal? cubicmiles)
@@ -2563,7 +2563,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMillimeters.
         /// </summary>
         public static Volume? FromCubicMillimeters(int? cubicmillimeters)
@@ -2578,7 +2578,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicMillimeters.
         /// </summary>
         public static Volume? FromCubicMillimeters(long? cubicmillimeters)
@@ -2593,7 +2593,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicMillimeters of type decimal.
         /// </summary>
         public static Volume? FromCubicMillimeters(decimal? cubicmillimeters)
@@ -2623,7 +2623,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicYards.
         /// </summary>
         public static Volume? FromCubicYards(int? cubicyards)
@@ -2638,7 +2638,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable CubicYards.
         /// </summary>
         public static Volume? FromCubicYards(long? cubicyards)
@@ -2653,7 +2653,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from CubicYards of type decimal.
         /// </summary>
         public static Volume? FromCubicYards(decimal? cubicyards)
@@ -2683,7 +2683,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Deciliters.
         /// </summary>
         public static Volume? FromDeciliters(int? deciliters)
@@ -2698,7 +2698,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Deciliters.
         /// </summary>
         public static Volume? FromDeciliters(long? deciliters)
@@ -2713,7 +2713,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Deciliters of type decimal.
         /// </summary>
         public static Volume? FromDeciliters(decimal? deciliters)
@@ -2743,7 +2743,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable HectocubicFeet.
         /// </summary>
         public static Volume? FromHectocubicFeet(int? hectocubicfeet)
@@ -2758,7 +2758,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable HectocubicFeet.
         /// </summary>
         public static Volume? FromHectocubicFeet(long? hectocubicfeet)
@@ -2773,7 +2773,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from HectocubicFeet of type decimal.
         /// </summary>
         public static Volume? FromHectocubicFeet(decimal? hectocubicfeet)
@@ -2803,7 +2803,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable HectocubicMeters.
         /// </summary>
         public static Volume? FromHectocubicMeters(int? hectocubicmeters)
@@ -2818,7 +2818,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable HectocubicMeters.
         /// </summary>
         public static Volume? FromHectocubicMeters(long? hectocubicmeters)
@@ -2833,7 +2833,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from HectocubicMeters of type decimal.
         /// </summary>
         public static Volume? FromHectocubicMeters(decimal? hectocubicmeters)
@@ -2863,7 +2863,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Hectoliters.
         /// </summary>
         public static Volume? FromHectoliters(int? hectoliters)
@@ -2878,7 +2878,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Hectoliters.
         /// </summary>
         public static Volume? FromHectoliters(long? hectoliters)
@@ -2893,7 +2893,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Hectoliters of type decimal.
         /// </summary>
         public static Volume? FromHectoliters(decimal? hectoliters)
@@ -2923,7 +2923,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable ImperialBeerBarrels.
         /// </summary>
         public static Volume? FromImperialBeerBarrels(int? imperialbeerbarrels)
@@ -2938,7 +2938,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable ImperialBeerBarrels.
         /// </summary>
         public static Volume? FromImperialBeerBarrels(long? imperialbeerbarrels)
@@ -2953,7 +2953,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from ImperialBeerBarrels of type decimal.
         /// </summary>
         public static Volume? FromImperialBeerBarrels(decimal? imperialbeerbarrels)
@@ -2983,7 +2983,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable ImperialGallons.
         /// </summary>
         public static Volume? FromImperialGallons(int? imperialgallons)
@@ -2998,7 +2998,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable ImperialGallons.
         /// </summary>
         public static Volume? FromImperialGallons(long? imperialgallons)
@@ -3013,7 +3013,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from ImperialGallons of type decimal.
         /// </summary>
         public static Volume? FromImperialGallons(decimal? imperialgallons)
@@ -3043,7 +3043,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable ImperialOunces.
         /// </summary>
         public static Volume? FromImperialOunces(int? imperialounces)
@@ -3058,7 +3058,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable ImperialOunces.
         /// </summary>
         public static Volume? FromImperialOunces(long? imperialounces)
@@ -3073,7 +3073,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from ImperialOunces of type decimal.
         /// </summary>
         public static Volume? FromImperialOunces(decimal? imperialounces)
@@ -3103,7 +3103,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KilocubicFeet.
         /// </summary>
         public static Volume? FromKilocubicFeet(int? kilocubicfeet)
@@ -3118,7 +3118,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KilocubicFeet.
         /// </summary>
         public static Volume? FromKilocubicFeet(long? kilocubicfeet)
@@ -3133,7 +3133,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from KilocubicFeet of type decimal.
         /// </summary>
         public static Volume? FromKilocubicFeet(decimal? kilocubicfeet)
@@ -3163,7 +3163,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KilocubicMeters.
         /// </summary>
         public static Volume? FromKilocubicMeters(int? kilocubicmeters)
@@ -3178,7 +3178,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KilocubicMeters.
         /// </summary>
         public static Volume? FromKilocubicMeters(long? kilocubicmeters)
@@ -3193,7 +3193,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from KilocubicMeters of type decimal.
         /// </summary>
         public static Volume? FromKilocubicMeters(decimal? kilocubicmeters)
@@ -3223,7 +3223,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KiloimperialGallons.
         /// </summary>
         public static Volume? FromKiloimperialGallons(int? kiloimperialgallons)
@@ -3238,7 +3238,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KiloimperialGallons.
         /// </summary>
         public static Volume? FromKiloimperialGallons(long? kiloimperialgallons)
@@ -3253,7 +3253,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from KiloimperialGallons of type decimal.
         /// </summary>
         public static Volume? FromKiloimperialGallons(decimal? kiloimperialgallons)
@@ -3283,7 +3283,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KilousGallons.
         /// </summary>
         public static Volume? FromKilousGallons(int? kilousgallons)
@@ -3298,7 +3298,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable KilousGallons.
         /// </summary>
         public static Volume? FromKilousGallons(long? kilousgallons)
@@ -3313,7 +3313,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from KilousGallons of type decimal.
         /// </summary>
         public static Volume? FromKilousGallons(decimal? kilousgallons)
@@ -3343,7 +3343,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Liters.
         /// </summary>
         public static Volume? FromLiters(int? liters)
@@ -3358,7 +3358,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Liters.
         /// </summary>
         public static Volume? FromLiters(long? liters)
@@ -3373,7 +3373,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Liters of type decimal.
         /// </summary>
         public static Volume? FromLiters(decimal? liters)
@@ -3403,7 +3403,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MegacubicFeet.
         /// </summary>
         public static Volume? FromMegacubicFeet(int? megacubicfeet)
@@ -3418,7 +3418,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MegacubicFeet.
         /// </summary>
         public static Volume? FromMegacubicFeet(long? megacubicfeet)
@@ -3433,7 +3433,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from MegacubicFeet of type decimal.
         /// </summary>
         public static Volume? FromMegacubicFeet(decimal? megacubicfeet)
@@ -3463,7 +3463,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MegaimperialGallons.
         /// </summary>
         public static Volume? FromMegaimperialGallons(int? megaimperialgallons)
@@ -3478,7 +3478,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MegaimperialGallons.
         /// </summary>
         public static Volume? FromMegaimperialGallons(long? megaimperialgallons)
@@ -3493,7 +3493,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from MegaimperialGallons of type decimal.
         /// </summary>
         public static Volume? FromMegaimperialGallons(decimal? megaimperialgallons)
@@ -3523,7 +3523,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MegausGallons.
         /// </summary>
         public static Volume? FromMegausGallons(int? megausgallons)
@@ -3538,7 +3538,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MegausGallons.
         /// </summary>
         public static Volume? FromMegausGallons(long? megausgallons)
@@ -3553,7 +3553,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from MegausGallons of type decimal.
         /// </summary>
         public static Volume? FromMegausGallons(decimal? megausgallons)
@@ -3583,7 +3583,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MetricCups.
         /// </summary>
         public static Volume? FromMetricCups(int? metriccups)
@@ -3598,7 +3598,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MetricCups.
         /// </summary>
         public static Volume? FromMetricCups(long? metriccups)
@@ -3613,7 +3613,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from MetricCups of type decimal.
         /// </summary>
         public static Volume? FromMetricCups(decimal? metriccups)
@@ -3643,7 +3643,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MetricTeaspoons.
         /// </summary>
         public static Volume? FromMetricTeaspoons(int? metricteaspoons)
@@ -3658,7 +3658,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable MetricTeaspoons.
         /// </summary>
         public static Volume? FromMetricTeaspoons(long? metricteaspoons)
@@ -3673,7 +3673,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from MetricTeaspoons of type decimal.
         /// </summary>
         public static Volume? FromMetricTeaspoons(decimal? metricteaspoons)
@@ -3703,7 +3703,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Microliters.
         /// </summary>
         public static Volume? FromMicroliters(int? microliters)
@@ -3718,7 +3718,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Microliters.
         /// </summary>
         public static Volume? FromMicroliters(long? microliters)
@@ -3733,7 +3733,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Microliters of type decimal.
         /// </summary>
         public static Volume? FromMicroliters(decimal? microliters)
@@ -3763,7 +3763,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Milliliters.
         /// </summary>
         public static Volume? FromMilliliters(int? milliliters)
@@ -3778,7 +3778,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Milliliters.
         /// </summary>
         public static Volume? FromMilliliters(long? milliliters)
@@ -3793,7 +3793,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Milliliters of type decimal.
         /// </summary>
         public static Volume? FromMilliliters(decimal? milliliters)
@@ -3823,7 +3823,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable OilBarrels.
         /// </summary>
         public static Volume? FromOilBarrels(int? oilbarrels)
@@ -3838,7 +3838,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable OilBarrels.
         /// </summary>
         public static Volume? FromOilBarrels(long? oilbarrels)
@@ -3853,7 +3853,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from OilBarrels of type decimal.
         /// </summary>
         public static Volume? FromOilBarrels(decimal? oilbarrels)
@@ -3883,7 +3883,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Tablespoons.
         /// </summary>
         public static Volume? FromTablespoons(int? tablespoons)
@@ -3898,7 +3898,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Tablespoons.
         /// </summary>
         public static Volume? FromTablespoons(long? tablespoons)
@@ -3913,7 +3913,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Tablespoons of type decimal.
         /// </summary>
         public static Volume? FromTablespoons(decimal? tablespoons)
@@ -3943,7 +3943,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Teaspoons.
         /// </summary>
         public static Volume? FromTeaspoons(int? teaspoons)
@@ -3958,7 +3958,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable Teaspoons.
         /// </summary>
         public static Volume? FromTeaspoons(long? teaspoons)
@@ -3973,7 +3973,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from Teaspoons of type decimal.
         /// </summary>
         public static Volume? FromTeaspoons(decimal? teaspoons)
@@ -4003,7 +4003,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UkTablespoons.
         /// </summary>
         public static Volume? FromUkTablespoons(int? uktablespoons)
@@ -4018,7 +4018,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UkTablespoons.
         /// </summary>
         public static Volume? FromUkTablespoons(long? uktablespoons)
@@ -4033,7 +4033,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UkTablespoons of type decimal.
         /// </summary>
         public static Volume? FromUkTablespoons(decimal? uktablespoons)
@@ -4063,7 +4063,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsBeerBarrels.
         /// </summary>
         public static Volume? FromUsBeerBarrels(int? usbeerbarrels)
@@ -4078,7 +4078,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsBeerBarrels.
         /// </summary>
         public static Volume? FromUsBeerBarrels(long? usbeerbarrels)
@@ -4093,7 +4093,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsBeerBarrels of type decimal.
         /// </summary>
         public static Volume? FromUsBeerBarrels(decimal? usbeerbarrels)
@@ -4123,7 +4123,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsCustomaryCups.
         /// </summary>
         public static Volume? FromUsCustomaryCups(int? uscustomarycups)
@@ -4138,7 +4138,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsCustomaryCups.
         /// </summary>
         public static Volume? FromUsCustomaryCups(long? uscustomarycups)
@@ -4153,7 +4153,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsCustomaryCups of type decimal.
         /// </summary>
         public static Volume? FromUsCustomaryCups(decimal? uscustomarycups)
@@ -4183,7 +4183,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsGallons.
         /// </summary>
         public static Volume? FromUsGallons(int? usgallons)
@@ -4198,7 +4198,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsGallons.
         /// </summary>
         public static Volume? FromUsGallons(long? usgallons)
@@ -4213,7 +4213,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsGallons of type decimal.
         /// </summary>
         public static Volume? FromUsGallons(decimal? usgallons)
@@ -4243,7 +4243,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsLegalCups.
         /// </summary>
         public static Volume? FromUsLegalCups(int? uslegalcups)
@@ -4258,7 +4258,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsLegalCups.
         /// </summary>
         public static Volume? FromUsLegalCups(long? uslegalcups)
@@ -4273,7 +4273,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsLegalCups of type decimal.
         /// </summary>
         public static Volume? FromUsLegalCups(decimal? uslegalcups)
@@ -4303,7 +4303,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsOunces.
         /// </summary>
         public static Volume? FromUsOunces(int? usounces)
@@ -4318,7 +4318,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsOunces.
         /// </summary>
         public static Volume? FromUsOunces(long? usounces)
@@ -4333,7 +4333,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsOunces of type decimal.
         /// </summary>
         public static Volume? FromUsOunces(decimal? usounces)
@@ -4363,7 +4363,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsTablespoons.
         /// </summary>
         public static Volume? FromUsTablespoons(int? ustablespoons)
@@ -4378,7 +4378,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsTablespoons.
         /// </summary>
         public static Volume? FromUsTablespoons(long? ustablespoons)
@@ -4393,7 +4393,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsTablespoons of type decimal.
         /// </summary>
         public static Volume? FromUsTablespoons(decimal? ustablespoons)
@@ -4423,7 +4423,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsTeaspoons.
         /// </summary>
         public static Volume? FromUsTeaspoons(int? usteaspoons)
@@ -4438,7 +4438,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from nullable UsTeaspoons.
         /// </summary>
         public static Volume? FromUsTeaspoons(long? usteaspoons)
@@ -4453,7 +4453,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable Volume from UsTeaspoons of type decimal.
         /// </summary>
         public static Volume? FromUsTeaspoons(decimal? usteaspoons)

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -479,6 +479,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from AuTablespoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromAuTablespoons(double autablespoons)
         {
             return new Volume(autablespoons*2e-5);
@@ -514,6 +517,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCentiliters(double centiliters)
         {
             return new Volume((centiliters/1e3) * 1e-2d);
@@ -549,6 +555,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicCentimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicCentimeters(double cubiccentimeters)
         {
             return new Volume(cubiccentimeters/1e6);
@@ -584,6 +593,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicDecimeters(double cubicdecimeters)
         {
             return new Volume(cubicdecimeters/1e3);
@@ -619,6 +631,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicFeet(double cubicfeet)
         {
             return new Volume(cubicfeet*0.0283168);
@@ -654,6 +669,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicInches(double cubicinches)
         {
             return new Volume(cubicinches*1.6387*1e-5);
@@ -689,6 +707,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicKilometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicKilometers(double cubickilometers)
         {
             return new Volume(cubickilometers*1e9);
@@ -724,6 +745,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicMeters(double cubicmeters)
         {
             return new Volume(cubicmeters);
@@ -759,6 +783,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMicrometers.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicMicrometers(double cubicmicrometers)
         {
             return new Volume(cubicmicrometers/1e18);
@@ -794,6 +821,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicMiles(double cubicmiles)
         {
             return new Volume(cubicmiles*4.16818183*1e9);
@@ -829,6 +859,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMillimeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicMillimeters(double cubicmillimeters)
         {
             return new Volume(cubicmillimeters/1e9);
@@ -864,6 +897,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromCubicYards(double cubicyards)
         {
             return new Volume(cubicyards*0.764554858);
@@ -899,6 +935,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Deciliters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromDeciliters(double deciliters)
         {
             return new Volume((deciliters/1e3) * 1e-1d);
@@ -934,6 +973,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromHectocubicFeet(double hectocubicfeet)
         {
             return new Volume((hectocubicfeet*0.0283168) * 1e2d);
@@ -969,6 +1011,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from HectocubicMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromHectocubicMeters(double hectocubicmeters)
         {
             return new Volume((hectocubicmeters) * 1e2d);
@@ -1004,6 +1049,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromHectoliters(double hectoliters)
         {
             return new Volume((hectoliters/1e3) * 1e2d);
@@ -1039,6 +1087,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromImperialBeerBarrels(double imperialbeerbarrels)
         {
             return new Volume(imperialbeerbarrels*0.16365924);
@@ -1074,6 +1125,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromImperialGallons(double imperialgallons)
         {
             return new Volume(imperialgallons*0.00454609000000181429905810072407);
@@ -1109,6 +1163,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialOunces.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromImperialOunces(double imperialounces)
         {
             return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
@@ -1144,6 +1201,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromKilocubicFeet(double kilocubicfeet)
         {
             return new Volume((kilocubicfeet*0.0283168) * 1e3d);
@@ -1179,6 +1239,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilocubicMeters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromKilocubicMeters(double kilocubicmeters)
         {
             return new Volume((kilocubicmeters) * 1e3d);
@@ -1214,6 +1277,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromKiloimperialGallons(double kiloimperialgallons)
         {
             return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
@@ -1249,6 +1315,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilousGallons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromKilousGallons(double kilousgallons)
         {
             return new Volume((kilousgallons*0.00378541) * 1e3d);
@@ -1284,6 +1353,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromLiters(double liters)
         {
             return new Volume(liters/1e3);
@@ -1319,6 +1391,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegacubicFeet.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMegacubicFeet(double megacubicfeet)
         {
             return new Volume((megacubicfeet*0.0283168) * 1e6d);
@@ -1354,6 +1429,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMegaimperialGallons(double megaimperialgallons)
         {
             return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
@@ -1389,6 +1467,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegausGallons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMegausGallons(double megausgallons)
         {
             return new Volume((megausgallons*0.00378541) * 1e6d);
@@ -1424,6 +1505,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMetricCups(double metriccups)
         {
             return new Volume(metriccups*0.00025);
@@ -1459,6 +1543,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MetricTeaspoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMetricTeaspoons(double metricteaspoons)
         {
             return new Volume(metricteaspoons*0.5e-5);
@@ -1494,6 +1581,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMicroliters(double microliters)
         {
             return new Volume((microliters/1e3) * 1e-6d);
@@ -1529,6 +1619,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromMilliliters(double milliliters)
         {
             return new Volume((milliliters/1e3) * 1e-3d);
@@ -1564,6 +1657,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromOilBarrels(double oilbarrels)
         {
             return new Volume(oilbarrels*0.158987294928);
@@ -1599,6 +1695,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Tablespoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromTablespoons(double tablespoons)
         {
             return new Volume(tablespoons*1.478676478125e-5);
@@ -1634,6 +1733,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Teaspoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromTeaspoons(double teaspoons)
         {
             return new Volume(teaspoons*4.92892159375e-6);
@@ -1669,6 +1771,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUkTablespoons(double uktablespoons)
         {
             return new Volume(uktablespoons*1.5e-5);
@@ -1704,6 +1809,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsBeerBarrels(double usbeerbarrels)
         {
             return new Volume(usbeerbarrels*0.1173477658);
@@ -1739,6 +1847,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsCustomaryCups.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsCustomaryCups(double uscustomarycups)
         {
             return new Volume(uscustomarycups*0.0002365882365);
@@ -1774,6 +1885,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsGallons(double usgallons)
         {
             return new Volume(usgallons*0.00378541);
@@ -1809,6 +1923,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsLegalCups.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsLegalCups(double uslegalcups)
         {
             return new Volume(uslegalcups*0.00024);
@@ -1844,6 +1961,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsOunces(double usounces)
         {
             return new Volume(usounces*2.957352956253760505068307980135e-5);
@@ -1879,6 +1999,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsTablespoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsTablespoons(double ustablespoons)
         {
             return new Volume(ustablespoons*1.478676478125e-5);
@@ -1914,6 +2037,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static Volume FromUsTeaspoons(double usteaspoons)
         {
             return new Volume(usteaspoons*4.92892159375e-6);

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -484,6 +484,33 @@ namespace UnitsNet
             return new Volume(autablespoons*2e-5);
         }
 
+		/// <summary>
+        ///     Get Volume from AuTablespoons.
+        /// </summary>
+        public static Volume FromAuTablespoons(int autablespoons)
+        {
+            return new Volume(autablespoons*2e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from AuTablespoons.
+        /// </summary>
+        public static Volume FromAuTablespoons(long autablespoons)
+        {
+            return new Volume(autablespoons*2e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from AuTablespoons of type decimal.
+        /// </summary>
+        public static Volume FromAuTablespoons(decimal autablespoons)
+        {
+	        return new Volume(Convert.ToDouble(autablespoons)*2e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
@@ -491,6 +518,33 @@ namespace UnitsNet
         {
             return new Volume((centiliters/1e3) * 1e-2d);
         }
+
+		/// <summary>
+        ///     Get Volume from Centiliters.
+        /// </summary>
+        public static Volume FromCentiliters(int centiliters)
+        {
+            return new Volume((centiliters/1e3) * 1e-2d);
+        }
+
+		/// <summary>
+        ///     Get Volume from Centiliters.
+        /// </summary>
+        public static Volume FromCentiliters(long centiliters)
+        {
+            return new Volume((centiliters/1e3) * 1e-2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Centiliters of type decimal.
+        /// </summary>
+        public static Volume FromCentiliters(decimal centiliters)
+        {
+	        return new Volume((Convert.ToDouble(centiliters)/1e3) * 1e-2d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from CubicCentimeters.
@@ -500,6 +554,33 @@ namespace UnitsNet
             return new Volume(cubiccentimeters/1e6);
         }
 
+		/// <summary>
+        ///     Get Volume from CubicCentimeters.
+        /// </summary>
+        public static Volume FromCubicCentimeters(int cubiccentimeters)
+        {
+            return new Volume(cubiccentimeters/1e6);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicCentimeters.
+        /// </summary>
+        public static Volume FromCubicCentimeters(long cubiccentimeters)
+        {
+            return new Volume(cubiccentimeters/1e6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicCentimeters of type decimal.
+        /// </summary>
+        public static Volume FromCubicCentimeters(decimal cubiccentimeters)
+        {
+	        return new Volume(Convert.ToDouble(cubiccentimeters)/1e6);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
@@ -507,6 +588,33 @@ namespace UnitsNet
         {
             return new Volume(cubicdecimeters/1e3);
         }
+
+		/// <summary>
+        ///     Get Volume from CubicDecimeters.
+        /// </summary>
+        public static Volume FromCubicDecimeters(int cubicdecimeters)
+        {
+            return new Volume(cubicdecimeters/1e3);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicDecimeters.
+        /// </summary>
+        public static Volume FromCubicDecimeters(long cubicdecimeters)
+        {
+            return new Volume(cubicdecimeters/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicDecimeters of type decimal.
+        /// </summary>
+        public static Volume FromCubicDecimeters(decimal cubicdecimeters)
+        {
+	        return new Volume(Convert.ToDouble(cubicdecimeters)/1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from CubicFeet.
@@ -516,6 +624,33 @@ namespace UnitsNet
             return new Volume(cubicfeet*0.0283168);
         }
 
+		/// <summary>
+        ///     Get Volume from CubicFeet.
+        /// </summary>
+        public static Volume FromCubicFeet(int cubicfeet)
+        {
+            return new Volume(cubicfeet*0.0283168);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicFeet.
+        /// </summary>
+        public static Volume FromCubicFeet(long cubicfeet)
+        {
+            return new Volume(cubicfeet*0.0283168);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicFeet of type decimal.
+        /// </summary>
+        public static Volume FromCubicFeet(decimal cubicfeet)
+        {
+	        return new Volume(Convert.ToDouble(cubicfeet)*0.0283168);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
@@ -523,6 +658,33 @@ namespace UnitsNet
         {
             return new Volume(cubicinches*1.6387*1e-5);
         }
+
+		/// <summary>
+        ///     Get Volume from CubicInches.
+        /// </summary>
+        public static Volume FromCubicInches(int cubicinches)
+        {
+            return new Volume(cubicinches*1.6387*1e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicInches.
+        /// </summary>
+        public static Volume FromCubicInches(long cubicinches)
+        {
+            return new Volume(cubicinches*1.6387*1e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicInches of type decimal.
+        /// </summary>
+        public static Volume FromCubicInches(decimal cubicinches)
+        {
+	        return new Volume(Convert.ToDouble(cubicinches)*1.6387*1e-5);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from CubicKilometers.
@@ -532,6 +694,33 @@ namespace UnitsNet
             return new Volume(cubickilometers*1e9);
         }
 
+		/// <summary>
+        ///     Get Volume from CubicKilometers.
+        /// </summary>
+        public static Volume FromCubicKilometers(int cubickilometers)
+        {
+            return new Volume(cubickilometers*1e9);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicKilometers.
+        /// </summary>
+        public static Volume FromCubicKilometers(long cubickilometers)
+        {
+            return new Volume(cubickilometers*1e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicKilometers of type decimal.
+        /// </summary>
+        public static Volume FromCubicKilometers(decimal cubickilometers)
+        {
+	        return new Volume(Convert.ToDouble(cubickilometers)*1e9);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
@@ -539,6 +728,33 @@ namespace UnitsNet
         {
             return new Volume(cubicmeters);
         }
+
+		/// <summary>
+        ///     Get Volume from CubicMeters.
+        /// </summary>
+        public static Volume FromCubicMeters(int cubicmeters)
+        {
+            return new Volume(cubicmeters);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicMeters.
+        /// </summary>
+        public static Volume FromCubicMeters(long cubicmeters)
+        {
+            return new Volume(cubicmeters);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicMeters of type decimal.
+        /// </summary>
+        public static Volume FromCubicMeters(decimal cubicmeters)
+        {
+	        return new Volume(Convert.ToDouble(cubicmeters));
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from CubicMicrometers.
@@ -548,6 +764,33 @@ namespace UnitsNet
             return new Volume(cubicmicrometers/1e18);
         }
 
+		/// <summary>
+        ///     Get Volume from CubicMicrometers.
+        /// </summary>
+        public static Volume FromCubicMicrometers(int cubicmicrometers)
+        {
+            return new Volume(cubicmicrometers/1e18);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicMicrometers.
+        /// </summary>
+        public static Volume FromCubicMicrometers(long cubicmicrometers)
+        {
+            return new Volume(cubicmicrometers/1e18);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicMicrometers of type decimal.
+        /// </summary>
+        public static Volume FromCubicMicrometers(decimal cubicmicrometers)
+        {
+	        return new Volume(Convert.ToDouble(cubicmicrometers)/1e18);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
@@ -555,6 +798,33 @@ namespace UnitsNet
         {
             return new Volume(cubicmiles*4.16818183*1e9);
         }
+
+		/// <summary>
+        ///     Get Volume from CubicMiles.
+        /// </summary>
+        public static Volume FromCubicMiles(int cubicmiles)
+        {
+            return new Volume(cubicmiles*4.16818183*1e9);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicMiles.
+        /// </summary>
+        public static Volume FromCubicMiles(long cubicmiles)
+        {
+            return new Volume(cubicmiles*4.16818183*1e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicMiles of type decimal.
+        /// </summary>
+        public static Volume FromCubicMiles(decimal cubicmiles)
+        {
+	        return new Volume(Convert.ToDouble(cubicmiles)*4.16818183*1e9);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from CubicMillimeters.
@@ -564,6 +834,33 @@ namespace UnitsNet
             return new Volume(cubicmillimeters/1e9);
         }
 
+		/// <summary>
+        ///     Get Volume from CubicMillimeters.
+        /// </summary>
+        public static Volume FromCubicMillimeters(int cubicmillimeters)
+        {
+            return new Volume(cubicmillimeters/1e9);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicMillimeters.
+        /// </summary>
+        public static Volume FromCubicMillimeters(long cubicmillimeters)
+        {
+            return new Volume(cubicmillimeters/1e9);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicMillimeters of type decimal.
+        /// </summary>
+        public static Volume FromCubicMillimeters(decimal cubicmillimeters)
+        {
+	        return new Volume(Convert.ToDouble(cubicmillimeters)/1e9);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
@@ -571,6 +868,33 @@ namespace UnitsNet
         {
             return new Volume(cubicyards*0.764554858);
         }
+
+		/// <summary>
+        ///     Get Volume from CubicYards.
+        /// </summary>
+        public static Volume FromCubicYards(int cubicyards)
+        {
+            return new Volume(cubicyards*0.764554858);
+        }
+
+		/// <summary>
+        ///     Get Volume from CubicYards.
+        /// </summary>
+        public static Volume FromCubicYards(long cubicyards)
+        {
+            return new Volume(cubicyards*0.764554858);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from CubicYards of type decimal.
+        /// </summary>
+        public static Volume FromCubicYards(decimal cubicyards)
+        {
+	        return new Volume(Convert.ToDouble(cubicyards)*0.764554858);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from Deciliters.
@@ -580,6 +904,33 @@ namespace UnitsNet
             return new Volume((deciliters/1e3) * 1e-1d);
         }
 
+		/// <summary>
+        ///     Get Volume from Deciliters.
+        /// </summary>
+        public static Volume FromDeciliters(int deciliters)
+        {
+            return new Volume((deciliters/1e3) * 1e-1d);
+        }
+
+		/// <summary>
+        ///     Get Volume from Deciliters.
+        /// </summary>
+        public static Volume FromDeciliters(long deciliters)
+        {
+            return new Volume((deciliters/1e3) * 1e-1d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Deciliters of type decimal.
+        /// </summary>
+        public static Volume FromDeciliters(decimal deciliters)
+        {
+	        return new Volume((Convert.ToDouble(deciliters)/1e3) * 1e-1d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
@@ -587,6 +938,33 @@ namespace UnitsNet
         {
             return new Volume((hectocubicfeet*0.0283168) * 1e2d);
         }
+
+		/// <summary>
+        ///     Get Volume from HectocubicFeet.
+        /// </summary>
+        public static Volume FromHectocubicFeet(int hectocubicfeet)
+        {
+            return new Volume((hectocubicfeet*0.0283168) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get Volume from HectocubicFeet.
+        /// </summary>
+        public static Volume FromHectocubicFeet(long hectocubicfeet)
+        {
+            return new Volume((hectocubicfeet*0.0283168) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from HectocubicFeet of type decimal.
+        /// </summary>
+        public static Volume FromHectocubicFeet(decimal hectocubicfeet)
+        {
+	        return new Volume((Convert.ToDouble(hectocubicfeet)*0.0283168) * 1e2d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from HectocubicMeters.
@@ -596,6 +974,33 @@ namespace UnitsNet
             return new Volume((hectocubicmeters) * 1e2d);
         }
 
+		/// <summary>
+        ///     Get Volume from HectocubicMeters.
+        /// </summary>
+        public static Volume FromHectocubicMeters(int hectocubicmeters)
+        {
+            return new Volume((hectocubicmeters) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get Volume from HectocubicMeters.
+        /// </summary>
+        public static Volume FromHectocubicMeters(long hectocubicmeters)
+        {
+            return new Volume((hectocubicmeters) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from HectocubicMeters of type decimal.
+        /// </summary>
+        public static Volume FromHectocubicMeters(decimal hectocubicmeters)
+        {
+	        return new Volume((Convert.ToDouble(hectocubicmeters)) * 1e2d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
@@ -603,6 +1008,33 @@ namespace UnitsNet
         {
             return new Volume((hectoliters/1e3) * 1e2d);
         }
+
+		/// <summary>
+        ///     Get Volume from Hectoliters.
+        /// </summary>
+        public static Volume FromHectoliters(int hectoliters)
+        {
+            return new Volume((hectoliters/1e3) * 1e2d);
+        }
+
+		/// <summary>
+        ///     Get Volume from Hectoliters.
+        /// </summary>
+        public static Volume FromHectoliters(long hectoliters)
+        {
+            return new Volume((hectoliters/1e3) * 1e2d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Hectoliters of type decimal.
+        /// </summary>
+        public static Volume FromHectoliters(decimal hectoliters)
+        {
+	        return new Volume((Convert.ToDouble(hectoliters)/1e3) * 1e2d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
@@ -612,6 +1044,33 @@ namespace UnitsNet
             return new Volume(imperialbeerbarrels*0.16365924);
         }
 
+		/// <summary>
+        ///     Get Volume from ImperialBeerBarrels.
+        /// </summary>
+        public static Volume FromImperialBeerBarrels(int imperialbeerbarrels)
+        {
+            return new Volume(imperialbeerbarrels*0.16365924);
+        }
+
+		/// <summary>
+        ///     Get Volume from ImperialBeerBarrels.
+        /// </summary>
+        public static Volume FromImperialBeerBarrels(long imperialbeerbarrels)
+        {
+            return new Volume(imperialbeerbarrels*0.16365924);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from ImperialBeerBarrels of type decimal.
+        /// </summary>
+        public static Volume FromImperialBeerBarrels(decimal imperialbeerbarrels)
+        {
+	        return new Volume(Convert.ToDouble(imperialbeerbarrels)*0.16365924);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
@@ -619,6 +1078,33 @@ namespace UnitsNet
         {
             return new Volume(imperialgallons*0.00454609000000181429905810072407);
         }
+
+		/// <summary>
+        ///     Get Volume from ImperialGallons.
+        /// </summary>
+        public static Volume FromImperialGallons(int imperialgallons)
+        {
+            return new Volume(imperialgallons*0.00454609000000181429905810072407);
+        }
+
+		/// <summary>
+        ///     Get Volume from ImperialGallons.
+        /// </summary>
+        public static Volume FromImperialGallons(long imperialgallons)
+        {
+            return new Volume(imperialgallons*0.00454609000000181429905810072407);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from ImperialGallons of type decimal.
+        /// </summary>
+        public static Volume FromImperialGallons(decimal imperialgallons)
+        {
+	        return new Volume(Convert.ToDouble(imperialgallons)*0.00454609000000181429905810072407);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from ImperialOunces.
@@ -628,6 +1114,33 @@ namespace UnitsNet
             return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
         }
 
+		/// <summary>
+        ///     Get Volume from ImperialOunces.
+        /// </summary>
+        public static Volume FromImperialOunces(int imperialounces)
+        {
+            return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from ImperialOunces.
+        /// </summary>
+        public static Volume FromImperialOunces(long imperialounces)
+        {
+            return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from ImperialOunces of type decimal.
+        /// </summary>
+        public static Volume FromImperialOunces(decimal imperialounces)
+        {
+	        return new Volume(Convert.ToDouble(imperialounces)*2.8413062499962901241875439064617e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
@@ -635,6 +1148,33 @@ namespace UnitsNet
         {
             return new Volume((kilocubicfeet*0.0283168) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Volume from KilocubicFeet.
+        /// </summary>
+        public static Volume FromKilocubicFeet(int kilocubicfeet)
+        {
+            return new Volume((kilocubicfeet*0.0283168) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Volume from KilocubicFeet.
+        /// </summary>
+        public static Volume FromKilocubicFeet(long kilocubicfeet)
+        {
+            return new Volume((kilocubicfeet*0.0283168) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from KilocubicFeet of type decimal.
+        /// </summary>
+        public static Volume FromKilocubicFeet(decimal kilocubicfeet)
+        {
+	        return new Volume((Convert.ToDouble(kilocubicfeet)*0.0283168) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from KilocubicMeters.
@@ -644,6 +1184,33 @@ namespace UnitsNet
             return new Volume((kilocubicmeters) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Volume from KilocubicMeters.
+        /// </summary>
+        public static Volume FromKilocubicMeters(int kilocubicmeters)
+        {
+            return new Volume((kilocubicmeters) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Volume from KilocubicMeters.
+        /// </summary>
+        public static Volume FromKilocubicMeters(long kilocubicmeters)
+        {
+            return new Volume((kilocubicmeters) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from KilocubicMeters of type decimal.
+        /// </summary>
+        public static Volume FromKilocubicMeters(decimal kilocubicmeters)
+        {
+	        return new Volume((Convert.ToDouble(kilocubicmeters)) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
@@ -651,6 +1218,33 @@ namespace UnitsNet
         {
             return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
         }
+
+		/// <summary>
+        ///     Get Volume from KiloimperialGallons.
+        /// </summary>
+        public static Volume FromKiloimperialGallons(int kiloimperialgallons)
+        {
+            return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Volume from KiloimperialGallons.
+        /// </summary>
+        public static Volume FromKiloimperialGallons(long kiloimperialgallons)
+        {
+            return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from KiloimperialGallons of type decimal.
+        /// </summary>
+        public static Volume FromKiloimperialGallons(decimal kiloimperialgallons)
+        {
+	        return new Volume((Convert.ToDouble(kiloimperialgallons)*0.00454609000000181429905810072407) * 1e3d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from KilousGallons.
@@ -660,6 +1254,33 @@ namespace UnitsNet
             return new Volume((kilousgallons*0.00378541) * 1e3d);
         }
 
+		/// <summary>
+        ///     Get Volume from KilousGallons.
+        /// </summary>
+        public static Volume FromKilousGallons(int kilousgallons)
+        {
+            return new Volume((kilousgallons*0.00378541) * 1e3d);
+        }
+
+		/// <summary>
+        ///     Get Volume from KilousGallons.
+        /// </summary>
+        public static Volume FromKilousGallons(long kilousgallons)
+        {
+            return new Volume((kilousgallons*0.00378541) * 1e3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from KilousGallons of type decimal.
+        /// </summary>
+        public static Volume FromKilousGallons(decimal kilousgallons)
+        {
+	        return new Volume((Convert.ToDouble(kilousgallons)*0.00378541) * 1e3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
@@ -667,6 +1288,33 @@ namespace UnitsNet
         {
             return new Volume(liters/1e3);
         }
+
+		/// <summary>
+        ///     Get Volume from Liters.
+        /// </summary>
+        public static Volume FromLiters(int liters)
+        {
+            return new Volume(liters/1e3);
+        }
+
+		/// <summary>
+        ///     Get Volume from Liters.
+        /// </summary>
+        public static Volume FromLiters(long liters)
+        {
+            return new Volume(liters/1e3);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Liters of type decimal.
+        /// </summary>
+        public static Volume FromLiters(decimal liters)
+        {
+	        return new Volume(Convert.ToDouble(liters)/1e3);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from MegacubicFeet.
@@ -676,6 +1324,33 @@ namespace UnitsNet
             return new Volume((megacubicfeet*0.0283168) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get Volume from MegacubicFeet.
+        /// </summary>
+        public static Volume FromMegacubicFeet(int megacubicfeet)
+        {
+            return new Volume((megacubicfeet*0.0283168) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Volume from MegacubicFeet.
+        /// </summary>
+        public static Volume FromMegacubicFeet(long megacubicfeet)
+        {
+            return new Volume((megacubicfeet*0.0283168) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from MegacubicFeet of type decimal.
+        /// </summary>
+        public static Volume FromMegacubicFeet(decimal megacubicfeet)
+        {
+	        return new Volume((Convert.ToDouble(megacubicfeet)*0.0283168) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
@@ -683,6 +1358,33 @@ namespace UnitsNet
         {
             return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
         }
+
+		/// <summary>
+        ///     Get Volume from MegaimperialGallons.
+        /// </summary>
+        public static Volume FromMegaimperialGallons(int megaimperialgallons)
+        {
+            return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Volume from MegaimperialGallons.
+        /// </summary>
+        public static Volume FromMegaimperialGallons(long megaimperialgallons)
+        {
+            return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from MegaimperialGallons of type decimal.
+        /// </summary>
+        public static Volume FromMegaimperialGallons(decimal megaimperialgallons)
+        {
+	        return new Volume((Convert.ToDouble(megaimperialgallons)*0.00454609000000181429905810072407) * 1e6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from MegausGallons.
@@ -692,6 +1394,33 @@ namespace UnitsNet
             return new Volume((megausgallons*0.00378541) * 1e6d);
         }
 
+		/// <summary>
+        ///     Get Volume from MegausGallons.
+        /// </summary>
+        public static Volume FromMegausGallons(int megausgallons)
+        {
+            return new Volume((megausgallons*0.00378541) * 1e6d);
+        }
+
+		/// <summary>
+        ///     Get Volume from MegausGallons.
+        /// </summary>
+        public static Volume FromMegausGallons(long megausgallons)
+        {
+            return new Volume((megausgallons*0.00378541) * 1e6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from MegausGallons of type decimal.
+        /// </summary>
+        public static Volume FromMegausGallons(decimal megausgallons)
+        {
+	        return new Volume((Convert.ToDouble(megausgallons)*0.00378541) * 1e6d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
@@ -699,6 +1428,33 @@ namespace UnitsNet
         {
             return new Volume(metriccups*0.00025);
         }
+
+		/// <summary>
+        ///     Get Volume from MetricCups.
+        /// </summary>
+        public static Volume FromMetricCups(int metriccups)
+        {
+            return new Volume(metriccups*0.00025);
+        }
+
+		/// <summary>
+        ///     Get Volume from MetricCups.
+        /// </summary>
+        public static Volume FromMetricCups(long metriccups)
+        {
+            return new Volume(metriccups*0.00025);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from MetricCups of type decimal.
+        /// </summary>
+        public static Volume FromMetricCups(decimal metriccups)
+        {
+	        return new Volume(Convert.ToDouble(metriccups)*0.00025);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from MetricTeaspoons.
@@ -708,6 +1464,33 @@ namespace UnitsNet
             return new Volume(metricteaspoons*0.5e-5);
         }
 
+		/// <summary>
+        ///     Get Volume from MetricTeaspoons.
+        /// </summary>
+        public static Volume FromMetricTeaspoons(int metricteaspoons)
+        {
+            return new Volume(metricteaspoons*0.5e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from MetricTeaspoons.
+        /// </summary>
+        public static Volume FromMetricTeaspoons(long metricteaspoons)
+        {
+            return new Volume(metricteaspoons*0.5e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from MetricTeaspoons of type decimal.
+        /// </summary>
+        public static Volume FromMetricTeaspoons(decimal metricteaspoons)
+        {
+	        return new Volume(Convert.ToDouble(metricteaspoons)*0.5e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
@@ -715,6 +1498,33 @@ namespace UnitsNet
         {
             return new Volume((microliters/1e3) * 1e-6d);
         }
+
+		/// <summary>
+        ///     Get Volume from Microliters.
+        /// </summary>
+        public static Volume FromMicroliters(int microliters)
+        {
+            return new Volume((microliters/1e3) * 1e-6d);
+        }
+
+		/// <summary>
+        ///     Get Volume from Microliters.
+        /// </summary>
+        public static Volume FromMicroliters(long microliters)
+        {
+            return new Volume((microliters/1e3) * 1e-6d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Microliters of type decimal.
+        /// </summary>
+        public static Volume FromMicroliters(decimal microliters)
+        {
+	        return new Volume((Convert.ToDouble(microliters)/1e3) * 1e-6d);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from Milliliters.
@@ -724,6 +1534,33 @@ namespace UnitsNet
             return new Volume((milliliters/1e3) * 1e-3d);
         }
 
+		/// <summary>
+        ///     Get Volume from Milliliters.
+        /// </summary>
+        public static Volume FromMilliliters(int milliliters)
+        {
+            return new Volume((milliliters/1e3) * 1e-3d);
+        }
+
+		/// <summary>
+        ///     Get Volume from Milliliters.
+        /// </summary>
+        public static Volume FromMilliliters(long milliliters)
+        {
+            return new Volume((milliliters/1e3) * 1e-3d);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Milliliters of type decimal.
+        /// </summary>
+        public static Volume FromMilliliters(decimal milliliters)
+        {
+	        return new Volume((Convert.ToDouble(milliliters)/1e3) * 1e-3d);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
@@ -731,6 +1568,33 @@ namespace UnitsNet
         {
             return new Volume(oilbarrels*0.158987294928);
         }
+
+		/// <summary>
+        ///     Get Volume from OilBarrels.
+        /// </summary>
+        public static Volume FromOilBarrels(int oilbarrels)
+        {
+            return new Volume(oilbarrels*0.158987294928);
+        }
+
+		/// <summary>
+        ///     Get Volume from OilBarrels.
+        /// </summary>
+        public static Volume FromOilBarrels(long oilbarrels)
+        {
+            return new Volume(oilbarrels*0.158987294928);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from OilBarrels of type decimal.
+        /// </summary>
+        public static Volume FromOilBarrels(decimal oilbarrels)
+        {
+	        return new Volume(Convert.ToDouble(oilbarrels)*0.158987294928);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from Tablespoons.
@@ -740,6 +1604,33 @@ namespace UnitsNet
             return new Volume(tablespoons*1.478676478125e-5);
         }
 
+		/// <summary>
+        ///     Get Volume from Tablespoons.
+        /// </summary>
+        public static Volume FromTablespoons(int tablespoons)
+        {
+            return new Volume(tablespoons*1.478676478125e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from Tablespoons.
+        /// </summary>
+        public static Volume FromTablespoons(long tablespoons)
+        {
+            return new Volume(tablespoons*1.478676478125e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Tablespoons of type decimal.
+        /// </summary>
+        public static Volume FromTablespoons(decimal tablespoons)
+        {
+	        return new Volume(Convert.ToDouble(tablespoons)*1.478676478125e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from Teaspoons.
         /// </summary>
@@ -747,6 +1638,33 @@ namespace UnitsNet
         {
             return new Volume(teaspoons*4.92892159375e-6);
         }
+
+		/// <summary>
+        ///     Get Volume from Teaspoons.
+        /// </summary>
+        public static Volume FromTeaspoons(int teaspoons)
+        {
+            return new Volume(teaspoons*4.92892159375e-6);
+        }
+
+		/// <summary>
+        ///     Get Volume from Teaspoons.
+        /// </summary>
+        public static Volume FromTeaspoons(long teaspoons)
+        {
+            return new Volume(teaspoons*4.92892159375e-6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from Teaspoons of type decimal.
+        /// </summary>
+        public static Volume FromTeaspoons(decimal teaspoons)
+        {
+	        return new Volume(Convert.ToDouble(teaspoons)*4.92892159375e-6);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from UkTablespoons.
@@ -756,6 +1674,33 @@ namespace UnitsNet
             return new Volume(uktablespoons*1.5e-5);
         }
 
+		/// <summary>
+        ///     Get Volume from UkTablespoons.
+        /// </summary>
+        public static Volume FromUkTablespoons(int uktablespoons)
+        {
+            return new Volume(uktablespoons*1.5e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from UkTablespoons.
+        /// </summary>
+        public static Volume FromUkTablespoons(long uktablespoons)
+        {
+            return new Volume(uktablespoons*1.5e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UkTablespoons of type decimal.
+        /// </summary>
+        public static Volume FromUkTablespoons(decimal uktablespoons)
+        {
+	        return new Volume(Convert.ToDouble(uktablespoons)*1.5e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
@@ -763,6 +1708,33 @@ namespace UnitsNet
         {
             return new Volume(usbeerbarrels*0.1173477658);
         }
+
+		/// <summary>
+        ///     Get Volume from UsBeerBarrels.
+        /// </summary>
+        public static Volume FromUsBeerBarrels(int usbeerbarrels)
+        {
+            return new Volume(usbeerbarrels*0.1173477658);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsBeerBarrels.
+        /// </summary>
+        public static Volume FromUsBeerBarrels(long usbeerbarrels)
+        {
+            return new Volume(usbeerbarrels*0.1173477658);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsBeerBarrels of type decimal.
+        /// </summary>
+        public static Volume FromUsBeerBarrels(decimal usbeerbarrels)
+        {
+	        return new Volume(Convert.ToDouble(usbeerbarrels)*0.1173477658);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from UsCustomaryCups.
@@ -772,6 +1744,33 @@ namespace UnitsNet
             return new Volume(uscustomarycups*0.0002365882365);
         }
 
+		/// <summary>
+        ///     Get Volume from UsCustomaryCups.
+        /// </summary>
+        public static Volume FromUsCustomaryCups(int uscustomarycups)
+        {
+            return new Volume(uscustomarycups*0.0002365882365);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsCustomaryCups.
+        /// </summary>
+        public static Volume FromUsCustomaryCups(long uscustomarycups)
+        {
+            return new Volume(uscustomarycups*0.0002365882365);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsCustomaryCups of type decimal.
+        /// </summary>
+        public static Volume FromUsCustomaryCups(decimal uscustomarycups)
+        {
+	        return new Volume(Convert.ToDouble(uscustomarycups)*0.0002365882365);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
@@ -779,6 +1778,33 @@ namespace UnitsNet
         {
             return new Volume(usgallons*0.00378541);
         }
+
+		/// <summary>
+        ///     Get Volume from UsGallons.
+        /// </summary>
+        public static Volume FromUsGallons(int usgallons)
+        {
+            return new Volume(usgallons*0.00378541);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsGallons.
+        /// </summary>
+        public static Volume FromUsGallons(long usgallons)
+        {
+            return new Volume(usgallons*0.00378541);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsGallons of type decimal.
+        /// </summary>
+        public static Volume FromUsGallons(decimal usgallons)
+        {
+	        return new Volume(Convert.ToDouble(usgallons)*0.00378541);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from UsLegalCups.
@@ -788,6 +1814,33 @@ namespace UnitsNet
             return new Volume(uslegalcups*0.00024);
         }
 
+		/// <summary>
+        ///     Get Volume from UsLegalCups.
+        /// </summary>
+        public static Volume FromUsLegalCups(int uslegalcups)
+        {
+            return new Volume(uslegalcups*0.00024);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsLegalCups.
+        /// </summary>
+        public static Volume FromUsLegalCups(long uslegalcups)
+        {
+            return new Volume(uslegalcups*0.00024);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsLegalCups of type decimal.
+        /// </summary>
+        public static Volume FromUsLegalCups(decimal uslegalcups)
+        {
+	        return new Volume(Convert.ToDouble(uslegalcups)*0.00024);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
@@ -795,6 +1848,33 @@ namespace UnitsNet
         {
             return new Volume(usounces*2.957352956253760505068307980135e-5);
         }
+
+		/// <summary>
+        ///     Get Volume from UsOunces.
+        /// </summary>
+        public static Volume FromUsOunces(int usounces)
+        {
+            return new Volume(usounces*2.957352956253760505068307980135e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsOunces.
+        /// </summary>
+        public static Volume FromUsOunces(long usounces)
+        {
+            return new Volume(usounces*2.957352956253760505068307980135e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsOunces of type decimal.
+        /// </summary>
+        public static Volume FromUsOunces(decimal usounces)
+        {
+	        return new Volume(Convert.ToDouble(usounces)*2.957352956253760505068307980135e-5);
+        }
+#endif
 
         /// <summary>
         ///     Get Volume from UsTablespoons.
@@ -804,6 +1884,33 @@ namespace UnitsNet
             return new Volume(ustablespoons*1.478676478125e-5);
         }
 
+		/// <summary>
+        ///     Get Volume from UsTablespoons.
+        /// </summary>
+        public static Volume FromUsTablespoons(int ustablespoons)
+        {
+            return new Volume(ustablespoons*1.478676478125e-5);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsTablespoons.
+        /// </summary>
+        public static Volume FromUsTablespoons(long ustablespoons)
+        {
+            return new Volume(ustablespoons*1.478676478125e-5);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsTablespoons of type decimal.
+        /// </summary>
+        public static Volume FromUsTablespoons(decimal ustablespoons)
+        {
+	        return new Volume(Convert.ToDouble(ustablespoons)*1.478676478125e-5);
+        }
+#endif
+
         /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
@@ -812,12 +1919,84 @@ namespace UnitsNet
             return new Volume(usteaspoons*4.92892159375e-6);
         }
 
+		/// <summary>
+        ///     Get Volume from UsTeaspoons.
+        /// </summary>
+        public static Volume FromUsTeaspoons(int usteaspoons)
+        {
+            return new Volume(usteaspoons*4.92892159375e-6);
+        }
+
+		/// <summary>
+        ///     Get Volume from UsTeaspoons.
+        /// </summary>
+        public static Volume FromUsTeaspoons(long usteaspoons)
+        {
+            return new Volume(usteaspoons*4.92892159375e-6);
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get Volume from UsTeaspoons of type decimal.
+        /// </summary>
+        public static Volume FromUsTeaspoons(decimal usteaspoons)
+        {
+	        return new Volume(Convert.ToDouble(usteaspoons)*4.92892159375e-6);
+        }
+#endif
+
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Volume from nullable AuTablespoons.
         /// </summary>
         public static Volume? FromAuTablespoons(double? autablespoons)
+        {
+            if (autablespoons.HasValue)
+            {
+                return FromAuTablespoons(autablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable AuTablespoons.
+        /// </summary>
+        public static Volume? FromAuTablespoons(int? autablespoons)
+        {
+            if (autablespoons.HasValue)
+            {
+                return FromAuTablespoons(autablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable AuTablespoons.
+        /// </summary>
+        public static Volume? FromAuTablespoons(long? autablespoons)
+        {
+            if (autablespoons.HasValue)
+            {
+                return FromAuTablespoons(autablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from AuTablespoons of type decimal.
+        /// </summary>
+        public static Volume? FromAuTablespoons(decimal? autablespoons)
         {
             if (autablespoons.HasValue)
             {
@@ -844,10 +2023,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable Centiliters.
+        /// </summary>
+        public static Volume? FromCentiliters(int? centiliters)
+        {
+            if (centiliters.HasValue)
+            {
+                return FromCentiliters(centiliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Centiliters.
+        /// </summary>
+        public static Volume? FromCentiliters(long? centiliters)
+        {
+            if (centiliters.HasValue)
+            {
+                return FromCentiliters(centiliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Centiliters of type decimal.
+        /// </summary>
+        public static Volume? FromCentiliters(decimal? centiliters)
+        {
+            if (centiliters.HasValue)
+            {
+                return FromCentiliters(centiliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable CubicCentimeters.
         /// </summary>
         public static Volume? FromCubicCentimeters(double? cubiccentimeters)
+        {
+            if (cubiccentimeters.HasValue)
+            {
+                return FromCubicCentimeters(cubiccentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicCentimeters.
+        /// </summary>
+        public static Volume? FromCubicCentimeters(int? cubiccentimeters)
+        {
+            if (cubiccentimeters.HasValue)
+            {
+                return FromCubicCentimeters(cubiccentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicCentimeters.
+        /// </summary>
+        public static Volume? FromCubicCentimeters(long? cubiccentimeters)
+        {
+            if (cubiccentimeters.HasValue)
+            {
+                return FromCubicCentimeters(cubiccentimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicCentimeters of type decimal.
+        /// </summary>
+        public static Volume? FromCubicCentimeters(decimal? cubiccentimeters)
         {
             if (cubiccentimeters.HasValue)
             {
@@ -874,10 +2143,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicDecimeters.
+        /// </summary>
+        public static Volume? FromCubicDecimeters(int? cubicdecimeters)
+        {
+            if (cubicdecimeters.HasValue)
+            {
+                return FromCubicDecimeters(cubicdecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicDecimeters.
+        /// </summary>
+        public static Volume? FromCubicDecimeters(long? cubicdecimeters)
+        {
+            if (cubicdecimeters.HasValue)
+            {
+                return FromCubicDecimeters(cubicdecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicDecimeters of type decimal.
+        /// </summary>
+        public static Volume? FromCubicDecimeters(decimal? cubicdecimeters)
+        {
+            if (cubicdecimeters.HasValue)
+            {
+                return FromCubicDecimeters(cubicdecimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable CubicFeet.
         /// </summary>
         public static Volume? FromCubicFeet(double? cubicfeet)
+        {
+            if (cubicfeet.HasValue)
+            {
+                return FromCubicFeet(cubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicFeet.
+        /// </summary>
+        public static Volume? FromCubicFeet(int? cubicfeet)
+        {
+            if (cubicfeet.HasValue)
+            {
+                return FromCubicFeet(cubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicFeet.
+        /// </summary>
+        public static Volume? FromCubicFeet(long? cubicfeet)
+        {
+            if (cubicfeet.HasValue)
+            {
+                return FromCubicFeet(cubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicFeet of type decimal.
+        /// </summary>
+        public static Volume? FromCubicFeet(decimal? cubicfeet)
         {
             if (cubicfeet.HasValue)
             {
@@ -904,10 +2263,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicInches.
+        /// </summary>
+        public static Volume? FromCubicInches(int? cubicinches)
+        {
+            if (cubicinches.HasValue)
+            {
+                return FromCubicInches(cubicinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicInches.
+        /// </summary>
+        public static Volume? FromCubicInches(long? cubicinches)
+        {
+            if (cubicinches.HasValue)
+            {
+                return FromCubicInches(cubicinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicInches of type decimal.
+        /// </summary>
+        public static Volume? FromCubicInches(decimal? cubicinches)
+        {
+            if (cubicinches.HasValue)
+            {
+                return FromCubicInches(cubicinches.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable CubicKilometers.
         /// </summary>
         public static Volume? FromCubicKilometers(double? cubickilometers)
+        {
+            if (cubickilometers.HasValue)
+            {
+                return FromCubicKilometers(cubickilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicKilometers.
+        /// </summary>
+        public static Volume? FromCubicKilometers(int? cubickilometers)
+        {
+            if (cubickilometers.HasValue)
+            {
+                return FromCubicKilometers(cubickilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicKilometers.
+        /// </summary>
+        public static Volume? FromCubicKilometers(long? cubickilometers)
+        {
+            if (cubickilometers.HasValue)
+            {
+                return FromCubicKilometers(cubickilometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicKilometers of type decimal.
+        /// </summary>
+        public static Volume? FromCubicKilometers(decimal? cubickilometers)
         {
             if (cubickilometers.HasValue)
             {
@@ -934,10 +2383,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMeters.
+        /// </summary>
+        public static Volume? FromCubicMeters(int? cubicmeters)
+        {
+            if (cubicmeters.HasValue)
+            {
+                return FromCubicMeters(cubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMeters.
+        /// </summary>
+        public static Volume? FromCubicMeters(long? cubicmeters)
+        {
+            if (cubicmeters.HasValue)
+            {
+                return FromCubicMeters(cubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicMeters of type decimal.
+        /// </summary>
+        public static Volume? FromCubicMeters(decimal? cubicmeters)
+        {
+            if (cubicmeters.HasValue)
+            {
+                return FromCubicMeters(cubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable CubicMicrometers.
         /// </summary>
         public static Volume? FromCubicMicrometers(double? cubicmicrometers)
+        {
+            if (cubicmicrometers.HasValue)
+            {
+                return FromCubicMicrometers(cubicmicrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMicrometers.
+        /// </summary>
+        public static Volume? FromCubicMicrometers(int? cubicmicrometers)
+        {
+            if (cubicmicrometers.HasValue)
+            {
+                return FromCubicMicrometers(cubicmicrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMicrometers.
+        /// </summary>
+        public static Volume? FromCubicMicrometers(long? cubicmicrometers)
+        {
+            if (cubicmicrometers.HasValue)
+            {
+                return FromCubicMicrometers(cubicmicrometers.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicMicrometers of type decimal.
+        /// </summary>
+        public static Volume? FromCubicMicrometers(decimal? cubicmicrometers)
         {
             if (cubicmicrometers.HasValue)
             {
@@ -964,10 +2503,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMiles.
+        /// </summary>
+        public static Volume? FromCubicMiles(int? cubicmiles)
+        {
+            if (cubicmiles.HasValue)
+            {
+                return FromCubicMiles(cubicmiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMiles.
+        /// </summary>
+        public static Volume? FromCubicMiles(long? cubicmiles)
+        {
+            if (cubicmiles.HasValue)
+            {
+                return FromCubicMiles(cubicmiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicMiles of type decimal.
+        /// </summary>
+        public static Volume? FromCubicMiles(decimal? cubicmiles)
+        {
+            if (cubicmiles.HasValue)
+            {
+                return FromCubicMiles(cubicmiles.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable CubicMillimeters.
         /// </summary>
         public static Volume? FromCubicMillimeters(double? cubicmillimeters)
+        {
+            if (cubicmillimeters.HasValue)
+            {
+                return FromCubicMillimeters(cubicmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMillimeters.
+        /// </summary>
+        public static Volume? FromCubicMillimeters(int? cubicmillimeters)
+        {
+            if (cubicmillimeters.HasValue)
+            {
+                return FromCubicMillimeters(cubicmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicMillimeters.
+        /// </summary>
+        public static Volume? FromCubicMillimeters(long? cubicmillimeters)
+        {
+            if (cubicmillimeters.HasValue)
+            {
+                return FromCubicMillimeters(cubicmillimeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicMillimeters of type decimal.
+        /// </summary>
+        public static Volume? FromCubicMillimeters(decimal? cubicmillimeters)
         {
             if (cubicmillimeters.HasValue)
             {
@@ -994,10 +2623,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicYards.
+        /// </summary>
+        public static Volume? FromCubicYards(int? cubicyards)
+        {
+            if (cubicyards.HasValue)
+            {
+                return FromCubicYards(cubicyards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable CubicYards.
+        /// </summary>
+        public static Volume? FromCubicYards(long? cubicyards)
+        {
+            if (cubicyards.HasValue)
+            {
+                return FromCubicYards(cubicyards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from CubicYards of type decimal.
+        /// </summary>
+        public static Volume? FromCubicYards(decimal? cubicyards)
+        {
+            if (cubicyards.HasValue)
+            {
+                return FromCubicYards(cubicyards.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable Deciliters.
         /// </summary>
         public static Volume? FromDeciliters(double? deciliters)
+        {
+            if (deciliters.HasValue)
+            {
+                return FromDeciliters(deciliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Deciliters.
+        /// </summary>
+        public static Volume? FromDeciliters(int? deciliters)
+        {
+            if (deciliters.HasValue)
+            {
+                return FromDeciliters(deciliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Deciliters.
+        /// </summary>
+        public static Volume? FromDeciliters(long? deciliters)
+        {
+            if (deciliters.HasValue)
+            {
+                return FromDeciliters(deciliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Deciliters of type decimal.
+        /// </summary>
+        public static Volume? FromDeciliters(decimal? deciliters)
         {
             if (deciliters.HasValue)
             {
@@ -1024,10 +2743,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable HectocubicFeet.
+        /// </summary>
+        public static Volume? FromHectocubicFeet(int? hectocubicfeet)
+        {
+            if (hectocubicfeet.HasValue)
+            {
+                return FromHectocubicFeet(hectocubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable HectocubicFeet.
+        /// </summary>
+        public static Volume? FromHectocubicFeet(long? hectocubicfeet)
+        {
+            if (hectocubicfeet.HasValue)
+            {
+                return FromHectocubicFeet(hectocubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from HectocubicFeet of type decimal.
+        /// </summary>
+        public static Volume? FromHectocubicFeet(decimal? hectocubicfeet)
+        {
+            if (hectocubicfeet.HasValue)
+            {
+                return FromHectocubicFeet(hectocubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable HectocubicMeters.
         /// </summary>
         public static Volume? FromHectocubicMeters(double? hectocubicmeters)
+        {
+            if (hectocubicmeters.HasValue)
+            {
+                return FromHectocubicMeters(hectocubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable HectocubicMeters.
+        /// </summary>
+        public static Volume? FromHectocubicMeters(int? hectocubicmeters)
+        {
+            if (hectocubicmeters.HasValue)
+            {
+                return FromHectocubicMeters(hectocubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable HectocubicMeters.
+        /// </summary>
+        public static Volume? FromHectocubicMeters(long? hectocubicmeters)
+        {
+            if (hectocubicmeters.HasValue)
+            {
+                return FromHectocubicMeters(hectocubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from HectocubicMeters of type decimal.
+        /// </summary>
+        public static Volume? FromHectocubicMeters(decimal? hectocubicmeters)
         {
             if (hectocubicmeters.HasValue)
             {
@@ -1054,10 +2863,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable Hectoliters.
+        /// </summary>
+        public static Volume? FromHectoliters(int? hectoliters)
+        {
+            if (hectoliters.HasValue)
+            {
+                return FromHectoliters(hectoliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Hectoliters.
+        /// </summary>
+        public static Volume? FromHectoliters(long? hectoliters)
+        {
+            if (hectoliters.HasValue)
+            {
+                return FromHectoliters(hectoliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Hectoliters of type decimal.
+        /// </summary>
+        public static Volume? FromHectoliters(decimal? hectoliters)
+        {
+            if (hectoliters.HasValue)
+            {
+                return FromHectoliters(hectoliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable ImperialBeerBarrels.
         /// </summary>
         public static Volume? FromImperialBeerBarrels(double? imperialbeerbarrels)
+        {
+            if (imperialbeerbarrels.HasValue)
+            {
+                return FromImperialBeerBarrels(imperialbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable ImperialBeerBarrels.
+        /// </summary>
+        public static Volume? FromImperialBeerBarrels(int? imperialbeerbarrels)
+        {
+            if (imperialbeerbarrels.HasValue)
+            {
+                return FromImperialBeerBarrels(imperialbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable ImperialBeerBarrels.
+        /// </summary>
+        public static Volume? FromImperialBeerBarrels(long? imperialbeerbarrels)
+        {
+            if (imperialbeerbarrels.HasValue)
+            {
+                return FromImperialBeerBarrels(imperialbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from ImperialBeerBarrels of type decimal.
+        /// </summary>
+        public static Volume? FromImperialBeerBarrels(decimal? imperialbeerbarrels)
         {
             if (imperialbeerbarrels.HasValue)
             {
@@ -1084,10 +2983,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable ImperialGallons.
+        /// </summary>
+        public static Volume? FromImperialGallons(int? imperialgallons)
+        {
+            if (imperialgallons.HasValue)
+            {
+                return FromImperialGallons(imperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable ImperialGallons.
+        /// </summary>
+        public static Volume? FromImperialGallons(long? imperialgallons)
+        {
+            if (imperialgallons.HasValue)
+            {
+                return FromImperialGallons(imperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from ImperialGallons of type decimal.
+        /// </summary>
+        public static Volume? FromImperialGallons(decimal? imperialgallons)
+        {
+            if (imperialgallons.HasValue)
+            {
+                return FromImperialGallons(imperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable ImperialOunces.
         /// </summary>
         public static Volume? FromImperialOunces(double? imperialounces)
+        {
+            if (imperialounces.HasValue)
+            {
+                return FromImperialOunces(imperialounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable ImperialOunces.
+        /// </summary>
+        public static Volume? FromImperialOunces(int? imperialounces)
+        {
+            if (imperialounces.HasValue)
+            {
+                return FromImperialOunces(imperialounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable ImperialOunces.
+        /// </summary>
+        public static Volume? FromImperialOunces(long? imperialounces)
+        {
+            if (imperialounces.HasValue)
+            {
+                return FromImperialOunces(imperialounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from ImperialOunces of type decimal.
+        /// </summary>
+        public static Volume? FromImperialOunces(decimal? imperialounces)
         {
             if (imperialounces.HasValue)
             {
@@ -1114,10 +3103,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable KilocubicFeet.
+        /// </summary>
+        public static Volume? FromKilocubicFeet(int? kilocubicfeet)
+        {
+            if (kilocubicfeet.HasValue)
+            {
+                return FromKilocubicFeet(kilocubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable KilocubicFeet.
+        /// </summary>
+        public static Volume? FromKilocubicFeet(long? kilocubicfeet)
+        {
+            if (kilocubicfeet.HasValue)
+            {
+                return FromKilocubicFeet(kilocubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from KilocubicFeet of type decimal.
+        /// </summary>
+        public static Volume? FromKilocubicFeet(decimal? kilocubicfeet)
+        {
+            if (kilocubicfeet.HasValue)
+            {
+                return FromKilocubicFeet(kilocubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable KilocubicMeters.
         /// </summary>
         public static Volume? FromKilocubicMeters(double? kilocubicmeters)
+        {
+            if (kilocubicmeters.HasValue)
+            {
+                return FromKilocubicMeters(kilocubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable KilocubicMeters.
+        /// </summary>
+        public static Volume? FromKilocubicMeters(int? kilocubicmeters)
+        {
+            if (kilocubicmeters.HasValue)
+            {
+                return FromKilocubicMeters(kilocubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable KilocubicMeters.
+        /// </summary>
+        public static Volume? FromKilocubicMeters(long? kilocubicmeters)
+        {
+            if (kilocubicmeters.HasValue)
+            {
+                return FromKilocubicMeters(kilocubicmeters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from KilocubicMeters of type decimal.
+        /// </summary>
+        public static Volume? FromKilocubicMeters(decimal? kilocubicmeters)
         {
             if (kilocubicmeters.HasValue)
             {
@@ -1144,10 +3223,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable KiloimperialGallons.
+        /// </summary>
+        public static Volume? FromKiloimperialGallons(int? kiloimperialgallons)
+        {
+            if (kiloimperialgallons.HasValue)
+            {
+                return FromKiloimperialGallons(kiloimperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable KiloimperialGallons.
+        /// </summary>
+        public static Volume? FromKiloimperialGallons(long? kiloimperialgallons)
+        {
+            if (kiloimperialgallons.HasValue)
+            {
+                return FromKiloimperialGallons(kiloimperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from KiloimperialGallons of type decimal.
+        /// </summary>
+        public static Volume? FromKiloimperialGallons(decimal? kiloimperialgallons)
+        {
+            if (kiloimperialgallons.HasValue)
+            {
+                return FromKiloimperialGallons(kiloimperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable KilousGallons.
         /// </summary>
         public static Volume? FromKilousGallons(double? kilousgallons)
+        {
+            if (kilousgallons.HasValue)
+            {
+                return FromKilousGallons(kilousgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable KilousGallons.
+        /// </summary>
+        public static Volume? FromKilousGallons(int? kilousgallons)
+        {
+            if (kilousgallons.HasValue)
+            {
+                return FromKilousGallons(kilousgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable KilousGallons.
+        /// </summary>
+        public static Volume? FromKilousGallons(long? kilousgallons)
+        {
+            if (kilousgallons.HasValue)
+            {
+                return FromKilousGallons(kilousgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from KilousGallons of type decimal.
+        /// </summary>
+        public static Volume? FromKilousGallons(decimal? kilousgallons)
         {
             if (kilousgallons.HasValue)
             {
@@ -1174,10 +3343,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable Liters.
+        /// </summary>
+        public static Volume? FromLiters(int? liters)
+        {
+            if (liters.HasValue)
+            {
+                return FromLiters(liters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Liters.
+        /// </summary>
+        public static Volume? FromLiters(long? liters)
+        {
+            if (liters.HasValue)
+            {
+                return FromLiters(liters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Liters of type decimal.
+        /// </summary>
+        public static Volume? FromLiters(decimal? liters)
+        {
+            if (liters.HasValue)
+            {
+                return FromLiters(liters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable MegacubicFeet.
         /// </summary>
         public static Volume? FromMegacubicFeet(double? megacubicfeet)
+        {
+            if (megacubicfeet.HasValue)
+            {
+                return FromMegacubicFeet(megacubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MegacubicFeet.
+        /// </summary>
+        public static Volume? FromMegacubicFeet(int? megacubicfeet)
+        {
+            if (megacubicfeet.HasValue)
+            {
+                return FromMegacubicFeet(megacubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MegacubicFeet.
+        /// </summary>
+        public static Volume? FromMegacubicFeet(long? megacubicfeet)
+        {
+            if (megacubicfeet.HasValue)
+            {
+                return FromMegacubicFeet(megacubicfeet.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from MegacubicFeet of type decimal.
+        /// </summary>
+        public static Volume? FromMegacubicFeet(decimal? megacubicfeet)
         {
             if (megacubicfeet.HasValue)
             {
@@ -1204,10 +3463,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable MegaimperialGallons.
+        /// </summary>
+        public static Volume? FromMegaimperialGallons(int? megaimperialgallons)
+        {
+            if (megaimperialgallons.HasValue)
+            {
+                return FromMegaimperialGallons(megaimperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MegaimperialGallons.
+        /// </summary>
+        public static Volume? FromMegaimperialGallons(long? megaimperialgallons)
+        {
+            if (megaimperialgallons.HasValue)
+            {
+                return FromMegaimperialGallons(megaimperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from MegaimperialGallons of type decimal.
+        /// </summary>
+        public static Volume? FromMegaimperialGallons(decimal? megaimperialgallons)
+        {
+            if (megaimperialgallons.HasValue)
+            {
+                return FromMegaimperialGallons(megaimperialgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable MegausGallons.
         /// </summary>
         public static Volume? FromMegausGallons(double? megausgallons)
+        {
+            if (megausgallons.HasValue)
+            {
+                return FromMegausGallons(megausgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MegausGallons.
+        /// </summary>
+        public static Volume? FromMegausGallons(int? megausgallons)
+        {
+            if (megausgallons.HasValue)
+            {
+                return FromMegausGallons(megausgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MegausGallons.
+        /// </summary>
+        public static Volume? FromMegausGallons(long? megausgallons)
+        {
+            if (megausgallons.HasValue)
+            {
+                return FromMegausGallons(megausgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from MegausGallons of type decimal.
+        /// </summary>
+        public static Volume? FromMegausGallons(decimal? megausgallons)
         {
             if (megausgallons.HasValue)
             {
@@ -1234,10 +3583,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable MetricCups.
+        /// </summary>
+        public static Volume? FromMetricCups(int? metriccups)
+        {
+            if (metriccups.HasValue)
+            {
+                return FromMetricCups(metriccups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MetricCups.
+        /// </summary>
+        public static Volume? FromMetricCups(long? metriccups)
+        {
+            if (metriccups.HasValue)
+            {
+                return FromMetricCups(metriccups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from MetricCups of type decimal.
+        /// </summary>
+        public static Volume? FromMetricCups(decimal? metriccups)
+        {
+            if (metriccups.HasValue)
+            {
+                return FromMetricCups(metriccups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable MetricTeaspoons.
         /// </summary>
         public static Volume? FromMetricTeaspoons(double? metricteaspoons)
+        {
+            if (metricteaspoons.HasValue)
+            {
+                return FromMetricTeaspoons(metricteaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MetricTeaspoons.
+        /// </summary>
+        public static Volume? FromMetricTeaspoons(int? metricteaspoons)
+        {
+            if (metricteaspoons.HasValue)
+            {
+                return FromMetricTeaspoons(metricteaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable MetricTeaspoons.
+        /// </summary>
+        public static Volume? FromMetricTeaspoons(long? metricteaspoons)
+        {
+            if (metricteaspoons.HasValue)
+            {
+                return FromMetricTeaspoons(metricteaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from MetricTeaspoons of type decimal.
+        /// </summary>
+        public static Volume? FromMetricTeaspoons(decimal? metricteaspoons)
         {
             if (metricteaspoons.HasValue)
             {
@@ -1264,10 +3703,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable Microliters.
+        /// </summary>
+        public static Volume? FromMicroliters(int? microliters)
+        {
+            if (microliters.HasValue)
+            {
+                return FromMicroliters(microliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Microliters.
+        /// </summary>
+        public static Volume? FromMicroliters(long? microliters)
+        {
+            if (microliters.HasValue)
+            {
+                return FromMicroliters(microliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Microliters of type decimal.
+        /// </summary>
+        public static Volume? FromMicroliters(decimal? microliters)
+        {
+            if (microliters.HasValue)
+            {
+                return FromMicroliters(microliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable Milliliters.
         /// </summary>
         public static Volume? FromMilliliters(double? milliliters)
+        {
+            if (milliliters.HasValue)
+            {
+                return FromMilliliters(milliliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Milliliters.
+        /// </summary>
+        public static Volume? FromMilliliters(int? milliliters)
+        {
+            if (milliliters.HasValue)
+            {
+                return FromMilliliters(milliliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Milliliters.
+        /// </summary>
+        public static Volume? FromMilliliters(long? milliliters)
+        {
+            if (milliliters.HasValue)
+            {
+                return FromMilliliters(milliliters.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Milliliters of type decimal.
+        /// </summary>
+        public static Volume? FromMilliliters(decimal? milliliters)
         {
             if (milliliters.HasValue)
             {
@@ -1294,10 +3823,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable OilBarrels.
+        /// </summary>
+        public static Volume? FromOilBarrels(int? oilbarrels)
+        {
+            if (oilbarrels.HasValue)
+            {
+                return FromOilBarrels(oilbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable OilBarrels.
+        /// </summary>
+        public static Volume? FromOilBarrels(long? oilbarrels)
+        {
+            if (oilbarrels.HasValue)
+            {
+                return FromOilBarrels(oilbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from OilBarrels of type decimal.
+        /// </summary>
+        public static Volume? FromOilBarrels(decimal? oilbarrels)
+        {
+            if (oilbarrels.HasValue)
+            {
+                return FromOilBarrels(oilbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable Tablespoons.
         /// </summary>
         public static Volume? FromTablespoons(double? tablespoons)
+        {
+            if (tablespoons.HasValue)
+            {
+                return FromTablespoons(tablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Tablespoons.
+        /// </summary>
+        public static Volume? FromTablespoons(int? tablespoons)
+        {
+            if (tablespoons.HasValue)
+            {
+                return FromTablespoons(tablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Tablespoons.
+        /// </summary>
+        public static Volume? FromTablespoons(long? tablespoons)
+        {
+            if (tablespoons.HasValue)
+            {
+                return FromTablespoons(tablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Tablespoons of type decimal.
+        /// </summary>
+        public static Volume? FromTablespoons(decimal? tablespoons)
         {
             if (tablespoons.HasValue)
             {
@@ -1324,10 +3943,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable Teaspoons.
+        /// </summary>
+        public static Volume? FromTeaspoons(int? teaspoons)
+        {
+            if (teaspoons.HasValue)
+            {
+                return FromTeaspoons(teaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable Teaspoons.
+        /// </summary>
+        public static Volume? FromTeaspoons(long? teaspoons)
+        {
+            if (teaspoons.HasValue)
+            {
+                return FromTeaspoons(teaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from Teaspoons of type decimal.
+        /// </summary>
+        public static Volume? FromTeaspoons(decimal? teaspoons)
+        {
+            if (teaspoons.HasValue)
+            {
+                return FromTeaspoons(teaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable UkTablespoons.
         /// </summary>
         public static Volume? FromUkTablespoons(double? uktablespoons)
+        {
+            if (uktablespoons.HasValue)
+            {
+                return FromUkTablespoons(uktablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UkTablespoons.
+        /// </summary>
+        public static Volume? FromUkTablespoons(int? uktablespoons)
+        {
+            if (uktablespoons.HasValue)
+            {
+                return FromUkTablespoons(uktablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UkTablespoons.
+        /// </summary>
+        public static Volume? FromUkTablespoons(long? uktablespoons)
+        {
+            if (uktablespoons.HasValue)
+            {
+                return FromUkTablespoons(uktablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UkTablespoons of type decimal.
+        /// </summary>
+        public static Volume? FromUkTablespoons(decimal? uktablespoons)
         {
             if (uktablespoons.HasValue)
             {
@@ -1354,10 +4063,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable UsBeerBarrels.
+        /// </summary>
+        public static Volume? FromUsBeerBarrels(int? usbeerbarrels)
+        {
+            if (usbeerbarrels.HasValue)
+            {
+                return FromUsBeerBarrels(usbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsBeerBarrels.
+        /// </summary>
+        public static Volume? FromUsBeerBarrels(long? usbeerbarrels)
+        {
+            if (usbeerbarrels.HasValue)
+            {
+                return FromUsBeerBarrels(usbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsBeerBarrels of type decimal.
+        /// </summary>
+        public static Volume? FromUsBeerBarrels(decimal? usbeerbarrels)
+        {
+            if (usbeerbarrels.HasValue)
+            {
+                return FromUsBeerBarrels(usbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable UsCustomaryCups.
         /// </summary>
         public static Volume? FromUsCustomaryCups(double? uscustomarycups)
+        {
+            if (uscustomarycups.HasValue)
+            {
+                return FromUsCustomaryCups(uscustomarycups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsCustomaryCups.
+        /// </summary>
+        public static Volume? FromUsCustomaryCups(int? uscustomarycups)
+        {
+            if (uscustomarycups.HasValue)
+            {
+                return FromUsCustomaryCups(uscustomarycups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsCustomaryCups.
+        /// </summary>
+        public static Volume? FromUsCustomaryCups(long? uscustomarycups)
+        {
+            if (uscustomarycups.HasValue)
+            {
+                return FromUsCustomaryCups(uscustomarycups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsCustomaryCups of type decimal.
+        /// </summary>
+        public static Volume? FromUsCustomaryCups(decimal? uscustomarycups)
         {
             if (uscustomarycups.HasValue)
             {
@@ -1384,10 +4183,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable UsGallons.
+        /// </summary>
+        public static Volume? FromUsGallons(int? usgallons)
+        {
+            if (usgallons.HasValue)
+            {
+                return FromUsGallons(usgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsGallons.
+        /// </summary>
+        public static Volume? FromUsGallons(long? usgallons)
+        {
+            if (usgallons.HasValue)
+            {
+                return FromUsGallons(usgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsGallons of type decimal.
+        /// </summary>
+        public static Volume? FromUsGallons(decimal? usgallons)
+        {
+            if (usgallons.HasValue)
+            {
+                return FromUsGallons(usgallons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable UsLegalCups.
         /// </summary>
         public static Volume? FromUsLegalCups(double? uslegalcups)
+        {
+            if (uslegalcups.HasValue)
+            {
+                return FromUsLegalCups(uslegalcups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsLegalCups.
+        /// </summary>
+        public static Volume? FromUsLegalCups(int? uslegalcups)
+        {
+            if (uslegalcups.HasValue)
+            {
+                return FromUsLegalCups(uslegalcups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsLegalCups.
+        /// </summary>
+        public static Volume? FromUsLegalCups(long? uslegalcups)
+        {
+            if (uslegalcups.HasValue)
+            {
+                return FromUsLegalCups(uslegalcups.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsLegalCups of type decimal.
+        /// </summary>
+        public static Volume? FromUsLegalCups(decimal? uslegalcups)
         {
             if (uslegalcups.HasValue)
             {
@@ -1414,6 +4303,51 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable UsOunces.
+        /// </summary>
+        public static Volume? FromUsOunces(int? usounces)
+        {
+            if (usounces.HasValue)
+            {
+                return FromUsOunces(usounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsOunces.
+        /// </summary>
+        public static Volume? FromUsOunces(long? usounces)
+        {
+            if (usounces.HasValue)
+            {
+                return FromUsOunces(usounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsOunces of type decimal.
+        /// </summary>
+        public static Volume? FromUsOunces(decimal? usounces)
+        {
+            if (usounces.HasValue)
+            {
+                return FromUsOunces(usounces.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable UsTablespoons.
         /// </summary>
@@ -1429,10 +4363,100 @@ namespace UnitsNet
             }
         }
 
+		/// <summary>
+        ///     Get nullable Volume from nullable UsTablespoons.
+        /// </summary>
+        public static Volume? FromUsTablespoons(int? ustablespoons)
+        {
+            if (ustablespoons.HasValue)
+            {
+                return FromUsTablespoons(ustablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsTablespoons.
+        /// </summary>
+        public static Volume? FromUsTablespoons(long? ustablespoons)
+        {
+            if (ustablespoons.HasValue)
+            {
+                return FromUsTablespoons(ustablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsTablespoons of type decimal.
+        /// </summary>
+        public static Volume? FromUsTablespoons(decimal? ustablespoons)
+        {
+            if (ustablespoons.HasValue)
+            {
+                return FromUsTablespoons(ustablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Get nullable Volume from nullable UsTeaspoons.
         /// </summary>
         public static Volume? FromUsTeaspoons(double? usteaspoons)
+        {
+            if (usteaspoons.HasValue)
+            {
+                return FromUsTeaspoons(usteaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsTeaspoons.
+        /// </summary>
+        public static Volume? FromUsTeaspoons(int? usteaspoons)
+        {
+            if (usteaspoons.HasValue)
+            {
+                return FromUsTeaspoons(usteaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from nullable UsTeaspoons.
+        /// </summary>
+        public static Volume? FromUsTeaspoons(long? usteaspoons)
+        {
+            if (usteaspoons.HasValue)
+            {
+                return FromUsTeaspoons(usteaspoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable Volume from UsTeaspoons of type decimal.
+        /// </summary>
+        public static Volume? FromUsTeaspoons(decimal? usteaspoons)
         {
             if (usteaspoons.HasValue)
             {

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -104,7 +104,7 @@ namespace UnitsNet
         /// </summary>
         private readonly $baseType $baseUnitFieldName;
 
-		// Windows Runtime Component requires a default constructor
+        // Windows Runtime Component requires a default constructor
 #if WINDOWS_UWP
         public $quantityName() : this(0)
         {
@@ -141,14 +141,14 @@ namespace UnitsNet
 
         #region Properties
 
-		/// <summary>
-		///     The <see cref="QuantityType" /> of this quantity.
-		/// </summary>
+        /// <summary>
+        ///     The <see cref="QuantityType" /> of this quantity.
+        /// </summary>
         public static QuantityType QuantityType => QuantityType.$quantityName;
 
-		/// <summary>
-		///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
-		/// </summary>
+        /// <summary>
+        ///     The base unit representation of this quantity for the numeric value stored internally. All conversions go via this value.
+        /// </summary>
         public static $unitEnumName BaseUnit
         {
             get { return $unitEnumName.$baseUnitSingularName; }
@@ -189,7 +189,7 @@ namespace UnitsNet
 "@; foreach ($unit in $units) {
     $valueParamName = $unit.PluralName.ToLowerInvariant();
         $func = $unit.FromUnitToBaseFunc.Replace("x", $valueParamName);
-		$decimalFunc = $unit.FromUnitToBaseFunc.Replace("x","Convert.ToDouble(" + $valueParamName + ")"); @"
+        $decimalFunc = $unit.FromUnitToBaseFunc.Replace("x","Convert.ToDouble(" + $valueParamName + ")"); @"
         /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>
@@ -198,7 +198,7 @@ namespace UnitsNet
             return new $quantityName($func);
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>
         public static $quantityName From$($unit.PluralName)(int $valueParamName)
@@ -206,7 +206,7 @@ namespace UnitsNet
             return new $quantityName($($func));
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>
         public static $quantityName From$($unit.PluralName)(long $valueParamName)
@@ -214,14 +214,14 @@ namespace UnitsNet
             return new $quantityName($($func));
         }
 
-		// Windows Runtime Component does not support decimal type
+        // Windows Runtime Component does not support decimal type
 #if !WINDOWS_UWP
-		/// <summary>
+        /// <summary>
         ///     Get $quantityName from $($unit.PluralName) of type decimal.
         /// </summary>
         public static $($quantityName) From$($unit.PluralName)(decimal $valueParamName)
         {
-	        return new $quantityName($($decimalFunc));
+            return new $quantityName($($decimalFunc));
         }
 #endif
 
@@ -246,7 +246,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable $quantityName from nullable $($unit.PluralName).
         /// </summary>
         public static $($quantityName)? From$($unit.PluralName)(int? $valueParamName)
@@ -261,7 +261,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable $quantityName from nullable $($unit.PluralName).
         /// </summary>
         public static $($quantityName)? From$($unit.PluralName)(long? $valueParamName)
@@ -276,7 +276,7 @@ namespace UnitsNet
             }
         }
 
-		/// <summary>
+        /// <summary>
         ///     Get nullable $quantityName from $($unit.PluralName) of type decimal.
         /// </summary>
         public static $($quantityName)? From$($unit.PluralName)(decimal? $valueParamName)

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -188,7 +188,8 @@ namespace UnitsNet
 
 "@; foreach ($unit in $units) {
     $valueParamName = $unit.PluralName.ToLowerInvariant();
-        $func = $unit.FromUnitToBaseFunc.Replace("x", $valueParamName);@"
+        $func = $unit.FromUnitToBaseFunc.Replace("x", $valueParamName);
+		$decimalFunc = $unit.FromUnitToBaseFunc.Replace("x","Convert.ToDouble(" + $valueParamName + ")"); @"
         /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>
@@ -196,6 +197,33 @@ namespace UnitsNet
         {
             return new $quantityName($func);
         }
+
+		/// <summary>
+        ///     Get $quantityName from $($unit.PluralName).
+        /// </summary>
+        public static $quantityName From$($unit.PluralName)(int $valueParamName)
+        {
+            return new $quantityName($($func));
+        }
+
+		/// <summary>
+        ///     Get $quantityName from $($unit.PluralName).
+        /// </summary>
+        public static $quantityName From$($unit.PluralName)(long $valueParamName)
+        {
+            return new $quantityName($($func));
+        }
+
+		// Windows Runtime Component does not support decimal type
+#if !WINDOWS_UWP
+		/// <summary>
+        ///     Get $quantityName from $($unit.PluralName) of type decimal.
+        /// </summary>
+        public static $($quantityName) From$($unit.PluralName)(decimal $valueParamName)
+        {
+	        return new $quantityName($($decimalFunc));
+        }
+#endif
 
 "@; }@"
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -207,6 +235,51 @@ namespace UnitsNet
         ///     Get nullable $quantityName from nullable $($unit.PluralName).
         /// </summary>
         public static $($quantityName)? From$($unit.PluralName)(double? $valueParamName)
+        {
+            if ($($valueParamName).HasValue)
+            {
+                return From$($unit.PluralName)($($valueParamName).Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable $quantityName from nullable $($unit.PluralName).
+        /// </summary>
+        public static $($quantityName)? From$($unit.PluralName)(int? $valueParamName)
+        {
+            if ($($valueParamName).HasValue)
+            {
+                return From$($unit.PluralName)($($valueParamName).Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable $quantityName from nullable $($unit.PluralName).
+        /// </summary>
+        public static $($quantityName)? From$($unit.PluralName)(long? $valueParamName)
+        {
+            if ($($valueParamName).HasValue)
+            {
+                return From$($unit.PluralName)($($valueParamName).Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+		/// <summary>
+        ///     Get nullable $quantityName from $($unit.PluralName) of type decimal.
+        /// </summary>
+        public static $($quantityName)? From$($unit.PluralName)(decimal? $valueParamName)
         {
             if ($($valueParamName).HasValue)
             {

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -193,6 +193,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>
+#if NETFX_CORE
+        [Windows.Foundation.Metadata.DefaultOverload]
+#endif
         public static $quantityName From$($unit.PluralName)(double $valueParamName)
         {
             return new $quantityName($func);


### PR DESCRIPTION
As discussed in #282 I've added decimal overloads. If decimal is added, int and long has to be added too for overload resolution to work in a decent way (otherwise a cast or a suffix is needed for integers).

This increases the size of the binary with 134 KB from 709 to 843 KB.

I had extremely bad timing with your renaming of variables in the scripts so the rebase was quite tricky. Be on the lookout for errors related to this. I'll review this (again) tomorrow when I've slept on it for a night so please don't merge before I've reviewed it once more.
