### PR TITLE
Use generic number type to reduce From() method overload count

### DIFF
--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -197,266 +197,126 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from CentimeterPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromCentimeterPerSecondSquared(double centimeterpersecondsquared)
         {
-            return new Acceleration((centimeterpersecondsquared) * 1e-2d);
+            double value = (double) centimeterpersecondsquared;
+            return new Acceleration((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Acceleration from CentimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromCentimeterPerSecondSquared(int centimeterpersecondsquared)
+#else
+        public static Acceleration FromCentimeterPerSecondSquared(QuantityValue centimeterpersecondsquared)
         {
-            return new Acceleration((centimeterpersecondsquared) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from CentimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromCentimeterPerSecondSquared(long centimeterpersecondsquared)
-        {
-            return new Acceleration((centimeterpersecondsquared) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from CentimeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromCentimeterPerSecondSquared(decimal centimeterpersecondsquared)
-        {
-            return new Acceleration((Convert.ToDouble(centimeterpersecondsquared)) * 1e-2d);
+            double value = (double) centimeterpersecondsquared;
+            return new Acceleration(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Acceleration from DecimeterPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromDecimeterPerSecondSquared(double decimeterpersecondsquared)
         {
-            return new Acceleration((decimeterpersecondsquared) * 1e-1d);
+            double value = (double) decimeterpersecondsquared;
+            return new Acceleration((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Acceleration from DecimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromDecimeterPerSecondSquared(int decimeterpersecondsquared)
+#else
+        public static Acceleration FromDecimeterPerSecondSquared(QuantityValue decimeterpersecondsquared)
         {
-            return new Acceleration((decimeterpersecondsquared) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from DecimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromDecimeterPerSecondSquared(long decimeterpersecondsquared)
-        {
-            return new Acceleration((decimeterpersecondsquared) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from DecimeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromDecimeterPerSecondSquared(decimal decimeterpersecondsquared)
-        {
-            return new Acceleration((Convert.ToDouble(decimeterpersecondsquared)) * 1e-1d);
+            double value = (double) decimeterpersecondsquared;
+            return new Acceleration(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Acceleration from KilometerPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromKilometerPerSecondSquared(double kilometerpersecondsquared)
         {
-            return new Acceleration((kilometerpersecondsquared) * 1e3d);
+            double value = (double) kilometerpersecondsquared;
+            return new Acceleration((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Acceleration from KilometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromKilometerPerSecondSquared(int kilometerpersecondsquared)
+#else
+        public static Acceleration FromKilometerPerSecondSquared(QuantityValue kilometerpersecondsquared)
         {
-            return new Acceleration((kilometerpersecondsquared) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from KilometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromKilometerPerSecondSquared(long kilometerpersecondsquared)
-        {
-            return new Acceleration((kilometerpersecondsquared) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from KilometerPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromKilometerPerSecondSquared(decimal kilometerpersecondsquared)
-        {
-            return new Acceleration((Convert.ToDouble(kilometerpersecondsquared)) * 1e3d);
+            double value = (double) kilometerpersecondsquared;
+            return new Acceleration(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Acceleration from MeterPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromMeterPerSecondSquared(double meterpersecondsquared)
         {
-            return new Acceleration(meterpersecondsquared);
+            double value = (double) meterpersecondsquared;
+            return new Acceleration(value);
         }
-
-        /// <summary>
-        ///     Get Acceleration from MeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromMeterPerSecondSquared(int meterpersecondsquared)
+#else
+        public static Acceleration FromMeterPerSecondSquared(QuantityValue meterpersecondsquared)
         {
-            return new Acceleration(meterpersecondsquared);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from MeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromMeterPerSecondSquared(long meterpersecondsquared)
-        {
-            return new Acceleration(meterpersecondsquared);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from MeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromMeterPerSecondSquared(decimal meterpersecondsquared)
-        {
-            return new Acceleration(Convert.ToDouble(meterpersecondsquared));
+            double value = (double) meterpersecondsquared;
+            return new Acceleration((value));
         }
 #endif
 
         /// <summary>
         ///     Get Acceleration from MicrometerPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromMicrometerPerSecondSquared(double micrometerpersecondsquared)
         {
-            return new Acceleration((micrometerpersecondsquared) * 1e-6d);
+            double value = (double) micrometerpersecondsquared;
+            return new Acceleration((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Acceleration from MicrometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromMicrometerPerSecondSquared(int micrometerpersecondsquared)
+#else
+        public static Acceleration FromMicrometerPerSecondSquared(QuantityValue micrometerpersecondsquared)
         {
-            return new Acceleration((micrometerpersecondsquared) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from MicrometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromMicrometerPerSecondSquared(long micrometerpersecondsquared)
-        {
-            return new Acceleration((micrometerpersecondsquared) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from MicrometerPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromMicrometerPerSecondSquared(decimal micrometerpersecondsquared)
-        {
-            return new Acceleration((Convert.ToDouble(micrometerpersecondsquared)) * 1e-6d);
+            double value = (double) micrometerpersecondsquared;
+            return new Acceleration(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Acceleration from MillimeterPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromMillimeterPerSecondSquared(double millimeterpersecondsquared)
         {
-            return new Acceleration((millimeterpersecondsquared) * 1e-3d);
+            double value = (double) millimeterpersecondsquared;
+            return new Acceleration((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Acceleration from MillimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromMillimeterPerSecondSquared(int millimeterpersecondsquared)
+#else
+        public static Acceleration FromMillimeterPerSecondSquared(QuantityValue millimeterpersecondsquared)
         {
-            return new Acceleration((millimeterpersecondsquared) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from MillimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromMillimeterPerSecondSquared(long millimeterpersecondsquared)
-        {
-            return new Acceleration((millimeterpersecondsquared) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from MillimeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromMillimeterPerSecondSquared(decimal millimeterpersecondsquared)
-        {
-            return new Acceleration((Convert.ToDouble(millimeterpersecondsquared)) * 1e-3d);
+            double value = (double) millimeterpersecondsquared;
+            return new Acceleration(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Acceleration from NanometerPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Acceleration FromNanometerPerSecondSquared(double nanometerpersecondsquared)
         {
-            return new Acceleration((nanometerpersecondsquared) * 1e-9d);
+            double value = (double) nanometerpersecondsquared;
+            return new Acceleration((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Acceleration from NanometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromNanometerPerSecondSquared(int nanometerpersecondsquared)
+#else
+        public static Acceleration FromNanometerPerSecondSquared(QuantityValue nanometerpersecondsquared)
         {
-            return new Acceleration((nanometerpersecondsquared) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Acceleration from NanometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration FromNanometerPerSecondSquared(long nanometerpersecondsquared)
-        {
-            return new Acceleration((nanometerpersecondsquared) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Acceleration from NanometerPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration FromNanometerPerSecondSquared(decimal nanometerpersecondsquared)
-        {
-            return new Acceleration((Convert.ToDouble(nanometerpersecondsquared)) * 1e-9d);
+            double value = (double) nanometerpersecondsquared;
+            return new Acceleration(((value) * 1e-9d));
         }
 #endif
 
@@ -465,52 +325,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromCentimeterPerSecondSquared(double? centimeterpersecondsquared)
-        {
-            if (centimeterpersecondsquared.HasValue)
-            {
-                return FromCentimeterPerSecondSquared(centimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromCentimeterPerSecondSquared(int? centimeterpersecondsquared)
-        {
-            if (centimeterpersecondsquared.HasValue)
-            {
-                return FromCentimeterPerSecondSquared(centimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable CentimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromCentimeterPerSecondSquared(long? centimeterpersecondsquared)
-        {
-            if (centimeterpersecondsquared.HasValue)
-            {
-                return FromCentimeterPerSecondSquared(centimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from CentimeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromCentimeterPerSecondSquared(decimal? centimeterpersecondsquared)
+        public static Acceleration? FromCentimeterPerSecondSquared(QuantityValue? centimeterpersecondsquared)
         {
             if (centimeterpersecondsquared.HasValue)
             {
@@ -525,52 +340,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromDecimeterPerSecondSquared(double? decimeterpersecondsquared)
-        {
-            if (decimeterpersecondsquared.HasValue)
-            {
-                return FromDecimeterPerSecondSquared(decimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromDecimeterPerSecondSquared(int? decimeterpersecondsquared)
-        {
-            if (decimeterpersecondsquared.HasValue)
-            {
-                return FromDecimeterPerSecondSquared(decimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable DecimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromDecimeterPerSecondSquared(long? decimeterpersecondsquared)
-        {
-            if (decimeterpersecondsquared.HasValue)
-            {
-                return FromDecimeterPerSecondSquared(decimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from DecimeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromDecimeterPerSecondSquared(decimal? decimeterpersecondsquared)
+        public static Acceleration? FromDecimeterPerSecondSquared(QuantityValue? decimeterpersecondsquared)
         {
             if (decimeterpersecondsquared.HasValue)
             {
@@ -585,52 +355,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromKilometerPerSecondSquared(double? kilometerpersecondsquared)
-        {
-            if (kilometerpersecondsquared.HasValue)
-            {
-                return FromKilometerPerSecondSquared(kilometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromKilometerPerSecondSquared(int? kilometerpersecondsquared)
-        {
-            if (kilometerpersecondsquared.HasValue)
-            {
-                return FromKilometerPerSecondSquared(kilometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable KilometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromKilometerPerSecondSquared(long? kilometerpersecondsquared)
-        {
-            if (kilometerpersecondsquared.HasValue)
-            {
-                return FromKilometerPerSecondSquared(kilometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from KilometerPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromKilometerPerSecondSquared(decimal? kilometerpersecondsquared)
+        public static Acceleration? FromKilometerPerSecondSquared(QuantityValue? kilometerpersecondsquared)
         {
             if (kilometerpersecondsquared.HasValue)
             {
@@ -645,52 +370,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromMeterPerSecondSquared(double? meterpersecondsquared)
-        {
-            if (meterpersecondsquared.HasValue)
-            {
-                return FromMeterPerSecondSquared(meterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromMeterPerSecondSquared(int? meterpersecondsquared)
-        {
-            if (meterpersecondsquared.HasValue)
-            {
-                return FromMeterPerSecondSquared(meterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable MeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromMeterPerSecondSquared(long? meterpersecondsquared)
-        {
-            if (meterpersecondsquared.HasValue)
-            {
-                return FromMeterPerSecondSquared(meterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from MeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromMeterPerSecondSquared(decimal? meterpersecondsquared)
+        public static Acceleration? FromMeterPerSecondSquared(QuantityValue? meterpersecondsquared)
         {
             if (meterpersecondsquared.HasValue)
             {
@@ -705,52 +385,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromMicrometerPerSecondSquared(double? micrometerpersecondsquared)
-        {
-            if (micrometerpersecondsquared.HasValue)
-            {
-                return FromMicrometerPerSecondSquared(micrometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromMicrometerPerSecondSquared(int? micrometerpersecondsquared)
-        {
-            if (micrometerpersecondsquared.HasValue)
-            {
-                return FromMicrometerPerSecondSquared(micrometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable MicrometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromMicrometerPerSecondSquared(long? micrometerpersecondsquared)
-        {
-            if (micrometerpersecondsquared.HasValue)
-            {
-                return FromMicrometerPerSecondSquared(micrometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from MicrometerPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromMicrometerPerSecondSquared(decimal? micrometerpersecondsquared)
+        public static Acceleration? FromMicrometerPerSecondSquared(QuantityValue? micrometerpersecondsquared)
         {
             if (micrometerpersecondsquared.HasValue)
             {
@@ -765,52 +400,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromMillimeterPerSecondSquared(double? millimeterpersecondsquared)
-        {
-            if (millimeterpersecondsquared.HasValue)
-            {
-                return FromMillimeterPerSecondSquared(millimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromMillimeterPerSecondSquared(int? millimeterpersecondsquared)
-        {
-            if (millimeterpersecondsquared.HasValue)
-            {
-                return FromMillimeterPerSecondSquared(millimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable MillimeterPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromMillimeterPerSecondSquared(long? millimeterpersecondsquared)
-        {
-            if (millimeterpersecondsquared.HasValue)
-            {
-                return FromMillimeterPerSecondSquared(millimeterpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from MillimeterPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromMillimeterPerSecondSquared(decimal? millimeterpersecondsquared)
+        public static Acceleration? FromMillimeterPerSecondSquared(QuantityValue? millimeterpersecondsquared)
         {
             if (millimeterpersecondsquared.HasValue)
             {
@@ -825,52 +415,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
         /// </summary>
-        public static Acceleration? FromNanometerPerSecondSquared(double? nanometerpersecondsquared)
-        {
-            if (nanometerpersecondsquared.HasValue)
-            {
-                return FromNanometerPerSecondSquared(nanometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromNanometerPerSecondSquared(int? nanometerpersecondsquared)
-        {
-            if (nanometerpersecondsquared.HasValue)
-            {
-                return FromNanometerPerSecondSquared(nanometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from nullable NanometerPerSecondSquared.
-        /// </summary>
-        public static Acceleration? FromNanometerPerSecondSquared(long? nanometerpersecondsquared)
-        {
-            if (nanometerpersecondsquared.HasValue)
-            {
-                return FromNanometerPerSecondSquared(nanometerpersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Acceleration from NanometerPerSecondSquared of type decimal.
-        /// </summary>
-        public static Acceleration? FromNanometerPerSecondSquared(decimal? nanometerpersecondsquared)
+        public static Acceleration? FromNanometerPerSecondSquared(QuantityValue? nanometerpersecondsquared)
         {
             if (nanometerpersecondsquared.HasValue)
             {
@@ -887,27 +432,33 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="AccelerationUnit" /> to <see cref="Acceleration" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Acceleration unit value.</returns>
-        public static Acceleration From(double val, AccelerationUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Acceleration From(double value, AccelerationUnit fromUnit)
+#else
+        public static Acceleration From(QuantityValue value, AccelerationUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case AccelerationUnit.CentimeterPerSecondSquared:
-                    return FromCentimeterPerSecondSquared(val);
+                    return FromCentimeterPerSecondSquared(value);
                 case AccelerationUnit.DecimeterPerSecondSquared:
-                    return FromDecimeterPerSecondSquared(val);
+                    return FromDecimeterPerSecondSquared(value);
                 case AccelerationUnit.KilometerPerSecondSquared:
-                    return FromKilometerPerSecondSquared(val);
+                    return FromKilometerPerSecondSquared(value);
                 case AccelerationUnit.MeterPerSecondSquared:
-                    return FromMeterPerSecondSquared(val);
+                    return FromMeterPerSecondSquared(value);
                 case AccelerationUnit.MicrometerPerSecondSquared:
-                    return FromMicrometerPerSecondSquared(val);
+                    return FromMicrometerPerSecondSquared(value);
                 case AccelerationUnit.MillimeterPerSecondSquared:
-                    return FromMillimeterPerSecondSquared(val);
+                    return FromMillimeterPerSecondSquared(value);
                 case AccelerationUnit.NanometerPerSecondSquared:
-                    return FromNanometerPerSecondSquared(val);
+                    return FromNanometerPerSecondSquared(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -922,7 +473,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Acceleration unit value.</returns>
-        public static Acceleration? From(double? value, AccelerationUnit fromUnit)
+        public static Acceleration? From(QuantityValue? value, AccelerationUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -253,532 +253,252 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Centimoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromCentimoles(double centimoles)
         {
-            return new AmountOfSubstance((centimoles) * 1e-2d);
+            double value = (double) centimoles;
+            return new AmountOfSubstance((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Centimoles.
-        /// </summary>
-        public static AmountOfSubstance FromCentimoles(int centimoles)
+#else
+        public static AmountOfSubstance FromCentimoles(QuantityValue centimoles)
         {
-            return new AmountOfSubstance((centimoles) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Centimoles.
-        /// </summary>
-        public static AmountOfSubstance FromCentimoles(long centimoles)
-        {
-            return new AmountOfSubstance((centimoles) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Centimoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromCentimoles(decimal centimoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(centimoles)) * 1e-2d);
+            double value = (double) centimoles;
+            return new AmountOfSubstance(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from CentipoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromCentipoundMoles(double centipoundmoles)
         {
-            return new AmountOfSubstance((centipoundmoles*453.59237) * 1e-2d);
+            double value = (double) centipoundmoles;
+            return new AmountOfSubstance((value*453.59237) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from CentipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromCentipoundMoles(int centipoundmoles)
+#else
+        public static AmountOfSubstance FromCentipoundMoles(QuantityValue centipoundmoles)
         {
-            return new AmountOfSubstance((centipoundmoles*453.59237) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from CentipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromCentipoundMoles(long centipoundmoles)
-        {
-            return new AmountOfSubstance((centipoundmoles*453.59237) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from CentipoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromCentipoundMoles(decimal centipoundmoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(centipoundmoles)*453.59237) * 1e-2d);
+            double value = (double) centipoundmoles;
+            return new AmountOfSubstance(((value*453.59237) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from Decimoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromDecimoles(double decimoles)
         {
-            return new AmountOfSubstance((decimoles) * 1e-1d);
+            double value = (double) decimoles;
+            return new AmountOfSubstance((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Decimoles.
-        /// </summary>
-        public static AmountOfSubstance FromDecimoles(int decimoles)
+#else
+        public static AmountOfSubstance FromDecimoles(QuantityValue decimoles)
         {
-            return new AmountOfSubstance((decimoles) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Decimoles.
-        /// </summary>
-        public static AmountOfSubstance FromDecimoles(long decimoles)
-        {
-            return new AmountOfSubstance((decimoles) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Decimoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromDecimoles(decimal decimoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(decimoles)) * 1e-1d);
+            double value = (double) decimoles;
+            return new AmountOfSubstance(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from DecipoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromDecipoundMoles(double decipoundmoles)
         {
-            return new AmountOfSubstance((decipoundmoles*453.59237) * 1e-1d);
+            double value = (double) decipoundmoles;
+            return new AmountOfSubstance((value*453.59237) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from DecipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromDecipoundMoles(int decipoundmoles)
+#else
+        public static AmountOfSubstance FromDecipoundMoles(QuantityValue decipoundmoles)
         {
-            return new AmountOfSubstance((decipoundmoles*453.59237) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from DecipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromDecipoundMoles(long decipoundmoles)
-        {
-            return new AmountOfSubstance((decipoundmoles*453.59237) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from DecipoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromDecipoundMoles(decimal decipoundmoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(decipoundmoles)*453.59237) * 1e-1d);
+            double value = (double) decipoundmoles;
+            return new AmountOfSubstance(((value*453.59237) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from Kilomoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromKilomoles(double kilomoles)
         {
-            return new AmountOfSubstance((kilomoles) * 1e3d);
+            double value = (double) kilomoles;
+            return new AmountOfSubstance((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Kilomoles.
-        /// </summary>
-        public static AmountOfSubstance FromKilomoles(int kilomoles)
+#else
+        public static AmountOfSubstance FromKilomoles(QuantityValue kilomoles)
         {
-            return new AmountOfSubstance((kilomoles) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Kilomoles.
-        /// </summary>
-        public static AmountOfSubstance FromKilomoles(long kilomoles)
-        {
-            return new AmountOfSubstance((kilomoles) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Kilomoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromKilomoles(decimal kilomoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(kilomoles)) * 1e3d);
+            double value = (double) kilomoles;
+            return new AmountOfSubstance(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from KilopoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromKilopoundMoles(double kilopoundmoles)
         {
-            return new AmountOfSubstance((kilopoundmoles*453.59237) * 1e3d);
+            double value = (double) kilopoundmoles;
+            return new AmountOfSubstance((value*453.59237) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from KilopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromKilopoundMoles(int kilopoundmoles)
+#else
+        public static AmountOfSubstance FromKilopoundMoles(QuantityValue kilopoundmoles)
         {
-            return new AmountOfSubstance((kilopoundmoles*453.59237) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from KilopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromKilopoundMoles(long kilopoundmoles)
-        {
-            return new AmountOfSubstance((kilopoundmoles*453.59237) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from KilopoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromKilopoundMoles(decimal kilopoundmoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(kilopoundmoles)*453.59237) * 1e3d);
+            double value = (double) kilopoundmoles;
+            return new AmountOfSubstance(((value*453.59237) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from Micromoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromMicromoles(double micromoles)
         {
-            return new AmountOfSubstance((micromoles) * 1e-6d);
+            double value = (double) micromoles;
+            return new AmountOfSubstance((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Micromoles.
-        /// </summary>
-        public static AmountOfSubstance FromMicromoles(int micromoles)
+#else
+        public static AmountOfSubstance FromMicromoles(QuantityValue micromoles)
         {
-            return new AmountOfSubstance((micromoles) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Micromoles.
-        /// </summary>
-        public static AmountOfSubstance FromMicromoles(long micromoles)
-        {
-            return new AmountOfSubstance((micromoles) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Micromoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromMicromoles(decimal micromoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(micromoles)) * 1e-6d);
+            double value = (double) micromoles;
+            return new AmountOfSubstance(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from MicropoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromMicropoundMoles(double micropoundmoles)
         {
-            return new AmountOfSubstance((micropoundmoles*453.59237) * 1e-6d);
+            double value = (double) micropoundmoles;
+            return new AmountOfSubstance((value*453.59237) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from MicropoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromMicropoundMoles(int micropoundmoles)
+#else
+        public static AmountOfSubstance FromMicropoundMoles(QuantityValue micropoundmoles)
         {
-            return new AmountOfSubstance((micropoundmoles*453.59237) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from MicropoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromMicropoundMoles(long micropoundmoles)
-        {
-            return new AmountOfSubstance((micropoundmoles*453.59237) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from MicropoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromMicropoundMoles(decimal micropoundmoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(micropoundmoles)*453.59237) * 1e-6d);
+            double value = (double) micropoundmoles;
+            return new AmountOfSubstance(((value*453.59237) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from Millimoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromMillimoles(double millimoles)
         {
-            return new AmountOfSubstance((millimoles) * 1e-3d);
+            double value = (double) millimoles;
+            return new AmountOfSubstance((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Millimoles.
-        /// </summary>
-        public static AmountOfSubstance FromMillimoles(int millimoles)
+#else
+        public static AmountOfSubstance FromMillimoles(QuantityValue millimoles)
         {
-            return new AmountOfSubstance((millimoles) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Millimoles.
-        /// </summary>
-        public static AmountOfSubstance FromMillimoles(long millimoles)
-        {
-            return new AmountOfSubstance((millimoles) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Millimoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromMillimoles(decimal millimoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(millimoles)) * 1e-3d);
+            double value = (double) millimoles;
+            return new AmountOfSubstance(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from MillipoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromMillipoundMoles(double millipoundmoles)
         {
-            return new AmountOfSubstance((millipoundmoles*453.59237) * 1e-3d);
+            double value = (double) millipoundmoles;
+            return new AmountOfSubstance((value*453.59237) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from MillipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromMillipoundMoles(int millipoundmoles)
+#else
+        public static AmountOfSubstance FromMillipoundMoles(QuantityValue millipoundmoles)
         {
-            return new AmountOfSubstance((millipoundmoles*453.59237) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from MillipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromMillipoundMoles(long millipoundmoles)
-        {
-            return new AmountOfSubstance((millipoundmoles*453.59237) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from MillipoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromMillipoundMoles(decimal millipoundmoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(millipoundmoles)*453.59237) * 1e-3d);
+            double value = (double) millipoundmoles;
+            return new AmountOfSubstance(((value*453.59237) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from Moles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromMoles(double moles)
         {
-            return new AmountOfSubstance(moles);
+            double value = (double) moles;
+            return new AmountOfSubstance(value);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Moles.
-        /// </summary>
-        public static AmountOfSubstance FromMoles(int moles)
+#else
+        public static AmountOfSubstance FromMoles(QuantityValue moles)
         {
-            return new AmountOfSubstance(moles);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Moles.
-        /// </summary>
-        public static AmountOfSubstance FromMoles(long moles)
-        {
-            return new AmountOfSubstance(moles);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Moles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromMoles(decimal moles)
-        {
-            return new AmountOfSubstance(Convert.ToDouble(moles));
+            double value = (double) moles;
+            return new AmountOfSubstance((value));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from Nanomoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromNanomoles(double nanomoles)
         {
-            return new AmountOfSubstance((nanomoles) * 1e-9d);
+            double value = (double) nanomoles;
+            return new AmountOfSubstance((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Nanomoles.
-        /// </summary>
-        public static AmountOfSubstance FromNanomoles(int nanomoles)
+#else
+        public static AmountOfSubstance FromNanomoles(QuantityValue nanomoles)
         {
-            return new AmountOfSubstance((nanomoles) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from Nanomoles.
-        /// </summary>
-        public static AmountOfSubstance FromNanomoles(long nanomoles)
-        {
-            return new AmountOfSubstance((nanomoles) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from Nanomoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromNanomoles(decimal nanomoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(nanomoles)) * 1e-9d);
+            double value = (double) nanomoles;
+            return new AmountOfSubstance(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from NanopoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromNanopoundMoles(double nanopoundmoles)
         {
-            return new AmountOfSubstance((nanopoundmoles*453.59237) * 1e-9d);
+            double value = (double) nanopoundmoles;
+            return new AmountOfSubstance((value*453.59237) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from NanopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromNanopoundMoles(int nanopoundmoles)
+#else
+        public static AmountOfSubstance FromNanopoundMoles(QuantityValue nanopoundmoles)
         {
-            return new AmountOfSubstance((nanopoundmoles*453.59237) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from NanopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromNanopoundMoles(long nanopoundmoles)
-        {
-            return new AmountOfSubstance((nanopoundmoles*453.59237) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from NanopoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromNanopoundMoles(decimal nanopoundmoles)
-        {
-            return new AmountOfSubstance((Convert.ToDouble(nanopoundmoles)*453.59237) * 1e-9d);
+            double value = (double) nanopoundmoles;
+            return new AmountOfSubstance(((value*453.59237) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get AmountOfSubstance from PoundMoles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmountOfSubstance FromPoundMoles(double poundmoles)
         {
-            return new AmountOfSubstance(poundmoles*453.59237);
+            double value = (double) poundmoles;
+            return new AmountOfSubstance(value*453.59237);
         }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from PoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromPoundMoles(int poundmoles)
+#else
+        public static AmountOfSubstance FromPoundMoles(QuantityValue poundmoles)
         {
-            return new AmountOfSubstance(poundmoles*453.59237);
-        }
-
-        /// <summary>
-        ///     Get AmountOfSubstance from PoundMoles.
-        /// </summary>
-        public static AmountOfSubstance FromPoundMoles(long poundmoles)
-        {
-            return new AmountOfSubstance(poundmoles*453.59237);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmountOfSubstance from PoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance FromPoundMoles(decimal poundmoles)
-        {
-            return new AmountOfSubstance(Convert.ToDouble(poundmoles)*453.59237);
+            double value = (double) poundmoles;
+            return new AmountOfSubstance((value*453.59237));
         }
 #endif
 
@@ -787,52 +507,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Centimoles.
         /// </summary>
-        public static AmountOfSubstance? FromCentimoles(double? centimoles)
-        {
-            if (centimoles.HasValue)
-            {
-                return FromCentimoles(centimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Centimoles.
-        /// </summary>
-        public static AmountOfSubstance? FromCentimoles(int? centimoles)
-        {
-            if (centimoles.HasValue)
-            {
-                return FromCentimoles(centimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Centimoles.
-        /// </summary>
-        public static AmountOfSubstance? FromCentimoles(long? centimoles)
-        {
-            if (centimoles.HasValue)
-            {
-                return FromCentimoles(centimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Centimoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromCentimoles(decimal? centimoles)
+        public static AmountOfSubstance? FromCentimoles(QuantityValue? centimoles)
         {
             if (centimoles.HasValue)
             {
@@ -847,52 +522,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable CentipoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromCentipoundMoles(double? centipoundmoles)
-        {
-            if (centipoundmoles.HasValue)
-            {
-                return FromCentipoundMoles(centipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable CentipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromCentipoundMoles(int? centipoundmoles)
-        {
-            if (centipoundmoles.HasValue)
-            {
-                return FromCentipoundMoles(centipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable CentipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromCentipoundMoles(long? centipoundmoles)
-        {
-            if (centipoundmoles.HasValue)
-            {
-                return FromCentipoundMoles(centipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from CentipoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromCentipoundMoles(decimal? centipoundmoles)
+        public static AmountOfSubstance? FromCentipoundMoles(QuantityValue? centipoundmoles)
         {
             if (centipoundmoles.HasValue)
             {
@@ -907,52 +537,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Decimoles.
         /// </summary>
-        public static AmountOfSubstance? FromDecimoles(double? decimoles)
-        {
-            if (decimoles.HasValue)
-            {
-                return FromDecimoles(decimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Decimoles.
-        /// </summary>
-        public static AmountOfSubstance? FromDecimoles(int? decimoles)
-        {
-            if (decimoles.HasValue)
-            {
-                return FromDecimoles(decimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Decimoles.
-        /// </summary>
-        public static AmountOfSubstance? FromDecimoles(long? decimoles)
-        {
-            if (decimoles.HasValue)
-            {
-                return FromDecimoles(decimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Decimoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromDecimoles(decimal? decimoles)
+        public static AmountOfSubstance? FromDecimoles(QuantityValue? decimoles)
         {
             if (decimoles.HasValue)
             {
@@ -967,52 +552,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable DecipoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromDecipoundMoles(double? decipoundmoles)
-        {
-            if (decipoundmoles.HasValue)
-            {
-                return FromDecipoundMoles(decipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable DecipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromDecipoundMoles(int? decipoundmoles)
-        {
-            if (decipoundmoles.HasValue)
-            {
-                return FromDecipoundMoles(decipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable DecipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromDecipoundMoles(long? decipoundmoles)
-        {
-            if (decipoundmoles.HasValue)
-            {
-                return FromDecipoundMoles(decipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from DecipoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromDecipoundMoles(decimal? decipoundmoles)
+        public static AmountOfSubstance? FromDecipoundMoles(QuantityValue? decipoundmoles)
         {
             if (decipoundmoles.HasValue)
             {
@@ -1027,52 +567,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Kilomoles.
         /// </summary>
-        public static AmountOfSubstance? FromKilomoles(double? kilomoles)
-        {
-            if (kilomoles.HasValue)
-            {
-                return FromKilomoles(kilomoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Kilomoles.
-        /// </summary>
-        public static AmountOfSubstance? FromKilomoles(int? kilomoles)
-        {
-            if (kilomoles.HasValue)
-            {
-                return FromKilomoles(kilomoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Kilomoles.
-        /// </summary>
-        public static AmountOfSubstance? FromKilomoles(long? kilomoles)
-        {
-            if (kilomoles.HasValue)
-            {
-                return FromKilomoles(kilomoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Kilomoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromKilomoles(decimal? kilomoles)
+        public static AmountOfSubstance? FromKilomoles(QuantityValue? kilomoles)
         {
             if (kilomoles.HasValue)
             {
@@ -1087,52 +582,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable KilopoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromKilopoundMoles(double? kilopoundmoles)
-        {
-            if (kilopoundmoles.HasValue)
-            {
-                return FromKilopoundMoles(kilopoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable KilopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromKilopoundMoles(int? kilopoundmoles)
-        {
-            if (kilopoundmoles.HasValue)
-            {
-                return FromKilopoundMoles(kilopoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable KilopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromKilopoundMoles(long? kilopoundmoles)
-        {
-            if (kilopoundmoles.HasValue)
-            {
-                return FromKilopoundMoles(kilopoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from KilopoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromKilopoundMoles(decimal? kilopoundmoles)
+        public static AmountOfSubstance? FromKilopoundMoles(QuantityValue? kilopoundmoles)
         {
             if (kilopoundmoles.HasValue)
             {
@@ -1147,52 +597,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Micromoles.
         /// </summary>
-        public static AmountOfSubstance? FromMicromoles(double? micromoles)
-        {
-            if (micromoles.HasValue)
-            {
-                return FromMicromoles(micromoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Micromoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMicromoles(int? micromoles)
-        {
-            if (micromoles.HasValue)
-            {
-                return FromMicromoles(micromoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Micromoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMicromoles(long? micromoles)
-        {
-            if (micromoles.HasValue)
-            {
-                return FromMicromoles(micromoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Micromoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromMicromoles(decimal? micromoles)
+        public static AmountOfSubstance? FromMicromoles(QuantityValue? micromoles)
         {
             if (micromoles.HasValue)
             {
@@ -1207,52 +612,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable MicropoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromMicropoundMoles(double? micropoundmoles)
-        {
-            if (micropoundmoles.HasValue)
-            {
-                return FromMicropoundMoles(micropoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable MicropoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMicropoundMoles(int? micropoundmoles)
-        {
-            if (micropoundmoles.HasValue)
-            {
-                return FromMicropoundMoles(micropoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable MicropoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMicropoundMoles(long? micropoundmoles)
-        {
-            if (micropoundmoles.HasValue)
-            {
-                return FromMicropoundMoles(micropoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from MicropoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromMicropoundMoles(decimal? micropoundmoles)
+        public static AmountOfSubstance? FromMicropoundMoles(QuantityValue? micropoundmoles)
         {
             if (micropoundmoles.HasValue)
             {
@@ -1267,52 +627,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Millimoles.
         /// </summary>
-        public static AmountOfSubstance? FromMillimoles(double? millimoles)
-        {
-            if (millimoles.HasValue)
-            {
-                return FromMillimoles(millimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Millimoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMillimoles(int? millimoles)
-        {
-            if (millimoles.HasValue)
-            {
-                return FromMillimoles(millimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Millimoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMillimoles(long? millimoles)
-        {
-            if (millimoles.HasValue)
-            {
-                return FromMillimoles(millimoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Millimoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromMillimoles(decimal? millimoles)
+        public static AmountOfSubstance? FromMillimoles(QuantityValue? millimoles)
         {
             if (millimoles.HasValue)
             {
@@ -1327,52 +642,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable MillipoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromMillipoundMoles(double? millipoundmoles)
-        {
-            if (millipoundmoles.HasValue)
-            {
-                return FromMillipoundMoles(millipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable MillipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMillipoundMoles(int? millipoundmoles)
-        {
-            if (millipoundmoles.HasValue)
-            {
-                return FromMillipoundMoles(millipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable MillipoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromMillipoundMoles(long? millipoundmoles)
-        {
-            if (millipoundmoles.HasValue)
-            {
-                return FromMillipoundMoles(millipoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from MillipoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromMillipoundMoles(decimal? millipoundmoles)
+        public static AmountOfSubstance? FromMillipoundMoles(QuantityValue? millipoundmoles)
         {
             if (millipoundmoles.HasValue)
             {
@@ -1387,52 +657,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Moles.
         /// </summary>
-        public static AmountOfSubstance? FromMoles(double? moles)
-        {
-            if (moles.HasValue)
-            {
-                return FromMoles(moles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Moles.
-        /// </summary>
-        public static AmountOfSubstance? FromMoles(int? moles)
-        {
-            if (moles.HasValue)
-            {
-                return FromMoles(moles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Moles.
-        /// </summary>
-        public static AmountOfSubstance? FromMoles(long? moles)
-        {
-            if (moles.HasValue)
-            {
-                return FromMoles(moles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Moles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromMoles(decimal? moles)
+        public static AmountOfSubstance? FromMoles(QuantityValue? moles)
         {
             if (moles.HasValue)
             {
@@ -1447,52 +672,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable Nanomoles.
         /// </summary>
-        public static AmountOfSubstance? FromNanomoles(double? nanomoles)
-        {
-            if (nanomoles.HasValue)
-            {
-                return FromNanomoles(nanomoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Nanomoles.
-        /// </summary>
-        public static AmountOfSubstance? FromNanomoles(int? nanomoles)
-        {
-            if (nanomoles.HasValue)
-            {
-                return FromNanomoles(nanomoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable Nanomoles.
-        /// </summary>
-        public static AmountOfSubstance? FromNanomoles(long? nanomoles)
-        {
-            if (nanomoles.HasValue)
-            {
-                return FromNanomoles(nanomoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from Nanomoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromNanomoles(decimal? nanomoles)
+        public static AmountOfSubstance? FromNanomoles(QuantityValue? nanomoles)
         {
             if (nanomoles.HasValue)
             {
@@ -1507,52 +687,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable NanopoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromNanopoundMoles(double? nanopoundmoles)
-        {
-            if (nanopoundmoles.HasValue)
-            {
-                return FromNanopoundMoles(nanopoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable NanopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromNanopoundMoles(int? nanopoundmoles)
-        {
-            if (nanopoundmoles.HasValue)
-            {
-                return FromNanopoundMoles(nanopoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable NanopoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromNanopoundMoles(long? nanopoundmoles)
-        {
-            if (nanopoundmoles.HasValue)
-            {
-                return FromNanopoundMoles(nanopoundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from NanopoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromNanopoundMoles(decimal? nanopoundmoles)
+        public static AmountOfSubstance? FromNanopoundMoles(QuantityValue? nanopoundmoles)
         {
             if (nanopoundmoles.HasValue)
             {
@@ -1567,52 +702,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmountOfSubstance from nullable PoundMoles.
         /// </summary>
-        public static AmountOfSubstance? FromPoundMoles(double? poundmoles)
-        {
-            if (poundmoles.HasValue)
-            {
-                return FromPoundMoles(poundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable PoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromPoundMoles(int? poundmoles)
-        {
-            if (poundmoles.HasValue)
-            {
-                return FromPoundMoles(poundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from nullable PoundMoles.
-        /// </summary>
-        public static AmountOfSubstance? FromPoundMoles(long? poundmoles)
-        {
-            if (poundmoles.HasValue)
-            {
-                return FromPoundMoles(poundmoles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmountOfSubstance from PoundMoles of type decimal.
-        /// </summary>
-        public static AmountOfSubstance? FromPoundMoles(decimal? poundmoles)
+        public static AmountOfSubstance? FromPoundMoles(QuantityValue? poundmoles)
         {
             if (poundmoles.HasValue)
             {
@@ -1629,41 +719,47 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="AmountOfSubstanceUnit" /> to <see cref="AmountOfSubstance" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>AmountOfSubstance unit value.</returns>
-        public static AmountOfSubstance From(double val, AmountOfSubstanceUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static AmountOfSubstance From(double value, AmountOfSubstanceUnit fromUnit)
+#else
+        public static AmountOfSubstance From(QuantityValue value, AmountOfSubstanceUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case AmountOfSubstanceUnit.Centimole:
-                    return FromCentimoles(val);
+                    return FromCentimoles(value);
                 case AmountOfSubstanceUnit.CentipoundMole:
-                    return FromCentipoundMoles(val);
+                    return FromCentipoundMoles(value);
                 case AmountOfSubstanceUnit.Decimole:
-                    return FromDecimoles(val);
+                    return FromDecimoles(value);
                 case AmountOfSubstanceUnit.DecipoundMole:
-                    return FromDecipoundMoles(val);
+                    return FromDecipoundMoles(value);
                 case AmountOfSubstanceUnit.Kilomole:
-                    return FromKilomoles(val);
+                    return FromKilomoles(value);
                 case AmountOfSubstanceUnit.KilopoundMole:
-                    return FromKilopoundMoles(val);
+                    return FromKilopoundMoles(value);
                 case AmountOfSubstanceUnit.Micromole:
-                    return FromMicromoles(val);
+                    return FromMicromoles(value);
                 case AmountOfSubstanceUnit.MicropoundMole:
-                    return FromMicropoundMoles(val);
+                    return FromMicropoundMoles(value);
                 case AmountOfSubstanceUnit.Millimole:
-                    return FromMillimoles(val);
+                    return FromMillimoles(value);
                 case AmountOfSubstanceUnit.MillipoundMole:
-                    return FromMillipoundMoles(val);
+                    return FromMillipoundMoles(value);
                 case AmountOfSubstanceUnit.Mole:
-                    return FromMoles(val);
+                    return FromMoles(value);
                 case AmountOfSubstanceUnit.Nanomole:
-                    return FromNanomoles(val);
+                    return FromNanomoles(value);
                 case AmountOfSubstanceUnit.NanopoundMole:
-                    return FromNanopoundMoles(val);
+                    return FromNanopoundMoles(value);
                 case AmountOfSubstanceUnit.PoundMole:
-                    return FromPoundMoles(val);
+                    return FromPoundMoles(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1678,7 +774,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>AmountOfSubstance unit value.</returns>
-        public static AmountOfSubstance? From(double? value, AmountOfSubstanceUnit fromUnit)
+        public static AmountOfSubstance? From(QuantityValue? value, AmountOfSubstanceUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -173,152 +173,72 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmplitudeRatio FromDecibelMicrovolts(double decibelmicrovolts)
         {
-            return new AmplitudeRatio(decibelmicrovolts - 120);
+            double value = (double) decibelmicrovolts;
+            return new AmplitudeRatio(value - 120);
         }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelMicrovolts.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelMicrovolts(int decibelmicrovolts)
+#else
+        public static AmplitudeRatio FromDecibelMicrovolts(QuantityValue decibelmicrovolts)
         {
-            return new AmplitudeRatio(decibelmicrovolts - 120);
-        }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelMicrovolts.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelMicrovolts(long decibelmicrovolts)
-        {
-            return new AmplitudeRatio(decibelmicrovolts - 120);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelMicrovolts of type decimal.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelMicrovolts(decimal decibelmicrovolts)
-        {
-            return new AmplitudeRatio(Convert.ToDouble(decibelmicrovolts) - 120);
+            double value = (double) decibelmicrovolts;
+            return new AmplitudeRatio((value - 120));
         }
 #endif
 
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmplitudeRatio FromDecibelMillivolts(double decibelmillivolts)
         {
-            return new AmplitudeRatio(decibelmillivolts - 60);
+            double value = (double) decibelmillivolts;
+            return new AmplitudeRatio(value - 60);
         }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelMillivolts.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelMillivolts(int decibelmillivolts)
+#else
+        public static AmplitudeRatio FromDecibelMillivolts(QuantityValue decibelmillivolts)
         {
-            return new AmplitudeRatio(decibelmillivolts - 60);
-        }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelMillivolts.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelMillivolts(long decibelmillivolts)
-        {
-            return new AmplitudeRatio(decibelmillivolts - 60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelMillivolts of type decimal.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelMillivolts(decimal decibelmillivolts)
-        {
-            return new AmplitudeRatio(Convert.ToDouble(decibelmillivolts) - 60);
+            double value = (double) decibelmillivolts;
+            return new AmplitudeRatio((value - 60));
         }
 #endif
 
         /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmplitudeRatio FromDecibelsUnloaded(double decibelsunloaded)
         {
-            return new AmplitudeRatio(decibelsunloaded - 2.218487499);
+            double value = (double) decibelsunloaded;
+            return new AmplitudeRatio(value - 2.218487499);
         }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelsUnloaded.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelsUnloaded(int decibelsunloaded)
+#else
+        public static AmplitudeRatio FromDecibelsUnloaded(QuantityValue decibelsunloaded)
         {
-            return new AmplitudeRatio(decibelsunloaded - 2.218487499);
-        }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelsUnloaded.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelsUnloaded(long decibelsunloaded)
-        {
-            return new AmplitudeRatio(decibelsunloaded - 2.218487499);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelsUnloaded of type decimal.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelsUnloaded(decimal decibelsunloaded)
-        {
-            return new AmplitudeRatio(Convert.ToDouble(decibelsunloaded) - 2.218487499);
+            double value = (double) decibelsunloaded;
+            return new AmplitudeRatio((value - 2.218487499));
         }
 #endif
 
         /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AmplitudeRatio FromDecibelVolts(double decibelvolts)
         {
-            return new AmplitudeRatio(decibelvolts);
+            double value = (double) decibelvolts;
+            return new AmplitudeRatio(value);
         }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelVolts.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelVolts(int decibelvolts)
+#else
+        public static AmplitudeRatio FromDecibelVolts(QuantityValue decibelvolts)
         {
-            return new AmplitudeRatio(decibelvolts);
-        }
-
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelVolts.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelVolts(long decibelvolts)
-        {
-            return new AmplitudeRatio(decibelvolts);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AmplitudeRatio from DecibelVolts of type decimal.
-        /// </summary>
-        public static AmplitudeRatio FromDecibelVolts(decimal decibelvolts)
-        {
-            return new AmplitudeRatio(Convert.ToDouble(decibelvolts));
+            double value = (double) decibelvolts;
+            return new AmplitudeRatio((value));
         }
 #endif
 
@@ -327,52 +247,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
         /// </summary>
-        public static AmplitudeRatio? FromDecibelMicrovolts(double? decibelmicrovolts)
-        {
-            if (decibelmicrovolts.HasValue)
-            {
-                return FromDecibelMicrovolts(decibelmicrovolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelMicrovolts(int? decibelmicrovolts)
-        {
-            if (decibelmicrovolts.HasValue)
-            {
-                return FromDecibelMicrovolts(decibelmicrovolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelMicrovolts.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelMicrovolts(long? decibelmicrovolts)
-        {
-            if (decibelmicrovolts.HasValue)
-            {
-                return FromDecibelMicrovolts(decibelmicrovolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from DecibelMicrovolts of type decimal.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelMicrovolts(decimal? decibelmicrovolts)
+        public static AmplitudeRatio? FromDecibelMicrovolts(QuantityValue? decibelmicrovolts)
         {
             if (decibelmicrovolts.HasValue)
             {
@@ -387,52 +262,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
         /// </summary>
-        public static AmplitudeRatio? FromDecibelMillivolts(double? decibelmillivolts)
-        {
-            if (decibelmillivolts.HasValue)
-            {
-                return FromDecibelMillivolts(decibelmillivolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelMillivolts(int? decibelmillivolts)
-        {
-            if (decibelmillivolts.HasValue)
-            {
-                return FromDecibelMillivolts(decibelmillivolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelMillivolts.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelMillivolts(long? decibelmillivolts)
-        {
-            if (decibelmillivolts.HasValue)
-            {
-                return FromDecibelMillivolts(decibelmillivolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from DecibelMillivolts of type decimal.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelMillivolts(decimal? decibelmillivolts)
+        public static AmplitudeRatio? FromDecibelMillivolts(QuantityValue? decibelmillivolts)
         {
             if (decibelmillivolts.HasValue)
             {
@@ -447,52 +277,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
         /// </summary>
-        public static AmplitudeRatio? FromDecibelsUnloaded(double? decibelsunloaded)
-        {
-            if (decibelsunloaded.HasValue)
-            {
-                return FromDecibelsUnloaded(decibelsunloaded.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelsUnloaded(int? decibelsunloaded)
-        {
-            if (decibelsunloaded.HasValue)
-            {
-                return FromDecibelsUnloaded(decibelsunloaded.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelsUnloaded(long? decibelsunloaded)
-        {
-            if (decibelsunloaded.HasValue)
-            {
-                return FromDecibelsUnloaded(decibelsunloaded.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from DecibelsUnloaded of type decimal.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelsUnloaded(decimal? decibelsunloaded)
+        public static AmplitudeRatio? FromDecibelsUnloaded(QuantityValue? decibelsunloaded)
         {
             if (decibelsunloaded.HasValue)
             {
@@ -507,52 +292,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
         /// </summary>
-        public static AmplitudeRatio? FromDecibelVolts(double? decibelvolts)
-        {
-            if (decibelvolts.HasValue)
-            {
-                return FromDecibelVolts(decibelvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelVolts(int? decibelvolts)
-        {
-            if (decibelvolts.HasValue)
-            {
-                return FromDecibelVolts(decibelvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelVolts(long? decibelvolts)
-        {
-            if (decibelvolts.HasValue)
-            {
-                return FromDecibelVolts(decibelvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AmplitudeRatio from DecibelVolts of type decimal.
-        /// </summary>
-        public static AmplitudeRatio? FromDecibelVolts(decimal? decibelvolts)
+        public static AmplitudeRatio? FromDecibelVolts(QuantityValue? decibelvolts)
         {
             if (decibelvolts.HasValue)
             {
@@ -569,21 +309,27 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="AmplitudeRatioUnit" /> to <see cref="AmplitudeRatio" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>AmplitudeRatio unit value.</returns>
-        public static AmplitudeRatio From(double val, AmplitudeRatioUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static AmplitudeRatio From(double value, AmplitudeRatioUnit fromUnit)
+#else
+        public static AmplitudeRatio From(QuantityValue value, AmplitudeRatioUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case AmplitudeRatioUnit.DecibelMicrovolt:
-                    return FromDecibelMicrovolts(val);
+                    return FromDecibelMicrovolts(value);
                 case AmplitudeRatioUnit.DecibelMillivolt:
-                    return FromDecibelMillivolts(val);
+                    return FromDecibelMillivolts(value);
                 case AmplitudeRatioUnit.DecibelUnloaded:
-                    return FromDecibelsUnloaded(val);
+                    return FromDecibelsUnloaded(value);
                 case AmplitudeRatioUnit.DecibelVolt:
-                    return FromDecibelVolts(val);
+                    return FromDecibelVolts(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -598,7 +344,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>AmplitudeRatio unit value.</returns>
-        public static AmplitudeRatio? From(double? value, AmplitudeRatioUnit fromUnit)
+        public static AmplitudeRatio? From(QuantityValue? value, AmplitudeRatioUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -245,494 +245,234 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcminutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromArcminutes(double arcminutes)
         {
-            return new Angle(arcminutes/60);
+            double value = (double) arcminutes;
+            return new Angle(value/60);
         }
-
-        /// <summary>
-        ///     Get Angle from Arcminutes.
-        /// </summary>
-        public static Angle FromArcminutes(int arcminutes)
+#else
+        public static Angle FromArcminutes(QuantityValue arcminutes)
         {
-            return new Angle(arcminutes/60);
-        }
-
-        /// <summary>
-        ///     Get Angle from Arcminutes.
-        /// </summary>
-        public static Angle FromArcminutes(long arcminutes)
-        {
-            return new Angle(arcminutes/60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Arcminutes of type decimal.
-        /// </summary>
-        public static Angle FromArcminutes(decimal arcminutes)
-        {
-            return new Angle(Convert.ToDouble(arcminutes)/60);
+            double value = (double) arcminutes;
+            return new Angle((value/60));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromArcseconds(double arcseconds)
         {
-            return new Angle(arcseconds/3600);
+            double value = (double) arcseconds;
+            return new Angle(value/3600);
         }
-
-        /// <summary>
-        ///     Get Angle from Arcseconds.
-        /// </summary>
-        public static Angle FromArcseconds(int arcseconds)
+#else
+        public static Angle FromArcseconds(QuantityValue arcseconds)
         {
-            return new Angle(arcseconds/3600);
-        }
-
-        /// <summary>
-        ///     Get Angle from Arcseconds.
-        /// </summary>
-        public static Angle FromArcseconds(long arcseconds)
-        {
-            return new Angle(arcseconds/3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Arcseconds of type decimal.
-        /// </summary>
-        public static Angle FromArcseconds(decimal arcseconds)
-        {
-            return new Angle(Convert.ToDouble(arcseconds)/3600);
+            double value = (double) arcseconds;
+            return new Angle((value/3600));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Centiradians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromCentiradians(double centiradians)
         {
-            return new Angle((centiradians*180/Math.PI) * 1e-2d);
+            double value = (double) centiradians;
+            return new Angle((value*180/Math.PI) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Angle from Centiradians.
-        /// </summary>
-        public static Angle FromCentiradians(int centiradians)
+#else
+        public static Angle FromCentiradians(QuantityValue centiradians)
         {
-            return new Angle((centiradians*180/Math.PI) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Centiradians.
-        /// </summary>
-        public static Angle FromCentiradians(long centiradians)
-        {
-            return new Angle((centiradians*180/Math.PI) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Centiradians of type decimal.
-        /// </summary>
-        public static Angle FromCentiradians(decimal centiradians)
-        {
-            return new Angle((Convert.ToDouble(centiradians)*180/Math.PI) * 1e-2d);
+            double value = (double) centiradians;
+            return new Angle(((value*180/Math.PI) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromDeciradians(double deciradians)
         {
-            return new Angle((deciradians*180/Math.PI) * 1e-1d);
+            double value = (double) deciradians;
+            return new Angle((value*180/Math.PI) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Angle from Deciradians.
-        /// </summary>
-        public static Angle FromDeciradians(int deciradians)
+#else
+        public static Angle FromDeciradians(QuantityValue deciradians)
         {
-            return new Angle((deciradians*180/Math.PI) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Deciradians.
-        /// </summary>
-        public static Angle FromDeciradians(long deciradians)
-        {
-            return new Angle((deciradians*180/Math.PI) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Deciradians of type decimal.
-        /// </summary>
-        public static Angle FromDeciradians(decimal deciradians)
-        {
-            return new Angle((Convert.ToDouble(deciradians)*180/Math.PI) * 1e-1d);
+            double value = (double) deciradians;
+            return new Angle(((value*180/Math.PI) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Degrees.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromDegrees(double degrees)
         {
-            return new Angle(degrees);
+            double value = (double) degrees;
+            return new Angle(value);
         }
-
-        /// <summary>
-        ///     Get Angle from Degrees.
-        /// </summary>
-        public static Angle FromDegrees(int degrees)
+#else
+        public static Angle FromDegrees(QuantityValue degrees)
         {
-            return new Angle(degrees);
-        }
-
-        /// <summary>
-        ///     Get Angle from Degrees.
-        /// </summary>
-        public static Angle FromDegrees(long degrees)
-        {
-            return new Angle(degrees);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Degrees of type decimal.
-        /// </summary>
-        public static Angle FromDegrees(decimal degrees)
-        {
-            return new Angle(Convert.ToDouble(degrees));
+            double value = (double) degrees;
+            return new Angle((value));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromGradians(double gradians)
         {
-            return new Angle(gradians*0.9);
+            double value = (double) gradians;
+            return new Angle(value*0.9);
         }
-
-        /// <summary>
-        ///     Get Angle from Gradians.
-        /// </summary>
-        public static Angle FromGradians(int gradians)
+#else
+        public static Angle FromGradians(QuantityValue gradians)
         {
-            return new Angle(gradians*0.9);
-        }
-
-        /// <summary>
-        ///     Get Angle from Gradians.
-        /// </summary>
-        public static Angle FromGradians(long gradians)
-        {
-            return new Angle(gradians*0.9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Gradians of type decimal.
-        /// </summary>
-        public static Angle FromGradians(decimal gradians)
-        {
-            return new Angle(Convert.ToDouble(gradians)*0.9);
+            double value = (double) gradians;
+            return new Angle((value*0.9));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Microdegrees.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromMicrodegrees(double microdegrees)
         {
-            return new Angle((microdegrees) * 1e-6d);
+            double value = (double) microdegrees;
+            return new Angle((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Angle from Microdegrees.
-        /// </summary>
-        public static Angle FromMicrodegrees(int microdegrees)
+#else
+        public static Angle FromMicrodegrees(QuantityValue microdegrees)
         {
-            return new Angle((microdegrees) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Microdegrees.
-        /// </summary>
-        public static Angle FromMicrodegrees(long microdegrees)
-        {
-            return new Angle((microdegrees) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Microdegrees of type decimal.
-        /// </summary>
-        public static Angle FromMicrodegrees(decimal microdegrees)
-        {
-            return new Angle((Convert.ToDouble(microdegrees)) * 1e-6d);
+            double value = (double) microdegrees;
+            return new Angle(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromMicroradians(double microradians)
         {
-            return new Angle((microradians*180/Math.PI) * 1e-6d);
+            double value = (double) microradians;
+            return new Angle((value*180/Math.PI) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Angle from Microradians.
-        /// </summary>
-        public static Angle FromMicroradians(int microradians)
+#else
+        public static Angle FromMicroradians(QuantityValue microradians)
         {
-            return new Angle((microradians*180/Math.PI) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Microradians.
-        /// </summary>
-        public static Angle FromMicroradians(long microradians)
-        {
-            return new Angle((microradians*180/Math.PI) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Microradians of type decimal.
-        /// </summary>
-        public static Angle FromMicroradians(decimal microradians)
-        {
-            return new Angle((Convert.ToDouble(microradians)*180/Math.PI) * 1e-6d);
+            double value = (double) microradians;
+            return new Angle(((value*180/Math.PI) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Millidegrees.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromMillidegrees(double millidegrees)
         {
-            return new Angle((millidegrees) * 1e-3d);
+            double value = (double) millidegrees;
+            return new Angle((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Angle from Millidegrees.
-        /// </summary>
-        public static Angle FromMillidegrees(int millidegrees)
+#else
+        public static Angle FromMillidegrees(QuantityValue millidegrees)
         {
-            return new Angle((millidegrees) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Millidegrees.
-        /// </summary>
-        public static Angle FromMillidegrees(long millidegrees)
-        {
-            return new Angle((millidegrees) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Millidegrees of type decimal.
-        /// </summary>
-        public static Angle FromMillidegrees(decimal millidegrees)
-        {
-            return new Angle((Convert.ToDouble(millidegrees)) * 1e-3d);
+            double value = (double) millidegrees;
+            return new Angle(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromMilliradians(double milliradians)
         {
-            return new Angle((milliradians*180/Math.PI) * 1e-3d);
+            double value = (double) milliradians;
+            return new Angle((value*180/Math.PI) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Angle from Milliradians.
-        /// </summary>
-        public static Angle FromMilliradians(int milliradians)
+#else
+        public static Angle FromMilliradians(QuantityValue milliradians)
         {
-            return new Angle((milliradians*180/Math.PI) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Milliradians.
-        /// </summary>
-        public static Angle FromMilliradians(long milliradians)
-        {
-            return new Angle((milliradians*180/Math.PI) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Milliradians of type decimal.
-        /// </summary>
-        public static Angle FromMilliradians(decimal milliradians)
-        {
-            return new Angle((Convert.ToDouble(milliradians)*180/Math.PI) * 1e-3d);
+            double value = (double) milliradians;
+            return new Angle(((value*180/Math.PI) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Nanodegrees.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromNanodegrees(double nanodegrees)
         {
-            return new Angle((nanodegrees) * 1e-9d);
+            double value = (double) nanodegrees;
+            return new Angle((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Angle from Nanodegrees.
-        /// </summary>
-        public static Angle FromNanodegrees(int nanodegrees)
+#else
+        public static Angle FromNanodegrees(QuantityValue nanodegrees)
         {
-            return new Angle((nanodegrees) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Nanodegrees.
-        /// </summary>
-        public static Angle FromNanodegrees(long nanodegrees)
-        {
-            return new Angle((nanodegrees) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Nanodegrees of type decimal.
-        /// </summary>
-        public static Angle FromNanodegrees(decimal nanodegrees)
-        {
-            return new Angle((Convert.ToDouble(nanodegrees)) * 1e-9d);
+            double value = (double) nanodegrees;
+            return new Angle(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromNanoradians(double nanoradians)
         {
-            return new Angle((nanoradians*180/Math.PI) * 1e-9d);
+            double value = (double) nanoradians;
+            return new Angle((value*180/Math.PI) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Angle from Nanoradians.
-        /// </summary>
-        public static Angle FromNanoradians(int nanoradians)
+#else
+        public static Angle FromNanoradians(QuantityValue nanoradians)
         {
-            return new Angle((nanoradians*180/Math.PI) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Angle from Nanoradians.
-        /// </summary>
-        public static Angle FromNanoradians(long nanoradians)
-        {
-            return new Angle((nanoradians*180/Math.PI) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Nanoradians of type decimal.
-        /// </summary>
-        public static Angle FromNanoradians(decimal nanoradians)
-        {
-            return new Angle((Convert.ToDouble(nanoradians)*180/Math.PI) * 1e-9d);
+            double value = (double) nanoradians;
+            return new Angle(((value*180/Math.PI) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Angle from Radians.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Angle FromRadians(double radians)
         {
-            return new Angle(radians*180/Math.PI);
+            double value = (double) radians;
+            return new Angle(value*180/Math.PI);
         }
-
-        /// <summary>
-        ///     Get Angle from Radians.
-        /// </summary>
-        public static Angle FromRadians(int radians)
+#else
+        public static Angle FromRadians(QuantityValue radians)
         {
-            return new Angle(radians*180/Math.PI);
-        }
-
-        /// <summary>
-        ///     Get Angle from Radians.
-        /// </summary>
-        public static Angle FromRadians(long radians)
-        {
-            return new Angle(radians*180/Math.PI);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Angle from Radians of type decimal.
-        /// </summary>
-        public static Angle FromRadians(decimal radians)
-        {
-            return new Angle(Convert.ToDouble(radians)*180/Math.PI);
+            double value = (double) radians;
+            return new Angle((value*180/Math.PI));
         }
 #endif
 
@@ -741,52 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Arcminutes.
         /// </summary>
-        public static Angle? FromArcminutes(double? arcminutes)
-        {
-            if (arcminutes.HasValue)
-            {
-                return FromArcminutes(arcminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Arcminutes.
-        /// </summary>
-        public static Angle? FromArcminutes(int? arcminutes)
-        {
-            if (arcminutes.HasValue)
-            {
-                return FromArcminutes(arcminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Arcminutes.
-        /// </summary>
-        public static Angle? FromArcminutes(long? arcminutes)
-        {
-            if (arcminutes.HasValue)
-            {
-                return FromArcminutes(arcminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Arcminutes of type decimal.
-        /// </summary>
-        public static Angle? FromArcminutes(decimal? arcminutes)
+        public static Angle? FromArcminutes(QuantityValue? arcminutes)
         {
             if (arcminutes.HasValue)
             {
@@ -801,52 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Arcseconds.
         /// </summary>
-        public static Angle? FromArcseconds(double? arcseconds)
-        {
-            if (arcseconds.HasValue)
-            {
-                return FromArcseconds(arcseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Arcseconds.
-        /// </summary>
-        public static Angle? FromArcseconds(int? arcseconds)
-        {
-            if (arcseconds.HasValue)
-            {
-                return FromArcseconds(arcseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Arcseconds.
-        /// </summary>
-        public static Angle? FromArcseconds(long? arcseconds)
-        {
-            if (arcseconds.HasValue)
-            {
-                return FromArcseconds(arcseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Arcseconds of type decimal.
-        /// </summary>
-        public static Angle? FromArcseconds(decimal? arcseconds)
+        public static Angle? FromArcseconds(QuantityValue? arcseconds)
         {
             if (arcseconds.HasValue)
             {
@@ -861,52 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Centiradians.
         /// </summary>
-        public static Angle? FromCentiradians(double? centiradians)
-        {
-            if (centiradians.HasValue)
-            {
-                return FromCentiradians(centiradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Centiradians.
-        /// </summary>
-        public static Angle? FromCentiradians(int? centiradians)
-        {
-            if (centiradians.HasValue)
-            {
-                return FromCentiradians(centiradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Centiradians.
-        /// </summary>
-        public static Angle? FromCentiradians(long? centiradians)
-        {
-            if (centiradians.HasValue)
-            {
-                return FromCentiradians(centiradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Centiradians of type decimal.
-        /// </summary>
-        public static Angle? FromCentiradians(decimal? centiradians)
+        public static Angle? FromCentiradians(QuantityValue? centiradians)
         {
             if (centiradians.HasValue)
             {
@@ -921,52 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Deciradians.
         /// </summary>
-        public static Angle? FromDeciradians(double? deciradians)
-        {
-            if (deciradians.HasValue)
-            {
-                return FromDeciradians(deciradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Deciradians.
-        /// </summary>
-        public static Angle? FromDeciradians(int? deciradians)
-        {
-            if (deciradians.HasValue)
-            {
-                return FromDeciradians(deciradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Deciradians.
-        /// </summary>
-        public static Angle? FromDeciradians(long? deciradians)
-        {
-            if (deciradians.HasValue)
-            {
-                return FromDeciradians(deciradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Deciradians of type decimal.
-        /// </summary>
-        public static Angle? FromDeciradians(decimal? deciradians)
+        public static Angle? FromDeciradians(QuantityValue? deciradians)
         {
             if (deciradians.HasValue)
             {
@@ -981,52 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Degrees.
         /// </summary>
-        public static Angle? FromDegrees(double? degrees)
-        {
-            if (degrees.HasValue)
-            {
-                return FromDegrees(degrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Degrees.
-        /// </summary>
-        public static Angle? FromDegrees(int? degrees)
-        {
-            if (degrees.HasValue)
-            {
-                return FromDegrees(degrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Degrees.
-        /// </summary>
-        public static Angle? FromDegrees(long? degrees)
-        {
-            if (degrees.HasValue)
-            {
-                return FromDegrees(degrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Degrees of type decimal.
-        /// </summary>
-        public static Angle? FromDegrees(decimal? degrees)
+        public static Angle? FromDegrees(QuantityValue? degrees)
         {
             if (degrees.HasValue)
             {
@@ -1041,52 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Gradians.
         /// </summary>
-        public static Angle? FromGradians(double? gradians)
-        {
-            if (gradians.HasValue)
-            {
-                return FromGradians(gradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Gradians.
-        /// </summary>
-        public static Angle? FromGradians(int? gradians)
-        {
-            if (gradians.HasValue)
-            {
-                return FromGradians(gradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Gradians.
-        /// </summary>
-        public static Angle? FromGradians(long? gradians)
-        {
-            if (gradians.HasValue)
-            {
-                return FromGradians(gradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Gradians of type decimal.
-        /// </summary>
-        public static Angle? FromGradians(decimal? gradians)
+        public static Angle? FromGradians(QuantityValue? gradians)
         {
             if (gradians.HasValue)
             {
@@ -1101,52 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Microdegrees.
         /// </summary>
-        public static Angle? FromMicrodegrees(double? microdegrees)
-        {
-            if (microdegrees.HasValue)
-            {
-                return FromMicrodegrees(microdegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Microdegrees.
-        /// </summary>
-        public static Angle? FromMicrodegrees(int? microdegrees)
-        {
-            if (microdegrees.HasValue)
-            {
-                return FromMicrodegrees(microdegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Microdegrees.
-        /// </summary>
-        public static Angle? FromMicrodegrees(long? microdegrees)
-        {
-            if (microdegrees.HasValue)
-            {
-                return FromMicrodegrees(microdegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Microdegrees of type decimal.
-        /// </summary>
-        public static Angle? FromMicrodegrees(decimal? microdegrees)
+        public static Angle? FromMicrodegrees(QuantityValue? microdegrees)
         {
             if (microdegrees.HasValue)
             {
@@ -1161,52 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Microradians.
         /// </summary>
-        public static Angle? FromMicroradians(double? microradians)
-        {
-            if (microradians.HasValue)
-            {
-                return FromMicroradians(microradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Microradians.
-        /// </summary>
-        public static Angle? FromMicroradians(int? microradians)
-        {
-            if (microradians.HasValue)
-            {
-                return FromMicroradians(microradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Microradians.
-        /// </summary>
-        public static Angle? FromMicroradians(long? microradians)
-        {
-            if (microradians.HasValue)
-            {
-                return FromMicroradians(microradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Microradians of type decimal.
-        /// </summary>
-        public static Angle? FromMicroradians(decimal? microradians)
+        public static Angle? FromMicroradians(QuantityValue? microradians)
         {
             if (microradians.HasValue)
             {
@@ -1221,52 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Millidegrees.
         /// </summary>
-        public static Angle? FromMillidegrees(double? millidegrees)
-        {
-            if (millidegrees.HasValue)
-            {
-                return FromMillidegrees(millidegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Millidegrees.
-        /// </summary>
-        public static Angle? FromMillidegrees(int? millidegrees)
-        {
-            if (millidegrees.HasValue)
-            {
-                return FromMillidegrees(millidegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Millidegrees.
-        /// </summary>
-        public static Angle? FromMillidegrees(long? millidegrees)
-        {
-            if (millidegrees.HasValue)
-            {
-                return FromMillidegrees(millidegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Millidegrees of type decimal.
-        /// </summary>
-        public static Angle? FromMillidegrees(decimal? millidegrees)
+        public static Angle? FromMillidegrees(QuantityValue? millidegrees)
         {
             if (millidegrees.HasValue)
             {
@@ -1281,52 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Milliradians.
         /// </summary>
-        public static Angle? FromMilliradians(double? milliradians)
-        {
-            if (milliradians.HasValue)
-            {
-                return FromMilliradians(milliradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Milliradians.
-        /// </summary>
-        public static Angle? FromMilliradians(int? milliradians)
-        {
-            if (milliradians.HasValue)
-            {
-                return FromMilliradians(milliradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Milliradians.
-        /// </summary>
-        public static Angle? FromMilliradians(long? milliradians)
-        {
-            if (milliradians.HasValue)
-            {
-                return FromMilliradians(milliradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Milliradians of type decimal.
-        /// </summary>
-        public static Angle? FromMilliradians(decimal? milliradians)
+        public static Angle? FromMilliradians(QuantityValue? milliradians)
         {
             if (milliradians.HasValue)
             {
@@ -1341,52 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Nanodegrees.
         /// </summary>
-        public static Angle? FromNanodegrees(double? nanodegrees)
-        {
-            if (nanodegrees.HasValue)
-            {
-                return FromNanodegrees(nanodegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Nanodegrees.
-        /// </summary>
-        public static Angle? FromNanodegrees(int? nanodegrees)
-        {
-            if (nanodegrees.HasValue)
-            {
-                return FromNanodegrees(nanodegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Nanodegrees.
-        /// </summary>
-        public static Angle? FromNanodegrees(long? nanodegrees)
-        {
-            if (nanodegrees.HasValue)
-            {
-                return FromNanodegrees(nanodegrees.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Nanodegrees of type decimal.
-        /// </summary>
-        public static Angle? FromNanodegrees(decimal? nanodegrees)
+        public static Angle? FromNanodegrees(QuantityValue? nanodegrees)
         {
             if (nanodegrees.HasValue)
             {
@@ -1401,52 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Nanoradians.
         /// </summary>
-        public static Angle? FromNanoradians(double? nanoradians)
-        {
-            if (nanoradians.HasValue)
-            {
-                return FromNanoradians(nanoradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Nanoradians.
-        /// </summary>
-        public static Angle? FromNanoradians(int? nanoradians)
-        {
-            if (nanoradians.HasValue)
-            {
-                return FromNanoradians(nanoradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Nanoradians.
-        /// </summary>
-        public static Angle? FromNanoradians(long? nanoradians)
-        {
-            if (nanoradians.HasValue)
-            {
-                return FromNanoradians(nanoradians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Nanoradians of type decimal.
-        /// </summary>
-        public static Angle? FromNanoradians(decimal? nanoradians)
+        public static Angle? FromNanoradians(QuantityValue? nanoradians)
         {
             if (nanoradians.HasValue)
             {
@@ -1461,52 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Angle from nullable Radians.
         /// </summary>
-        public static Angle? FromRadians(double? radians)
-        {
-            if (radians.HasValue)
-            {
-                return FromRadians(radians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Radians.
-        /// </summary>
-        public static Angle? FromRadians(int? radians)
-        {
-            if (radians.HasValue)
-            {
-                return FromRadians(radians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from nullable Radians.
-        /// </summary>
-        public static Angle? FromRadians(long? radians)
-        {
-            if (radians.HasValue)
-            {
-                return FromRadians(radians.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Angle from Radians of type decimal.
-        /// </summary>
-        public static Angle? FromRadians(decimal? radians)
+        public static Angle? FromRadians(QuantityValue? radians)
         {
             if (radians.HasValue)
             {
@@ -1523,39 +678,45 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="AngleUnit" /> to <see cref="Angle" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Angle unit value.</returns>
-        public static Angle From(double val, AngleUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Angle From(double value, AngleUnit fromUnit)
+#else
+        public static Angle From(QuantityValue value, AngleUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case AngleUnit.Arcminute:
-                    return FromArcminutes(val);
+                    return FromArcminutes(value);
                 case AngleUnit.Arcsecond:
-                    return FromArcseconds(val);
+                    return FromArcseconds(value);
                 case AngleUnit.Centiradian:
-                    return FromCentiradians(val);
+                    return FromCentiradians(value);
                 case AngleUnit.Deciradian:
-                    return FromDeciradians(val);
+                    return FromDeciradians(value);
                 case AngleUnit.Degree:
-                    return FromDegrees(val);
+                    return FromDegrees(value);
                 case AngleUnit.Gradian:
-                    return FromGradians(val);
+                    return FromGradians(value);
                 case AngleUnit.Microdegree:
-                    return FromMicrodegrees(val);
+                    return FromMicrodegrees(value);
                 case AngleUnit.Microradian:
-                    return FromMicroradians(val);
+                    return FromMicroradians(value);
                 case AngleUnit.Millidegree:
-                    return FromMillidegrees(val);
+                    return FromMillidegrees(value);
                 case AngleUnit.Milliradian:
-                    return FromMilliradians(val);
+                    return FromMilliradians(value);
                 case AngleUnit.Nanodegree:
-                    return FromNanodegrees(val);
+                    return FromNanodegrees(value);
                 case AngleUnit.Nanoradian:
-                    return FromNanoradians(val);
+                    return FromNanoradians(value);
                 case AngleUnit.Radian:
-                    return FromRadians(val);
+                    return FromRadians(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1570,7 +731,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Angle unit value.</returns>
-        public static Angle? From(double? value, AngleUnit fromUnit)
+        public static Angle? From(QuantityValue? value, AngleUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -165,114 +165,54 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Kilovoltamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ApparentPower FromKilovoltamperes(double kilovoltamperes)
         {
-            return new ApparentPower((kilovoltamperes) * 1e3d);
+            double value = (double) kilovoltamperes;
+            return new ApparentPower((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ApparentPower from Kilovoltamperes.
-        /// </summary>
-        public static ApparentPower FromKilovoltamperes(int kilovoltamperes)
+#else
+        public static ApparentPower FromKilovoltamperes(QuantityValue kilovoltamperes)
         {
-            return new ApparentPower((kilovoltamperes) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ApparentPower from Kilovoltamperes.
-        /// </summary>
-        public static ApparentPower FromKilovoltamperes(long kilovoltamperes)
-        {
-            return new ApparentPower((kilovoltamperes) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ApparentPower from Kilovoltamperes of type decimal.
-        /// </summary>
-        public static ApparentPower FromKilovoltamperes(decimal kilovoltamperes)
-        {
-            return new ApparentPower((Convert.ToDouble(kilovoltamperes)) * 1e3d);
+            double value = (double) kilovoltamperes;
+            return new ApparentPower(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ApparentPower FromMegavoltamperes(double megavoltamperes)
         {
-            return new ApparentPower((megavoltamperes) * 1e6d);
+            double value = (double) megavoltamperes;
+            return new ApparentPower((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ApparentPower from Megavoltamperes.
-        /// </summary>
-        public static ApparentPower FromMegavoltamperes(int megavoltamperes)
+#else
+        public static ApparentPower FromMegavoltamperes(QuantityValue megavoltamperes)
         {
-            return new ApparentPower((megavoltamperes) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ApparentPower from Megavoltamperes.
-        /// </summary>
-        public static ApparentPower FromMegavoltamperes(long megavoltamperes)
-        {
-            return new ApparentPower((megavoltamperes) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ApparentPower from Megavoltamperes of type decimal.
-        /// </summary>
-        public static ApparentPower FromMegavoltamperes(decimal megavoltamperes)
-        {
-            return new ApparentPower((Convert.ToDouble(megavoltamperes)) * 1e6d);
+            double value = (double) megavoltamperes;
+            return new ApparentPower(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ApparentPower from Voltamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ApparentPower FromVoltamperes(double voltamperes)
         {
-            return new ApparentPower(voltamperes);
+            double value = (double) voltamperes;
+            return new ApparentPower(value);
         }
-
-        /// <summary>
-        ///     Get ApparentPower from Voltamperes.
-        /// </summary>
-        public static ApparentPower FromVoltamperes(int voltamperes)
+#else
+        public static ApparentPower FromVoltamperes(QuantityValue voltamperes)
         {
-            return new ApparentPower(voltamperes);
-        }
-
-        /// <summary>
-        ///     Get ApparentPower from Voltamperes.
-        /// </summary>
-        public static ApparentPower FromVoltamperes(long voltamperes)
-        {
-            return new ApparentPower(voltamperes);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ApparentPower from Voltamperes of type decimal.
-        /// </summary>
-        public static ApparentPower FromVoltamperes(decimal voltamperes)
-        {
-            return new ApparentPower(Convert.ToDouble(voltamperes));
+            double value = (double) voltamperes;
+            return new ApparentPower((value));
         }
 #endif
 
@@ -281,52 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ApparentPower from nullable Kilovoltamperes.
         /// </summary>
-        public static ApparentPower? FromKilovoltamperes(double? kilovoltamperes)
-        {
-            if (kilovoltamperes.HasValue)
-            {
-                return FromKilovoltamperes(kilovoltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from nullable Kilovoltamperes.
-        /// </summary>
-        public static ApparentPower? FromKilovoltamperes(int? kilovoltamperes)
-        {
-            if (kilovoltamperes.HasValue)
-            {
-                return FromKilovoltamperes(kilovoltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from nullable Kilovoltamperes.
-        /// </summary>
-        public static ApparentPower? FromKilovoltamperes(long? kilovoltamperes)
-        {
-            if (kilovoltamperes.HasValue)
-            {
-                return FromKilovoltamperes(kilovoltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from Kilovoltamperes of type decimal.
-        /// </summary>
-        public static ApparentPower? FromKilovoltamperes(decimal? kilovoltamperes)
+        public static ApparentPower? FromKilovoltamperes(QuantityValue? kilovoltamperes)
         {
             if (kilovoltamperes.HasValue)
             {
@@ -341,52 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ApparentPower from nullable Megavoltamperes.
         /// </summary>
-        public static ApparentPower? FromMegavoltamperes(double? megavoltamperes)
-        {
-            if (megavoltamperes.HasValue)
-            {
-                return FromMegavoltamperes(megavoltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from nullable Megavoltamperes.
-        /// </summary>
-        public static ApparentPower? FromMegavoltamperes(int? megavoltamperes)
-        {
-            if (megavoltamperes.HasValue)
-            {
-                return FromMegavoltamperes(megavoltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from nullable Megavoltamperes.
-        /// </summary>
-        public static ApparentPower? FromMegavoltamperes(long? megavoltamperes)
-        {
-            if (megavoltamperes.HasValue)
-            {
-                return FromMegavoltamperes(megavoltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from Megavoltamperes of type decimal.
-        /// </summary>
-        public static ApparentPower? FromMegavoltamperes(decimal? megavoltamperes)
+        public static ApparentPower? FromMegavoltamperes(QuantityValue? megavoltamperes)
         {
             if (megavoltamperes.HasValue)
             {
@@ -401,52 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ApparentPower from nullable Voltamperes.
         /// </summary>
-        public static ApparentPower? FromVoltamperes(double? voltamperes)
-        {
-            if (voltamperes.HasValue)
-            {
-                return FromVoltamperes(voltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from nullable Voltamperes.
-        /// </summary>
-        public static ApparentPower? FromVoltamperes(int? voltamperes)
-        {
-            if (voltamperes.HasValue)
-            {
-                return FromVoltamperes(voltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from nullable Voltamperes.
-        /// </summary>
-        public static ApparentPower? FromVoltamperes(long? voltamperes)
-        {
-            if (voltamperes.HasValue)
-            {
-                return FromVoltamperes(voltamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ApparentPower from Voltamperes of type decimal.
-        /// </summary>
-        public static ApparentPower? FromVoltamperes(decimal? voltamperes)
+        public static ApparentPower? FromVoltamperes(QuantityValue? voltamperes)
         {
             if (voltamperes.HasValue)
             {
@@ -463,19 +268,25 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ApparentPowerUnit" /> to <see cref="ApparentPower" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ApparentPower unit value.</returns>
-        public static ApparentPower From(double val, ApparentPowerUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ApparentPower From(double value, ApparentPowerUnit fromUnit)
+#else
+        public static ApparentPower From(QuantityValue value, ApparentPowerUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ApparentPowerUnit.Kilovoltampere:
-                    return FromKilovoltamperes(val);
+                    return FromKilovoltamperes(value);
                 case ApparentPowerUnit.Megavoltampere:
-                    return FromMegavoltamperes(val);
+                    return FromMegavoltamperes(value);
                 case ApparentPowerUnit.Voltampere:
-                    return FromVoltamperes(val);
+                    return FromVoltamperes(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -490,7 +301,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ApparentPower unit value.</returns>
-        public static ApparentPower? From(double? value, ApparentPowerUnit fromUnit)
+        public static ApparentPower? From(QuantityValue? value, ApparentPowerUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -237,456 +237,216 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Acres.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromAcres(double acres)
         {
-            return new Area(acres*4046.85642);
+            double value = (double) acres;
+            return new Area(value*4046.85642);
         }
-
-        /// <summary>
-        ///     Get Area from Acres.
-        /// </summary>
-        public static Area FromAcres(int acres)
+#else
+        public static Area FromAcres(QuantityValue acres)
         {
-            return new Area(acres*4046.85642);
-        }
-
-        /// <summary>
-        ///     Get Area from Acres.
-        /// </summary>
-        public static Area FromAcres(long acres)
-        {
-            return new Area(acres*4046.85642);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from Acres of type decimal.
-        /// </summary>
-        public static Area FromAcres(decimal acres)
-        {
-            return new Area(Convert.ToDouble(acres)*4046.85642);
+            double value = (double) acres;
+            return new Area((value*4046.85642));
         }
 #endif
 
         /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromHectares(double hectares)
         {
-            return new Area(hectares*1e4);
+            double value = (double) hectares;
+            return new Area(value*1e4);
         }
-
-        /// <summary>
-        ///     Get Area from Hectares.
-        /// </summary>
-        public static Area FromHectares(int hectares)
+#else
+        public static Area FromHectares(QuantityValue hectares)
         {
-            return new Area(hectares*1e4);
-        }
-
-        /// <summary>
-        ///     Get Area from Hectares.
-        /// </summary>
-        public static Area FromHectares(long hectares)
-        {
-            return new Area(hectares*1e4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from Hectares of type decimal.
-        /// </summary>
-        public static Area FromHectares(decimal hectares)
-        {
-            return new Area(Convert.ToDouble(hectares)*1e4);
+            double value = (double) hectares;
+            return new Area((value*1e4));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareCentimeters(double squarecentimeters)
         {
-            return new Area(squarecentimeters*1e-4);
+            double value = (double) squarecentimeters;
+            return new Area(value*1e-4);
         }
-
-        /// <summary>
-        ///     Get Area from SquareCentimeters.
-        /// </summary>
-        public static Area FromSquareCentimeters(int squarecentimeters)
+#else
+        public static Area FromSquareCentimeters(QuantityValue squarecentimeters)
         {
-            return new Area(squarecentimeters*1e-4);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareCentimeters.
-        /// </summary>
-        public static Area FromSquareCentimeters(long squarecentimeters)
-        {
-            return new Area(squarecentimeters*1e-4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareCentimeters of type decimal.
-        /// </summary>
-        public static Area FromSquareCentimeters(decimal squarecentimeters)
-        {
-            return new Area(Convert.ToDouble(squarecentimeters)*1e-4);
+            double value = (double) squarecentimeters;
+            return new Area((value*1e-4));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareDecimeters(double squaredecimeters)
         {
-            return new Area(squaredecimeters*1e-2);
+            double value = (double) squaredecimeters;
+            return new Area(value*1e-2);
         }
-
-        /// <summary>
-        ///     Get Area from SquareDecimeters.
-        /// </summary>
-        public static Area FromSquareDecimeters(int squaredecimeters)
+#else
+        public static Area FromSquareDecimeters(QuantityValue squaredecimeters)
         {
-            return new Area(squaredecimeters*1e-2);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareDecimeters.
-        /// </summary>
-        public static Area FromSquareDecimeters(long squaredecimeters)
-        {
-            return new Area(squaredecimeters*1e-2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareDecimeters of type decimal.
-        /// </summary>
-        public static Area FromSquareDecimeters(decimal squaredecimeters)
-        {
-            return new Area(Convert.ToDouble(squaredecimeters)*1e-2);
+            double value = (double) squaredecimeters;
+            return new Area((value*1e-2));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareFeet(double squarefeet)
         {
-            return new Area(squarefeet*0.092903);
+            double value = (double) squarefeet;
+            return new Area(value*0.092903);
         }
-
-        /// <summary>
-        ///     Get Area from SquareFeet.
-        /// </summary>
-        public static Area FromSquareFeet(int squarefeet)
+#else
+        public static Area FromSquareFeet(QuantityValue squarefeet)
         {
-            return new Area(squarefeet*0.092903);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareFeet.
-        /// </summary>
-        public static Area FromSquareFeet(long squarefeet)
-        {
-            return new Area(squarefeet*0.092903);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareFeet of type decimal.
-        /// </summary>
-        public static Area FromSquareFeet(decimal squarefeet)
-        {
-            return new Area(Convert.ToDouble(squarefeet)*0.092903);
+            double value = (double) squarefeet;
+            return new Area((value*0.092903));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareInches(double squareinches)
         {
-            return new Area(squareinches*0.00064516);
+            double value = (double) squareinches;
+            return new Area(value*0.00064516);
         }
-
-        /// <summary>
-        ///     Get Area from SquareInches.
-        /// </summary>
-        public static Area FromSquareInches(int squareinches)
+#else
+        public static Area FromSquareInches(QuantityValue squareinches)
         {
-            return new Area(squareinches*0.00064516);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareInches.
-        /// </summary>
-        public static Area FromSquareInches(long squareinches)
-        {
-            return new Area(squareinches*0.00064516);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareInches of type decimal.
-        /// </summary>
-        public static Area FromSquareInches(decimal squareinches)
-        {
-            return new Area(Convert.ToDouble(squareinches)*0.00064516);
+            double value = (double) squareinches;
+            return new Area((value*0.00064516));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareKilometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareKilometers(double squarekilometers)
         {
-            return new Area(squarekilometers*1e6);
+            double value = (double) squarekilometers;
+            return new Area(value*1e6);
         }
-
-        /// <summary>
-        ///     Get Area from SquareKilometers.
-        /// </summary>
-        public static Area FromSquareKilometers(int squarekilometers)
+#else
+        public static Area FromSquareKilometers(QuantityValue squarekilometers)
         {
-            return new Area(squarekilometers*1e6);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareKilometers.
-        /// </summary>
-        public static Area FromSquareKilometers(long squarekilometers)
-        {
-            return new Area(squarekilometers*1e6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareKilometers of type decimal.
-        /// </summary>
-        public static Area FromSquareKilometers(decimal squarekilometers)
-        {
-            return new Area(Convert.ToDouble(squarekilometers)*1e6);
+            double value = (double) squarekilometers;
+            return new Area((value*1e6));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareMeters(double squaremeters)
         {
-            return new Area(squaremeters);
+            double value = (double) squaremeters;
+            return new Area(value);
         }
-
-        /// <summary>
-        ///     Get Area from SquareMeters.
-        /// </summary>
-        public static Area FromSquareMeters(int squaremeters)
+#else
+        public static Area FromSquareMeters(QuantityValue squaremeters)
         {
-            return new Area(squaremeters);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareMeters.
-        /// </summary>
-        public static Area FromSquareMeters(long squaremeters)
-        {
-            return new Area(squaremeters);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareMeters of type decimal.
-        /// </summary>
-        public static Area FromSquareMeters(decimal squaremeters)
-        {
-            return new Area(Convert.ToDouble(squaremeters));
+            double value = (double) squaremeters;
+            return new Area((value));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareMicrometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareMicrometers(double squaremicrometers)
         {
-            return new Area(squaremicrometers*1e-12);
+            double value = (double) squaremicrometers;
+            return new Area(value*1e-12);
         }
-
-        /// <summary>
-        ///     Get Area from SquareMicrometers.
-        /// </summary>
-        public static Area FromSquareMicrometers(int squaremicrometers)
+#else
+        public static Area FromSquareMicrometers(QuantityValue squaremicrometers)
         {
-            return new Area(squaremicrometers*1e-12);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareMicrometers.
-        /// </summary>
-        public static Area FromSquareMicrometers(long squaremicrometers)
-        {
-            return new Area(squaremicrometers*1e-12);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareMicrometers of type decimal.
-        /// </summary>
-        public static Area FromSquareMicrometers(decimal squaremicrometers)
-        {
-            return new Area(Convert.ToDouble(squaremicrometers)*1e-12);
+            double value = (double) squaremicrometers;
+            return new Area((value*1e-12));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareMiles(double squaremiles)
         {
-            return new Area(squaremiles*2.59e6);
+            double value = (double) squaremiles;
+            return new Area(value*2.59e6);
         }
-
-        /// <summary>
-        ///     Get Area from SquareMiles.
-        /// </summary>
-        public static Area FromSquareMiles(int squaremiles)
+#else
+        public static Area FromSquareMiles(QuantityValue squaremiles)
         {
-            return new Area(squaremiles*2.59e6);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareMiles.
-        /// </summary>
-        public static Area FromSquareMiles(long squaremiles)
-        {
-            return new Area(squaremiles*2.59e6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareMiles of type decimal.
-        /// </summary>
-        public static Area FromSquareMiles(decimal squaremiles)
-        {
-            return new Area(Convert.ToDouble(squaremiles)*2.59e6);
+            double value = (double) squaremiles;
+            return new Area((value*2.59e6));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareMillimeters(double squaremillimeters)
         {
-            return new Area(squaremillimeters*1e-6);
+            double value = (double) squaremillimeters;
+            return new Area(value*1e-6);
         }
-
-        /// <summary>
-        ///     Get Area from SquareMillimeters.
-        /// </summary>
-        public static Area FromSquareMillimeters(int squaremillimeters)
+#else
+        public static Area FromSquareMillimeters(QuantityValue squaremillimeters)
         {
-            return new Area(squaremillimeters*1e-6);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareMillimeters.
-        /// </summary>
-        public static Area FromSquareMillimeters(long squaremillimeters)
-        {
-            return new Area(squaremillimeters*1e-6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareMillimeters of type decimal.
-        /// </summary>
-        public static Area FromSquareMillimeters(decimal squaremillimeters)
-        {
-            return new Area(Convert.ToDouble(squaremillimeters)*1e-6);
+            double value = (double) squaremillimeters;
+            return new Area((value*1e-6));
         }
 #endif
 
         /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Area FromSquareYards(double squareyards)
         {
-            return new Area(squareyards*0.836127);
+            double value = (double) squareyards;
+            return new Area(value*0.836127);
         }
-
-        /// <summary>
-        ///     Get Area from SquareYards.
-        /// </summary>
-        public static Area FromSquareYards(int squareyards)
+#else
+        public static Area FromSquareYards(QuantityValue squareyards)
         {
-            return new Area(squareyards*0.836127);
-        }
-
-        /// <summary>
-        ///     Get Area from SquareYards.
-        /// </summary>
-        public static Area FromSquareYards(long squareyards)
-        {
-            return new Area(squareyards*0.836127);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Area from SquareYards of type decimal.
-        /// </summary>
-        public static Area FromSquareYards(decimal squareyards)
-        {
-            return new Area(Convert.ToDouble(squareyards)*0.836127);
+            double value = (double) squareyards;
+            return new Area((value*0.836127));
         }
 #endif
 
@@ -695,52 +455,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable Acres.
         /// </summary>
-        public static Area? FromAcres(double? acres)
-        {
-            if (acres.HasValue)
-            {
-                return FromAcres(acres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable Acres.
-        /// </summary>
-        public static Area? FromAcres(int? acres)
-        {
-            if (acres.HasValue)
-            {
-                return FromAcres(acres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable Acres.
-        /// </summary>
-        public static Area? FromAcres(long? acres)
-        {
-            if (acres.HasValue)
-            {
-                return FromAcres(acres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from Acres of type decimal.
-        /// </summary>
-        public static Area? FromAcres(decimal? acres)
+        public static Area? FromAcres(QuantityValue? acres)
         {
             if (acres.HasValue)
             {
@@ -755,52 +470,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable Hectares.
         /// </summary>
-        public static Area? FromHectares(double? hectares)
-        {
-            if (hectares.HasValue)
-            {
-                return FromHectares(hectares.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable Hectares.
-        /// </summary>
-        public static Area? FromHectares(int? hectares)
-        {
-            if (hectares.HasValue)
-            {
-                return FromHectares(hectares.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable Hectares.
-        /// </summary>
-        public static Area? FromHectares(long? hectares)
-        {
-            if (hectares.HasValue)
-            {
-                return FromHectares(hectares.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from Hectares of type decimal.
-        /// </summary>
-        public static Area? FromHectares(decimal? hectares)
+        public static Area? FromHectares(QuantityValue? hectares)
         {
             if (hectares.HasValue)
             {
@@ -815,52 +485,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareCentimeters.
         /// </summary>
-        public static Area? FromSquareCentimeters(double? squarecentimeters)
-        {
-            if (squarecentimeters.HasValue)
-            {
-                return FromSquareCentimeters(squarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareCentimeters.
-        /// </summary>
-        public static Area? FromSquareCentimeters(int? squarecentimeters)
-        {
-            if (squarecentimeters.HasValue)
-            {
-                return FromSquareCentimeters(squarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareCentimeters.
-        /// </summary>
-        public static Area? FromSquareCentimeters(long? squarecentimeters)
-        {
-            if (squarecentimeters.HasValue)
-            {
-                return FromSquareCentimeters(squarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareCentimeters of type decimal.
-        /// </summary>
-        public static Area? FromSquareCentimeters(decimal? squarecentimeters)
+        public static Area? FromSquareCentimeters(QuantityValue? squarecentimeters)
         {
             if (squarecentimeters.HasValue)
             {
@@ -875,52 +500,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareDecimeters.
         /// </summary>
-        public static Area? FromSquareDecimeters(double? squaredecimeters)
-        {
-            if (squaredecimeters.HasValue)
-            {
-                return FromSquareDecimeters(squaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareDecimeters.
-        /// </summary>
-        public static Area? FromSquareDecimeters(int? squaredecimeters)
-        {
-            if (squaredecimeters.HasValue)
-            {
-                return FromSquareDecimeters(squaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareDecimeters.
-        /// </summary>
-        public static Area? FromSquareDecimeters(long? squaredecimeters)
-        {
-            if (squaredecimeters.HasValue)
-            {
-                return FromSquareDecimeters(squaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareDecimeters of type decimal.
-        /// </summary>
-        public static Area? FromSquareDecimeters(decimal? squaredecimeters)
+        public static Area? FromSquareDecimeters(QuantityValue? squaredecimeters)
         {
             if (squaredecimeters.HasValue)
             {
@@ -935,52 +515,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareFeet.
         /// </summary>
-        public static Area? FromSquareFeet(double? squarefeet)
-        {
-            if (squarefeet.HasValue)
-            {
-                return FromSquareFeet(squarefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareFeet.
-        /// </summary>
-        public static Area? FromSquareFeet(int? squarefeet)
-        {
-            if (squarefeet.HasValue)
-            {
-                return FromSquareFeet(squarefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareFeet.
-        /// </summary>
-        public static Area? FromSquareFeet(long? squarefeet)
-        {
-            if (squarefeet.HasValue)
-            {
-                return FromSquareFeet(squarefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareFeet of type decimal.
-        /// </summary>
-        public static Area? FromSquareFeet(decimal? squarefeet)
+        public static Area? FromSquareFeet(QuantityValue? squarefeet)
         {
             if (squarefeet.HasValue)
             {
@@ -995,52 +530,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareInches.
         /// </summary>
-        public static Area? FromSquareInches(double? squareinches)
-        {
-            if (squareinches.HasValue)
-            {
-                return FromSquareInches(squareinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareInches.
-        /// </summary>
-        public static Area? FromSquareInches(int? squareinches)
-        {
-            if (squareinches.HasValue)
-            {
-                return FromSquareInches(squareinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareInches.
-        /// </summary>
-        public static Area? FromSquareInches(long? squareinches)
-        {
-            if (squareinches.HasValue)
-            {
-                return FromSquareInches(squareinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareInches of type decimal.
-        /// </summary>
-        public static Area? FromSquareInches(decimal? squareinches)
+        public static Area? FromSquareInches(QuantityValue? squareinches)
         {
             if (squareinches.HasValue)
             {
@@ -1055,52 +545,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareKilometers.
         /// </summary>
-        public static Area? FromSquareKilometers(double? squarekilometers)
-        {
-            if (squarekilometers.HasValue)
-            {
-                return FromSquareKilometers(squarekilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareKilometers.
-        /// </summary>
-        public static Area? FromSquareKilometers(int? squarekilometers)
-        {
-            if (squarekilometers.HasValue)
-            {
-                return FromSquareKilometers(squarekilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareKilometers.
-        /// </summary>
-        public static Area? FromSquareKilometers(long? squarekilometers)
-        {
-            if (squarekilometers.HasValue)
-            {
-                return FromSquareKilometers(squarekilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareKilometers of type decimal.
-        /// </summary>
-        public static Area? FromSquareKilometers(decimal? squarekilometers)
+        public static Area? FromSquareKilometers(QuantityValue? squarekilometers)
         {
             if (squarekilometers.HasValue)
             {
@@ -1115,52 +560,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareMeters.
         /// </summary>
-        public static Area? FromSquareMeters(double? squaremeters)
-        {
-            if (squaremeters.HasValue)
-            {
-                return FromSquareMeters(squaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMeters.
-        /// </summary>
-        public static Area? FromSquareMeters(int? squaremeters)
-        {
-            if (squaremeters.HasValue)
-            {
-                return FromSquareMeters(squaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMeters.
-        /// </summary>
-        public static Area? FromSquareMeters(long? squaremeters)
-        {
-            if (squaremeters.HasValue)
-            {
-                return FromSquareMeters(squaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareMeters of type decimal.
-        /// </summary>
-        public static Area? FromSquareMeters(decimal? squaremeters)
+        public static Area? FromSquareMeters(QuantityValue? squaremeters)
         {
             if (squaremeters.HasValue)
             {
@@ -1175,52 +575,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareMicrometers.
         /// </summary>
-        public static Area? FromSquareMicrometers(double? squaremicrometers)
-        {
-            if (squaremicrometers.HasValue)
-            {
-                return FromSquareMicrometers(squaremicrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMicrometers.
-        /// </summary>
-        public static Area? FromSquareMicrometers(int? squaremicrometers)
-        {
-            if (squaremicrometers.HasValue)
-            {
-                return FromSquareMicrometers(squaremicrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMicrometers.
-        /// </summary>
-        public static Area? FromSquareMicrometers(long? squaremicrometers)
-        {
-            if (squaremicrometers.HasValue)
-            {
-                return FromSquareMicrometers(squaremicrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareMicrometers of type decimal.
-        /// </summary>
-        public static Area? FromSquareMicrometers(decimal? squaremicrometers)
+        public static Area? FromSquareMicrometers(QuantityValue? squaremicrometers)
         {
             if (squaremicrometers.HasValue)
             {
@@ -1235,52 +590,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareMiles.
         /// </summary>
-        public static Area? FromSquareMiles(double? squaremiles)
-        {
-            if (squaremiles.HasValue)
-            {
-                return FromSquareMiles(squaremiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMiles.
-        /// </summary>
-        public static Area? FromSquareMiles(int? squaremiles)
-        {
-            if (squaremiles.HasValue)
-            {
-                return FromSquareMiles(squaremiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMiles.
-        /// </summary>
-        public static Area? FromSquareMiles(long? squaremiles)
-        {
-            if (squaremiles.HasValue)
-            {
-                return FromSquareMiles(squaremiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareMiles of type decimal.
-        /// </summary>
-        public static Area? FromSquareMiles(decimal? squaremiles)
+        public static Area? FromSquareMiles(QuantityValue? squaremiles)
         {
             if (squaremiles.HasValue)
             {
@@ -1295,52 +605,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareMillimeters.
         /// </summary>
-        public static Area? FromSquareMillimeters(double? squaremillimeters)
-        {
-            if (squaremillimeters.HasValue)
-            {
-                return FromSquareMillimeters(squaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMillimeters.
-        /// </summary>
-        public static Area? FromSquareMillimeters(int? squaremillimeters)
-        {
-            if (squaremillimeters.HasValue)
-            {
-                return FromSquareMillimeters(squaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareMillimeters.
-        /// </summary>
-        public static Area? FromSquareMillimeters(long? squaremillimeters)
-        {
-            if (squaremillimeters.HasValue)
-            {
-                return FromSquareMillimeters(squaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareMillimeters of type decimal.
-        /// </summary>
-        public static Area? FromSquareMillimeters(decimal? squaremillimeters)
+        public static Area? FromSquareMillimeters(QuantityValue? squaremillimeters)
         {
             if (squaremillimeters.HasValue)
             {
@@ -1355,52 +620,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Area from nullable SquareYards.
         /// </summary>
-        public static Area? FromSquareYards(double? squareyards)
-        {
-            if (squareyards.HasValue)
-            {
-                return FromSquareYards(squareyards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareYards.
-        /// </summary>
-        public static Area? FromSquareYards(int? squareyards)
-        {
-            if (squareyards.HasValue)
-            {
-                return FromSquareYards(squareyards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from nullable SquareYards.
-        /// </summary>
-        public static Area? FromSquareYards(long? squareyards)
-        {
-            if (squareyards.HasValue)
-            {
-                return FromSquareYards(squareyards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Area from SquareYards of type decimal.
-        /// </summary>
-        public static Area? FromSquareYards(decimal? squareyards)
+        public static Area? FromSquareYards(QuantityValue? squareyards)
         {
             if (squareyards.HasValue)
             {
@@ -1417,37 +637,43 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="AreaUnit" /> to <see cref="Area" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Area unit value.</returns>
-        public static Area From(double val, AreaUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Area From(double value, AreaUnit fromUnit)
+#else
+        public static Area From(QuantityValue value, AreaUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case AreaUnit.Acre:
-                    return FromAcres(val);
+                    return FromAcres(value);
                 case AreaUnit.Hectare:
-                    return FromHectares(val);
+                    return FromHectares(value);
                 case AreaUnit.SquareCentimeter:
-                    return FromSquareCentimeters(val);
+                    return FromSquareCentimeters(value);
                 case AreaUnit.SquareDecimeter:
-                    return FromSquareDecimeters(val);
+                    return FromSquareDecimeters(value);
                 case AreaUnit.SquareFoot:
-                    return FromSquareFeet(val);
+                    return FromSquareFeet(value);
                 case AreaUnit.SquareInch:
-                    return FromSquareInches(val);
+                    return FromSquareInches(value);
                 case AreaUnit.SquareKilometer:
-                    return FromSquareKilometers(val);
+                    return FromSquareKilometers(value);
                 case AreaUnit.SquareMeter:
-                    return FromSquareMeters(val);
+                    return FromSquareMeters(value);
                 case AreaUnit.SquareMicrometer:
-                    return FromSquareMicrometers(val);
+                    return FromSquareMicrometers(value);
                 case AreaUnit.SquareMile:
-                    return FromSquareMiles(val);
+                    return FromSquareMiles(value);
                 case AreaUnit.SquareMillimeter:
-                    return FromSquareMillimeters(val);
+                    return FromSquareMillimeters(value);
                 case AreaUnit.SquareYard:
-                    return FromSquareYards(val);
+                    return FromSquareYards(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1462,7 +688,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Area unit value.</returns>
-        public static Area? From(double? value, AreaUnit fromUnit)
+        public static Area? From(QuantityValue? value, AreaUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -189,228 +189,108 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AreaMomentOfInertia FromCentimetersToTheFourth(double centimeterstothefourth)
         {
-            return new AreaMomentOfInertia(centimeterstothefourth/1e8);
+            double value = (double) centimeterstothefourth;
+            return new AreaMomentOfInertia(value/1e8);
         }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromCentimetersToTheFourth(int centimeterstothefourth)
+#else
+        public static AreaMomentOfInertia FromCentimetersToTheFourth(QuantityValue centimeterstothefourth)
         {
-            return new AreaMomentOfInertia(centimeterstothefourth/1e8);
-        }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromCentimetersToTheFourth(long centimeterstothefourth)
-        {
-            return new AreaMomentOfInertia(centimeterstothefourth/1e8);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AreaMomentOfInertia from CentimetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia FromCentimetersToTheFourth(decimal centimeterstothefourth)
-        {
-            return new AreaMomentOfInertia(Convert.ToDouble(centimeterstothefourth)/1e8);
+            double value = (double) centimeterstothefourth;
+            return new AreaMomentOfInertia((value/1e8));
         }
 #endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AreaMomentOfInertia FromDecimetersToTheFourth(double decimeterstothefourth)
         {
-            return new AreaMomentOfInertia(decimeterstothefourth/1e4);
+            double value = (double) decimeterstothefourth;
+            return new AreaMomentOfInertia(value/1e4);
         }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromDecimetersToTheFourth(int decimeterstothefourth)
+#else
+        public static AreaMomentOfInertia FromDecimetersToTheFourth(QuantityValue decimeterstothefourth)
         {
-            return new AreaMomentOfInertia(decimeterstothefourth/1e4);
-        }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromDecimetersToTheFourth(long decimeterstothefourth)
-        {
-            return new AreaMomentOfInertia(decimeterstothefourth/1e4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AreaMomentOfInertia from DecimetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia FromDecimetersToTheFourth(decimal decimeterstothefourth)
-        {
-            return new AreaMomentOfInertia(Convert.ToDouble(decimeterstothefourth)/1e4);
+            double value = (double) decimeterstothefourth;
+            return new AreaMomentOfInertia((value/1e4));
         }
 #endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AreaMomentOfInertia FromFeetToTheFourth(double feettothefourth)
         {
-            return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
+            double value = (double) feettothefourth;
+            return new AreaMomentOfInertia(value*Math.Pow(0.3048, 4));
         }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from FeetToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromFeetToTheFourth(int feettothefourth)
+#else
+        public static AreaMomentOfInertia FromFeetToTheFourth(QuantityValue feettothefourth)
         {
-            return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
-        }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from FeetToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromFeetToTheFourth(long feettothefourth)
-        {
-            return new AreaMomentOfInertia(feettothefourth*Math.Pow(0.3048, 4));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AreaMomentOfInertia from FeetToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia FromFeetToTheFourth(decimal feettothefourth)
-        {
-            return new AreaMomentOfInertia(Convert.ToDouble(feettothefourth)*Math.Pow(0.3048, 4));
+            double value = (double) feettothefourth;
+            return new AreaMomentOfInertia((value*Math.Pow(0.3048, 4)));
         }
 #endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AreaMomentOfInertia FromInchesToTheFourth(double inchestothefourth)
         {
-            return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
+            double value = (double) inchestothefourth;
+            return new AreaMomentOfInertia(value*Math.Pow(2.54e-2, 4));
         }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from InchesToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromInchesToTheFourth(int inchestothefourth)
+#else
+        public static AreaMomentOfInertia FromInchesToTheFourth(QuantityValue inchestothefourth)
         {
-            return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
-        }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from InchesToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromInchesToTheFourth(long inchestothefourth)
-        {
-            return new AreaMomentOfInertia(inchestothefourth*Math.Pow(2.54e-2, 4));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AreaMomentOfInertia from InchesToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia FromInchesToTheFourth(decimal inchestothefourth)
-        {
-            return new AreaMomentOfInertia(Convert.ToDouble(inchestothefourth)*Math.Pow(2.54e-2, 4));
+            double value = (double) inchestothefourth;
+            return new AreaMomentOfInertia((value*Math.Pow(2.54e-2, 4)));
         }
 #endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AreaMomentOfInertia FromMetersToTheFourth(double meterstothefourth)
         {
-            return new AreaMomentOfInertia(meterstothefourth);
+            double value = (double) meterstothefourth;
+            return new AreaMomentOfInertia(value);
         }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from MetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromMetersToTheFourth(int meterstothefourth)
+#else
+        public static AreaMomentOfInertia FromMetersToTheFourth(QuantityValue meterstothefourth)
         {
-            return new AreaMomentOfInertia(meterstothefourth);
-        }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from MetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromMetersToTheFourth(long meterstothefourth)
-        {
-            return new AreaMomentOfInertia(meterstothefourth);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AreaMomentOfInertia from MetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia FromMetersToTheFourth(decimal meterstothefourth)
-        {
-            return new AreaMomentOfInertia(Convert.ToDouble(meterstothefourth));
+            double value = (double) meterstothefourth;
+            return new AreaMomentOfInertia((value));
         }
 #endif
 
         /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static AreaMomentOfInertia FromMillimetersToTheFourth(double millimeterstothefourth)
         {
-            return new AreaMomentOfInertia(millimeterstothefourth/1e12);
+            double value = (double) millimeterstothefourth;
+            return new AreaMomentOfInertia(value/1e12);
         }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromMillimetersToTheFourth(int millimeterstothefourth)
+#else
+        public static AreaMomentOfInertia FromMillimetersToTheFourth(QuantityValue millimeterstothefourth)
         {
-            return new AreaMomentOfInertia(millimeterstothefourth/1e12);
-        }
-
-        /// <summary>
-        ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia FromMillimetersToTheFourth(long millimeterstothefourth)
-        {
-            return new AreaMomentOfInertia(millimeterstothefourth/1e12);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get AreaMomentOfInertia from MillimetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia FromMillimetersToTheFourth(decimal millimeterstothefourth)
-        {
-            return new AreaMomentOfInertia(Convert.ToDouble(millimeterstothefourth)/1e12);
+            double value = (double) millimeterstothefourth;
+            return new AreaMomentOfInertia((value/1e12));
         }
 #endif
 
@@ -419,52 +299,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia? FromCentimetersToTheFourth(double? centimeterstothefourth)
-        {
-            if (centimeterstothefourth.HasValue)
-            {
-                return FromCentimetersToTheFourth(centimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromCentimetersToTheFourth(int? centimeterstothefourth)
-        {
-            if (centimeterstothefourth.HasValue)
-            {
-                return FromCentimetersToTheFourth(centimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable CentimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromCentimetersToTheFourth(long? centimeterstothefourth)
-        {
-            if (centimeterstothefourth.HasValue)
-            {
-                return FromCentimetersToTheFourth(centimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from CentimetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia? FromCentimetersToTheFourth(decimal? centimeterstothefourth)
+        public static AreaMomentOfInertia? FromCentimetersToTheFourth(QuantityValue? centimeterstothefourth)
         {
             if (centimeterstothefourth.HasValue)
             {
@@ -479,52 +314,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia? FromDecimetersToTheFourth(double? decimeterstothefourth)
-        {
-            if (decimeterstothefourth.HasValue)
-            {
-                return FromDecimetersToTheFourth(decimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromDecimetersToTheFourth(int? decimeterstothefourth)
-        {
-            if (decimeterstothefourth.HasValue)
-            {
-                return FromDecimetersToTheFourth(decimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable DecimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromDecimetersToTheFourth(long? decimeterstothefourth)
-        {
-            if (decimeterstothefourth.HasValue)
-            {
-                return FromDecimetersToTheFourth(decimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from DecimetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia? FromDecimetersToTheFourth(decimal? decimeterstothefourth)
+        public static AreaMomentOfInertia? FromDecimetersToTheFourth(QuantityValue? decimeterstothefourth)
         {
             if (decimeterstothefourth.HasValue)
             {
@@ -539,52 +329,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia? FromFeetToTheFourth(double? feettothefourth)
-        {
-            if (feettothefourth.HasValue)
-            {
-                return FromFeetToTheFourth(feettothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromFeetToTheFourth(int? feettothefourth)
-        {
-            if (feettothefourth.HasValue)
-            {
-                return FromFeetToTheFourth(feettothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable FeetToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromFeetToTheFourth(long? feettothefourth)
-        {
-            if (feettothefourth.HasValue)
-            {
-                return FromFeetToTheFourth(feettothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from FeetToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia? FromFeetToTheFourth(decimal? feettothefourth)
+        public static AreaMomentOfInertia? FromFeetToTheFourth(QuantityValue? feettothefourth)
         {
             if (feettothefourth.HasValue)
             {
@@ -599,52 +344,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia? FromInchesToTheFourth(double? inchestothefourth)
-        {
-            if (inchestothefourth.HasValue)
-            {
-                return FromInchesToTheFourth(inchestothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromInchesToTheFourth(int? inchestothefourth)
-        {
-            if (inchestothefourth.HasValue)
-            {
-                return FromInchesToTheFourth(inchestothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable InchesToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromInchesToTheFourth(long? inchestothefourth)
-        {
-            if (inchestothefourth.HasValue)
-            {
-                return FromInchesToTheFourth(inchestothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from InchesToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia? FromInchesToTheFourth(decimal? inchestothefourth)
+        public static AreaMomentOfInertia? FromInchesToTheFourth(QuantityValue? inchestothefourth)
         {
             if (inchestothefourth.HasValue)
             {
@@ -659,52 +359,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia? FromMetersToTheFourth(double? meterstothefourth)
-        {
-            if (meterstothefourth.HasValue)
-            {
-                return FromMetersToTheFourth(meterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromMetersToTheFourth(int? meterstothefourth)
-        {
-            if (meterstothefourth.HasValue)
-            {
-                return FromMetersToTheFourth(meterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable MetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromMetersToTheFourth(long? meterstothefourth)
-        {
-            if (meterstothefourth.HasValue)
-            {
-                return FromMetersToTheFourth(meterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from MetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia? FromMetersToTheFourth(decimal? meterstothefourth)
+        public static AreaMomentOfInertia? FromMetersToTheFourth(QuantityValue? meterstothefourth)
         {
             if (meterstothefourth.HasValue)
             {
@@ -719,52 +374,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia? FromMillimetersToTheFourth(double? millimeterstothefourth)
-        {
-            if (millimeterstothefourth.HasValue)
-            {
-                return FromMillimetersToTheFourth(millimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromMillimetersToTheFourth(int? millimeterstothefourth)
-        {
-            if (millimeterstothefourth.HasValue)
-            {
-                return FromMillimetersToTheFourth(millimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from nullable MillimetersToTheFourth.
-        /// </summary>
-        public static AreaMomentOfInertia? FromMillimetersToTheFourth(long? millimeterstothefourth)
-        {
-            if (millimeterstothefourth.HasValue)
-            {
-                return FromMillimetersToTheFourth(millimeterstothefourth.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable AreaMomentOfInertia from MillimetersToTheFourth of type decimal.
-        /// </summary>
-        public static AreaMomentOfInertia? FromMillimetersToTheFourth(decimal? millimeterstothefourth)
+        public static AreaMomentOfInertia? FromMillimetersToTheFourth(QuantityValue? millimeterstothefourth)
         {
             if (millimeterstothefourth.HasValue)
             {
@@ -781,25 +391,31 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="AreaMomentOfInertiaUnit" /> to <see cref="AreaMomentOfInertia" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>AreaMomentOfInertia unit value.</returns>
-        public static AreaMomentOfInertia From(double val, AreaMomentOfInertiaUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static AreaMomentOfInertia From(double value, AreaMomentOfInertiaUnit fromUnit)
+#else
+        public static AreaMomentOfInertia From(QuantityValue value, AreaMomentOfInertiaUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case AreaMomentOfInertiaUnit.CentimeterToTheFourth:
-                    return FromCentimetersToTheFourth(val);
+                    return FromCentimetersToTheFourth(value);
                 case AreaMomentOfInertiaUnit.DecimeterToTheFourth:
-                    return FromDecimetersToTheFourth(val);
+                    return FromDecimetersToTheFourth(value);
                 case AreaMomentOfInertiaUnit.FootToTheFourth:
-                    return FromFeetToTheFourth(val);
+                    return FromFeetToTheFourth(value);
                 case AreaMomentOfInertiaUnit.InchToTheFourth:
-                    return FromInchesToTheFourth(val);
+                    return FromInchesToTheFourth(value);
                 case AreaMomentOfInertiaUnit.MeterToTheFourth:
-                    return FromMetersToTheFourth(val);
+                    return FromMetersToTheFourth(value);
                 case AreaMomentOfInertiaUnit.MillimeterToTheFourth:
-                    return FromMillimetersToTheFourth(val);
+                    return FromMillimetersToTheFourth(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -814,7 +430,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>AreaMomentOfInertia unit value.</returns>
-        public static AreaMomentOfInertia? From(double? value, AreaMomentOfInertiaUnit fromUnit)
+        public static AreaMomentOfInertia? From(QuantityValue? value, AreaMomentOfInertiaUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -165,114 +165,54 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(double gramsperkilowatthour)
         {
-            return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
+            double value = (double) gramsperkilowatthour;
+            return new BrakeSpecificFuelConsumption(value/3.6e9);
         }
-
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(int gramsperkilowatthour)
+#else
+        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(QuantityValue gramsperkilowatthour)
         {
-            return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
-        }
-
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(long gramsperkilowatthour)
-        {
-            return new BrakeSpecificFuelConsumption(gramsperkilowatthour/3.6e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour of type decimal.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(decimal gramsperkilowatthour)
-        {
-            return new BrakeSpecificFuelConsumption(Convert.ToDouble(gramsperkilowatthour)/3.6e9);
+            double value = (double) gramsperkilowatthour;
+            return new BrakeSpecificFuelConsumption((value/3.6e9));
         }
 #endif
 
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(double kilogramsperjoule)
         {
-            return new BrakeSpecificFuelConsumption(kilogramsperjoule);
+            double value = (double) kilogramsperjoule;
+            return new BrakeSpecificFuelConsumption(value);
         }
-
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(int kilogramsperjoule)
+#else
+        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(QuantityValue kilogramsperjoule)
         {
-            return new BrakeSpecificFuelConsumption(kilogramsperjoule);
-        }
-
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(long kilogramsperjoule)
-        {
-            return new BrakeSpecificFuelConsumption(kilogramsperjoule);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule of type decimal.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(decimal kilogramsperjoule)
-        {
-            return new BrakeSpecificFuelConsumption(Convert.ToDouble(kilogramsperjoule));
+            double value = (double) kilogramsperjoule;
+            return new BrakeSpecificFuelConsumption((value));
         }
 #endif
 
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(double poundspermechanicalhorsepowerhour)
         {
-            return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
+            double value = (double) poundspermechanicalhorsepowerhour;
+            return new BrakeSpecificFuelConsumption(value*1.689659410672e-7);
         }
-
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(int poundspermechanicalhorsepowerhour)
+#else
+        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(QuantityValue poundspermechanicalhorsepowerhour)
         {
-            return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
-        }
-
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(long poundspermechanicalhorsepowerhour)
-        {
-            return new BrakeSpecificFuelConsumption(poundspermechanicalhorsepowerhour*1.689659410672e-7);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour of type decimal.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(decimal poundspermechanicalhorsepowerhour)
-        {
-            return new BrakeSpecificFuelConsumption(Convert.ToDouble(poundspermechanicalhorsepowerhour)*1.689659410672e-7);
+            double value = (double) poundspermechanicalhorsepowerhour;
+            return new BrakeSpecificFuelConsumption((value*1.689659410672e-7));
         }
 #endif
 
@@ -281,52 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
         /// </summary>
-        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(double? gramsperkilowatthour)
-        {
-            if (gramsperkilowatthour.HasValue)
-            {
-                return FromGramsPerKiloWattHour(gramsperkilowatthour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(int? gramsperkilowatthour)
-        {
-            if (gramsperkilowatthour.HasValue)
-            {
-                return FromGramsPerKiloWattHour(gramsperkilowatthour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from nullable GramsPerKiloWattHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(long? gramsperkilowatthour)
-        {
-            if (gramsperkilowatthour.HasValue)
-            {
-                return FromGramsPerKiloWattHour(gramsperkilowatthour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from GramsPerKiloWattHour of type decimal.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(decimal? gramsperkilowatthour)
+        public static BrakeSpecificFuelConsumption? FromGramsPerKiloWattHour(QuantityValue? gramsperkilowatthour)
         {
             if (gramsperkilowatthour.HasValue)
             {
@@ -341,52 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
         /// </summary>
-        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(double? kilogramsperjoule)
-        {
-            if (kilogramsperjoule.HasValue)
-            {
-                return FromKilogramsPerJoule(kilogramsperjoule.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(int? kilogramsperjoule)
-        {
-            if (kilogramsperjoule.HasValue)
-            {
-                return FromKilogramsPerJoule(kilogramsperjoule.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from nullable KilogramsPerJoule.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(long? kilogramsperjoule)
-        {
-            if (kilogramsperjoule.HasValue)
-            {
-                return FromKilogramsPerJoule(kilogramsperjoule.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from KilogramsPerJoule of type decimal.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(decimal? kilogramsperjoule)
+        public static BrakeSpecificFuelConsumption? FromKilogramsPerJoule(QuantityValue? kilogramsperjoule)
         {
             if (kilogramsperjoule.HasValue)
             {
@@ -401,52 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
         /// </summary>
-        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(double? poundspermechanicalhorsepowerhour)
-        {
-            if (poundspermechanicalhorsepowerhour.HasValue)
-            {
-                return FromPoundsPerMechanicalHorsepowerHour(poundspermechanicalhorsepowerhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(int? poundspermechanicalhorsepowerhour)
-        {
-            if (poundspermechanicalhorsepowerhour.HasValue)
-            {
-                return FromPoundsPerMechanicalHorsepowerHour(poundspermechanicalhorsepowerhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from nullable PoundsPerMechanicalHorsepowerHour.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(long? poundspermechanicalhorsepowerhour)
-        {
-            if (poundspermechanicalhorsepowerhour.HasValue)
-            {
-                return FromPoundsPerMechanicalHorsepowerHour(poundspermechanicalhorsepowerhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour of type decimal.
-        /// </summary>
-        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(decimal? poundspermechanicalhorsepowerhour)
+        public static BrakeSpecificFuelConsumption? FromPoundsPerMechanicalHorsepowerHour(QuantityValue? poundspermechanicalhorsepowerhour)
         {
             if (poundspermechanicalhorsepowerhour.HasValue)
             {
@@ -463,19 +268,25 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="BrakeSpecificFuelConsumptionUnit" /> to <see cref="BrakeSpecificFuelConsumption" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>BrakeSpecificFuelConsumption unit value.</returns>
-        public static BrakeSpecificFuelConsumption From(double val, BrakeSpecificFuelConsumptionUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static BrakeSpecificFuelConsumption From(double value, BrakeSpecificFuelConsumptionUnit fromUnit)
+#else
+        public static BrakeSpecificFuelConsumption From(QuantityValue value, BrakeSpecificFuelConsumptionUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour:
-                    return FromGramsPerKiloWattHour(val);
+                    return FromGramsPerKiloWattHour(value);
                 case BrakeSpecificFuelConsumptionUnit.KilogramPerJoule:
-                    return FromKilogramsPerJoule(val);
+                    return FromKilogramsPerJoule(value);
                 case BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour:
-                    return FromPoundsPerMechanicalHorsepowerHour(val);
+                    return FromPoundsPerMechanicalHorsepowerHour(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -490,7 +301,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>BrakeSpecificFuelConsumption unit value.</returns>
-        public static BrakeSpecificFuelConsumption? From(double? value, BrakeSpecificFuelConsumptionUnit fromUnit)
+        public static BrakeSpecificFuelConsumption? From(QuantityValue? value, BrakeSpecificFuelConsumptionUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -421,1330 +421,630 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromCentigramsPerDeciLiter(double centigramsperdeciliter)
         {
-            return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
+            double value = (double) centigramsperdeciliter;
+            return new Density((value/1e-1) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Density from CentigramsPerDeciLiter.
-        /// </summary>
-        public static Density FromCentigramsPerDeciLiter(int centigramsperdeciliter)
+#else
+        public static Density FromCentigramsPerDeciLiter(QuantityValue centigramsperdeciliter)
         {
-            return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Density from CentigramsPerDeciLiter.
-        /// </summary>
-        public static Density FromCentigramsPerDeciLiter(long centigramsperdeciliter)
-        {
-            return new Density((centigramsperdeciliter/1e-1) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from CentigramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromCentigramsPerDeciLiter(decimal centigramsperdeciliter)
-        {
-            return new Density((Convert.ToDouble(centigramsperdeciliter)/1e-1) * 1e-2d);
+            double value = (double) centigramsperdeciliter;
+            return new Density(((value/1e-1) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromCentigramsPerLiter(double centigramsperliter)
         {
-            return new Density((centigramsperliter/1) * 1e-2d);
+            double value = (double) centigramsperliter;
+            return new Density((value/1) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Density from CentigramsPerLiter.
-        /// </summary>
-        public static Density FromCentigramsPerLiter(int centigramsperliter)
+#else
+        public static Density FromCentigramsPerLiter(QuantityValue centigramsperliter)
         {
-            return new Density((centigramsperliter/1) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Density from CentigramsPerLiter.
-        /// </summary>
-        public static Density FromCentigramsPerLiter(long centigramsperliter)
-        {
-            return new Density((centigramsperliter/1) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from CentigramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromCentigramsPerLiter(decimal centigramsperliter)
-        {
-            return new Density((Convert.ToDouble(centigramsperliter)/1) * 1e-2d);
+            double value = (double) centigramsperliter;
+            return new Density(((value/1) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromCentigramsPerMilliliter(double centigramspermilliliter)
         {
-            return new Density((centigramspermilliliter/1e-3) * 1e-2d);
+            double value = (double) centigramspermilliliter;
+            return new Density((value/1e-3) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Density from CentigramsPerMilliliter.
-        /// </summary>
-        public static Density FromCentigramsPerMilliliter(int centigramspermilliliter)
+#else
+        public static Density FromCentigramsPerMilliliter(QuantityValue centigramspermilliliter)
         {
-            return new Density((centigramspermilliliter/1e-3) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Density from CentigramsPerMilliliter.
-        /// </summary>
-        public static Density FromCentigramsPerMilliliter(long centigramspermilliliter)
-        {
-            return new Density((centigramspermilliliter/1e-3) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from CentigramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromCentigramsPerMilliliter(decimal centigramspermilliliter)
-        {
-            return new Density((Convert.ToDouble(centigramspermilliliter)/1e-3) * 1e-2d);
+            double value = (double) centigramspermilliliter;
+            return new Density(((value/1e-3) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromDecigramsPerDeciLiter(double decigramsperdeciliter)
         {
-            return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
+            double value = (double) decigramsperdeciliter;
+            return new Density((value/1e-1) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Density from DecigramsPerDeciLiter.
-        /// </summary>
-        public static Density FromDecigramsPerDeciLiter(int decigramsperdeciliter)
+#else
+        public static Density FromDecigramsPerDeciLiter(QuantityValue decigramsperdeciliter)
         {
-            return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Density from DecigramsPerDeciLiter.
-        /// </summary>
-        public static Density FromDecigramsPerDeciLiter(long decigramsperdeciliter)
-        {
-            return new Density((decigramsperdeciliter/1e-1) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from DecigramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromDecigramsPerDeciLiter(decimal decigramsperdeciliter)
-        {
-            return new Density((Convert.ToDouble(decigramsperdeciliter)/1e-1) * 1e-1d);
+            double value = (double) decigramsperdeciliter;
+            return new Density(((value/1e-1) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from DecigramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromDecigramsPerLiter(double decigramsperliter)
         {
-            return new Density((decigramsperliter/1) * 1e-1d);
+            double value = (double) decigramsperliter;
+            return new Density((value/1) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Density from DecigramsPerLiter.
-        /// </summary>
-        public static Density FromDecigramsPerLiter(int decigramsperliter)
+#else
+        public static Density FromDecigramsPerLiter(QuantityValue decigramsperliter)
         {
-            return new Density((decigramsperliter/1) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Density from DecigramsPerLiter.
-        /// </summary>
-        public static Density FromDecigramsPerLiter(long decigramsperliter)
-        {
-            return new Density((decigramsperliter/1) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from DecigramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromDecigramsPerLiter(decimal decigramsperliter)
-        {
-            return new Density((Convert.ToDouble(decigramsperliter)/1) * 1e-1d);
+            double value = (double) decigramsperliter;
+            return new Density(((value/1) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromDecigramsPerMilliliter(double decigramspermilliliter)
         {
-            return new Density((decigramspermilliliter/1e-3) * 1e-1d);
+            double value = (double) decigramspermilliliter;
+            return new Density((value/1e-3) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Density from DecigramsPerMilliliter.
-        /// </summary>
-        public static Density FromDecigramsPerMilliliter(int decigramspermilliliter)
+#else
+        public static Density FromDecigramsPerMilliliter(QuantityValue decigramspermilliliter)
         {
-            return new Density((decigramspermilliliter/1e-3) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Density from DecigramsPerMilliliter.
-        /// </summary>
-        public static Density FromDecigramsPerMilliliter(long decigramspermilliliter)
-        {
-            return new Density((decigramspermilliliter/1e-3) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from DecigramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromDecigramsPerMilliliter(decimal decigramspermilliliter)
-        {
-            return new Density((Convert.ToDouble(decigramspermilliliter)/1e-3) * 1e-1d);
+            double value = (double) decigramspermilliliter;
+            return new Density(((value/1e-3) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromGramsPerCubicCentimeter(double gramspercubiccentimeter)
         {
-            return new Density(gramspercubiccentimeter/1e-3);
+            double value = (double) gramspercubiccentimeter;
+            return new Density(value/1e-3);
         }
-
-        /// <summary>
-        ///     Get Density from GramsPerCubicCentimeter.
-        /// </summary>
-        public static Density FromGramsPerCubicCentimeter(int gramspercubiccentimeter)
+#else
+        public static Density FromGramsPerCubicCentimeter(QuantityValue gramspercubiccentimeter)
         {
-            return new Density(gramspercubiccentimeter/1e-3);
-        }
-
-        /// <summary>
-        ///     Get Density from GramsPerCubicCentimeter.
-        /// </summary>
-        public static Density FromGramsPerCubicCentimeter(long gramspercubiccentimeter)
-        {
-            return new Density(gramspercubiccentimeter/1e-3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from GramsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static Density FromGramsPerCubicCentimeter(decimal gramspercubiccentimeter)
-        {
-            return new Density(Convert.ToDouble(gramspercubiccentimeter)/1e-3);
+            double value = (double) gramspercubiccentimeter;
+            return new Density((value/1e-3));
         }
 #endif
 
         /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromGramsPerCubicMeter(double gramspercubicmeter)
         {
-            return new Density(gramspercubicmeter/1e3);
+            double value = (double) gramspercubicmeter;
+            return new Density(value/1e3);
         }
-
-        /// <summary>
-        ///     Get Density from GramsPerCubicMeter.
-        /// </summary>
-        public static Density FromGramsPerCubicMeter(int gramspercubicmeter)
+#else
+        public static Density FromGramsPerCubicMeter(QuantityValue gramspercubicmeter)
         {
-            return new Density(gramspercubicmeter/1e3);
-        }
-
-        /// <summary>
-        ///     Get Density from GramsPerCubicMeter.
-        /// </summary>
-        public static Density FromGramsPerCubicMeter(long gramspercubicmeter)
-        {
-            return new Density(gramspercubicmeter/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from GramsPerCubicMeter of type decimal.
-        /// </summary>
-        public static Density FromGramsPerCubicMeter(decimal gramspercubicmeter)
-        {
-            return new Density(Convert.ToDouble(gramspercubicmeter)/1e3);
+            double value = (double) gramspercubicmeter;
+            return new Density((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromGramsPerCubicMillimeter(double gramspercubicmillimeter)
         {
-            return new Density(gramspercubicmillimeter/1e-6);
+            double value = (double) gramspercubicmillimeter;
+            return new Density(value/1e-6);
         }
-
-        /// <summary>
-        ///     Get Density from GramsPerCubicMillimeter.
-        /// </summary>
-        public static Density FromGramsPerCubicMillimeter(int gramspercubicmillimeter)
+#else
+        public static Density FromGramsPerCubicMillimeter(QuantityValue gramspercubicmillimeter)
         {
-            return new Density(gramspercubicmillimeter/1e-6);
-        }
-
-        /// <summary>
-        ///     Get Density from GramsPerCubicMillimeter.
-        /// </summary>
-        public static Density FromGramsPerCubicMillimeter(long gramspercubicmillimeter)
-        {
-            return new Density(gramspercubicmillimeter/1e-6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from GramsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static Density FromGramsPerCubicMillimeter(decimal gramspercubicmillimeter)
-        {
-            return new Density(Convert.ToDouble(gramspercubicmillimeter)/1e-6);
+            double value = (double) gramspercubicmillimeter;
+            return new Density((value/1e-6));
         }
 #endif
 
         /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromGramsPerDeciLiter(double gramsperdeciliter)
         {
-            return new Density(gramsperdeciliter/1e-1);
+            double value = (double) gramsperdeciliter;
+            return new Density(value/1e-1);
         }
-
-        /// <summary>
-        ///     Get Density from GramsPerDeciLiter.
-        /// </summary>
-        public static Density FromGramsPerDeciLiter(int gramsperdeciliter)
+#else
+        public static Density FromGramsPerDeciLiter(QuantityValue gramsperdeciliter)
         {
-            return new Density(gramsperdeciliter/1e-1);
-        }
-
-        /// <summary>
-        ///     Get Density from GramsPerDeciLiter.
-        /// </summary>
-        public static Density FromGramsPerDeciLiter(long gramsperdeciliter)
-        {
-            return new Density(gramsperdeciliter/1e-1);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from GramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromGramsPerDeciLiter(decimal gramsperdeciliter)
-        {
-            return new Density(Convert.ToDouble(gramsperdeciliter)/1e-1);
+            double value = (double) gramsperdeciliter;
+            return new Density((value/1e-1));
         }
 #endif
 
         /// <summary>
         ///     Get Density from GramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromGramsPerLiter(double gramsperliter)
         {
-            return new Density(gramsperliter/1);
+            double value = (double) gramsperliter;
+            return new Density(value/1);
         }
-
-        /// <summary>
-        ///     Get Density from GramsPerLiter.
-        /// </summary>
-        public static Density FromGramsPerLiter(int gramsperliter)
+#else
+        public static Density FromGramsPerLiter(QuantityValue gramsperliter)
         {
-            return new Density(gramsperliter/1);
-        }
-
-        /// <summary>
-        ///     Get Density from GramsPerLiter.
-        /// </summary>
-        public static Density FromGramsPerLiter(long gramsperliter)
-        {
-            return new Density(gramsperliter/1);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from GramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromGramsPerLiter(decimal gramsperliter)
-        {
-            return new Density(Convert.ToDouble(gramsperliter)/1);
+            double value = (double) gramsperliter;
+            return new Density((value/1));
         }
 #endif
 
         /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromGramsPerMilliliter(double gramspermilliliter)
         {
-            return new Density(gramspermilliliter/1e-3);
+            double value = (double) gramspermilliliter;
+            return new Density(value/1e-3);
         }
-
-        /// <summary>
-        ///     Get Density from GramsPerMilliliter.
-        /// </summary>
-        public static Density FromGramsPerMilliliter(int gramspermilliliter)
+#else
+        public static Density FromGramsPerMilliliter(QuantityValue gramspermilliliter)
         {
-            return new Density(gramspermilliliter/1e-3);
-        }
-
-        /// <summary>
-        ///     Get Density from GramsPerMilliliter.
-        /// </summary>
-        public static Density FromGramsPerMilliliter(long gramspermilliliter)
-        {
-            return new Density(gramspermilliliter/1e-3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from GramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromGramsPerMilliliter(decimal gramspermilliliter)
-        {
-            return new Density(Convert.ToDouble(gramspermilliliter)/1e-3);
+            double value = (double) gramspermilliliter;
+            return new Density((value/1e-3));
         }
 #endif
 
         /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromKilogramsPerCubicCentimeter(double kilogramspercubiccentimeter)
         {
-            return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
+            double value = (double) kilogramspercubiccentimeter;
+            return new Density((value/1e-3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicCentimeter.
-        /// </summary>
-        public static Density FromKilogramsPerCubicCentimeter(int kilogramspercubiccentimeter)
+#else
+        public static Density FromKilogramsPerCubicCentimeter(QuantityValue kilogramspercubiccentimeter)
         {
-            return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicCentimeter.
-        /// </summary>
-        public static Density FromKilogramsPerCubicCentimeter(long kilogramspercubiccentimeter)
-        {
-            return new Density((kilogramspercubiccentimeter/1e-3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static Density FromKilogramsPerCubicCentimeter(decimal kilogramspercubiccentimeter)
-        {
-            return new Density((Convert.ToDouble(kilogramspercubiccentimeter)/1e-3) * 1e3d);
+            double value = (double) kilogramspercubiccentimeter;
+            return new Density(((value/1e-3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromKilogramsPerCubicMeter(double kilogramspercubicmeter)
         {
-            return new Density((kilogramspercubicmeter/1e3) * 1e3d);
+            double value = (double) kilogramspercubicmeter;
+            return new Density((value/1e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicMeter.
-        /// </summary>
-        public static Density FromKilogramsPerCubicMeter(int kilogramspercubicmeter)
+#else
+        public static Density FromKilogramsPerCubicMeter(QuantityValue kilogramspercubicmeter)
         {
-            return new Density((kilogramspercubicmeter/1e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicMeter.
-        /// </summary>
-        public static Density FromKilogramsPerCubicMeter(long kilogramspercubicmeter)
-        {
-            return new Density((kilogramspercubicmeter/1e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicMeter of type decimal.
-        /// </summary>
-        public static Density FromKilogramsPerCubicMeter(decimal kilogramspercubicmeter)
-        {
-            return new Density((Convert.ToDouble(kilogramspercubicmeter)/1e3) * 1e3d);
+            double value = (double) kilogramspercubicmeter;
+            return new Density(((value/1e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromKilogramsPerCubicMillimeter(double kilogramspercubicmillimeter)
         {
-            return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
+            double value = (double) kilogramspercubicmillimeter;
+            return new Density((value/1e-6) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicMillimeter.
-        /// </summary>
-        public static Density FromKilogramsPerCubicMillimeter(int kilogramspercubicmillimeter)
+#else
+        public static Density FromKilogramsPerCubicMillimeter(QuantityValue kilogramspercubicmillimeter)
         {
-            return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicMillimeter.
-        /// </summary>
-        public static Density FromKilogramsPerCubicMillimeter(long kilogramspercubicmillimeter)
-        {
-            return new Density((kilogramspercubicmillimeter/1e-6) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from KilogramsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static Density FromKilogramsPerCubicMillimeter(decimal kilogramspercubicmillimeter)
-        {
-            return new Density((Convert.ToDouble(kilogramspercubicmillimeter)/1e-6) * 1e3d);
+            double value = (double) kilogramspercubicmillimeter;
+            return new Density(((value/1e-6) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromKilopoundsPerCubicFoot(double kilopoundspercubicfoot)
         {
-            return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
+            double value = (double) kilopoundspercubicfoot;
+            return new Density((value/0.062427961) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Density from KilopoundsPerCubicFoot.
-        /// </summary>
-        public static Density FromKilopoundsPerCubicFoot(int kilopoundspercubicfoot)
+#else
+        public static Density FromKilopoundsPerCubicFoot(QuantityValue kilopoundspercubicfoot)
         {
-            return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Density from KilopoundsPerCubicFoot.
-        /// </summary>
-        public static Density FromKilopoundsPerCubicFoot(long kilopoundspercubicfoot)
-        {
-            return new Density((kilopoundspercubicfoot/0.062427961) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from KilopoundsPerCubicFoot of type decimal.
-        /// </summary>
-        public static Density FromKilopoundsPerCubicFoot(decimal kilopoundspercubicfoot)
-        {
-            return new Density((Convert.ToDouble(kilopoundspercubicfoot)/0.062427961) * 1e3d);
+            double value = (double) kilopoundspercubicfoot;
+            return new Density(((value/0.062427961) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromKilopoundsPerCubicInch(double kilopoundspercubicinch)
         {
-            return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
+            double value = (double) kilopoundspercubicinch;
+            return new Density((value/3.6127298147753e-5) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Density from KilopoundsPerCubicInch.
-        /// </summary>
-        public static Density FromKilopoundsPerCubicInch(int kilopoundspercubicinch)
+#else
+        public static Density FromKilopoundsPerCubicInch(QuantityValue kilopoundspercubicinch)
         {
-            return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Density from KilopoundsPerCubicInch.
-        /// </summary>
-        public static Density FromKilopoundsPerCubicInch(long kilopoundspercubicinch)
-        {
-            return new Density((kilopoundspercubicinch/3.6127298147753e-5) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from KilopoundsPerCubicInch of type decimal.
-        /// </summary>
-        public static Density FromKilopoundsPerCubicInch(decimal kilopoundspercubicinch)
-        {
-            return new Density((Convert.ToDouble(kilopoundspercubicinch)/3.6127298147753e-5) * 1e3d);
+            double value = (double) kilopoundspercubicinch;
+            return new Density(((value/3.6127298147753e-5) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromMicrogramsPerDeciLiter(double microgramsperdeciliter)
         {
-            return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
+            double value = (double) microgramsperdeciliter;
+            return new Density((value/1e-1) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Density from MicrogramsPerDeciLiter.
-        /// </summary>
-        public static Density FromMicrogramsPerDeciLiter(int microgramsperdeciliter)
+#else
+        public static Density FromMicrogramsPerDeciLiter(QuantityValue microgramsperdeciliter)
         {
-            return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Density from MicrogramsPerDeciLiter.
-        /// </summary>
-        public static Density FromMicrogramsPerDeciLiter(long microgramsperdeciliter)
-        {
-            return new Density((microgramsperdeciliter/1e-1) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from MicrogramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromMicrogramsPerDeciLiter(decimal microgramsperdeciliter)
-        {
-            return new Density((Convert.ToDouble(microgramsperdeciliter)/1e-1) * 1e-6d);
+            double value = (double) microgramsperdeciliter;
+            return new Density(((value/1e-1) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from MicrogramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromMicrogramsPerLiter(double microgramsperliter)
         {
-            return new Density((microgramsperliter/1) * 1e-6d);
+            double value = (double) microgramsperliter;
+            return new Density((value/1) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Density from MicrogramsPerLiter.
-        /// </summary>
-        public static Density FromMicrogramsPerLiter(int microgramsperliter)
+#else
+        public static Density FromMicrogramsPerLiter(QuantityValue microgramsperliter)
         {
-            return new Density((microgramsperliter/1) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Density from MicrogramsPerLiter.
-        /// </summary>
-        public static Density FromMicrogramsPerLiter(long microgramsperliter)
-        {
-            return new Density((microgramsperliter/1) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from MicrogramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromMicrogramsPerLiter(decimal microgramsperliter)
-        {
-            return new Density((Convert.ToDouble(microgramsperliter)/1) * 1e-6d);
+            double value = (double) microgramsperliter;
+            return new Density(((value/1) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromMicrogramsPerMilliliter(double microgramspermilliliter)
         {
-            return new Density((microgramspermilliliter/1e-3) * 1e-6d);
+            double value = (double) microgramspermilliliter;
+            return new Density((value/1e-3) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Density from MicrogramsPerMilliliter.
-        /// </summary>
-        public static Density FromMicrogramsPerMilliliter(int microgramspermilliliter)
+#else
+        public static Density FromMicrogramsPerMilliliter(QuantityValue microgramspermilliliter)
         {
-            return new Density((microgramspermilliliter/1e-3) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Density from MicrogramsPerMilliliter.
-        /// </summary>
-        public static Density FromMicrogramsPerMilliliter(long microgramspermilliliter)
-        {
-            return new Density((microgramspermilliliter/1e-3) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from MicrogramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromMicrogramsPerMilliliter(decimal microgramspermilliliter)
-        {
-            return new Density((Convert.ToDouble(microgramspermilliliter)/1e-3) * 1e-6d);
+            double value = (double) microgramspermilliliter;
+            return new Density(((value/1e-3) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromMilligramsPerDeciLiter(double milligramsperdeciliter)
         {
-            return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
+            double value = (double) milligramsperdeciliter;
+            return new Density((value/1e-1) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Density from MilligramsPerDeciLiter.
-        /// </summary>
-        public static Density FromMilligramsPerDeciLiter(int milligramsperdeciliter)
+#else
+        public static Density FromMilligramsPerDeciLiter(QuantityValue milligramsperdeciliter)
         {
-            return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Density from MilligramsPerDeciLiter.
-        /// </summary>
-        public static Density FromMilligramsPerDeciLiter(long milligramsperdeciliter)
-        {
-            return new Density((milligramsperdeciliter/1e-1) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from MilligramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromMilligramsPerDeciLiter(decimal milligramsperdeciliter)
-        {
-            return new Density((Convert.ToDouble(milligramsperdeciliter)/1e-1) * 1e-3d);
+            double value = (double) milligramsperdeciliter;
+            return new Density(((value/1e-1) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromMilligramsPerLiter(double milligramsperliter)
         {
-            return new Density((milligramsperliter/1) * 1e-3d);
+            double value = (double) milligramsperliter;
+            return new Density((value/1) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Density from MilligramsPerLiter.
-        /// </summary>
-        public static Density FromMilligramsPerLiter(int milligramsperliter)
+#else
+        public static Density FromMilligramsPerLiter(QuantityValue milligramsperliter)
         {
-            return new Density((milligramsperliter/1) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Density from MilligramsPerLiter.
-        /// </summary>
-        public static Density FromMilligramsPerLiter(long milligramsperliter)
-        {
-            return new Density((milligramsperliter/1) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from MilligramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromMilligramsPerLiter(decimal milligramsperliter)
-        {
-            return new Density((Convert.ToDouble(milligramsperliter)/1) * 1e-3d);
+            double value = (double) milligramsperliter;
+            return new Density(((value/1) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromMilligramsPerMilliliter(double milligramspermilliliter)
         {
-            return new Density((milligramspermilliliter/1e-3) * 1e-3d);
+            double value = (double) milligramspermilliliter;
+            return new Density((value/1e-3) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Density from MilligramsPerMilliliter.
-        /// </summary>
-        public static Density FromMilligramsPerMilliliter(int milligramspermilliliter)
+#else
+        public static Density FromMilligramsPerMilliliter(QuantityValue milligramspermilliliter)
         {
-            return new Density((milligramspermilliliter/1e-3) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Density from MilligramsPerMilliliter.
-        /// </summary>
-        public static Density FromMilligramsPerMilliliter(long milligramspermilliliter)
-        {
-            return new Density((milligramspermilliliter/1e-3) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from MilligramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromMilligramsPerMilliliter(decimal milligramspermilliliter)
-        {
-            return new Density((Convert.ToDouble(milligramspermilliliter)/1e-3) * 1e-3d);
+            double value = (double) milligramspermilliliter;
+            return new Density(((value/1e-3) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromNanogramsPerDeciLiter(double nanogramsperdeciliter)
         {
-            return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
+            double value = (double) nanogramsperdeciliter;
+            return new Density((value/1e-1) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Density from NanogramsPerDeciLiter.
-        /// </summary>
-        public static Density FromNanogramsPerDeciLiter(int nanogramsperdeciliter)
+#else
+        public static Density FromNanogramsPerDeciLiter(QuantityValue nanogramsperdeciliter)
         {
-            return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Density from NanogramsPerDeciLiter.
-        /// </summary>
-        public static Density FromNanogramsPerDeciLiter(long nanogramsperdeciliter)
-        {
-            return new Density((nanogramsperdeciliter/1e-1) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from NanogramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromNanogramsPerDeciLiter(decimal nanogramsperdeciliter)
-        {
-            return new Density((Convert.ToDouble(nanogramsperdeciliter)/1e-1) * 1e-9d);
+            double value = (double) nanogramsperdeciliter;
+            return new Density(((value/1e-1) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from NanogramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromNanogramsPerLiter(double nanogramsperliter)
         {
-            return new Density((nanogramsperliter/1) * 1e-9d);
+            double value = (double) nanogramsperliter;
+            return new Density((value/1) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Density from NanogramsPerLiter.
-        /// </summary>
-        public static Density FromNanogramsPerLiter(int nanogramsperliter)
+#else
+        public static Density FromNanogramsPerLiter(QuantityValue nanogramsperliter)
         {
-            return new Density((nanogramsperliter/1) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Density from NanogramsPerLiter.
-        /// </summary>
-        public static Density FromNanogramsPerLiter(long nanogramsperliter)
-        {
-            return new Density((nanogramsperliter/1) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from NanogramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromNanogramsPerLiter(decimal nanogramsperliter)
-        {
-            return new Density((Convert.ToDouble(nanogramsperliter)/1) * 1e-9d);
+            double value = (double) nanogramsperliter;
+            return new Density(((value/1) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromNanogramsPerMilliliter(double nanogramspermilliliter)
         {
-            return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
+            double value = (double) nanogramspermilliliter;
+            return new Density((value/1e-3) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Density from NanogramsPerMilliliter.
-        /// </summary>
-        public static Density FromNanogramsPerMilliliter(int nanogramspermilliliter)
+#else
+        public static Density FromNanogramsPerMilliliter(QuantityValue nanogramspermilliliter)
         {
-            return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Density from NanogramsPerMilliliter.
-        /// </summary>
-        public static Density FromNanogramsPerMilliliter(long nanogramspermilliliter)
-        {
-            return new Density((nanogramspermilliliter/1e-3) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from NanogramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromNanogramsPerMilliliter(decimal nanogramspermilliliter)
-        {
-            return new Density((Convert.ToDouble(nanogramspermilliliter)/1e-3) * 1e-9d);
+            double value = (double) nanogramspermilliliter;
+            return new Density(((value/1e-3) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromPicogramsPerDeciLiter(double picogramsperdeciliter)
         {
-            return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
+            double value = (double) picogramsperdeciliter;
+            return new Density((value/1e-1) * 1e-12d);
         }
-
-        /// <summary>
-        ///     Get Density from PicogramsPerDeciLiter.
-        /// </summary>
-        public static Density FromPicogramsPerDeciLiter(int picogramsperdeciliter)
+#else
+        public static Density FromPicogramsPerDeciLiter(QuantityValue picogramsperdeciliter)
         {
-            return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
-        }
-
-        /// <summary>
-        ///     Get Density from PicogramsPerDeciLiter.
-        /// </summary>
-        public static Density FromPicogramsPerDeciLiter(long picogramsperdeciliter)
-        {
-            return new Density((picogramsperdeciliter/1e-1) * 1e-12d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from PicogramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density FromPicogramsPerDeciLiter(decimal picogramsperdeciliter)
-        {
-            return new Density((Convert.ToDouble(picogramsperdeciliter)/1e-1) * 1e-12d);
+            double value = (double) picogramsperdeciliter;
+            return new Density(((value/1e-1) * 1e-12d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromPicogramsPerLiter(double picogramsperliter)
         {
-            return new Density((picogramsperliter/1) * 1e-12d);
+            double value = (double) picogramsperliter;
+            return new Density((value/1) * 1e-12d);
         }
-
-        /// <summary>
-        ///     Get Density from PicogramsPerLiter.
-        /// </summary>
-        public static Density FromPicogramsPerLiter(int picogramsperliter)
+#else
+        public static Density FromPicogramsPerLiter(QuantityValue picogramsperliter)
         {
-            return new Density((picogramsperliter/1) * 1e-12d);
-        }
-
-        /// <summary>
-        ///     Get Density from PicogramsPerLiter.
-        /// </summary>
-        public static Density FromPicogramsPerLiter(long picogramsperliter)
-        {
-            return new Density((picogramsperliter/1) * 1e-12d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from PicogramsPerLiter of type decimal.
-        /// </summary>
-        public static Density FromPicogramsPerLiter(decimal picogramsperliter)
-        {
-            return new Density((Convert.ToDouble(picogramsperliter)/1) * 1e-12d);
+            double value = (double) picogramsperliter;
+            return new Density(((value/1) * 1e-12d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromPicogramsPerMilliliter(double picogramspermilliliter)
         {
-            return new Density((picogramspermilliliter/1e-3) * 1e-12d);
+            double value = (double) picogramspermilliliter;
+            return new Density((value/1e-3) * 1e-12d);
         }
-
-        /// <summary>
-        ///     Get Density from PicogramsPerMilliliter.
-        /// </summary>
-        public static Density FromPicogramsPerMilliliter(int picogramspermilliliter)
+#else
+        public static Density FromPicogramsPerMilliliter(QuantityValue picogramspermilliliter)
         {
-            return new Density((picogramspermilliliter/1e-3) * 1e-12d);
-        }
-
-        /// <summary>
-        ///     Get Density from PicogramsPerMilliliter.
-        /// </summary>
-        public static Density FromPicogramsPerMilliliter(long picogramspermilliliter)
-        {
-            return new Density((picogramspermilliliter/1e-3) * 1e-12d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from PicogramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density FromPicogramsPerMilliliter(decimal picogramspermilliliter)
-        {
-            return new Density((Convert.ToDouble(picogramspermilliliter)/1e-3) * 1e-12d);
+            double value = (double) picogramspermilliliter;
+            return new Density(((value/1e-3) * 1e-12d));
         }
 #endif
 
         /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromPoundsPerCubicFoot(double poundspercubicfoot)
         {
-            return new Density(poundspercubicfoot/0.062427961);
+            double value = (double) poundspercubicfoot;
+            return new Density(value/0.062427961);
         }
-
-        /// <summary>
-        ///     Get Density from PoundsPerCubicFoot.
-        /// </summary>
-        public static Density FromPoundsPerCubicFoot(int poundspercubicfoot)
+#else
+        public static Density FromPoundsPerCubicFoot(QuantityValue poundspercubicfoot)
         {
-            return new Density(poundspercubicfoot/0.062427961);
-        }
-
-        /// <summary>
-        ///     Get Density from PoundsPerCubicFoot.
-        /// </summary>
-        public static Density FromPoundsPerCubicFoot(long poundspercubicfoot)
-        {
-            return new Density(poundspercubicfoot/0.062427961);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from PoundsPerCubicFoot of type decimal.
-        /// </summary>
-        public static Density FromPoundsPerCubicFoot(decimal poundspercubicfoot)
-        {
-            return new Density(Convert.ToDouble(poundspercubicfoot)/0.062427961);
+            double value = (double) poundspercubicfoot;
+            return new Density((value/0.062427961));
         }
 #endif
 
         /// <summary>
         ///     Get Density from PoundsPerCubicInch.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromPoundsPerCubicInch(double poundspercubicinch)
         {
-            return new Density(poundspercubicinch/3.6127298147753e-5);
+            double value = (double) poundspercubicinch;
+            return new Density(value/3.6127298147753e-5);
         }
-
-        /// <summary>
-        ///     Get Density from PoundsPerCubicInch.
-        /// </summary>
-        public static Density FromPoundsPerCubicInch(int poundspercubicinch)
+#else
+        public static Density FromPoundsPerCubicInch(QuantityValue poundspercubicinch)
         {
-            return new Density(poundspercubicinch/3.6127298147753e-5);
-        }
-
-        /// <summary>
-        ///     Get Density from PoundsPerCubicInch.
-        /// </summary>
-        public static Density FromPoundsPerCubicInch(long poundspercubicinch)
-        {
-            return new Density(poundspercubicinch/3.6127298147753e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from PoundsPerCubicInch of type decimal.
-        /// </summary>
-        public static Density FromPoundsPerCubicInch(decimal poundspercubicinch)
-        {
-            return new Density(Convert.ToDouble(poundspercubicinch)/3.6127298147753e-5);
+            double value = (double) poundspercubicinch;
+            return new Density((value/3.6127298147753e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromSlugsPerCubicFoot(double slugspercubicfoot)
         {
-            return new Density(slugspercubicfoot*515.378818);
+            double value = (double) slugspercubicfoot;
+            return new Density(value*515.378818);
         }
-
-        /// <summary>
-        ///     Get Density from SlugsPerCubicFoot.
-        /// </summary>
-        public static Density FromSlugsPerCubicFoot(int slugspercubicfoot)
+#else
+        public static Density FromSlugsPerCubicFoot(QuantityValue slugspercubicfoot)
         {
-            return new Density(slugspercubicfoot*515.378818);
-        }
-
-        /// <summary>
-        ///     Get Density from SlugsPerCubicFoot.
-        /// </summary>
-        public static Density FromSlugsPerCubicFoot(long slugspercubicfoot)
-        {
-            return new Density(slugspercubicfoot*515.378818);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from SlugsPerCubicFoot of type decimal.
-        /// </summary>
-        public static Density FromSlugsPerCubicFoot(decimal slugspercubicfoot)
-        {
-            return new Density(Convert.ToDouble(slugspercubicfoot)*515.378818);
+            double value = (double) slugspercubicfoot;
+            return new Density((value*515.378818));
         }
 #endif
 
         /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromTonnesPerCubicCentimeter(double tonnespercubiccentimeter)
         {
-            return new Density(tonnespercubiccentimeter/1e-9);
+            double value = (double) tonnespercubiccentimeter;
+            return new Density(value/1e-9);
         }
-
-        /// <summary>
-        ///     Get Density from TonnesPerCubicCentimeter.
-        /// </summary>
-        public static Density FromTonnesPerCubicCentimeter(int tonnespercubiccentimeter)
+#else
+        public static Density FromTonnesPerCubicCentimeter(QuantityValue tonnespercubiccentimeter)
         {
-            return new Density(tonnespercubiccentimeter/1e-9);
-        }
-
-        /// <summary>
-        ///     Get Density from TonnesPerCubicCentimeter.
-        /// </summary>
-        public static Density FromTonnesPerCubicCentimeter(long tonnespercubiccentimeter)
-        {
-            return new Density(tonnespercubiccentimeter/1e-9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from TonnesPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static Density FromTonnesPerCubicCentimeter(decimal tonnespercubiccentimeter)
-        {
-            return new Density(Convert.ToDouble(tonnespercubiccentimeter)/1e-9);
+            double value = (double) tonnespercubiccentimeter;
+            return new Density((value/1e-9));
         }
 #endif
 
         /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromTonnesPerCubicMeter(double tonnespercubicmeter)
         {
-            return new Density(tonnespercubicmeter/0.001);
+            double value = (double) tonnespercubicmeter;
+            return new Density(value/0.001);
         }
-
-        /// <summary>
-        ///     Get Density from TonnesPerCubicMeter.
-        /// </summary>
-        public static Density FromTonnesPerCubicMeter(int tonnespercubicmeter)
+#else
+        public static Density FromTonnesPerCubicMeter(QuantityValue tonnespercubicmeter)
         {
-            return new Density(tonnespercubicmeter/0.001);
-        }
-
-        /// <summary>
-        ///     Get Density from TonnesPerCubicMeter.
-        /// </summary>
-        public static Density FromTonnesPerCubicMeter(long tonnespercubicmeter)
-        {
-            return new Density(tonnespercubicmeter/0.001);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from TonnesPerCubicMeter of type decimal.
-        /// </summary>
-        public static Density FromTonnesPerCubicMeter(decimal tonnespercubicmeter)
-        {
-            return new Density(Convert.ToDouble(tonnespercubicmeter)/0.001);
+            double value = (double) tonnespercubicmeter;
+            return new Density((value/0.001));
         }
 #endif
 
         /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Density FromTonnesPerCubicMillimeter(double tonnespercubicmillimeter)
         {
-            return new Density(tonnespercubicmillimeter/1e-12);
+            double value = (double) tonnespercubicmillimeter;
+            return new Density(value/1e-12);
         }
-
-        /// <summary>
-        ///     Get Density from TonnesPerCubicMillimeter.
-        /// </summary>
-        public static Density FromTonnesPerCubicMillimeter(int tonnespercubicmillimeter)
+#else
+        public static Density FromTonnesPerCubicMillimeter(QuantityValue tonnespercubicmillimeter)
         {
-            return new Density(tonnespercubicmillimeter/1e-12);
-        }
-
-        /// <summary>
-        ///     Get Density from TonnesPerCubicMillimeter.
-        /// </summary>
-        public static Density FromTonnesPerCubicMillimeter(long tonnespercubicmillimeter)
-        {
-            return new Density(tonnespercubicmillimeter/1e-12);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Density from TonnesPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static Density FromTonnesPerCubicMillimeter(decimal tonnespercubicmillimeter)
-        {
-            return new Density(Convert.ToDouble(tonnespercubicmillimeter)/1e-12);
+            double value = (double) tonnespercubicmillimeter;
+            return new Density((value/1e-12));
         }
 #endif
 
@@ -1753,52 +1053,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable CentigramsPerDeciLiter.
         /// </summary>
-        public static Density? FromCentigramsPerDeciLiter(double? centigramsperdeciliter)
-        {
-            if (centigramsperdeciliter.HasValue)
-            {
-                return FromCentigramsPerDeciLiter(centigramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable CentigramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromCentigramsPerDeciLiter(int? centigramsperdeciliter)
-        {
-            if (centigramsperdeciliter.HasValue)
-            {
-                return FromCentigramsPerDeciLiter(centigramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable CentigramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromCentigramsPerDeciLiter(long? centigramsperdeciliter)
-        {
-            if (centigramsperdeciliter.HasValue)
-            {
-                return FromCentigramsPerDeciLiter(centigramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from CentigramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromCentigramsPerDeciLiter(decimal? centigramsperdeciliter)
+        public static Density? FromCentigramsPerDeciLiter(QuantityValue? centigramsperdeciliter)
         {
             if (centigramsperdeciliter.HasValue)
             {
@@ -1813,52 +1068,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable CentigramsPerLiter.
         /// </summary>
-        public static Density? FromCentigramsPerLiter(double? centigramsperliter)
-        {
-            if (centigramsperliter.HasValue)
-            {
-                return FromCentigramsPerLiter(centigramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable CentigramsPerLiter.
-        /// </summary>
-        public static Density? FromCentigramsPerLiter(int? centigramsperliter)
-        {
-            if (centigramsperliter.HasValue)
-            {
-                return FromCentigramsPerLiter(centigramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable CentigramsPerLiter.
-        /// </summary>
-        public static Density? FromCentigramsPerLiter(long? centigramsperliter)
-        {
-            if (centigramsperliter.HasValue)
-            {
-                return FromCentigramsPerLiter(centigramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from CentigramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromCentigramsPerLiter(decimal? centigramsperliter)
+        public static Density? FromCentigramsPerLiter(QuantityValue? centigramsperliter)
         {
             if (centigramsperliter.HasValue)
             {
@@ -1873,52 +1083,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable CentigramsPerMilliliter.
         /// </summary>
-        public static Density? FromCentigramsPerMilliliter(double? centigramspermilliliter)
-        {
-            if (centigramspermilliliter.HasValue)
-            {
-                return FromCentigramsPerMilliliter(centigramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable CentigramsPerMilliliter.
-        /// </summary>
-        public static Density? FromCentigramsPerMilliliter(int? centigramspermilliliter)
-        {
-            if (centigramspermilliliter.HasValue)
-            {
-                return FromCentigramsPerMilliliter(centigramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable CentigramsPerMilliliter.
-        /// </summary>
-        public static Density? FromCentigramsPerMilliliter(long? centigramspermilliliter)
-        {
-            if (centigramspermilliliter.HasValue)
-            {
-                return FromCentigramsPerMilliliter(centigramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from CentigramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromCentigramsPerMilliliter(decimal? centigramspermilliliter)
+        public static Density? FromCentigramsPerMilliliter(QuantityValue? centigramspermilliliter)
         {
             if (centigramspermilliliter.HasValue)
             {
@@ -1933,52 +1098,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable DecigramsPerDeciLiter.
         /// </summary>
-        public static Density? FromDecigramsPerDeciLiter(double? decigramsperdeciliter)
-        {
-            if (decigramsperdeciliter.HasValue)
-            {
-                return FromDecigramsPerDeciLiter(decigramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable DecigramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromDecigramsPerDeciLiter(int? decigramsperdeciliter)
-        {
-            if (decigramsperdeciliter.HasValue)
-            {
-                return FromDecigramsPerDeciLiter(decigramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable DecigramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromDecigramsPerDeciLiter(long? decigramsperdeciliter)
-        {
-            if (decigramsperdeciliter.HasValue)
-            {
-                return FromDecigramsPerDeciLiter(decigramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from DecigramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromDecigramsPerDeciLiter(decimal? decigramsperdeciliter)
+        public static Density? FromDecigramsPerDeciLiter(QuantityValue? decigramsperdeciliter)
         {
             if (decigramsperdeciliter.HasValue)
             {
@@ -1993,52 +1113,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable DecigramsPerLiter.
         /// </summary>
-        public static Density? FromDecigramsPerLiter(double? decigramsperliter)
-        {
-            if (decigramsperliter.HasValue)
-            {
-                return FromDecigramsPerLiter(decigramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable DecigramsPerLiter.
-        /// </summary>
-        public static Density? FromDecigramsPerLiter(int? decigramsperliter)
-        {
-            if (decigramsperliter.HasValue)
-            {
-                return FromDecigramsPerLiter(decigramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable DecigramsPerLiter.
-        /// </summary>
-        public static Density? FromDecigramsPerLiter(long? decigramsperliter)
-        {
-            if (decigramsperliter.HasValue)
-            {
-                return FromDecigramsPerLiter(decigramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from DecigramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromDecigramsPerLiter(decimal? decigramsperliter)
+        public static Density? FromDecigramsPerLiter(QuantityValue? decigramsperliter)
         {
             if (decigramsperliter.HasValue)
             {
@@ -2053,52 +1128,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable DecigramsPerMilliliter.
         /// </summary>
-        public static Density? FromDecigramsPerMilliliter(double? decigramspermilliliter)
-        {
-            if (decigramspermilliliter.HasValue)
-            {
-                return FromDecigramsPerMilliliter(decigramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable DecigramsPerMilliliter.
-        /// </summary>
-        public static Density? FromDecigramsPerMilliliter(int? decigramspermilliliter)
-        {
-            if (decigramspermilliliter.HasValue)
-            {
-                return FromDecigramsPerMilliliter(decigramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable DecigramsPerMilliliter.
-        /// </summary>
-        public static Density? FromDecigramsPerMilliliter(long? decigramspermilliliter)
-        {
-            if (decigramspermilliliter.HasValue)
-            {
-                return FromDecigramsPerMilliliter(decigramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from DecigramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromDecigramsPerMilliliter(decimal? decigramspermilliliter)
+        public static Density? FromDecigramsPerMilliliter(QuantityValue? decigramspermilliliter)
         {
             if (decigramspermilliliter.HasValue)
             {
@@ -2113,52 +1143,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicCentimeter.
         /// </summary>
-        public static Density? FromGramsPerCubicCentimeter(double? gramspercubiccentimeter)
-        {
-            if (gramspercubiccentimeter.HasValue)
-            {
-                return FromGramsPerCubicCentimeter(gramspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerCubicCentimeter.
-        /// </summary>
-        public static Density? FromGramsPerCubicCentimeter(int? gramspercubiccentimeter)
-        {
-            if (gramspercubiccentimeter.HasValue)
-            {
-                return FromGramsPerCubicCentimeter(gramspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerCubicCentimeter.
-        /// </summary>
-        public static Density? FromGramsPerCubicCentimeter(long? gramspercubiccentimeter)
-        {
-            if (gramspercubiccentimeter.HasValue)
-            {
-                return FromGramsPerCubicCentimeter(gramspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from GramsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static Density? FromGramsPerCubicCentimeter(decimal? gramspercubiccentimeter)
+        public static Density? FromGramsPerCubicCentimeter(QuantityValue? gramspercubiccentimeter)
         {
             if (gramspercubiccentimeter.HasValue)
             {
@@ -2173,52 +1158,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMeter.
         /// </summary>
-        public static Density? FromGramsPerCubicMeter(double? gramspercubicmeter)
-        {
-            if (gramspercubicmeter.HasValue)
-            {
-                return FromGramsPerCubicMeter(gramspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerCubicMeter.
-        /// </summary>
-        public static Density? FromGramsPerCubicMeter(int? gramspercubicmeter)
-        {
-            if (gramspercubicmeter.HasValue)
-            {
-                return FromGramsPerCubicMeter(gramspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerCubicMeter.
-        /// </summary>
-        public static Density? FromGramsPerCubicMeter(long? gramspercubicmeter)
-        {
-            if (gramspercubicmeter.HasValue)
-            {
-                return FromGramsPerCubicMeter(gramspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from GramsPerCubicMeter of type decimal.
-        /// </summary>
-        public static Density? FromGramsPerCubicMeter(decimal? gramspercubicmeter)
+        public static Density? FromGramsPerCubicMeter(QuantityValue? gramspercubicmeter)
         {
             if (gramspercubicmeter.HasValue)
             {
@@ -2233,52 +1173,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable GramsPerCubicMillimeter.
         /// </summary>
-        public static Density? FromGramsPerCubicMillimeter(double? gramspercubicmillimeter)
-        {
-            if (gramspercubicmillimeter.HasValue)
-            {
-                return FromGramsPerCubicMillimeter(gramspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerCubicMillimeter.
-        /// </summary>
-        public static Density? FromGramsPerCubicMillimeter(int? gramspercubicmillimeter)
-        {
-            if (gramspercubicmillimeter.HasValue)
-            {
-                return FromGramsPerCubicMillimeter(gramspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerCubicMillimeter.
-        /// </summary>
-        public static Density? FromGramsPerCubicMillimeter(long? gramspercubicmillimeter)
-        {
-            if (gramspercubicmillimeter.HasValue)
-            {
-                return FromGramsPerCubicMillimeter(gramspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from GramsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static Density? FromGramsPerCubicMillimeter(decimal? gramspercubicmillimeter)
+        public static Density? FromGramsPerCubicMillimeter(QuantityValue? gramspercubicmillimeter)
         {
             if (gramspercubicmillimeter.HasValue)
             {
@@ -2293,52 +1188,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable GramsPerDeciLiter.
         /// </summary>
-        public static Density? FromGramsPerDeciLiter(double? gramsperdeciliter)
-        {
-            if (gramsperdeciliter.HasValue)
-            {
-                return FromGramsPerDeciLiter(gramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromGramsPerDeciLiter(int? gramsperdeciliter)
-        {
-            if (gramsperdeciliter.HasValue)
-            {
-                return FromGramsPerDeciLiter(gramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromGramsPerDeciLiter(long? gramsperdeciliter)
-        {
-            if (gramsperdeciliter.HasValue)
-            {
-                return FromGramsPerDeciLiter(gramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from GramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromGramsPerDeciLiter(decimal? gramsperdeciliter)
+        public static Density? FromGramsPerDeciLiter(QuantityValue? gramsperdeciliter)
         {
             if (gramsperdeciliter.HasValue)
             {
@@ -2353,52 +1203,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable GramsPerLiter.
         /// </summary>
-        public static Density? FromGramsPerLiter(double? gramsperliter)
-        {
-            if (gramsperliter.HasValue)
-            {
-                return FromGramsPerLiter(gramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerLiter.
-        /// </summary>
-        public static Density? FromGramsPerLiter(int? gramsperliter)
-        {
-            if (gramsperliter.HasValue)
-            {
-                return FromGramsPerLiter(gramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerLiter.
-        /// </summary>
-        public static Density? FromGramsPerLiter(long? gramsperliter)
-        {
-            if (gramsperliter.HasValue)
-            {
-                return FromGramsPerLiter(gramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from GramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromGramsPerLiter(decimal? gramsperliter)
+        public static Density? FromGramsPerLiter(QuantityValue? gramsperliter)
         {
             if (gramsperliter.HasValue)
             {
@@ -2413,52 +1218,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable GramsPerMilliliter.
         /// </summary>
-        public static Density? FromGramsPerMilliliter(double? gramspermilliliter)
-        {
-            if (gramspermilliliter.HasValue)
-            {
-                return FromGramsPerMilliliter(gramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerMilliliter.
-        /// </summary>
-        public static Density? FromGramsPerMilliliter(int? gramspermilliliter)
-        {
-            if (gramspermilliliter.HasValue)
-            {
-                return FromGramsPerMilliliter(gramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable GramsPerMilliliter.
-        /// </summary>
-        public static Density? FromGramsPerMilliliter(long? gramspermilliliter)
-        {
-            if (gramspermilliliter.HasValue)
-            {
-                return FromGramsPerMilliliter(gramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from GramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromGramsPerMilliliter(decimal? gramspermilliliter)
+        public static Density? FromGramsPerMilliliter(QuantityValue? gramspermilliliter)
         {
             if (gramspermilliliter.HasValue)
             {
@@ -2473,52 +1233,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
         /// </summary>
-        public static Density? FromKilogramsPerCubicCentimeter(double? kilogramspercubiccentimeter)
-        {
-            if (kilogramspercubiccentimeter.HasValue)
-            {
-                return FromKilogramsPerCubicCentimeter(kilogramspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicCentimeter(int? kilogramspercubiccentimeter)
-        {
-            if (kilogramspercubiccentimeter.HasValue)
-            {
-                return FromKilogramsPerCubicCentimeter(kilogramspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilogramsPerCubicCentimeter.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicCentimeter(long? kilogramspercubiccentimeter)
-        {
-            if (kilogramspercubiccentimeter.HasValue)
-            {
-                return FromKilogramsPerCubicCentimeter(kilogramspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from KilogramsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicCentimeter(decimal? kilogramspercubiccentimeter)
+        public static Density? FromKilogramsPerCubicCentimeter(QuantityValue? kilogramspercubiccentimeter)
         {
             if (kilogramspercubiccentimeter.HasValue)
             {
@@ -2533,52 +1248,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMeter.
         /// </summary>
-        public static Density? FromKilogramsPerCubicMeter(double? kilogramspercubicmeter)
-        {
-            if (kilogramspercubicmeter.HasValue)
-            {
-                return FromKilogramsPerCubicMeter(kilogramspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilogramsPerCubicMeter.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicMeter(int? kilogramspercubicmeter)
-        {
-            if (kilogramspercubicmeter.HasValue)
-            {
-                return FromKilogramsPerCubicMeter(kilogramspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilogramsPerCubicMeter.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicMeter(long? kilogramspercubicmeter)
-        {
-            if (kilogramspercubicmeter.HasValue)
-            {
-                return FromKilogramsPerCubicMeter(kilogramspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from KilogramsPerCubicMeter of type decimal.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicMeter(decimal? kilogramspercubicmeter)
+        public static Density? FromKilogramsPerCubicMeter(QuantityValue? kilogramspercubicmeter)
         {
             if (kilogramspercubicmeter.HasValue)
             {
@@ -2593,52 +1263,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
         /// </summary>
-        public static Density? FromKilogramsPerCubicMillimeter(double? kilogramspercubicmillimeter)
-        {
-            if (kilogramspercubicmillimeter.HasValue)
-            {
-                return FromKilogramsPerCubicMillimeter(kilogramspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicMillimeter(int? kilogramspercubicmillimeter)
-        {
-            if (kilogramspercubicmillimeter.HasValue)
-            {
-                return FromKilogramsPerCubicMillimeter(kilogramspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilogramsPerCubicMillimeter.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicMillimeter(long? kilogramspercubicmillimeter)
-        {
-            if (kilogramspercubicmillimeter.HasValue)
-            {
-                return FromKilogramsPerCubicMillimeter(kilogramspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from KilogramsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static Density? FromKilogramsPerCubicMillimeter(decimal? kilogramspercubicmillimeter)
+        public static Density? FromKilogramsPerCubicMillimeter(QuantityValue? kilogramspercubicmillimeter)
         {
             if (kilogramspercubicmillimeter.HasValue)
             {
@@ -2653,52 +1278,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
         /// </summary>
-        public static Density? FromKilopoundsPerCubicFoot(double? kilopoundspercubicfoot)
-        {
-            if (kilopoundspercubicfoot.HasValue)
-            {
-                return FromKilopoundsPerCubicFoot(kilopoundspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
-        /// </summary>
-        public static Density? FromKilopoundsPerCubicFoot(int? kilopoundspercubicfoot)
-        {
-            if (kilopoundspercubicfoot.HasValue)
-            {
-                return FromKilopoundsPerCubicFoot(kilopoundspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilopoundsPerCubicFoot.
-        /// </summary>
-        public static Density? FromKilopoundsPerCubicFoot(long? kilopoundspercubicfoot)
-        {
-            if (kilopoundspercubicfoot.HasValue)
-            {
-                return FromKilopoundsPerCubicFoot(kilopoundspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from KilopoundsPerCubicFoot of type decimal.
-        /// </summary>
-        public static Density? FromKilopoundsPerCubicFoot(decimal? kilopoundspercubicfoot)
+        public static Density? FromKilopoundsPerCubicFoot(QuantityValue? kilopoundspercubicfoot)
         {
             if (kilopoundspercubicfoot.HasValue)
             {
@@ -2713,52 +1293,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable KilopoundsPerCubicInch.
         /// </summary>
-        public static Density? FromKilopoundsPerCubicInch(double? kilopoundspercubicinch)
-        {
-            if (kilopoundspercubicinch.HasValue)
-            {
-                return FromKilopoundsPerCubicInch(kilopoundspercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilopoundsPerCubicInch.
-        /// </summary>
-        public static Density? FromKilopoundsPerCubicInch(int? kilopoundspercubicinch)
-        {
-            if (kilopoundspercubicinch.HasValue)
-            {
-                return FromKilopoundsPerCubicInch(kilopoundspercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable KilopoundsPerCubicInch.
-        /// </summary>
-        public static Density? FromKilopoundsPerCubicInch(long? kilopoundspercubicinch)
-        {
-            if (kilopoundspercubicinch.HasValue)
-            {
-                return FromKilopoundsPerCubicInch(kilopoundspercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from KilopoundsPerCubicInch of type decimal.
-        /// </summary>
-        public static Density? FromKilopoundsPerCubicInch(decimal? kilopoundspercubicinch)
+        public static Density? FromKilopoundsPerCubicInch(QuantityValue? kilopoundspercubicinch)
         {
             if (kilopoundspercubicinch.HasValue)
             {
@@ -2773,52 +1308,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
         /// </summary>
-        public static Density? FromMicrogramsPerDeciLiter(double? microgramsperdeciliter)
-        {
-            if (microgramsperdeciliter.HasValue)
-            {
-                return FromMicrogramsPerDeciLiter(microgramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromMicrogramsPerDeciLiter(int? microgramsperdeciliter)
-        {
-            if (microgramsperdeciliter.HasValue)
-            {
-                return FromMicrogramsPerDeciLiter(microgramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MicrogramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromMicrogramsPerDeciLiter(long? microgramsperdeciliter)
-        {
-            if (microgramsperdeciliter.HasValue)
-            {
-                return FromMicrogramsPerDeciLiter(microgramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from MicrogramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromMicrogramsPerDeciLiter(decimal? microgramsperdeciliter)
+        public static Density? FromMicrogramsPerDeciLiter(QuantityValue? microgramsperdeciliter)
         {
             if (microgramsperdeciliter.HasValue)
             {
@@ -2833,52 +1323,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerLiter.
         /// </summary>
-        public static Density? FromMicrogramsPerLiter(double? microgramsperliter)
-        {
-            if (microgramsperliter.HasValue)
-            {
-                return FromMicrogramsPerLiter(microgramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MicrogramsPerLiter.
-        /// </summary>
-        public static Density? FromMicrogramsPerLiter(int? microgramsperliter)
-        {
-            if (microgramsperliter.HasValue)
-            {
-                return FromMicrogramsPerLiter(microgramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MicrogramsPerLiter.
-        /// </summary>
-        public static Density? FromMicrogramsPerLiter(long? microgramsperliter)
-        {
-            if (microgramsperliter.HasValue)
-            {
-                return FromMicrogramsPerLiter(microgramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from MicrogramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromMicrogramsPerLiter(decimal? microgramsperliter)
+        public static Density? FromMicrogramsPerLiter(QuantityValue? microgramsperliter)
         {
             if (microgramsperliter.HasValue)
             {
@@ -2893,52 +1338,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable MicrogramsPerMilliliter.
         /// </summary>
-        public static Density? FromMicrogramsPerMilliliter(double? microgramspermilliliter)
-        {
-            if (microgramspermilliliter.HasValue)
-            {
-                return FromMicrogramsPerMilliliter(microgramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MicrogramsPerMilliliter.
-        /// </summary>
-        public static Density? FromMicrogramsPerMilliliter(int? microgramspermilliliter)
-        {
-            if (microgramspermilliliter.HasValue)
-            {
-                return FromMicrogramsPerMilliliter(microgramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MicrogramsPerMilliliter.
-        /// </summary>
-        public static Density? FromMicrogramsPerMilliliter(long? microgramspermilliliter)
-        {
-            if (microgramspermilliliter.HasValue)
-            {
-                return FromMicrogramsPerMilliliter(microgramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from MicrogramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromMicrogramsPerMilliliter(decimal? microgramspermilliliter)
+        public static Density? FromMicrogramsPerMilliliter(QuantityValue? microgramspermilliliter)
         {
             if (microgramspermilliliter.HasValue)
             {
@@ -2953,52 +1353,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable MilligramsPerDeciLiter.
         /// </summary>
-        public static Density? FromMilligramsPerDeciLiter(double? milligramsperdeciliter)
-        {
-            if (milligramsperdeciliter.HasValue)
-            {
-                return FromMilligramsPerDeciLiter(milligramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MilligramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromMilligramsPerDeciLiter(int? milligramsperdeciliter)
-        {
-            if (milligramsperdeciliter.HasValue)
-            {
-                return FromMilligramsPerDeciLiter(milligramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MilligramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromMilligramsPerDeciLiter(long? milligramsperdeciliter)
-        {
-            if (milligramsperdeciliter.HasValue)
-            {
-                return FromMilligramsPerDeciLiter(milligramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from MilligramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromMilligramsPerDeciLiter(decimal? milligramsperdeciliter)
+        public static Density? FromMilligramsPerDeciLiter(QuantityValue? milligramsperdeciliter)
         {
             if (milligramsperdeciliter.HasValue)
             {
@@ -3013,52 +1368,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable MilligramsPerLiter.
         /// </summary>
-        public static Density? FromMilligramsPerLiter(double? milligramsperliter)
-        {
-            if (milligramsperliter.HasValue)
-            {
-                return FromMilligramsPerLiter(milligramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MilligramsPerLiter.
-        /// </summary>
-        public static Density? FromMilligramsPerLiter(int? milligramsperliter)
-        {
-            if (milligramsperliter.HasValue)
-            {
-                return FromMilligramsPerLiter(milligramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MilligramsPerLiter.
-        /// </summary>
-        public static Density? FromMilligramsPerLiter(long? milligramsperliter)
-        {
-            if (milligramsperliter.HasValue)
-            {
-                return FromMilligramsPerLiter(milligramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from MilligramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromMilligramsPerLiter(decimal? milligramsperliter)
+        public static Density? FromMilligramsPerLiter(QuantityValue? milligramsperliter)
         {
             if (milligramsperliter.HasValue)
             {
@@ -3073,52 +1383,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable MilligramsPerMilliliter.
         /// </summary>
-        public static Density? FromMilligramsPerMilliliter(double? milligramspermilliliter)
-        {
-            if (milligramspermilliliter.HasValue)
-            {
-                return FromMilligramsPerMilliliter(milligramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MilligramsPerMilliliter.
-        /// </summary>
-        public static Density? FromMilligramsPerMilliliter(int? milligramspermilliliter)
-        {
-            if (milligramspermilliliter.HasValue)
-            {
-                return FromMilligramsPerMilliliter(milligramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable MilligramsPerMilliliter.
-        /// </summary>
-        public static Density? FromMilligramsPerMilliliter(long? milligramspermilliliter)
-        {
-            if (milligramspermilliliter.HasValue)
-            {
-                return FromMilligramsPerMilliliter(milligramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from MilligramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromMilligramsPerMilliliter(decimal? milligramspermilliliter)
+        public static Density? FromMilligramsPerMilliliter(QuantityValue? milligramspermilliliter)
         {
             if (milligramspermilliliter.HasValue)
             {
@@ -3133,52 +1398,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable NanogramsPerDeciLiter.
         /// </summary>
-        public static Density? FromNanogramsPerDeciLiter(double? nanogramsperdeciliter)
-        {
-            if (nanogramsperdeciliter.HasValue)
-            {
-                return FromNanogramsPerDeciLiter(nanogramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable NanogramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromNanogramsPerDeciLiter(int? nanogramsperdeciliter)
-        {
-            if (nanogramsperdeciliter.HasValue)
-            {
-                return FromNanogramsPerDeciLiter(nanogramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable NanogramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromNanogramsPerDeciLiter(long? nanogramsperdeciliter)
-        {
-            if (nanogramsperdeciliter.HasValue)
-            {
-                return FromNanogramsPerDeciLiter(nanogramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from NanogramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromNanogramsPerDeciLiter(decimal? nanogramsperdeciliter)
+        public static Density? FromNanogramsPerDeciLiter(QuantityValue? nanogramsperdeciliter)
         {
             if (nanogramsperdeciliter.HasValue)
             {
@@ -3193,52 +1413,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable NanogramsPerLiter.
         /// </summary>
-        public static Density? FromNanogramsPerLiter(double? nanogramsperliter)
-        {
-            if (nanogramsperliter.HasValue)
-            {
-                return FromNanogramsPerLiter(nanogramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable NanogramsPerLiter.
-        /// </summary>
-        public static Density? FromNanogramsPerLiter(int? nanogramsperliter)
-        {
-            if (nanogramsperliter.HasValue)
-            {
-                return FromNanogramsPerLiter(nanogramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable NanogramsPerLiter.
-        /// </summary>
-        public static Density? FromNanogramsPerLiter(long? nanogramsperliter)
-        {
-            if (nanogramsperliter.HasValue)
-            {
-                return FromNanogramsPerLiter(nanogramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from NanogramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromNanogramsPerLiter(decimal? nanogramsperliter)
+        public static Density? FromNanogramsPerLiter(QuantityValue? nanogramsperliter)
         {
             if (nanogramsperliter.HasValue)
             {
@@ -3253,52 +1428,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable NanogramsPerMilliliter.
         /// </summary>
-        public static Density? FromNanogramsPerMilliliter(double? nanogramspermilliliter)
-        {
-            if (nanogramspermilliliter.HasValue)
-            {
-                return FromNanogramsPerMilliliter(nanogramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable NanogramsPerMilliliter.
-        /// </summary>
-        public static Density? FromNanogramsPerMilliliter(int? nanogramspermilliliter)
-        {
-            if (nanogramspermilliliter.HasValue)
-            {
-                return FromNanogramsPerMilliliter(nanogramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable NanogramsPerMilliliter.
-        /// </summary>
-        public static Density? FromNanogramsPerMilliliter(long? nanogramspermilliliter)
-        {
-            if (nanogramspermilliliter.HasValue)
-            {
-                return FromNanogramsPerMilliliter(nanogramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from NanogramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromNanogramsPerMilliliter(decimal? nanogramspermilliliter)
+        public static Density? FromNanogramsPerMilliliter(QuantityValue? nanogramspermilliliter)
         {
             if (nanogramspermilliliter.HasValue)
             {
@@ -3313,52 +1443,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable PicogramsPerDeciLiter.
         /// </summary>
-        public static Density? FromPicogramsPerDeciLiter(double? picogramsperdeciliter)
-        {
-            if (picogramsperdeciliter.HasValue)
-            {
-                return FromPicogramsPerDeciLiter(picogramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PicogramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromPicogramsPerDeciLiter(int? picogramsperdeciliter)
-        {
-            if (picogramsperdeciliter.HasValue)
-            {
-                return FromPicogramsPerDeciLiter(picogramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PicogramsPerDeciLiter.
-        /// </summary>
-        public static Density? FromPicogramsPerDeciLiter(long? picogramsperdeciliter)
-        {
-            if (picogramsperdeciliter.HasValue)
-            {
-                return FromPicogramsPerDeciLiter(picogramsperdeciliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from PicogramsPerDeciLiter of type decimal.
-        /// </summary>
-        public static Density? FromPicogramsPerDeciLiter(decimal? picogramsperdeciliter)
+        public static Density? FromPicogramsPerDeciLiter(QuantityValue? picogramsperdeciliter)
         {
             if (picogramsperdeciliter.HasValue)
             {
@@ -3373,52 +1458,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable PicogramsPerLiter.
         /// </summary>
-        public static Density? FromPicogramsPerLiter(double? picogramsperliter)
-        {
-            if (picogramsperliter.HasValue)
-            {
-                return FromPicogramsPerLiter(picogramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PicogramsPerLiter.
-        /// </summary>
-        public static Density? FromPicogramsPerLiter(int? picogramsperliter)
-        {
-            if (picogramsperliter.HasValue)
-            {
-                return FromPicogramsPerLiter(picogramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PicogramsPerLiter.
-        /// </summary>
-        public static Density? FromPicogramsPerLiter(long? picogramsperliter)
-        {
-            if (picogramsperliter.HasValue)
-            {
-                return FromPicogramsPerLiter(picogramsperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from PicogramsPerLiter of type decimal.
-        /// </summary>
-        public static Density? FromPicogramsPerLiter(decimal? picogramsperliter)
+        public static Density? FromPicogramsPerLiter(QuantityValue? picogramsperliter)
         {
             if (picogramsperliter.HasValue)
             {
@@ -3433,52 +1473,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable PicogramsPerMilliliter.
         /// </summary>
-        public static Density? FromPicogramsPerMilliliter(double? picogramspermilliliter)
-        {
-            if (picogramspermilliliter.HasValue)
-            {
-                return FromPicogramsPerMilliliter(picogramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PicogramsPerMilliliter.
-        /// </summary>
-        public static Density? FromPicogramsPerMilliliter(int? picogramspermilliliter)
-        {
-            if (picogramspermilliliter.HasValue)
-            {
-                return FromPicogramsPerMilliliter(picogramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PicogramsPerMilliliter.
-        /// </summary>
-        public static Density? FromPicogramsPerMilliliter(long? picogramspermilliliter)
-        {
-            if (picogramspermilliliter.HasValue)
-            {
-                return FromPicogramsPerMilliliter(picogramspermilliliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from PicogramsPerMilliliter of type decimal.
-        /// </summary>
-        public static Density? FromPicogramsPerMilliliter(decimal? picogramspermilliliter)
+        public static Density? FromPicogramsPerMilliliter(QuantityValue? picogramspermilliliter)
         {
             if (picogramspermilliliter.HasValue)
             {
@@ -3493,52 +1488,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicFoot.
         /// </summary>
-        public static Density? FromPoundsPerCubicFoot(double? poundspercubicfoot)
-        {
-            if (poundspercubicfoot.HasValue)
-            {
-                return FromPoundsPerCubicFoot(poundspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PoundsPerCubicFoot.
-        /// </summary>
-        public static Density? FromPoundsPerCubicFoot(int? poundspercubicfoot)
-        {
-            if (poundspercubicfoot.HasValue)
-            {
-                return FromPoundsPerCubicFoot(poundspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PoundsPerCubicFoot.
-        /// </summary>
-        public static Density? FromPoundsPerCubicFoot(long? poundspercubicfoot)
-        {
-            if (poundspercubicfoot.HasValue)
-            {
-                return FromPoundsPerCubicFoot(poundspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from PoundsPerCubicFoot of type decimal.
-        /// </summary>
-        public static Density? FromPoundsPerCubicFoot(decimal? poundspercubicfoot)
+        public static Density? FromPoundsPerCubicFoot(QuantityValue? poundspercubicfoot)
         {
             if (poundspercubicfoot.HasValue)
             {
@@ -3553,52 +1503,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable PoundsPerCubicInch.
         /// </summary>
-        public static Density? FromPoundsPerCubicInch(double? poundspercubicinch)
-        {
-            if (poundspercubicinch.HasValue)
-            {
-                return FromPoundsPerCubicInch(poundspercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PoundsPerCubicInch.
-        /// </summary>
-        public static Density? FromPoundsPerCubicInch(int? poundspercubicinch)
-        {
-            if (poundspercubicinch.HasValue)
-            {
-                return FromPoundsPerCubicInch(poundspercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable PoundsPerCubicInch.
-        /// </summary>
-        public static Density? FromPoundsPerCubicInch(long? poundspercubicinch)
-        {
-            if (poundspercubicinch.HasValue)
-            {
-                return FromPoundsPerCubicInch(poundspercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from PoundsPerCubicInch of type decimal.
-        /// </summary>
-        public static Density? FromPoundsPerCubicInch(decimal? poundspercubicinch)
+        public static Density? FromPoundsPerCubicInch(QuantityValue? poundspercubicinch)
         {
             if (poundspercubicinch.HasValue)
             {
@@ -3613,52 +1518,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable SlugsPerCubicFoot.
         /// </summary>
-        public static Density? FromSlugsPerCubicFoot(double? slugspercubicfoot)
-        {
-            if (slugspercubicfoot.HasValue)
-            {
-                return FromSlugsPerCubicFoot(slugspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable SlugsPerCubicFoot.
-        /// </summary>
-        public static Density? FromSlugsPerCubicFoot(int? slugspercubicfoot)
-        {
-            if (slugspercubicfoot.HasValue)
-            {
-                return FromSlugsPerCubicFoot(slugspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable SlugsPerCubicFoot.
-        /// </summary>
-        public static Density? FromSlugsPerCubicFoot(long? slugspercubicfoot)
-        {
-            if (slugspercubicfoot.HasValue)
-            {
-                return FromSlugsPerCubicFoot(slugspercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from SlugsPerCubicFoot of type decimal.
-        /// </summary>
-        public static Density? FromSlugsPerCubicFoot(decimal? slugspercubicfoot)
+        public static Density? FromSlugsPerCubicFoot(QuantityValue? slugspercubicfoot)
         {
             if (slugspercubicfoot.HasValue)
             {
@@ -3673,52 +1533,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
         /// </summary>
-        public static Density? FromTonnesPerCubicCentimeter(double? tonnespercubiccentimeter)
-        {
-            if (tonnespercubiccentimeter.HasValue)
-            {
-                return FromTonnesPerCubicCentimeter(tonnespercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
-        /// </summary>
-        public static Density? FromTonnesPerCubicCentimeter(int? tonnespercubiccentimeter)
-        {
-            if (tonnespercubiccentimeter.HasValue)
-            {
-                return FromTonnesPerCubicCentimeter(tonnespercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable TonnesPerCubicCentimeter.
-        /// </summary>
-        public static Density? FromTonnesPerCubicCentimeter(long? tonnespercubiccentimeter)
-        {
-            if (tonnespercubiccentimeter.HasValue)
-            {
-                return FromTonnesPerCubicCentimeter(tonnespercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from TonnesPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static Density? FromTonnesPerCubicCentimeter(decimal? tonnespercubiccentimeter)
+        public static Density? FromTonnesPerCubicCentimeter(QuantityValue? tonnespercubiccentimeter)
         {
             if (tonnespercubiccentimeter.HasValue)
             {
@@ -3733,52 +1548,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMeter.
         /// </summary>
-        public static Density? FromTonnesPerCubicMeter(double? tonnespercubicmeter)
-        {
-            if (tonnespercubicmeter.HasValue)
-            {
-                return FromTonnesPerCubicMeter(tonnespercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable TonnesPerCubicMeter.
-        /// </summary>
-        public static Density? FromTonnesPerCubicMeter(int? tonnespercubicmeter)
-        {
-            if (tonnespercubicmeter.HasValue)
-            {
-                return FromTonnesPerCubicMeter(tonnespercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable TonnesPerCubicMeter.
-        /// </summary>
-        public static Density? FromTonnesPerCubicMeter(long? tonnespercubicmeter)
-        {
-            if (tonnespercubicmeter.HasValue)
-            {
-                return FromTonnesPerCubicMeter(tonnespercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from TonnesPerCubicMeter of type decimal.
-        /// </summary>
-        public static Density? FromTonnesPerCubicMeter(decimal? tonnespercubicmeter)
+        public static Density? FromTonnesPerCubicMeter(QuantityValue? tonnespercubicmeter)
         {
             if (tonnespercubicmeter.HasValue)
             {
@@ -3793,52 +1563,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
         /// </summary>
-        public static Density? FromTonnesPerCubicMillimeter(double? tonnespercubicmillimeter)
-        {
-            if (tonnespercubicmillimeter.HasValue)
-            {
-                return FromTonnesPerCubicMillimeter(tonnespercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
-        /// </summary>
-        public static Density? FromTonnesPerCubicMillimeter(int? tonnespercubicmillimeter)
-        {
-            if (tonnespercubicmillimeter.HasValue)
-            {
-                return FromTonnesPerCubicMillimeter(tonnespercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from nullable TonnesPerCubicMillimeter.
-        /// </summary>
-        public static Density? FromTonnesPerCubicMillimeter(long? tonnespercubicmillimeter)
-        {
-            if (tonnespercubicmillimeter.HasValue)
-            {
-                return FromTonnesPerCubicMillimeter(tonnespercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Density from TonnesPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static Density? FromTonnesPerCubicMillimeter(decimal? tonnespercubicmillimeter)
+        public static Density? FromTonnesPerCubicMillimeter(QuantityValue? tonnespercubicmillimeter)
         {
             if (tonnespercubicmillimeter.HasValue)
             {
@@ -3855,83 +1580,89 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="DensityUnit" /> to <see cref="Density" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Density unit value.</returns>
-        public static Density From(double val, DensityUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Density From(double value, DensityUnit fromUnit)
+#else
+        public static Density From(QuantityValue value, DensityUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case DensityUnit.CentigramPerDeciliter:
-                    return FromCentigramsPerDeciLiter(val);
+                    return FromCentigramsPerDeciLiter(value);
                 case DensityUnit.CentigramPerLiter:
-                    return FromCentigramsPerLiter(val);
+                    return FromCentigramsPerLiter(value);
                 case DensityUnit.CentigramPerMilliliter:
-                    return FromCentigramsPerMilliliter(val);
+                    return FromCentigramsPerMilliliter(value);
                 case DensityUnit.DecigramPerDeciliter:
-                    return FromDecigramsPerDeciLiter(val);
+                    return FromDecigramsPerDeciLiter(value);
                 case DensityUnit.DecigramPerLiter:
-                    return FromDecigramsPerLiter(val);
+                    return FromDecigramsPerLiter(value);
                 case DensityUnit.DecigramPerMilliliter:
-                    return FromDecigramsPerMilliliter(val);
+                    return FromDecigramsPerMilliliter(value);
                 case DensityUnit.GramPerCubicCentimeter:
-                    return FromGramsPerCubicCentimeter(val);
+                    return FromGramsPerCubicCentimeter(value);
                 case DensityUnit.GramPerCubicMeter:
-                    return FromGramsPerCubicMeter(val);
+                    return FromGramsPerCubicMeter(value);
                 case DensityUnit.GramPerCubicMillimeter:
-                    return FromGramsPerCubicMillimeter(val);
+                    return FromGramsPerCubicMillimeter(value);
                 case DensityUnit.GramPerDeciliter:
-                    return FromGramsPerDeciLiter(val);
+                    return FromGramsPerDeciLiter(value);
                 case DensityUnit.GramPerLiter:
-                    return FromGramsPerLiter(val);
+                    return FromGramsPerLiter(value);
                 case DensityUnit.GramPerMilliliter:
-                    return FromGramsPerMilliliter(val);
+                    return FromGramsPerMilliliter(value);
                 case DensityUnit.KilogramPerCubicCentimeter:
-                    return FromKilogramsPerCubicCentimeter(val);
+                    return FromKilogramsPerCubicCentimeter(value);
                 case DensityUnit.KilogramPerCubicMeter:
-                    return FromKilogramsPerCubicMeter(val);
+                    return FromKilogramsPerCubicMeter(value);
                 case DensityUnit.KilogramPerCubicMillimeter:
-                    return FromKilogramsPerCubicMillimeter(val);
+                    return FromKilogramsPerCubicMillimeter(value);
                 case DensityUnit.KilopoundPerCubicFoot:
-                    return FromKilopoundsPerCubicFoot(val);
+                    return FromKilopoundsPerCubicFoot(value);
                 case DensityUnit.KilopoundPerCubicInch:
-                    return FromKilopoundsPerCubicInch(val);
+                    return FromKilopoundsPerCubicInch(value);
                 case DensityUnit.MicrogramPerDeciliter:
-                    return FromMicrogramsPerDeciLiter(val);
+                    return FromMicrogramsPerDeciLiter(value);
                 case DensityUnit.MicrogramPerLiter:
-                    return FromMicrogramsPerLiter(val);
+                    return FromMicrogramsPerLiter(value);
                 case DensityUnit.MicrogramPerMilliliter:
-                    return FromMicrogramsPerMilliliter(val);
+                    return FromMicrogramsPerMilliliter(value);
                 case DensityUnit.MilligramPerDeciliter:
-                    return FromMilligramsPerDeciLiter(val);
+                    return FromMilligramsPerDeciLiter(value);
                 case DensityUnit.MilligramPerLiter:
-                    return FromMilligramsPerLiter(val);
+                    return FromMilligramsPerLiter(value);
                 case DensityUnit.MilligramPerMilliliter:
-                    return FromMilligramsPerMilliliter(val);
+                    return FromMilligramsPerMilliliter(value);
                 case DensityUnit.NanogramPerDeciliter:
-                    return FromNanogramsPerDeciLiter(val);
+                    return FromNanogramsPerDeciLiter(value);
                 case DensityUnit.NanogramPerLiter:
-                    return FromNanogramsPerLiter(val);
+                    return FromNanogramsPerLiter(value);
                 case DensityUnit.NanogramPerMilliliter:
-                    return FromNanogramsPerMilliliter(val);
+                    return FromNanogramsPerMilliliter(value);
                 case DensityUnit.PicogramPerDeciliter:
-                    return FromPicogramsPerDeciLiter(val);
+                    return FromPicogramsPerDeciLiter(value);
                 case DensityUnit.PicogramPerLiter:
-                    return FromPicogramsPerLiter(val);
+                    return FromPicogramsPerLiter(value);
                 case DensityUnit.PicogramPerMilliliter:
-                    return FromPicogramsPerMilliliter(val);
+                    return FromPicogramsPerMilliliter(value);
                 case DensityUnit.PoundPerCubicFoot:
-                    return FromPoundsPerCubicFoot(val);
+                    return FromPoundsPerCubicFoot(value);
                 case DensityUnit.PoundPerCubicInch:
-                    return FromPoundsPerCubicInch(val);
+                    return FromPoundsPerCubicInch(value);
                 case DensityUnit.SlugPerCubicFoot:
-                    return FromSlugsPerCubicFoot(val);
+                    return FromSlugsPerCubicFoot(value);
                 case DensityUnit.TonnePerCubicCentimeter:
-                    return FromTonnesPerCubicCentimeter(val);
+                    return FromTonnesPerCubicCentimeter(value);
                 case DensityUnit.TonnePerCubicMeter:
-                    return FromTonnesPerCubicMeter(val);
+                    return FromTonnesPerCubicMeter(value);
                 case DensityUnit.TonnePerCubicMillimeter:
-                    return FromTonnesPerCubicMillimeter(val);
+                    return FromTonnesPerCubicMillimeter(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -3946,7 +1677,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Density unit value.</returns>
-        public static Density? From(double? value, DensityUnit fromUnit)
+        public static Density? From(QuantityValue? value, DensityUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -221,380 +221,180 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Days.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromDays(double days)
         {
-            return new Duration(days*24*3600);
+            double value = (double) days;
+            return new Duration(value*24*3600);
         }
-
-        /// <summary>
-        ///     Get Duration from Days.
-        /// </summary>
-        public static Duration FromDays(int days)
+#else
+        public static Duration FromDays(QuantityValue days)
         {
-            return new Duration(days*24*3600);
-        }
-
-        /// <summary>
-        ///     Get Duration from Days.
-        /// </summary>
-        public static Duration FromDays(long days)
-        {
-            return new Duration(days*24*3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Days of type decimal.
-        /// </summary>
-        public static Duration FromDays(decimal days)
-        {
-            return new Duration(Convert.ToDouble(days)*24*3600);
+            double value = (double) days;
+            return new Duration((value*24*3600));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromHours(double hours)
         {
-            return new Duration(hours*3600);
+            double value = (double) hours;
+            return new Duration(value*3600);
         }
-
-        /// <summary>
-        ///     Get Duration from Hours.
-        /// </summary>
-        public static Duration FromHours(int hours)
+#else
+        public static Duration FromHours(QuantityValue hours)
         {
-            return new Duration(hours*3600);
-        }
-
-        /// <summary>
-        ///     Get Duration from Hours.
-        /// </summary>
-        public static Duration FromHours(long hours)
-        {
-            return new Duration(hours*3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Hours of type decimal.
-        /// </summary>
-        public static Duration FromHours(decimal hours)
-        {
-            return new Duration(Convert.ToDouble(hours)*3600);
+            double value = (double) hours;
+            return new Duration((value*3600));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Microseconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromMicroseconds(double microseconds)
         {
-            return new Duration(microseconds/1e6);
+            double value = (double) microseconds;
+            return new Duration(value/1e6);
         }
-
-        /// <summary>
-        ///     Get Duration from Microseconds.
-        /// </summary>
-        public static Duration FromMicroseconds(int microseconds)
+#else
+        public static Duration FromMicroseconds(QuantityValue microseconds)
         {
-            return new Duration(microseconds/1e6);
-        }
-
-        /// <summary>
-        ///     Get Duration from Microseconds.
-        /// </summary>
-        public static Duration FromMicroseconds(long microseconds)
-        {
-            return new Duration(microseconds/1e6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Microseconds of type decimal.
-        /// </summary>
-        public static Duration FromMicroseconds(decimal microseconds)
-        {
-            return new Duration(Convert.ToDouble(microseconds)/1e6);
+            double value = (double) microseconds;
+            return new Duration((value/1e6));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromMilliseconds(double milliseconds)
         {
-            return new Duration(milliseconds/1e3);
+            double value = (double) milliseconds;
+            return new Duration(value/1e3);
         }
-
-        /// <summary>
-        ///     Get Duration from Milliseconds.
-        /// </summary>
-        public static Duration FromMilliseconds(int milliseconds)
+#else
+        public static Duration FromMilliseconds(QuantityValue milliseconds)
         {
-            return new Duration(milliseconds/1e3);
-        }
-
-        /// <summary>
-        ///     Get Duration from Milliseconds.
-        /// </summary>
-        public static Duration FromMilliseconds(long milliseconds)
-        {
-            return new Duration(milliseconds/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Milliseconds of type decimal.
-        /// </summary>
-        public static Duration FromMilliseconds(decimal milliseconds)
-        {
-            return new Duration(Convert.ToDouble(milliseconds)/1e3);
+            double value = (double) milliseconds;
+            return new Duration((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Minutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromMinutes(double minutes)
         {
-            return new Duration(minutes*60);
+            double value = (double) minutes;
+            return new Duration(value*60);
         }
-
-        /// <summary>
-        ///     Get Duration from Minutes.
-        /// </summary>
-        public static Duration FromMinutes(int minutes)
+#else
+        public static Duration FromMinutes(QuantityValue minutes)
         {
-            return new Duration(minutes*60);
-        }
-
-        /// <summary>
-        ///     Get Duration from Minutes.
-        /// </summary>
-        public static Duration FromMinutes(long minutes)
-        {
-            return new Duration(minutes*60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Minutes of type decimal.
-        /// </summary>
-        public static Duration FromMinutes(decimal minutes)
-        {
-            return new Duration(Convert.ToDouble(minutes)*60);
+            double value = (double) minutes;
+            return new Duration((value*60));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Months.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromMonths(double months)
         {
-            return new Duration(months*30*24*3600);
+            double value = (double) months;
+            return new Duration(value*30*24*3600);
         }
-
-        /// <summary>
-        ///     Get Duration from Months.
-        /// </summary>
-        public static Duration FromMonths(int months)
+#else
+        public static Duration FromMonths(QuantityValue months)
         {
-            return new Duration(months*30*24*3600);
-        }
-
-        /// <summary>
-        ///     Get Duration from Months.
-        /// </summary>
-        public static Duration FromMonths(long months)
-        {
-            return new Duration(months*30*24*3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Months of type decimal.
-        /// </summary>
-        public static Duration FromMonths(decimal months)
-        {
-            return new Duration(Convert.ToDouble(months)*30*24*3600);
+            double value = (double) months;
+            return new Duration((value*30*24*3600));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Nanoseconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromNanoseconds(double nanoseconds)
         {
-            return new Duration(nanoseconds/1e9);
+            double value = (double) nanoseconds;
+            return new Duration(value/1e9);
         }
-
-        /// <summary>
-        ///     Get Duration from Nanoseconds.
-        /// </summary>
-        public static Duration FromNanoseconds(int nanoseconds)
+#else
+        public static Duration FromNanoseconds(QuantityValue nanoseconds)
         {
-            return new Duration(nanoseconds/1e9);
-        }
-
-        /// <summary>
-        ///     Get Duration from Nanoseconds.
-        /// </summary>
-        public static Duration FromNanoseconds(long nanoseconds)
-        {
-            return new Duration(nanoseconds/1e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Nanoseconds of type decimal.
-        /// </summary>
-        public static Duration FromNanoseconds(decimal nanoseconds)
-        {
-            return new Duration(Convert.ToDouble(nanoseconds)/1e9);
+            double value = (double) nanoseconds;
+            return new Duration((value/1e9));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromSeconds(double seconds)
         {
-            return new Duration(seconds);
+            double value = (double) seconds;
+            return new Duration(value);
         }
-
-        /// <summary>
-        ///     Get Duration from Seconds.
-        /// </summary>
-        public static Duration FromSeconds(int seconds)
+#else
+        public static Duration FromSeconds(QuantityValue seconds)
         {
-            return new Duration(seconds);
-        }
-
-        /// <summary>
-        ///     Get Duration from Seconds.
-        /// </summary>
-        public static Duration FromSeconds(long seconds)
-        {
-            return new Duration(seconds);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Seconds of type decimal.
-        /// </summary>
-        public static Duration FromSeconds(decimal seconds)
-        {
-            return new Duration(Convert.ToDouble(seconds));
+            double value = (double) seconds;
+            return new Duration((value));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Weeks.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromWeeks(double weeks)
         {
-            return new Duration(weeks*7*24*3600);
+            double value = (double) weeks;
+            return new Duration(value*7*24*3600);
         }
-
-        /// <summary>
-        ///     Get Duration from Weeks.
-        /// </summary>
-        public static Duration FromWeeks(int weeks)
+#else
+        public static Duration FromWeeks(QuantityValue weeks)
         {
-            return new Duration(weeks*7*24*3600);
-        }
-
-        /// <summary>
-        ///     Get Duration from Weeks.
-        /// </summary>
-        public static Duration FromWeeks(long weeks)
-        {
-            return new Duration(weeks*7*24*3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Weeks of type decimal.
-        /// </summary>
-        public static Duration FromWeeks(decimal weeks)
-        {
-            return new Duration(Convert.ToDouble(weeks)*7*24*3600);
+            double value = (double) weeks;
+            return new Duration((value*7*24*3600));
         }
 #endif
 
         /// <summary>
         ///     Get Duration from Years.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Duration FromYears(double years)
         {
-            return new Duration(years*365*24*3600);
+            double value = (double) years;
+            return new Duration(value*365*24*3600);
         }
-
-        /// <summary>
-        ///     Get Duration from Years.
-        /// </summary>
-        public static Duration FromYears(int years)
+#else
+        public static Duration FromYears(QuantityValue years)
         {
-            return new Duration(years*365*24*3600);
-        }
-
-        /// <summary>
-        ///     Get Duration from Years.
-        /// </summary>
-        public static Duration FromYears(long years)
-        {
-            return new Duration(years*365*24*3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Duration from Years of type decimal.
-        /// </summary>
-        public static Duration FromYears(decimal years)
-        {
-            return new Duration(Convert.ToDouble(years)*365*24*3600);
+            double value = (double) years;
+            return new Duration((value*365*24*3600));
         }
 #endif
 
@@ -603,52 +403,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Days.
         /// </summary>
-        public static Duration? FromDays(double? days)
-        {
-            if (days.HasValue)
-            {
-                return FromDays(days.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Days.
-        /// </summary>
-        public static Duration? FromDays(int? days)
-        {
-            if (days.HasValue)
-            {
-                return FromDays(days.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Days.
-        /// </summary>
-        public static Duration? FromDays(long? days)
-        {
-            if (days.HasValue)
-            {
-                return FromDays(days.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Days of type decimal.
-        /// </summary>
-        public static Duration? FromDays(decimal? days)
+        public static Duration? FromDays(QuantityValue? days)
         {
             if (days.HasValue)
             {
@@ -663,52 +418,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Hours.
         /// </summary>
-        public static Duration? FromHours(double? hours)
-        {
-            if (hours.HasValue)
-            {
-                return FromHours(hours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Hours.
-        /// </summary>
-        public static Duration? FromHours(int? hours)
-        {
-            if (hours.HasValue)
-            {
-                return FromHours(hours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Hours.
-        /// </summary>
-        public static Duration? FromHours(long? hours)
-        {
-            if (hours.HasValue)
-            {
-                return FromHours(hours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Hours of type decimal.
-        /// </summary>
-        public static Duration? FromHours(decimal? hours)
+        public static Duration? FromHours(QuantityValue? hours)
         {
             if (hours.HasValue)
             {
@@ -723,52 +433,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Microseconds.
         /// </summary>
-        public static Duration? FromMicroseconds(double? microseconds)
-        {
-            if (microseconds.HasValue)
-            {
-                return FromMicroseconds(microseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Microseconds.
-        /// </summary>
-        public static Duration? FromMicroseconds(int? microseconds)
-        {
-            if (microseconds.HasValue)
-            {
-                return FromMicroseconds(microseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Microseconds.
-        /// </summary>
-        public static Duration? FromMicroseconds(long? microseconds)
-        {
-            if (microseconds.HasValue)
-            {
-                return FromMicroseconds(microseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Microseconds of type decimal.
-        /// </summary>
-        public static Duration? FromMicroseconds(decimal? microseconds)
+        public static Duration? FromMicroseconds(QuantityValue? microseconds)
         {
             if (microseconds.HasValue)
             {
@@ -783,52 +448,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Milliseconds.
         /// </summary>
-        public static Duration? FromMilliseconds(double? milliseconds)
-        {
-            if (milliseconds.HasValue)
-            {
-                return FromMilliseconds(milliseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Milliseconds.
-        /// </summary>
-        public static Duration? FromMilliseconds(int? milliseconds)
-        {
-            if (milliseconds.HasValue)
-            {
-                return FromMilliseconds(milliseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Milliseconds.
-        /// </summary>
-        public static Duration? FromMilliseconds(long? milliseconds)
-        {
-            if (milliseconds.HasValue)
-            {
-                return FromMilliseconds(milliseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Milliseconds of type decimal.
-        /// </summary>
-        public static Duration? FromMilliseconds(decimal? milliseconds)
+        public static Duration? FromMilliseconds(QuantityValue? milliseconds)
         {
             if (milliseconds.HasValue)
             {
@@ -843,52 +463,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Minutes.
         /// </summary>
-        public static Duration? FromMinutes(double? minutes)
-        {
-            if (minutes.HasValue)
-            {
-                return FromMinutes(minutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Minutes.
-        /// </summary>
-        public static Duration? FromMinutes(int? minutes)
-        {
-            if (minutes.HasValue)
-            {
-                return FromMinutes(minutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Minutes.
-        /// </summary>
-        public static Duration? FromMinutes(long? minutes)
-        {
-            if (minutes.HasValue)
-            {
-                return FromMinutes(minutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Minutes of type decimal.
-        /// </summary>
-        public static Duration? FromMinutes(decimal? minutes)
+        public static Duration? FromMinutes(QuantityValue? minutes)
         {
             if (minutes.HasValue)
             {
@@ -903,52 +478,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Months.
         /// </summary>
-        public static Duration? FromMonths(double? months)
-        {
-            if (months.HasValue)
-            {
-                return FromMonths(months.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Months.
-        /// </summary>
-        public static Duration? FromMonths(int? months)
-        {
-            if (months.HasValue)
-            {
-                return FromMonths(months.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Months.
-        /// </summary>
-        public static Duration? FromMonths(long? months)
-        {
-            if (months.HasValue)
-            {
-                return FromMonths(months.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Months of type decimal.
-        /// </summary>
-        public static Duration? FromMonths(decimal? months)
+        public static Duration? FromMonths(QuantityValue? months)
         {
             if (months.HasValue)
             {
@@ -963,52 +493,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Nanoseconds.
         /// </summary>
-        public static Duration? FromNanoseconds(double? nanoseconds)
-        {
-            if (nanoseconds.HasValue)
-            {
-                return FromNanoseconds(nanoseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Nanoseconds.
-        /// </summary>
-        public static Duration? FromNanoseconds(int? nanoseconds)
-        {
-            if (nanoseconds.HasValue)
-            {
-                return FromNanoseconds(nanoseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Nanoseconds.
-        /// </summary>
-        public static Duration? FromNanoseconds(long? nanoseconds)
-        {
-            if (nanoseconds.HasValue)
-            {
-                return FromNanoseconds(nanoseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Nanoseconds of type decimal.
-        /// </summary>
-        public static Duration? FromNanoseconds(decimal? nanoseconds)
+        public static Duration? FromNanoseconds(QuantityValue? nanoseconds)
         {
             if (nanoseconds.HasValue)
             {
@@ -1023,52 +508,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Seconds.
         /// </summary>
-        public static Duration? FromSeconds(double? seconds)
-        {
-            if (seconds.HasValue)
-            {
-                return FromSeconds(seconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Seconds.
-        /// </summary>
-        public static Duration? FromSeconds(int? seconds)
-        {
-            if (seconds.HasValue)
-            {
-                return FromSeconds(seconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Seconds.
-        /// </summary>
-        public static Duration? FromSeconds(long? seconds)
-        {
-            if (seconds.HasValue)
-            {
-                return FromSeconds(seconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Seconds of type decimal.
-        /// </summary>
-        public static Duration? FromSeconds(decimal? seconds)
+        public static Duration? FromSeconds(QuantityValue? seconds)
         {
             if (seconds.HasValue)
             {
@@ -1083,52 +523,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Weeks.
         /// </summary>
-        public static Duration? FromWeeks(double? weeks)
-        {
-            if (weeks.HasValue)
-            {
-                return FromWeeks(weeks.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Weeks.
-        /// </summary>
-        public static Duration? FromWeeks(int? weeks)
-        {
-            if (weeks.HasValue)
-            {
-                return FromWeeks(weeks.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Weeks.
-        /// </summary>
-        public static Duration? FromWeeks(long? weeks)
-        {
-            if (weeks.HasValue)
-            {
-                return FromWeeks(weeks.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Weeks of type decimal.
-        /// </summary>
-        public static Duration? FromWeeks(decimal? weeks)
+        public static Duration? FromWeeks(QuantityValue? weeks)
         {
             if (weeks.HasValue)
             {
@@ -1143,52 +538,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Duration from nullable Years.
         /// </summary>
-        public static Duration? FromYears(double? years)
-        {
-            if (years.HasValue)
-            {
-                return FromYears(years.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Years.
-        /// </summary>
-        public static Duration? FromYears(int? years)
-        {
-            if (years.HasValue)
-            {
-                return FromYears(years.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from nullable Years.
-        /// </summary>
-        public static Duration? FromYears(long? years)
-        {
-            if (years.HasValue)
-            {
-                return FromYears(years.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Duration from Years of type decimal.
-        /// </summary>
-        public static Duration? FromYears(decimal? years)
+        public static Duration? FromYears(QuantityValue? years)
         {
             if (years.HasValue)
             {
@@ -1205,33 +555,39 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="DurationUnit" /> to <see cref="Duration" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Duration unit value.</returns>
-        public static Duration From(double val, DurationUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Duration From(double value, DurationUnit fromUnit)
+#else
+        public static Duration From(QuantityValue value, DurationUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case DurationUnit.Day:
-                    return FromDays(val);
+                    return FromDays(value);
                 case DurationUnit.Hour:
-                    return FromHours(val);
+                    return FromHours(value);
                 case DurationUnit.Microsecond:
-                    return FromMicroseconds(val);
+                    return FromMicroseconds(value);
                 case DurationUnit.Millisecond:
-                    return FromMilliseconds(val);
+                    return FromMilliseconds(value);
                 case DurationUnit.Minute:
-                    return FromMinutes(val);
+                    return FromMinutes(value);
                 case DurationUnit.Month:
-                    return FromMonths(val);
+                    return FromMonths(value);
                 case DurationUnit.Nanosecond:
-                    return FromNanoseconds(val);
+                    return FromNanoseconds(value);
                 case DurationUnit.Second:
-                    return FromSeconds(val);
+                    return FromSeconds(value);
                 case DurationUnit.Week:
-                    return FromWeeks(val);
+                    return FromWeeks(value);
                 case DurationUnit.Year:
-                    return FromYears(val);
+                    return FromYears(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1246,7 +602,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Duration unit value.</returns>
-        public static Duration? From(double? value, DurationUnit fromUnit)
+        public static Duration? From(QuantityValue? value, DurationUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -189,228 +189,108 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Centipoise.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static DynamicViscosity FromCentipoise(double centipoise)
         {
-            return new DynamicViscosity((centipoise/10) * 1e-2d);
+            double value = (double) centipoise;
+            return new DynamicViscosity((value/10) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get DynamicViscosity from Centipoise.
-        /// </summary>
-        public static DynamicViscosity FromCentipoise(int centipoise)
+#else
+        public static DynamicViscosity FromCentipoise(QuantityValue centipoise)
         {
-            return new DynamicViscosity((centipoise/10) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get DynamicViscosity from Centipoise.
-        /// </summary>
-        public static DynamicViscosity FromCentipoise(long centipoise)
-        {
-            return new DynamicViscosity((centipoise/10) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get DynamicViscosity from Centipoise of type decimal.
-        /// </summary>
-        public static DynamicViscosity FromCentipoise(decimal centipoise)
-        {
-            return new DynamicViscosity((Convert.ToDouble(centipoise)/10) * 1e-2d);
+            double value = (double) centipoise;
+            return new DynamicViscosity(((value/10) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get DynamicViscosity from MicropascalSeconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static DynamicViscosity FromMicropascalSeconds(double micropascalseconds)
         {
-            return new DynamicViscosity((micropascalseconds) * 1e-6d);
+            double value = (double) micropascalseconds;
+            return new DynamicViscosity((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get DynamicViscosity from MicropascalSeconds.
-        /// </summary>
-        public static DynamicViscosity FromMicropascalSeconds(int micropascalseconds)
+#else
+        public static DynamicViscosity FromMicropascalSeconds(QuantityValue micropascalseconds)
         {
-            return new DynamicViscosity((micropascalseconds) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get DynamicViscosity from MicropascalSeconds.
-        /// </summary>
-        public static DynamicViscosity FromMicropascalSeconds(long micropascalseconds)
-        {
-            return new DynamicViscosity((micropascalseconds) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get DynamicViscosity from MicropascalSeconds of type decimal.
-        /// </summary>
-        public static DynamicViscosity FromMicropascalSeconds(decimal micropascalseconds)
-        {
-            return new DynamicViscosity((Convert.ToDouble(micropascalseconds)) * 1e-6d);
+            double value = (double) micropascalseconds;
+            return new DynamicViscosity(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static DynamicViscosity FromMillipascalSeconds(double millipascalseconds)
         {
-            return new DynamicViscosity((millipascalseconds) * 1e-3d);
+            double value = (double) millipascalseconds;
+            return new DynamicViscosity((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get DynamicViscosity from MillipascalSeconds.
-        /// </summary>
-        public static DynamicViscosity FromMillipascalSeconds(int millipascalseconds)
+#else
+        public static DynamicViscosity FromMillipascalSeconds(QuantityValue millipascalseconds)
         {
-            return new DynamicViscosity((millipascalseconds) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get DynamicViscosity from MillipascalSeconds.
-        /// </summary>
-        public static DynamicViscosity FromMillipascalSeconds(long millipascalseconds)
-        {
-            return new DynamicViscosity((millipascalseconds) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get DynamicViscosity from MillipascalSeconds of type decimal.
-        /// </summary>
-        public static DynamicViscosity FromMillipascalSeconds(decimal millipascalseconds)
-        {
-            return new DynamicViscosity((Convert.ToDouble(millipascalseconds)) * 1e-3d);
+            double value = (double) millipascalseconds;
+            return new DynamicViscosity(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(double newtonsecondspermetersquared)
         {
-            return new DynamicViscosity(newtonsecondspermetersquared);
+            double value = (double) newtonsecondspermetersquared;
+            return new DynamicViscosity(value);
         }
-
-        /// <summary>
-        ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
-        /// </summary>
-        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(int newtonsecondspermetersquared)
+#else
+        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(QuantityValue newtonsecondspermetersquared)
         {
-            return new DynamicViscosity(newtonsecondspermetersquared);
-        }
-
-        /// <summary>
-        ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
-        /// </summary>
-        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(long newtonsecondspermetersquared)
-        {
-            return new DynamicViscosity(newtonsecondspermetersquared);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared of type decimal.
-        /// </summary>
-        public static DynamicViscosity FromNewtonSecondsPerMeterSquared(decimal newtonsecondspermetersquared)
-        {
-            return new DynamicViscosity(Convert.ToDouble(newtonsecondspermetersquared));
+            double value = (double) newtonsecondspermetersquared;
+            return new DynamicViscosity((value));
         }
 #endif
 
         /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static DynamicViscosity FromPascalSeconds(double pascalseconds)
         {
-            return new DynamicViscosity(pascalseconds);
+            double value = (double) pascalseconds;
+            return new DynamicViscosity(value);
         }
-
-        /// <summary>
-        ///     Get DynamicViscosity from PascalSeconds.
-        /// </summary>
-        public static DynamicViscosity FromPascalSeconds(int pascalseconds)
+#else
+        public static DynamicViscosity FromPascalSeconds(QuantityValue pascalseconds)
         {
-            return new DynamicViscosity(pascalseconds);
-        }
-
-        /// <summary>
-        ///     Get DynamicViscosity from PascalSeconds.
-        /// </summary>
-        public static DynamicViscosity FromPascalSeconds(long pascalseconds)
-        {
-            return new DynamicViscosity(pascalseconds);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get DynamicViscosity from PascalSeconds of type decimal.
-        /// </summary>
-        public static DynamicViscosity FromPascalSeconds(decimal pascalseconds)
-        {
-            return new DynamicViscosity(Convert.ToDouble(pascalseconds));
+            double value = (double) pascalseconds;
+            return new DynamicViscosity((value));
         }
 #endif
 
         /// <summary>
         ///     Get DynamicViscosity from Poise.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static DynamicViscosity FromPoise(double poise)
         {
-            return new DynamicViscosity(poise/10);
+            double value = (double) poise;
+            return new DynamicViscosity(value/10);
         }
-
-        /// <summary>
-        ///     Get DynamicViscosity from Poise.
-        /// </summary>
-        public static DynamicViscosity FromPoise(int poise)
+#else
+        public static DynamicViscosity FromPoise(QuantityValue poise)
         {
-            return new DynamicViscosity(poise/10);
-        }
-
-        /// <summary>
-        ///     Get DynamicViscosity from Poise.
-        /// </summary>
-        public static DynamicViscosity FromPoise(long poise)
-        {
-            return new DynamicViscosity(poise/10);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get DynamicViscosity from Poise of type decimal.
-        /// </summary>
-        public static DynamicViscosity FromPoise(decimal poise)
-        {
-            return new DynamicViscosity(Convert.ToDouble(poise)/10);
+            double value = (double) poise;
+            return new DynamicViscosity((value/10));
         }
 #endif
 
@@ -419,52 +299,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable Centipoise.
         /// </summary>
-        public static DynamicViscosity? FromCentipoise(double? centipoise)
-        {
-            if (centipoise.HasValue)
-            {
-                return FromCentipoise(centipoise.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable Centipoise.
-        /// </summary>
-        public static DynamicViscosity? FromCentipoise(int? centipoise)
-        {
-            if (centipoise.HasValue)
-            {
-                return FromCentipoise(centipoise.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable Centipoise.
-        /// </summary>
-        public static DynamicViscosity? FromCentipoise(long? centipoise)
-        {
-            if (centipoise.HasValue)
-            {
-                return FromCentipoise(centipoise.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from Centipoise of type decimal.
-        /// </summary>
-        public static DynamicViscosity? FromCentipoise(decimal? centipoise)
+        public static DynamicViscosity? FromCentipoise(QuantityValue? centipoise)
         {
             if (centipoise.HasValue)
             {
@@ -479,52 +314,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable MicropascalSeconds.
         /// </summary>
-        public static DynamicViscosity? FromMicropascalSeconds(double? micropascalseconds)
-        {
-            if (micropascalseconds.HasValue)
-            {
-                return FromMicropascalSeconds(micropascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable MicropascalSeconds.
-        /// </summary>
-        public static DynamicViscosity? FromMicropascalSeconds(int? micropascalseconds)
-        {
-            if (micropascalseconds.HasValue)
-            {
-                return FromMicropascalSeconds(micropascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable MicropascalSeconds.
-        /// </summary>
-        public static DynamicViscosity? FromMicropascalSeconds(long? micropascalseconds)
-        {
-            if (micropascalseconds.HasValue)
-            {
-                return FromMicropascalSeconds(micropascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from MicropascalSeconds of type decimal.
-        /// </summary>
-        public static DynamicViscosity? FromMicropascalSeconds(decimal? micropascalseconds)
+        public static DynamicViscosity? FromMicropascalSeconds(QuantityValue? micropascalseconds)
         {
             if (micropascalseconds.HasValue)
             {
@@ -539,52 +329,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
         /// </summary>
-        public static DynamicViscosity? FromMillipascalSeconds(double? millipascalseconds)
-        {
-            if (millipascalseconds.HasValue)
-            {
-                return FromMillipascalSeconds(millipascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
-        /// </summary>
-        public static DynamicViscosity? FromMillipascalSeconds(int? millipascalseconds)
-        {
-            if (millipascalseconds.HasValue)
-            {
-                return FromMillipascalSeconds(millipascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable MillipascalSeconds.
-        /// </summary>
-        public static DynamicViscosity? FromMillipascalSeconds(long? millipascalseconds)
-        {
-            if (millipascalseconds.HasValue)
-            {
-                return FromMillipascalSeconds(millipascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from MillipascalSeconds of type decimal.
-        /// </summary>
-        public static DynamicViscosity? FromMillipascalSeconds(decimal? millipascalseconds)
+        public static DynamicViscosity? FromMillipascalSeconds(QuantityValue? millipascalseconds)
         {
             if (millipascalseconds.HasValue)
             {
@@ -599,52 +344,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
         /// </summary>
-        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(double? newtonsecondspermetersquared)
-        {
-            if (newtonsecondspermetersquared.HasValue)
-            {
-                return FromNewtonSecondsPerMeterSquared(newtonsecondspermetersquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
-        /// </summary>
-        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(int? newtonsecondspermetersquared)
-        {
-            if (newtonsecondspermetersquared.HasValue)
-            {
-                return FromNewtonSecondsPerMeterSquared(newtonsecondspermetersquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable NewtonSecondsPerMeterSquared.
-        /// </summary>
-        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(long? newtonsecondspermetersquared)
-        {
-            if (newtonsecondspermetersquared.HasValue)
-            {
-                return FromNewtonSecondsPerMeterSquared(newtonsecondspermetersquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from NewtonSecondsPerMeterSquared of type decimal.
-        /// </summary>
-        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(decimal? newtonsecondspermetersquared)
+        public static DynamicViscosity? FromNewtonSecondsPerMeterSquared(QuantityValue? newtonsecondspermetersquared)
         {
             if (newtonsecondspermetersquared.HasValue)
             {
@@ -659,52 +359,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable PascalSeconds.
         /// </summary>
-        public static DynamicViscosity? FromPascalSeconds(double? pascalseconds)
-        {
-            if (pascalseconds.HasValue)
-            {
-                return FromPascalSeconds(pascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable PascalSeconds.
-        /// </summary>
-        public static DynamicViscosity? FromPascalSeconds(int? pascalseconds)
-        {
-            if (pascalseconds.HasValue)
-            {
-                return FromPascalSeconds(pascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable PascalSeconds.
-        /// </summary>
-        public static DynamicViscosity? FromPascalSeconds(long? pascalseconds)
-        {
-            if (pascalseconds.HasValue)
-            {
-                return FromPascalSeconds(pascalseconds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from PascalSeconds of type decimal.
-        /// </summary>
-        public static DynamicViscosity? FromPascalSeconds(decimal? pascalseconds)
+        public static DynamicViscosity? FromPascalSeconds(QuantityValue? pascalseconds)
         {
             if (pascalseconds.HasValue)
             {
@@ -719,52 +374,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable DynamicViscosity from nullable Poise.
         /// </summary>
-        public static DynamicViscosity? FromPoise(double? poise)
-        {
-            if (poise.HasValue)
-            {
-                return FromPoise(poise.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable Poise.
-        /// </summary>
-        public static DynamicViscosity? FromPoise(int? poise)
-        {
-            if (poise.HasValue)
-            {
-                return FromPoise(poise.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from nullable Poise.
-        /// </summary>
-        public static DynamicViscosity? FromPoise(long? poise)
-        {
-            if (poise.HasValue)
-            {
-                return FromPoise(poise.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable DynamicViscosity from Poise of type decimal.
-        /// </summary>
-        public static DynamicViscosity? FromPoise(decimal? poise)
+        public static DynamicViscosity? FromPoise(QuantityValue? poise)
         {
             if (poise.HasValue)
             {
@@ -781,25 +391,31 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="DynamicViscosityUnit" /> to <see cref="DynamicViscosity" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>DynamicViscosity unit value.</returns>
-        public static DynamicViscosity From(double val, DynamicViscosityUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static DynamicViscosity From(double value, DynamicViscosityUnit fromUnit)
+#else
+        public static DynamicViscosity From(QuantityValue value, DynamicViscosityUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case DynamicViscosityUnit.Centipoise:
-                    return FromCentipoise(val);
+                    return FromCentipoise(value);
                 case DynamicViscosityUnit.MicropascalSecond:
-                    return FromMicropascalSeconds(val);
+                    return FromMicropascalSeconds(value);
                 case DynamicViscosityUnit.MillipascalSecond:
-                    return FromMillipascalSeconds(val);
+                    return FromMillipascalSeconds(value);
                 case DynamicViscosityUnit.NewtonSecondPerMeterSquared:
-                    return FromNewtonSecondsPerMeterSquared(val);
+                    return FromNewtonSecondsPerMeterSquared(value);
                 case DynamicViscosityUnit.PascalSecond:
-                    return FromPascalSeconds(val);
+                    return FromPascalSeconds(value);
                 case DynamicViscosityUnit.Poise:
-                    return FromPoise(val);
+                    return FromPoise(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -814,7 +430,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>DynamicViscosity unit value.</returns>
-        public static DynamicViscosity? From(double? value, DynamicViscosityUnit fromUnit)
+        public static DynamicViscosity? From(QuantityValue? value, DynamicViscosityUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -173,152 +173,72 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Microsiemens.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricAdmittance FromMicrosiemens(double microsiemens)
         {
-            return new ElectricAdmittance((microsiemens) * 1e-6d);
+            double value = (double) microsiemens;
+            return new ElectricAdmittance((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Microsiemens.
-        /// </summary>
-        public static ElectricAdmittance FromMicrosiemens(int microsiemens)
+#else
+        public static ElectricAdmittance FromMicrosiemens(QuantityValue microsiemens)
         {
-            return new ElectricAdmittance((microsiemens) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Microsiemens.
-        /// </summary>
-        public static ElectricAdmittance FromMicrosiemens(long microsiemens)
-        {
-            return new ElectricAdmittance((microsiemens) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricAdmittance from Microsiemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance FromMicrosiemens(decimal microsiemens)
-        {
-            return new ElectricAdmittance((Convert.ToDouble(microsiemens)) * 1e-6d);
+            double value = (double) microsiemens;
+            return new ElectricAdmittance(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricAdmittance FromMillisiemens(double millisiemens)
         {
-            return new ElectricAdmittance((millisiemens) * 1e-3d);
+            double value = (double) millisiemens;
+            return new ElectricAdmittance((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Millisiemens.
-        /// </summary>
-        public static ElectricAdmittance FromMillisiemens(int millisiemens)
+#else
+        public static ElectricAdmittance FromMillisiemens(QuantityValue millisiemens)
         {
-            return new ElectricAdmittance((millisiemens) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Millisiemens.
-        /// </summary>
-        public static ElectricAdmittance FromMillisiemens(long millisiemens)
-        {
-            return new ElectricAdmittance((millisiemens) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricAdmittance from Millisiemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance FromMillisiemens(decimal millisiemens)
-        {
-            return new ElectricAdmittance((Convert.ToDouble(millisiemens)) * 1e-3d);
+            double value = (double) millisiemens;
+            return new ElectricAdmittance(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricAdmittance FromNanosiemens(double nanosiemens)
         {
-            return new ElectricAdmittance((nanosiemens) * 1e-9d);
+            double value = (double) nanosiemens;
+            return new ElectricAdmittance((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Nanosiemens.
-        /// </summary>
-        public static ElectricAdmittance FromNanosiemens(int nanosiemens)
+#else
+        public static ElectricAdmittance FromNanosiemens(QuantityValue nanosiemens)
         {
-            return new ElectricAdmittance((nanosiemens) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Nanosiemens.
-        /// </summary>
-        public static ElectricAdmittance FromNanosiemens(long nanosiemens)
-        {
-            return new ElectricAdmittance((nanosiemens) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricAdmittance from Nanosiemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance FromNanosiemens(decimal nanosiemens)
-        {
-            return new ElectricAdmittance((Convert.ToDouble(nanosiemens)) * 1e-9d);
+            double value = (double) nanosiemens;
+            return new ElectricAdmittance(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricAdmittance FromSiemens(double siemens)
         {
-            return new ElectricAdmittance(siemens);
+            double value = (double) siemens;
+            return new ElectricAdmittance(value);
         }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Siemens.
-        /// </summary>
-        public static ElectricAdmittance FromSiemens(int siemens)
+#else
+        public static ElectricAdmittance FromSiemens(QuantityValue siemens)
         {
-            return new ElectricAdmittance(siemens);
-        }
-
-        /// <summary>
-        ///     Get ElectricAdmittance from Siemens.
-        /// </summary>
-        public static ElectricAdmittance FromSiemens(long siemens)
-        {
-            return new ElectricAdmittance(siemens);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricAdmittance from Siemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance FromSiemens(decimal siemens)
-        {
-            return new ElectricAdmittance(Convert.ToDouble(siemens));
+            double value = (double) siemens;
+            return new ElectricAdmittance((value));
         }
 #endif
 
@@ -327,52 +247,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Microsiemens.
         /// </summary>
-        public static ElectricAdmittance? FromMicrosiemens(double? microsiemens)
-        {
-            if (microsiemens.HasValue)
-            {
-                return FromMicrosiemens(microsiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Microsiemens.
-        /// </summary>
-        public static ElectricAdmittance? FromMicrosiemens(int? microsiemens)
-        {
-            if (microsiemens.HasValue)
-            {
-                return FromMicrosiemens(microsiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Microsiemens.
-        /// </summary>
-        public static ElectricAdmittance? FromMicrosiemens(long? microsiemens)
-        {
-            if (microsiemens.HasValue)
-            {
-                return FromMicrosiemens(microsiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from Microsiemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance? FromMicrosiemens(decimal? microsiemens)
+        public static ElectricAdmittance? FromMicrosiemens(QuantityValue? microsiemens)
         {
             if (microsiemens.HasValue)
             {
@@ -387,52 +262,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Millisiemens.
         /// </summary>
-        public static ElectricAdmittance? FromMillisiemens(double? millisiemens)
-        {
-            if (millisiemens.HasValue)
-            {
-                return FromMillisiemens(millisiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Millisiemens.
-        /// </summary>
-        public static ElectricAdmittance? FromMillisiemens(int? millisiemens)
-        {
-            if (millisiemens.HasValue)
-            {
-                return FromMillisiemens(millisiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Millisiemens.
-        /// </summary>
-        public static ElectricAdmittance? FromMillisiemens(long? millisiemens)
-        {
-            if (millisiemens.HasValue)
-            {
-                return FromMillisiemens(millisiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from Millisiemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance? FromMillisiemens(decimal? millisiemens)
+        public static ElectricAdmittance? FromMillisiemens(QuantityValue? millisiemens)
         {
             if (millisiemens.HasValue)
             {
@@ -447,52 +277,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
         /// </summary>
-        public static ElectricAdmittance? FromNanosiemens(double? nanosiemens)
-        {
-            if (nanosiemens.HasValue)
-            {
-                return FromNanosiemens(nanosiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
-        /// </summary>
-        public static ElectricAdmittance? FromNanosiemens(int? nanosiemens)
-        {
-            if (nanosiemens.HasValue)
-            {
-                return FromNanosiemens(nanosiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Nanosiemens.
-        /// </summary>
-        public static ElectricAdmittance? FromNanosiemens(long? nanosiemens)
-        {
-            if (nanosiemens.HasValue)
-            {
-                return FromNanosiemens(nanosiemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from Nanosiemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance? FromNanosiemens(decimal? nanosiemens)
+        public static ElectricAdmittance? FromNanosiemens(QuantityValue? nanosiemens)
         {
             if (nanosiemens.HasValue)
             {
@@ -507,52 +292,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricAdmittance from nullable Siemens.
         /// </summary>
-        public static ElectricAdmittance? FromSiemens(double? siemens)
-        {
-            if (siemens.HasValue)
-            {
-                return FromSiemens(siemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Siemens.
-        /// </summary>
-        public static ElectricAdmittance? FromSiemens(int? siemens)
-        {
-            if (siemens.HasValue)
-            {
-                return FromSiemens(siemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from nullable Siemens.
-        /// </summary>
-        public static ElectricAdmittance? FromSiemens(long? siemens)
-        {
-            if (siemens.HasValue)
-            {
-                return FromSiemens(siemens.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricAdmittance from Siemens of type decimal.
-        /// </summary>
-        public static ElectricAdmittance? FromSiemens(decimal? siemens)
+        public static ElectricAdmittance? FromSiemens(QuantityValue? siemens)
         {
             if (siemens.HasValue)
             {
@@ -569,21 +309,27 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricAdmittanceUnit" /> to <see cref="ElectricAdmittance" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricAdmittance unit value.</returns>
-        public static ElectricAdmittance From(double val, ElectricAdmittanceUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ElectricAdmittance From(double value, ElectricAdmittanceUnit fromUnit)
+#else
+        public static ElectricAdmittance From(QuantityValue value, ElectricAdmittanceUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ElectricAdmittanceUnit.Microsiemens:
-                    return FromMicrosiemens(val);
+                    return FromMicrosiemens(value);
                 case ElectricAdmittanceUnit.Millisiemens:
-                    return FromMillisiemens(val);
+                    return FromMillisiemens(value);
                 case ElectricAdmittanceUnit.Nanosiemens:
-                    return FromNanosiemens(val);
+                    return FromNanosiemens(value);
                 case ElectricAdmittanceUnit.Siemens:
-                    return FromSiemens(val);
+                    return FromSiemens(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -598,7 +344,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricAdmittance unit value.</returns>
-        public static ElectricAdmittance? From(double? value, ElectricAdmittanceUnit fromUnit)
+        public static ElectricAdmittance? From(QuantityValue? value, ElectricAdmittanceUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -197,266 +197,126 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Amperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromAmperes(double amperes)
         {
-            return new ElectricCurrent(amperes);
+            double value = (double) amperes;
+            return new ElectricCurrent(value);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Amperes.
-        /// </summary>
-        public static ElectricCurrent FromAmperes(int amperes)
+#else
+        public static ElectricCurrent FromAmperes(QuantityValue amperes)
         {
-            return new ElectricCurrent(amperes);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Amperes.
-        /// </summary>
-        public static ElectricCurrent FromAmperes(long amperes)
-        {
-            return new ElectricCurrent(amperes);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Amperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromAmperes(decimal amperes)
-        {
-            return new ElectricCurrent(Convert.ToDouble(amperes));
+            double value = (double) amperes;
+            return new ElectricCurrent((value));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromKiloamperes(double kiloamperes)
         {
-            return new ElectricCurrent((kiloamperes) * 1e3d);
+            double value = (double) kiloamperes;
+            return new ElectricCurrent((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Kiloamperes.
-        /// </summary>
-        public static ElectricCurrent FromKiloamperes(int kiloamperes)
+#else
+        public static ElectricCurrent FromKiloamperes(QuantityValue kiloamperes)
         {
-            return new ElectricCurrent((kiloamperes) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Kiloamperes.
-        /// </summary>
-        public static ElectricCurrent FromKiloamperes(long kiloamperes)
-        {
-            return new ElectricCurrent((kiloamperes) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Kiloamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromKiloamperes(decimal kiloamperes)
-        {
-            return new ElectricCurrent((Convert.ToDouble(kiloamperes)) * 1e3d);
+            double value = (double) kiloamperes;
+            return new ElectricCurrent(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromMegaamperes(double megaamperes)
         {
-            return new ElectricCurrent((megaamperes) * 1e6d);
+            double value = (double) megaamperes;
+            return new ElectricCurrent((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Megaamperes.
-        /// </summary>
-        public static ElectricCurrent FromMegaamperes(int megaamperes)
+#else
+        public static ElectricCurrent FromMegaamperes(QuantityValue megaamperes)
         {
-            return new ElectricCurrent((megaamperes) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Megaamperes.
-        /// </summary>
-        public static ElectricCurrent FromMegaamperes(long megaamperes)
-        {
-            return new ElectricCurrent((megaamperes) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Megaamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromMegaamperes(decimal megaamperes)
-        {
-            return new ElectricCurrent((Convert.ToDouble(megaamperes)) * 1e6d);
+            double value = (double) megaamperes;
+            return new ElectricCurrent(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromMicroamperes(double microamperes)
         {
-            return new ElectricCurrent((microamperes) * 1e-6d);
+            double value = (double) microamperes;
+            return new ElectricCurrent((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Microamperes.
-        /// </summary>
-        public static ElectricCurrent FromMicroamperes(int microamperes)
+#else
+        public static ElectricCurrent FromMicroamperes(QuantityValue microamperes)
         {
-            return new ElectricCurrent((microamperes) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Microamperes.
-        /// </summary>
-        public static ElectricCurrent FromMicroamperes(long microamperes)
-        {
-            return new ElectricCurrent((microamperes) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Microamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromMicroamperes(decimal microamperes)
-        {
-            return new ElectricCurrent((Convert.ToDouble(microamperes)) * 1e-6d);
+            double value = (double) microamperes;
+            return new ElectricCurrent(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromMilliamperes(double milliamperes)
         {
-            return new ElectricCurrent((milliamperes) * 1e-3d);
+            double value = (double) milliamperes;
+            return new ElectricCurrent((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Milliamperes.
-        /// </summary>
-        public static ElectricCurrent FromMilliamperes(int milliamperes)
+#else
+        public static ElectricCurrent FromMilliamperes(QuantityValue milliamperes)
         {
-            return new ElectricCurrent((milliamperes) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Milliamperes.
-        /// </summary>
-        public static ElectricCurrent FromMilliamperes(long milliamperes)
-        {
-            return new ElectricCurrent((milliamperes) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Milliamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromMilliamperes(decimal milliamperes)
-        {
-            return new ElectricCurrent((Convert.ToDouble(milliamperes)) * 1e-3d);
+            double value = (double) milliamperes;
+            return new ElectricCurrent(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromNanoamperes(double nanoamperes)
         {
-            return new ElectricCurrent((nanoamperes) * 1e-9d);
+            double value = (double) nanoamperes;
+            return new ElectricCurrent((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Nanoamperes.
-        /// </summary>
-        public static ElectricCurrent FromNanoamperes(int nanoamperes)
+#else
+        public static ElectricCurrent FromNanoamperes(QuantityValue nanoamperes)
         {
-            return new ElectricCurrent((nanoamperes) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Nanoamperes.
-        /// </summary>
-        public static ElectricCurrent FromNanoamperes(long nanoamperes)
-        {
-            return new ElectricCurrent((nanoamperes) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Nanoamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromNanoamperes(decimal nanoamperes)
-        {
-            return new ElectricCurrent((Convert.ToDouble(nanoamperes)) * 1e-9d);
+            double value = (double) nanoamperes;
+            return new ElectricCurrent(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricCurrent FromPicoamperes(double picoamperes)
         {
-            return new ElectricCurrent((picoamperes) * 1e-12d);
+            double value = (double) picoamperes;
+            return new ElectricCurrent((value) * 1e-12d);
         }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Picoamperes.
-        /// </summary>
-        public static ElectricCurrent FromPicoamperes(int picoamperes)
+#else
+        public static ElectricCurrent FromPicoamperes(QuantityValue picoamperes)
         {
-            return new ElectricCurrent((picoamperes) * 1e-12d);
-        }
-
-        /// <summary>
-        ///     Get ElectricCurrent from Picoamperes.
-        /// </summary>
-        public static ElectricCurrent FromPicoamperes(long picoamperes)
-        {
-            return new ElectricCurrent((picoamperes) * 1e-12d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricCurrent from Picoamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent FromPicoamperes(decimal picoamperes)
-        {
-            return new ElectricCurrent((Convert.ToDouble(picoamperes)) * 1e-12d);
+            double value = (double) picoamperes;
+            return new ElectricCurrent(((value) * 1e-12d));
         }
 #endif
 
@@ -465,52 +325,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Amperes.
         /// </summary>
-        public static ElectricCurrent? FromAmperes(double? amperes)
-        {
-            if (amperes.HasValue)
-            {
-                return FromAmperes(amperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Amperes.
-        /// </summary>
-        public static ElectricCurrent? FromAmperes(int? amperes)
-        {
-            if (amperes.HasValue)
-            {
-                return FromAmperes(amperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Amperes.
-        /// </summary>
-        public static ElectricCurrent? FromAmperes(long? amperes)
-        {
-            if (amperes.HasValue)
-            {
-                return FromAmperes(amperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Amperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromAmperes(decimal? amperes)
+        public static ElectricCurrent? FromAmperes(QuantityValue? amperes)
         {
             if (amperes.HasValue)
             {
@@ -525,52 +340,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Kiloamperes.
         /// </summary>
-        public static ElectricCurrent? FromKiloamperes(double? kiloamperes)
-        {
-            if (kiloamperes.HasValue)
-            {
-                return FromKiloamperes(kiloamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Kiloamperes.
-        /// </summary>
-        public static ElectricCurrent? FromKiloamperes(int? kiloamperes)
-        {
-            if (kiloamperes.HasValue)
-            {
-                return FromKiloamperes(kiloamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Kiloamperes.
-        /// </summary>
-        public static ElectricCurrent? FromKiloamperes(long? kiloamperes)
-        {
-            if (kiloamperes.HasValue)
-            {
-                return FromKiloamperes(kiloamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Kiloamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromKiloamperes(decimal? kiloamperes)
+        public static ElectricCurrent? FromKiloamperes(QuantityValue? kiloamperes)
         {
             if (kiloamperes.HasValue)
             {
@@ -585,52 +355,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Megaamperes.
         /// </summary>
-        public static ElectricCurrent? FromMegaamperes(double? megaamperes)
-        {
-            if (megaamperes.HasValue)
-            {
-                return FromMegaamperes(megaamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Megaamperes.
-        /// </summary>
-        public static ElectricCurrent? FromMegaamperes(int? megaamperes)
-        {
-            if (megaamperes.HasValue)
-            {
-                return FromMegaamperes(megaamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Megaamperes.
-        /// </summary>
-        public static ElectricCurrent? FromMegaamperes(long? megaamperes)
-        {
-            if (megaamperes.HasValue)
-            {
-                return FromMegaamperes(megaamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Megaamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromMegaamperes(decimal? megaamperes)
+        public static ElectricCurrent? FromMegaamperes(QuantityValue? megaamperes)
         {
             if (megaamperes.HasValue)
             {
@@ -645,52 +370,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Microamperes.
         /// </summary>
-        public static ElectricCurrent? FromMicroamperes(double? microamperes)
-        {
-            if (microamperes.HasValue)
-            {
-                return FromMicroamperes(microamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Microamperes.
-        /// </summary>
-        public static ElectricCurrent? FromMicroamperes(int? microamperes)
-        {
-            if (microamperes.HasValue)
-            {
-                return FromMicroamperes(microamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Microamperes.
-        /// </summary>
-        public static ElectricCurrent? FromMicroamperes(long? microamperes)
-        {
-            if (microamperes.HasValue)
-            {
-                return FromMicroamperes(microamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Microamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromMicroamperes(decimal? microamperes)
+        public static ElectricCurrent? FromMicroamperes(QuantityValue? microamperes)
         {
             if (microamperes.HasValue)
             {
@@ -705,52 +385,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Milliamperes.
         /// </summary>
-        public static ElectricCurrent? FromMilliamperes(double? milliamperes)
-        {
-            if (milliamperes.HasValue)
-            {
-                return FromMilliamperes(milliamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Milliamperes.
-        /// </summary>
-        public static ElectricCurrent? FromMilliamperes(int? milliamperes)
-        {
-            if (milliamperes.HasValue)
-            {
-                return FromMilliamperes(milliamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Milliamperes.
-        /// </summary>
-        public static ElectricCurrent? FromMilliamperes(long? milliamperes)
-        {
-            if (milliamperes.HasValue)
-            {
-                return FromMilliamperes(milliamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Milliamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromMilliamperes(decimal? milliamperes)
+        public static ElectricCurrent? FromMilliamperes(QuantityValue? milliamperes)
         {
             if (milliamperes.HasValue)
             {
@@ -765,52 +400,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Nanoamperes.
         /// </summary>
-        public static ElectricCurrent? FromNanoamperes(double? nanoamperes)
-        {
-            if (nanoamperes.HasValue)
-            {
-                return FromNanoamperes(nanoamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Nanoamperes.
-        /// </summary>
-        public static ElectricCurrent? FromNanoamperes(int? nanoamperes)
-        {
-            if (nanoamperes.HasValue)
-            {
-                return FromNanoamperes(nanoamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Nanoamperes.
-        /// </summary>
-        public static ElectricCurrent? FromNanoamperes(long? nanoamperes)
-        {
-            if (nanoamperes.HasValue)
-            {
-                return FromNanoamperes(nanoamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Nanoamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromNanoamperes(decimal? nanoamperes)
+        public static ElectricCurrent? FromNanoamperes(QuantityValue? nanoamperes)
         {
             if (nanoamperes.HasValue)
             {
@@ -825,52 +415,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricCurrent from nullable Picoamperes.
         /// </summary>
-        public static ElectricCurrent? FromPicoamperes(double? picoamperes)
-        {
-            if (picoamperes.HasValue)
-            {
-                return FromPicoamperes(picoamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Picoamperes.
-        /// </summary>
-        public static ElectricCurrent? FromPicoamperes(int? picoamperes)
-        {
-            if (picoamperes.HasValue)
-            {
-                return FromPicoamperes(picoamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from nullable Picoamperes.
-        /// </summary>
-        public static ElectricCurrent? FromPicoamperes(long? picoamperes)
-        {
-            if (picoamperes.HasValue)
-            {
-                return FromPicoamperes(picoamperes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricCurrent from Picoamperes of type decimal.
-        /// </summary>
-        public static ElectricCurrent? FromPicoamperes(decimal? picoamperes)
+        public static ElectricCurrent? FromPicoamperes(QuantityValue? picoamperes)
         {
             if (picoamperes.HasValue)
             {
@@ -887,27 +432,33 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricCurrentUnit" /> to <see cref="ElectricCurrent" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricCurrent unit value.</returns>
-        public static ElectricCurrent From(double val, ElectricCurrentUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ElectricCurrent From(double value, ElectricCurrentUnit fromUnit)
+#else
+        public static ElectricCurrent From(QuantityValue value, ElectricCurrentUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ElectricCurrentUnit.Ampere:
-                    return FromAmperes(val);
+                    return FromAmperes(value);
                 case ElectricCurrentUnit.Kiloampere:
-                    return FromKiloamperes(val);
+                    return FromKiloamperes(value);
                 case ElectricCurrentUnit.Megaampere:
-                    return FromMegaamperes(val);
+                    return FromMegaamperes(value);
                 case ElectricCurrentUnit.Microampere:
-                    return FromMicroamperes(val);
+                    return FromMicroamperes(value);
                 case ElectricCurrentUnit.Milliampere:
-                    return FromMilliamperes(val);
+                    return FromMilliamperes(value);
                 case ElectricCurrentUnit.Nanoampere:
-                    return FromNanoamperes(val);
+                    return FromNanoamperes(value);
                 case ElectricCurrentUnit.Picoampere:
-                    return FromPicoamperes(val);
+                    return FromPicoamperes(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -922,7 +473,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricCurrent unit value.</returns>
-        public static ElectricCurrent? From(double? value, ElectricCurrentUnit fromUnit)
+        public static ElectricCurrent? From(QuantityValue? value, ElectricCurrentUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -181,190 +181,90 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Kilovolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotential FromKilovolts(double kilovolts)
         {
-            return new ElectricPotential((kilovolts) * 1e3d);
+            double value = (double) kilovolts;
+            return new ElectricPotential((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotential from Kilovolts.
-        /// </summary>
-        public static ElectricPotential FromKilovolts(int kilovolts)
+#else
+        public static ElectricPotential FromKilovolts(QuantityValue kilovolts)
         {
-            return new ElectricPotential((kilovolts) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotential from Kilovolts.
-        /// </summary>
-        public static ElectricPotential FromKilovolts(long kilovolts)
-        {
-            return new ElectricPotential((kilovolts) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotential from Kilovolts of type decimal.
-        /// </summary>
-        public static ElectricPotential FromKilovolts(decimal kilovolts)
-        {
-            return new ElectricPotential((Convert.ToDouble(kilovolts)) * 1e3d);
+            double value = (double) kilovolts;
+            return new ElectricPotential(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotential FromMegavolts(double megavolts)
         {
-            return new ElectricPotential((megavolts) * 1e6d);
+            double value = (double) megavolts;
+            return new ElectricPotential((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotential from Megavolts.
-        /// </summary>
-        public static ElectricPotential FromMegavolts(int megavolts)
+#else
+        public static ElectricPotential FromMegavolts(QuantityValue megavolts)
         {
-            return new ElectricPotential((megavolts) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotential from Megavolts.
-        /// </summary>
-        public static ElectricPotential FromMegavolts(long megavolts)
-        {
-            return new ElectricPotential((megavolts) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotential from Megavolts of type decimal.
-        /// </summary>
-        public static ElectricPotential FromMegavolts(decimal megavolts)
-        {
-            return new ElectricPotential((Convert.ToDouble(megavolts)) * 1e6d);
+            double value = (double) megavolts;
+            return new ElectricPotential(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotential FromMicrovolts(double microvolts)
         {
-            return new ElectricPotential((microvolts) * 1e-6d);
+            double value = (double) microvolts;
+            return new ElectricPotential((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotential from Microvolts.
-        /// </summary>
-        public static ElectricPotential FromMicrovolts(int microvolts)
+#else
+        public static ElectricPotential FromMicrovolts(QuantityValue microvolts)
         {
-            return new ElectricPotential((microvolts) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotential from Microvolts.
-        /// </summary>
-        public static ElectricPotential FromMicrovolts(long microvolts)
-        {
-            return new ElectricPotential((microvolts) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotential from Microvolts of type decimal.
-        /// </summary>
-        public static ElectricPotential FromMicrovolts(decimal microvolts)
-        {
-            return new ElectricPotential((Convert.ToDouble(microvolts)) * 1e-6d);
+            double value = (double) microvolts;
+            return new ElectricPotential(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotential FromMillivolts(double millivolts)
         {
-            return new ElectricPotential((millivolts) * 1e-3d);
+            double value = (double) millivolts;
+            return new ElectricPotential((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotential from Millivolts.
-        /// </summary>
-        public static ElectricPotential FromMillivolts(int millivolts)
+#else
+        public static ElectricPotential FromMillivolts(QuantityValue millivolts)
         {
-            return new ElectricPotential((millivolts) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotential from Millivolts.
-        /// </summary>
-        public static ElectricPotential FromMillivolts(long millivolts)
-        {
-            return new ElectricPotential((millivolts) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotential from Millivolts of type decimal.
-        /// </summary>
-        public static ElectricPotential FromMillivolts(decimal millivolts)
-        {
-            return new ElectricPotential((Convert.ToDouble(millivolts)) * 1e-3d);
+            double value = (double) millivolts;
+            return new ElectricPotential(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotential from Volts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotential FromVolts(double volts)
         {
-            return new ElectricPotential(volts);
+            double value = (double) volts;
+            return new ElectricPotential(value);
         }
-
-        /// <summary>
-        ///     Get ElectricPotential from Volts.
-        /// </summary>
-        public static ElectricPotential FromVolts(int volts)
+#else
+        public static ElectricPotential FromVolts(QuantityValue volts)
         {
-            return new ElectricPotential(volts);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotential from Volts.
-        /// </summary>
-        public static ElectricPotential FromVolts(long volts)
-        {
-            return new ElectricPotential(volts);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotential from Volts of type decimal.
-        /// </summary>
-        public static ElectricPotential FromVolts(decimal volts)
-        {
-            return new ElectricPotential(Convert.ToDouble(volts));
+            double value = (double) volts;
+            return new ElectricPotential((value));
         }
 #endif
 
@@ -373,52 +273,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Kilovolts.
         /// </summary>
-        public static ElectricPotential? FromKilovolts(double? kilovolts)
-        {
-            if (kilovolts.HasValue)
-            {
-                return FromKilovolts(kilovolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Kilovolts.
-        /// </summary>
-        public static ElectricPotential? FromKilovolts(int? kilovolts)
-        {
-            if (kilovolts.HasValue)
-            {
-                return FromKilovolts(kilovolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Kilovolts.
-        /// </summary>
-        public static ElectricPotential? FromKilovolts(long? kilovolts)
-        {
-            if (kilovolts.HasValue)
-            {
-                return FromKilovolts(kilovolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from Kilovolts of type decimal.
-        /// </summary>
-        public static ElectricPotential? FromKilovolts(decimal? kilovolts)
+        public static ElectricPotential? FromKilovolts(QuantityValue? kilovolts)
         {
             if (kilovolts.HasValue)
             {
@@ -433,52 +288,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Megavolts.
         /// </summary>
-        public static ElectricPotential? FromMegavolts(double? megavolts)
-        {
-            if (megavolts.HasValue)
-            {
-                return FromMegavolts(megavolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Megavolts.
-        /// </summary>
-        public static ElectricPotential? FromMegavolts(int? megavolts)
-        {
-            if (megavolts.HasValue)
-            {
-                return FromMegavolts(megavolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Megavolts.
-        /// </summary>
-        public static ElectricPotential? FromMegavolts(long? megavolts)
-        {
-            if (megavolts.HasValue)
-            {
-                return FromMegavolts(megavolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from Megavolts of type decimal.
-        /// </summary>
-        public static ElectricPotential? FromMegavolts(decimal? megavolts)
+        public static ElectricPotential? FromMegavolts(QuantityValue? megavolts)
         {
             if (megavolts.HasValue)
             {
@@ -493,52 +303,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Microvolts.
         /// </summary>
-        public static ElectricPotential? FromMicrovolts(double? microvolts)
-        {
-            if (microvolts.HasValue)
-            {
-                return FromMicrovolts(microvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Microvolts.
-        /// </summary>
-        public static ElectricPotential? FromMicrovolts(int? microvolts)
-        {
-            if (microvolts.HasValue)
-            {
-                return FromMicrovolts(microvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Microvolts.
-        /// </summary>
-        public static ElectricPotential? FromMicrovolts(long? microvolts)
-        {
-            if (microvolts.HasValue)
-            {
-                return FromMicrovolts(microvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from Microvolts of type decimal.
-        /// </summary>
-        public static ElectricPotential? FromMicrovolts(decimal? microvolts)
+        public static ElectricPotential? FromMicrovolts(QuantityValue? microvolts)
         {
             if (microvolts.HasValue)
             {
@@ -553,52 +318,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Millivolts.
         /// </summary>
-        public static ElectricPotential? FromMillivolts(double? millivolts)
-        {
-            if (millivolts.HasValue)
-            {
-                return FromMillivolts(millivolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Millivolts.
-        /// </summary>
-        public static ElectricPotential? FromMillivolts(int? millivolts)
-        {
-            if (millivolts.HasValue)
-            {
-                return FromMillivolts(millivolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Millivolts.
-        /// </summary>
-        public static ElectricPotential? FromMillivolts(long? millivolts)
-        {
-            if (millivolts.HasValue)
-            {
-                return FromMillivolts(millivolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from Millivolts of type decimal.
-        /// </summary>
-        public static ElectricPotential? FromMillivolts(decimal? millivolts)
+        public static ElectricPotential? FromMillivolts(QuantityValue? millivolts)
         {
             if (millivolts.HasValue)
             {
@@ -613,52 +333,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotential from nullable Volts.
         /// </summary>
-        public static ElectricPotential? FromVolts(double? volts)
-        {
-            if (volts.HasValue)
-            {
-                return FromVolts(volts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Volts.
-        /// </summary>
-        public static ElectricPotential? FromVolts(int? volts)
-        {
-            if (volts.HasValue)
-            {
-                return FromVolts(volts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from nullable Volts.
-        /// </summary>
-        public static ElectricPotential? FromVolts(long? volts)
-        {
-            if (volts.HasValue)
-            {
-                return FromVolts(volts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotential from Volts of type decimal.
-        /// </summary>
-        public static ElectricPotential? FromVolts(decimal? volts)
+        public static ElectricPotential? FromVolts(QuantityValue? volts)
         {
             if (volts.HasValue)
             {
@@ -675,23 +350,29 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricPotentialUnit" /> to <see cref="ElectricPotential" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricPotential unit value.</returns>
-        public static ElectricPotential From(double val, ElectricPotentialUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ElectricPotential From(double value, ElectricPotentialUnit fromUnit)
+#else
+        public static ElectricPotential From(QuantityValue value, ElectricPotentialUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ElectricPotentialUnit.Kilovolt:
-                    return FromKilovolts(val);
+                    return FromKilovolts(value);
                 case ElectricPotentialUnit.Megavolt:
-                    return FromMegavolts(val);
+                    return FromMegavolts(value);
                 case ElectricPotentialUnit.Microvolt:
-                    return FromMicrovolts(val);
+                    return FromMicrovolts(value);
                 case ElectricPotentialUnit.Millivolt:
-                    return FromMillivolts(val);
+                    return FromMillivolts(value);
                 case ElectricPotentialUnit.Volt:
-                    return FromVolts(val);
+                    return FromVolts(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -706,7 +387,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricPotential unit value.</returns>
-        public static ElectricPotential? From(double? value, ElectricPotentialUnit fromUnit)
+        public static ElectricPotential? From(QuantityValue? value, ElectricPotentialUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -181,190 +181,90 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialAc FromKilovoltsAc(double kilovoltsac)
         {
-            return new ElectricPotentialAc((kilovoltsac) * 1e3d);
+            double value = (double) kilovoltsac;
+            return new ElectricPotentialAc((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from KilovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromKilovoltsAc(int kilovoltsac)
+#else
+        public static ElectricPotentialAc FromKilovoltsAc(QuantityValue kilovoltsac)
         {
-            return new ElectricPotentialAc((kilovoltsac) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from KilovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromKilovoltsAc(long kilovoltsac)
-        {
-            return new ElectricPotentialAc((kilovoltsac) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialAc from KilovoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc FromKilovoltsAc(decimal kilovoltsac)
-        {
-            return new ElectricPotentialAc((Convert.ToDouble(kilovoltsac)) * 1e3d);
+            double value = (double) kilovoltsac;
+            return new ElectricPotentialAc(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialAc FromMegavoltsAc(double megavoltsac)
         {
-            return new ElectricPotentialAc((megavoltsac) * 1e6d);
+            double value = (double) megavoltsac;
+            return new ElectricPotentialAc((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from MegavoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromMegavoltsAc(int megavoltsac)
+#else
+        public static ElectricPotentialAc FromMegavoltsAc(QuantityValue megavoltsac)
         {
-            return new ElectricPotentialAc((megavoltsac) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from MegavoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromMegavoltsAc(long megavoltsac)
-        {
-            return new ElectricPotentialAc((megavoltsac) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialAc from MegavoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc FromMegavoltsAc(decimal megavoltsac)
-        {
-            return new ElectricPotentialAc((Convert.ToDouble(megavoltsac)) * 1e6d);
+            double value = (double) megavoltsac;
+            return new ElectricPotentialAc(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialAc FromMicrovoltsAc(double microvoltsac)
         {
-            return new ElectricPotentialAc((microvoltsac) * 1e-6d);
+            double value = (double) microvoltsac;
+            return new ElectricPotentialAc((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from MicrovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromMicrovoltsAc(int microvoltsac)
+#else
+        public static ElectricPotentialAc FromMicrovoltsAc(QuantityValue microvoltsac)
         {
-            return new ElectricPotentialAc((microvoltsac) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from MicrovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromMicrovoltsAc(long microvoltsac)
-        {
-            return new ElectricPotentialAc((microvoltsac) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialAc from MicrovoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc FromMicrovoltsAc(decimal microvoltsac)
-        {
-            return new ElectricPotentialAc((Convert.ToDouble(microvoltsac)) * 1e-6d);
+            double value = (double) microvoltsac;
+            return new ElectricPotentialAc(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialAc FromMillivoltsAc(double millivoltsac)
         {
-            return new ElectricPotentialAc((millivoltsac) * 1e-3d);
+            double value = (double) millivoltsac;
+            return new ElectricPotentialAc((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from MillivoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromMillivoltsAc(int millivoltsac)
+#else
+        public static ElectricPotentialAc FromMillivoltsAc(QuantityValue millivoltsac)
         {
-            return new ElectricPotentialAc((millivoltsac) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from MillivoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromMillivoltsAc(long millivoltsac)
-        {
-            return new ElectricPotentialAc((millivoltsac) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialAc from MillivoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc FromMillivoltsAc(decimal millivoltsac)
-        {
-            return new ElectricPotentialAc((Convert.ToDouble(millivoltsac)) * 1e-3d);
+            double value = (double) millivoltsac;
+            return new ElectricPotentialAc(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialAc FromVoltsAc(double voltsac)
         {
-            return new ElectricPotentialAc(voltsac);
+            double value = (double) voltsac;
+            return new ElectricPotentialAc(value);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from VoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromVoltsAc(int voltsac)
+#else
+        public static ElectricPotentialAc FromVoltsAc(QuantityValue voltsac)
         {
-            return new ElectricPotentialAc(voltsac);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialAc from VoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc FromVoltsAc(long voltsac)
-        {
-            return new ElectricPotentialAc(voltsac);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialAc from VoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc FromVoltsAc(decimal voltsac)
-        {
-            return new ElectricPotentialAc(Convert.ToDouble(voltsac));
+            double value = (double) voltsac;
+            return new ElectricPotentialAc((value));
         }
 #endif
 
@@ -373,52 +273,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
         /// </summary>
-        public static ElectricPotentialAc? FromKilovoltsAc(double? kilovoltsac)
-        {
-            if (kilovoltsac.HasValue)
-            {
-                return FromKilovoltsAc(kilovoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromKilovoltsAc(int? kilovoltsac)
-        {
-            if (kilovoltsac.HasValue)
-            {
-                return FromKilovoltsAc(kilovoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable KilovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromKilovoltsAc(long? kilovoltsac)
-        {
-            if (kilovoltsac.HasValue)
-            {
-                return FromKilovoltsAc(kilovoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from KilovoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc? FromKilovoltsAc(decimal? kilovoltsac)
+        public static ElectricPotentialAc? FromKilovoltsAc(QuantityValue? kilovoltsac)
         {
             if (kilovoltsac.HasValue)
             {
@@ -433,52 +288,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
         /// </summary>
-        public static ElectricPotentialAc? FromMegavoltsAc(double? megavoltsac)
-        {
-            if (megavoltsac.HasValue)
-            {
-                return FromMegavoltsAc(megavoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromMegavoltsAc(int? megavoltsac)
-        {
-            if (megavoltsac.HasValue)
-            {
-                return FromMegavoltsAc(megavoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable MegavoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromMegavoltsAc(long? megavoltsac)
-        {
-            if (megavoltsac.HasValue)
-            {
-                return FromMegavoltsAc(megavoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from MegavoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc? FromMegavoltsAc(decimal? megavoltsac)
+        public static ElectricPotentialAc? FromMegavoltsAc(QuantityValue? megavoltsac)
         {
             if (megavoltsac.HasValue)
             {
@@ -493,52 +303,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
         /// </summary>
-        public static ElectricPotentialAc? FromMicrovoltsAc(double? microvoltsac)
-        {
-            if (microvoltsac.HasValue)
-            {
-                return FromMicrovoltsAc(microvoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromMicrovoltsAc(int? microvoltsac)
-        {
-            if (microvoltsac.HasValue)
-            {
-                return FromMicrovoltsAc(microvoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable MicrovoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromMicrovoltsAc(long? microvoltsac)
-        {
-            if (microvoltsac.HasValue)
-            {
-                return FromMicrovoltsAc(microvoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from MicrovoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc? FromMicrovoltsAc(decimal? microvoltsac)
+        public static ElectricPotentialAc? FromMicrovoltsAc(QuantityValue? microvoltsac)
         {
             if (microvoltsac.HasValue)
             {
@@ -553,52 +318,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
         /// </summary>
-        public static ElectricPotentialAc? FromMillivoltsAc(double? millivoltsac)
-        {
-            if (millivoltsac.HasValue)
-            {
-                return FromMillivoltsAc(millivoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromMillivoltsAc(int? millivoltsac)
-        {
-            if (millivoltsac.HasValue)
-            {
-                return FromMillivoltsAc(millivoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable MillivoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromMillivoltsAc(long? millivoltsac)
-        {
-            if (millivoltsac.HasValue)
-            {
-                return FromMillivoltsAc(millivoltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from MillivoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc? FromMillivoltsAc(decimal? millivoltsac)
+        public static ElectricPotentialAc? FromMillivoltsAc(QuantityValue? millivoltsac)
         {
             if (millivoltsac.HasValue)
             {
@@ -613,52 +333,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
         /// </summary>
-        public static ElectricPotentialAc? FromVoltsAc(double? voltsac)
-        {
-            if (voltsac.HasValue)
-            {
-                return FromVoltsAc(voltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromVoltsAc(int? voltsac)
-        {
-            if (voltsac.HasValue)
-            {
-                return FromVoltsAc(voltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from nullable VoltsAc.
-        /// </summary>
-        public static ElectricPotentialAc? FromVoltsAc(long? voltsac)
-        {
-            if (voltsac.HasValue)
-            {
-                return FromVoltsAc(voltsac.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialAc from VoltsAc of type decimal.
-        /// </summary>
-        public static ElectricPotentialAc? FromVoltsAc(decimal? voltsac)
+        public static ElectricPotentialAc? FromVoltsAc(QuantityValue? voltsac)
         {
             if (voltsac.HasValue)
             {
@@ -675,23 +350,29 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricPotentialAcUnit" /> to <see cref="ElectricPotentialAc" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricPotentialAc unit value.</returns>
-        public static ElectricPotentialAc From(double val, ElectricPotentialAcUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ElectricPotentialAc From(double value, ElectricPotentialAcUnit fromUnit)
+#else
+        public static ElectricPotentialAc From(QuantityValue value, ElectricPotentialAcUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ElectricPotentialAcUnit.KilovoltAc:
-                    return FromKilovoltsAc(val);
+                    return FromKilovoltsAc(value);
                 case ElectricPotentialAcUnit.MegavoltAc:
-                    return FromMegavoltsAc(val);
+                    return FromMegavoltsAc(value);
                 case ElectricPotentialAcUnit.MicrovoltAc:
-                    return FromMicrovoltsAc(val);
+                    return FromMicrovoltsAc(value);
                 case ElectricPotentialAcUnit.MillivoltAc:
-                    return FromMillivoltsAc(val);
+                    return FromMillivoltsAc(value);
                 case ElectricPotentialAcUnit.VoltAc:
-                    return FromVoltsAc(val);
+                    return FromVoltsAc(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -706,7 +387,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricPotentialAc unit value.</returns>
-        public static ElectricPotentialAc? From(double? value, ElectricPotentialAcUnit fromUnit)
+        public static ElectricPotentialAc? From(QuantityValue? value, ElectricPotentialAcUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -181,190 +181,90 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialDc FromKilovoltsDc(double kilovoltsdc)
         {
-            return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
+            double value = (double) kilovoltsdc;
+            return new ElectricPotentialDc((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from KilovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromKilovoltsDc(int kilovoltsdc)
+#else
+        public static ElectricPotentialDc FromKilovoltsDc(QuantityValue kilovoltsdc)
         {
-            return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from KilovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromKilovoltsDc(long kilovoltsdc)
-        {
-            return new ElectricPotentialDc((kilovoltsdc) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialDc from KilovoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc FromKilovoltsDc(decimal kilovoltsdc)
-        {
-            return new ElectricPotentialDc((Convert.ToDouble(kilovoltsdc)) * 1e3d);
+            double value = (double) kilovoltsdc;
+            return new ElectricPotentialDc(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialDc FromMegavoltsDc(double megavoltsdc)
         {
-            return new ElectricPotentialDc((megavoltsdc) * 1e6d);
+            double value = (double) megavoltsdc;
+            return new ElectricPotentialDc((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from MegavoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromMegavoltsDc(int megavoltsdc)
+#else
+        public static ElectricPotentialDc FromMegavoltsDc(QuantityValue megavoltsdc)
         {
-            return new ElectricPotentialDc((megavoltsdc) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from MegavoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromMegavoltsDc(long megavoltsdc)
-        {
-            return new ElectricPotentialDc((megavoltsdc) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialDc from MegavoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc FromMegavoltsDc(decimal megavoltsdc)
-        {
-            return new ElectricPotentialDc((Convert.ToDouble(megavoltsdc)) * 1e6d);
+            double value = (double) megavoltsdc;
+            return new ElectricPotentialDc(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialDc FromMicrovoltsDc(double microvoltsdc)
         {
-            return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
+            double value = (double) microvoltsdc;
+            return new ElectricPotentialDc((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from MicrovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromMicrovoltsDc(int microvoltsdc)
+#else
+        public static ElectricPotentialDc FromMicrovoltsDc(QuantityValue microvoltsdc)
         {
-            return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from MicrovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromMicrovoltsDc(long microvoltsdc)
-        {
-            return new ElectricPotentialDc((microvoltsdc) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialDc from MicrovoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc FromMicrovoltsDc(decimal microvoltsdc)
-        {
-            return new ElectricPotentialDc((Convert.ToDouble(microvoltsdc)) * 1e-6d);
+            double value = (double) microvoltsdc;
+            return new ElectricPotentialDc(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialDc FromMillivoltsDc(double millivoltsdc)
         {
-            return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
+            double value = (double) millivoltsdc;
+            return new ElectricPotentialDc((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from MillivoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromMillivoltsDc(int millivoltsdc)
+#else
+        public static ElectricPotentialDc FromMillivoltsDc(QuantityValue millivoltsdc)
         {
-            return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from MillivoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromMillivoltsDc(long millivoltsdc)
-        {
-            return new ElectricPotentialDc((millivoltsdc) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialDc from MillivoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc FromMillivoltsDc(decimal millivoltsdc)
-        {
-            return new ElectricPotentialDc((Convert.ToDouble(millivoltsdc)) * 1e-3d);
+            double value = (double) millivoltsdc;
+            return new ElectricPotentialDc(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricPotentialDc FromVoltsDc(double voltsdc)
         {
-            return new ElectricPotentialDc(voltsdc);
+            double value = (double) voltsdc;
+            return new ElectricPotentialDc(value);
         }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from VoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromVoltsDc(int voltsdc)
+#else
+        public static ElectricPotentialDc FromVoltsDc(QuantityValue voltsdc)
         {
-            return new ElectricPotentialDc(voltsdc);
-        }
-
-        /// <summary>
-        ///     Get ElectricPotentialDc from VoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc FromVoltsDc(long voltsdc)
-        {
-            return new ElectricPotentialDc(voltsdc);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricPotentialDc from VoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc FromVoltsDc(decimal voltsdc)
-        {
-            return new ElectricPotentialDc(Convert.ToDouble(voltsdc));
+            double value = (double) voltsdc;
+            return new ElectricPotentialDc((value));
         }
 #endif
 
@@ -373,52 +273,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
         /// </summary>
-        public static ElectricPotentialDc? FromKilovoltsDc(double? kilovoltsdc)
-        {
-            if (kilovoltsdc.HasValue)
-            {
-                return FromKilovoltsDc(kilovoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromKilovoltsDc(int? kilovoltsdc)
-        {
-            if (kilovoltsdc.HasValue)
-            {
-                return FromKilovoltsDc(kilovoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable KilovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromKilovoltsDc(long? kilovoltsdc)
-        {
-            if (kilovoltsdc.HasValue)
-            {
-                return FromKilovoltsDc(kilovoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from KilovoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc? FromKilovoltsDc(decimal? kilovoltsdc)
+        public static ElectricPotentialDc? FromKilovoltsDc(QuantityValue? kilovoltsdc)
         {
             if (kilovoltsdc.HasValue)
             {
@@ -433,52 +288,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
         /// </summary>
-        public static ElectricPotentialDc? FromMegavoltsDc(double? megavoltsdc)
-        {
-            if (megavoltsdc.HasValue)
-            {
-                return FromMegavoltsDc(megavoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromMegavoltsDc(int? megavoltsdc)
-        {
-            if (megavoltsdc.HasValue)
-            {
-                return FromMegavoltsDc(megavoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable MegavoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromMegavoltsDc(long? megavoltsdc)
-        {
-            if (megavoltsdc.HasValue)
-            {
-                return FromMegavoltsDc(megavoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from MegavoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc? FromMegavoltsDc(decimal? megavoltsdc)
+        public static ElectricPotentialDc? FromMegavoltsDc(QuantityValue? megavoltsdc)
         {
             if (megavoltsdc.HasValue)
             {
@@ -493,52 +303,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
         /// </summary>
-        public static ElectricPotentialDc? FromMicrovoltsDc(double? microvoltsdc)
-        {
-            if (microvoltsdc.HasValue)
-            {
-                return FromMicrovoltsDc(microvoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromMicrovoltsDc(int? microvoltsdc)
-        {
-            if (microvoltsdc.HasValue)
-            {
-                return FromMicrovoltsDc(microvoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable MicrovoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromMicrovoltsDc(long? microvoltsdc)
-        {
-            if (microvoltsdc.HasValue)
-            {
-                return FromMicrovoltsDc(microvoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from MicrovoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc? FromMicrovoltsDc(decimal? microvoltsdc)
+        public static ElectricPotentialDc? FromMicrovoltsDc(QuantityValue? microvoltsdc)
         {
             if (microvoltsdc.HasValue)
             {
@@ -553,52 +318,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
         /// </summary>
-        public static ElectricPotentialDc? FromMillivoltsDc(double? millivoltsdc)
-        {
-            if (millivoltsdc.HasValue)
-            {
-                return FromMillivoltsDc(millivoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromMillivoltsDc(int? millivoltsdc)
-        {
-            if (millivoltsdc.HasValue)
-            {
-                return FromMillivoltsDc(millivoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable MillivoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromMillivoltsDc(long? millivoltsdc)
-        {
-            if (millivoltsdc.HasValue)
-            {
-                return FromMillivoltsDc(millivoltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from MillivoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc? FromMillivoltsDc(decimal? millivoltsdc)
+        public static ElectricPotentialDc? FromMillivoltsDc(QuantityValue? millivoltsdc)
         {
             if (millivoltsdc.HasValue)
             {
@@ -613,52 +333,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
         /// </summary>
-        public static ElectricPotentialDc? FromVoltsDc(double? voltsdc)
-        {
-            if (voltsdc.HasValue)
-            {
-                return FromVoltsDc(voltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromVoltsDc(int? voltsdc)
-        {
-            if (voltsdc.HasValue)
-            {
-                return FromVoltsDc(voltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from nullable VoltsDc.
-        /// </summary>
-        public static ElectricPotentialDc? FromVoltsDc(long? voltsdc)
-        {
-            if (voltsdc.HasValue)
-            {
-                return FromVoltsDc(voltsdc.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricPotentialDc from VoltsDc of type decimal.
-        /// </summary>
-        public static ElectricPotentialDc? FromVoltsDc(decimal? voltsdc)
+        public static ElectricPotentialDc? FromVoltsDc(QuantityValue? voltsdc)
         {
             if (voltsdc.HasValue)
             {
@@ -675,23 +350,29 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricPotentialDcUnit" /> to <see cref="ElectricPotentialDc" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricPotentialDc unit value.</returns>
-        public static ElectricPotentialDc From(double val, ElectricPotentialDcUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ElectricPotentialDc From(double value, ElectricPotentialDcUnit fromUnit)
+#else
+        public static ElectricPotentialDc From(QuantityValue value, ElectricPotentialDcUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ElectricPotentialDcUnit.KilovoltDc:
-                    return FromKilovoltsDc(val);
+                    return FromKilovoltsDc(value);
                 case ElectricPotentialDcUnit.MegavoltDc:
-                    return FromMegavoltsDc(val);
+                    return FromMegavoltsDc(value);
                 case ElectricPotentialDcUnit.MicrovoltDc:
-                    return FromMicrovoltsDc(val);
+                    return FromMicrovoltsDc(value);
                 case ElectricPotentialDcUnit.MillivoltDc:
-                    return FromMillivoltsDc(val);
+                    return FromMillivoltsDc(value);
                 case ElectricPotentialDcUnit.VoltDc:
-                    return FromVoltsDc(val);
+                    return FromVoltsDc(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -706,7 +387,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricPotentialDc unit value.</returns>
-        public static ElectricPotentialDc? From(double? value, ElectricPotentialDcUnit fromUnit)
+        public static ElectricPotentialDc? From(QuantityValue? value, ElectricPotentialDcUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -173,152 +173,72 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Kiloohms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricResistance FromKiloohms(double kiloohms)
         {
-            return new ElectricResistance((kiloohms) * 1e3d);
+            double value = (double) kiloohms;
+            return new ElectricResistance((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ElectricResistance from Kiloohms.
-        /// </summary>
-        public static ElectricResistance FromKiloohms(int kiloohms)
+#else
+        public static ElectricResistance FromKiloohms(QuantityValue kiloohms)
         {
-            return new ElectricResistance((kiloohms) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricResistance from Kiloohms.
-        /// </summary>
-        public static ElectricResistance FromKiloohms(long kiloohms)
-        {
-            return new ElectricResistance((kiloohms) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricResistance from Kiloohms of type decimal.
-        /// </summary>
-        public static ElectricResistance FromKiloohms(decimal kiloohms)
-        {
-            return new ElectricResistance((Convert.ToDouble(kiloohms)) * 1e3d);
+            double value = (double) kiloohms;
+            return new ElectricResistance(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricResistance FromMegaohms(double megaohms)
         {
-            return new ElectricResistance((megaohms) * 1e6d);
+            double value = (double) megaohms;
+            return new ElectricResistance((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ElectricResistance from Megaohms.
-        /// </summary>
-        public static ElectricResistance FromMegaohms(int megaohms)
+#else
+        public static ElectricResistance FromMegaohms(QuantityValue megaohms)
         {
-            return new ElectricResistance((megaohms) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ElectricResistance from Megaohms.
-        /// </summary>
-        public static ElectricResistance FromMegaohms(long megaohms)
-        {
-            return new ElectricResistance((megaohms) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricResistance from Megaohms of type decimal.
-        /// </summary>
-        public static ElectricResistance FromMegaohms(decimal megaohms)
-        {
-            return new ElectricResistance((Convert.ToDouble(megaohms)) * 1e6d);
+            double value = (double) megaohms;
+            return new ElectricResistance(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricResistance from Milliohms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricResistance FromMilliohms(double milliohms)
         {
-            return new ElectricResistance((milliohms) * 1e-3d);
+            double value = (double) milliohms;
+            return new ElectricResistance((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ElectricResistance from Milliohms.
-        /// </summary>
-        public static ElectricResistance FromMilliohms(int milliohms)
+#else
+        public static ElectricResistance FromMilliohms(QuantityValue milliohms)
         {
-            return new ElectricResistance((milliohms) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ElectricResistance from Milliohms.
-        /// </summary>
-        public static ElectricResistance FromMilliohms(long milliohms)
-        {
-            return new ElectricResistance((milliohms) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricResistance from Milliohms of type decimal.
-        /// </summary>
-        public static ElectricResistance FromMilliohms(decimal milliohms)
-        {
-            return new ElectricResistance((Convert.ToDouble(milliohms)) * 1e-3d);
+            double value = (double) milliohms;
+            return new ElectricResistance(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ElectricResistance FromOhms(double ohms)
         {
-            return new ElectricResistance(ohms);
+            double value = (double) ohms;
+            return new ElectricResistance(value);
         }
-
-        /// <summary>
-        ///     Get ElectricResistance from Ohms.
-        /// </summary>
-        public static ElectricResistance FromOhms(int ohms)
+#else
+        public static ElectricResistance FromOhms(QuantityValue ohms)
         {
-            return new ElectricResistance(ohms);
-        }
-
-        /// <summary>
-        ///     Get ElectricResistance from Ohms.
-        /// </summary>
-        public static ElectricResistance FromOhms(long ohms)
-        {
-            return new ElectricResistance(ohms);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ElectricResistance from Ohms of type decimal.
-        /// </summary>
-        public static ElectricResistance FromOhms(decimal ohms)
-        {
-            return new ElectricResistance(Convert.ToDouble(ohms));
+            double value = (double) ohms;
+            return new ElectricResistance((value));
         }
 #endif
 
@@ -327,52 +247,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Kiloohms.
         /// </summary>
-        public static ElectricResistance? FromKiloohms(double? kiloohms)
-        {
-            if (kiloohms.HasValue)
-            {
-                return FromKiloohms(kiloohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Kiloohms.
-        /// </summary>
-        public static ElectricResistance? FromKiloohms(int? kiloohms)
-        {
-            if (kiloohms.HasValue)
-            {
-                return FromKiloohms(kiloohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Kiloohms.
-        /// </summary>
-        public static ElectricResistance? FromKiloohms(long? kiloohms)
-        {
-            if (kiloohms.HasValue)
-            {
-                return FromKiloohms(kiloohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from Kiloohms of type decimal.
-        /// </summary>
-        public static ElectricResistance? FromKiloohms(decimal? kiloohms)
+        public static ElectricResistance? FromKiloohms(QuantityValue? kiloohms)
         {
             if (kiloohms.HasValue)
             {
@@ -387,52 +262,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Megaohms.
         /// </summary>
-        public static ElectricResistance? FromMegaohms(double? megaohms)
-        {
-            if (megaohms.HasValue)
-            {
-                return FromMegaohms(megaohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Megaohms.
-        /// </summary>
-        public static ElectricResistance? FromMegaohms(int? megaohms)
-        {
-            if (megaohms.HasValue)
-            {
-                return FromMegaohms(megaohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Megaohms.
-        /// </summary>
-        public static ElectricResistance? FromMegaohms(long? megaohms)
-        {
-            if (megaohms.HasValue)
-            {
-                return FromMegaohms(megaohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from Megaohms of type decimal.
-        /// </summary>
-        public static ElectricResistance? FromMegaohms(decimal? megaohms)
+        public static ElectricResistance? FromMegaohms(QuantityValue? megaohms)
         {
             if (megaohms.HasValue)
             {
@@ -447,52 +277,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Milliohms.
         /// </summary>
-        public static ElectricResistance? FromMilliohms(double? milliohms)
-        {
-            if (milliohms.HasValue)
-            {
-                return FromMilliohms(milliohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Milliohms.
-        /// </summary>
-        public static ElectricResistance? FromMilliohms(int? milliohms)
-        {
-            if (milliohms.HasValue)
-            {
-                return FromMilliohms(milliohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Milliohms.
-        /// </summary>
-        public static ElectricResistance? FromMilliohms(long? milliohms)
-        {
-            if (milliohms.HasValue)
-            {
-                return FromMilliohms(milliohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from Milliohms of type decimal.
-        /// </summary>
-        public static ElectricResistance? FromMilliohms(decimal? milliohms)
+        public static ElectricResistance? FromMilliohms(QuantityValue? milliohms)
         {
             if (milliohms.HasValue)
             {
@@ -507,52 +292,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ElectricResistance from nullable Ohms.
         /// </summary>
-        public static ElectricResistance? FromOhms(double? ohms)
-        {
-            if (ohms.HasValue)
-            {
-                return FromOhms(ohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Ohms.
-        /// </summary>
-        public static ElectricResistance? FromOhms(int? ohms)
-        {
-            if (ohms.HasValue)
-            {
-                return FromOhms(ohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from nullable Ohms.
-        /// </summary>
-        public static ElectricResistance? FromOhms(long? ohms)
-        {
-            if (ohms.HasValue)
-            {
-                return FromOhms(ohms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ElectricResistance from Ohms of type decimal.
-        /// </summary>
-        public static ElectricResistance? FromOhms(decimal? ohms)
+        public static ElectricResistance? FromOhms(QuantityValue? ohms)
         {
             if (ohms.HasValue)
             {
@@ -569,21 +309,27 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricResistanceUnit" /> to <see cref="ElectricResistance" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricResistance unit value.</returns>
-        public static ElectricResistance From(double val, ElectricResistanceUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ElectricResistance From(double value, ElectricResistanceUnit fromUnit)
+#else
+        public static ElectricResistance From(QuantityValue value, ElectricResistanceUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ElectricResistanceUnit.Kiloohm:
-                    return FromKiloohms(val);
+                    return FromKiloohms(value);
                 case ElectricResistanceUnit.Megaohm:
-                    return FromMegaohms(val);
+                    return FromMegaohms(value);
                 case ElectricResistanceUnit.Milliohm:
-                    return FromMilliohms(val);
+                    return FromMilliohms(value);
                 case ElectricResistanceUnit.Ohm:
-                    return FromOhms(val);
+                    return FromOhms(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -598,7 +344,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ElectricResistance unit value.</returns>
-        public static ElectricResistance? From(double? value, ElectricResistanceUnit fromUnit)
+        public static ElectricResistance? From(QuantityValue? value, ElectricResistanceUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -317,836 +317,396 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from BritishThermalUnits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromBritishThermalUnits(double britishthermalunits)
         {
-            return new Energy(britishthermalunits*1055.05585262);
+            double value = (double) britishthermalunits;
+            return new Energy(value*1055.05585262);
         }
-
-        /// <summary>
-        ///     Get Energy from BritishThermalUnits.
-        /// </summary>
-        public static Energy FromBritishThermalUnits(int britishthermalunits)
+#else
+        public static Energy FromBritishThermalUnits(QuantityValue britishthermalunits)
         {
-            return new Energy(britishthermalunits*1055.05585262);
-        }
-
-        /// <summary>
-        ///     Get Energy from BritishThermalUnits.
-        /// </summary>
-        public static Energy FromBritishThermalUnits(long britishthermalunits)
-        {
-            return new Energy(britishthermalunits*1055.05585262);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from BritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy FromBritishThermalUnits(decimal britishthermalunits)
-        {
-            return new Energy(Convert.ToDouble(britishthermalunits)*1055.05585262);
+            double value = (double) britishthermalunits;
+            return new Energy((value*1055.05585262));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromCalories(double calories)
         {
-            return new Energy(calories*4.184);
+            double value = (double) calories;
+            return new Energy(value*4.184);
         }
-
-        /// <summary>
-        ///     Get Energy from Calories.
-        /// </summary>
-        public static Energy FromCalories(int calories)
+#else
+        public static Energy FromCalories(QuantityValue calories)
         {
-            return new Energy(calories*4.184);
-        }
-
-        /// <summary>
-        ///     Get Energy from Calories.
-        /// </summary>
-        public static Energy FromCalories(long calories)
-        {
-            return new Energy(calories*4.184);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from Calories of type decimal.
-        /// </summary>
-        public static Energy FromCalories(decimal calories)
-        {
-            return new Energy(Convert.ToDouble(calories)*4.184);
+            double value = (double) calories;
+            return new Energy((value*4.184));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from DecathermsEc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromDecathermsEc(double decathermsec)
         {
-            return new Energy((decathermsec*105505585.262) * 1e1d);
+            double value = (double) decathermsec;
+            return new Energy((value*105505585.262) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get Energy from DecathermsEc.
-        /// </summary>
-        public static Energy FromDecathermsEc(int decathermsec)
+#else
+        public static Energy FromDecathermsEc(QuantityValue decathermsec)
         {
-            return new Energy((decathermsec*105505585.262) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get Energy from DecathermsEc.
-        /// </summary>
-        public static Energy FromDecathermsEc(long decathermsec)
-        {
-            return new Energy((decathermsec*105505585.262) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from DecathermsEc of type decimal.
-        /// </summary>
-        public static Energy FromDecathermsEc(decimal decathermsec)
-        {
-            return new Energy((Convert.ToDouble(decathermsec)*105505585.262) * 1e1d);
+            double value = (double) decathermsec;
+            return new Energy(((value*105505585.262) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromDecathermsImperial(double decathermsimperial)
         {
-            return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
+            double value = (double) decathermsimperial;
+            return new Energy((value*1.05505585257348e+14) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get Energy from DecathermsImperial.
-        /// </summary>
-        public static Energy FromDecathermsImperial(int decathermsimperial)
+#else
+        public static Energy FromDecathermsImperial(QuantityValue decathermsimperial)
         {
-            return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get Energy from DecathermsImperial.
-        /// </summary>
-        public static Energy FromDecathermsImperial(long decathermsimperial)
-        {
-            return new Energy((decathermsimperial*1.05505585257348e+14) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from DecathermsImperial of type decimal.
-        /// </summary>
-        public static Energy FromDecathermsImperial(decimal decathermsimperial)
-        {
-            return new Energy((Convert.ToDouble(decathermsimperial)*1.05505585257348e+14) * 1e1d);
+            double value = (double) decathermsimperial;
+            return new Energy(((value*1.05505585257348e+14) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from DecathermsUs.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromDecathermsUs(double decathermsus)
         {
-            return new Energy((decathermsus*1.054804e+8) * 1e1d);
+            double value = (double) decathermsus;
+            return new Energy((value*1.054804e+8) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get Energy from DecathermsUs.
-        /// </summary>
-        public static Energy FromDecathermsUs(int decathermsus)
+#else
+        public static Energy FromDecathermsUs(QuantityValue decathermsus)
         {
-            return new Energy((decathermsus*1.054804e+8) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get Energy from DecathermsUs.
-        /// </summary>
-        public static Energy FromDecathermsUs(long decathermsus)
-        {
-            return new Energy((decathermsus*1.054804e+8) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from DecathermsUs of type decimal.
-        /// </summary>
-        public static Energy FromDecathermsUs(decimal decathermsus)
-        {
-            return new Energy((Convert.ToDouble(decathermsus)*1.054804e+8) * 1e1d);
+            double value = (double) decathermsus;
+            return new Energy(((value*1.054804e+8) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromElectronVolts(double electronvolts)
         {
-            return new Energy(electronvolts*1.602176565e-19);
+            double value = (double) electronvolts;
+            return new Energy(value*1.602176565e-19);
         }
-
-        /// <summary>
-        ///     Get Energy from ElectronVolts.
-        /// </summary>
-        public static Energy FromElectronVolts(int electronvolts)
+#else
+        public static Energy FromElectronVolts(QuantityValue electronvolts)
         {
-            return new Energy(electronvolts*1.602176565e-19);
-        }
-
-        /// <summary>
-        ///     Get Energy from ElectronVolts.
-        /// </summary>
-        public static Energy FromElectronVolts(long electronvolts)
-        {
-            return new Energy(electronvolts*1.602176565e-19);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from ElectronVolts of type decimal.
-        /// </summary>
-        public static Energy FromElectronVolts(decimal electronvolts)
-        {
-            return new Energy(Convert.ToDouble(electronvolts)*1.602176565e-19);
+            double value = (double) electronvolts;
+            return new Energy((value*1.602176565e-19));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from Ergs.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromErgs(double ergs)
         {
-            return new Energy(ergs*1e-7);
+            double value = (double) ergs;
+            return new Energy(value*1e-7);
         }
-
-        /// <summary>
-        ///     Get Energy from Ergs.
-        /// </summary>
-        public static Energy FromErgs(int ergs)
+#else
+        public static Energy FromErgs(QuantityValue ergs)
         {
-            return new Energy(ergs*1e-7);
-        }
-
-        /// <summary>
-        ///     Get Energy from Ergs.
-        /// </summary>
-        public static Energy FromErgs(long ergs)
-        {
-            return new Energy(ergs*1e-7);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from Ergs of type decimal.
-        /// </summary>
-        public static Energy FromErgs(decimal ergs)
-        {
-            return new Energy(Convert.ToDouble(ergs)*1e-7);
+            double value = (double) ergs;
+            return new Energy((value*1e-7));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromFootPounds(double footpounds)
         {
-            return new Energy(footpounds*1.355817948);
+            double value = (double) footpounds;
+            return new Energy(value*1.355817948);
         }
-
-        /// <summary>
-        ///     Get Energy from FootPounds.
-        /// </summary>
-        public static Energy FromFootPounds(int footpounds)
+#else
+        public static Energy FromFootPounds(QuantityValue footpounds)
         {
-            return new Energy(footpounds*1.355817948);
-        }
-
-        /// <summary>
-        ///     Get Energy from FootPounds.
-        /// </summary>
-        public static Energy FromFootPounds(long footpounds)
-        {
-            return new Energy(footpounds*1.355817948);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from FootPounds of type decimal.
-        /// </summary>
-        public static Energy FromFootPounds(decimal footpounds)
-        {
-            return new Energy(Convert.ToDouble(footpounds)*1.355817948);
+            double value = (double) footpounds;
+            return new Energy((value*1.355817948));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromGigabritishThermalUnits(double gigabritishthermalunits)
         {
-            return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
+            double value = (double) gigabritishthermalunits;
+            return new Energy((value*1055.05585262) * 1e9d);
         }
-
-        /// <summary>
-        ///     Get Energy from GigabritishThermalUnits.
-        /// </summary>
-        public static Energy FromGigabritishThermalUnits(int gigabritishthermalunits)
+#else
+        public static Energy FromGigabritishThermalUnits(QuantityValue gigabritishthermalunits)
         {
-            return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
-        }
-
-        /// <summary>
-        ///     Get Energy from GigabritishThermalUnits.
-        /// </summary>
-        public static Energy FromGigabritishThermalUnits(long gigabritishthermalunits)
-        {
-            return new Energy((gigabritishthermalunits*1055.05585262) * 1e9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from GigabritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy FromGigabritishThermalUnits(decimal gigabritishthermalunits)
-        {
-            return new Energy((Convert.ToDouble(gigabritishthermalunits)*1055.05585262) * 1e9d);
+            double value = (double) gigabritishthermalunits;
+            return new Energy(((value*1055.05585262) * 1e9d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromGigawattHours(double gigawatthours)
         {
-            return new Energy((gigawatthours*3600d) * 1e9d);
+            double value = (double) gigawatthours;
+            return new Energy((value*3600d) * 1e9d);
         }
-
-        /// <summary>
-        ///     Get Energy from GigawattHours.
-        /// </summary>
-        public static Energy FromGigawattHours(int gigawatthours)
+#else
+        public static Energy FromGigawattHours(QuantityValue gigawatthours)
         {
-            return new Energy((gigawatthours*3600d) * 1e9d);
-        }
-
-        /// <summary>
-        ///     Get Energy from GigawattHours.
-        /// </summary>
-        public static Energy FromGigawattHours(long gigawatthours)
-        {
-            return new Energy((gigawatthours*3600d) * 1e9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from GigawattHours of type decimal.
-        /// </summary>
-        public static Energy FromGigawattHours(decimal gigawatthours)
-        {
-            return new Energy((Convert.ToDouble(gigawatthours)*3600d) * 1e9d);
+            double value = (double) gigawatthours;
+            return new Energy(((value*3600d) * 1e9d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from Joules.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromJoules(double joules)
         {
-            return new Energy(joules);
+            double value = (double) joules;
+            return new Energy(value);
         }
-
-        /// <summary>
-        ///     Get Energy from Joules.
-        /// </summary>
-        public static Energy FromJoules(int joules)
+#else
+        public static Energy FromJoules(QuantityValue joules)
         {
-            return new Energy(joules);
-        }
-
-        /// <summary>
-        ///     Get Energy from Joules.
-        /// </summary>
-        public static Energy FromJoules(long joules)
-        {
-            return new Energy(joules);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from Joules of type decimal.
-        /// </summary>
-        public static Energy FromJoules(decimal joules)
-        {
-            return new Energy(Convert.ToDouble(joules));
+            double value = (double) joules;
+            return new Energy((value));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromKilobritishThermalUnits(double kilobritishthermalunits)
         {
-            return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
+            double value = (double) kilobritishthermalunits;
+            return new Energy((value*1055.05585262) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Energy from KilobritishThermalUnits.
-        /// </summary>
-        public static Energy FromKilobritishThermalUnits(int kilobritishthermalunits)
+#else
+        public static Energy FromKilobritishThermalUnits(QuantityValue kilobritishthermalunits)
         {
-            return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Energy from KilobritishThermalUnits.
-        /// </summary>
-        public static Energy FromKilobritishThermalUnits(long kilobritishthermalunits)
-        {
-            return new Energy((kilobritishthermalunits*1055.05585262) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from KilobritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy FromKilobritishThermalUnits(decimal kilobritishthermalunits)
-        {
-            return new Energy((Convert.ToDouble(kilobritishthermalunits)*1055.05585262) * 1e3d);
+            double value = (double) kilobritishthermalunits;
+            return new Energy(((value*1055.05585262) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from Kilocalories.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromKilocalories(double kilocalories)
         {
-            return new Energy((kilocalories*4.184) * 1e3d);
+            double value = (double) kilocalories;
+            return new Energy((value*4.184) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Energy from Kilocalories.
-        /// </summary>
-        public static Energy FromKilocalories(int kilocalories)
+#else
+        public static Energy FromKilocalories(QuantityValue kilocalories)
         {
-            return new Energy((kilocalories*4.184) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Energy from Kilocalories.
-        /// </summary>
-        public static Energy FromKilocalories(long kilocalories)
-        {
-            return new Energy((kilocalories*4.184) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from Kilocalories of type decimal.
-        /// </summary>
-        public static Energy FromKilocalories(decimal kilocalories)
-        {
-            return new Energy((Convert.ToDouble(kilocalories)*4.184) * 1e3d);
+            double value = (double) kilocalories;
+            return new Energy(((value*4.184) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromKilojoules(double kilojoules)
         {
-            return new Energy((kilojoules) * 1e3d);
+            double value = (double) kilojoules;
+            return new Energy((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Energy from Kilojoules.
-        /// </summary>
-        public static Energy FromKilojoules(int kilojoules)
+#else
+        public static Energy FromKilojoules(QuantityValue kilojoules)
         {
-            return new Energy((kilojoules) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Energy from Kilojoules.
-        /// </summary>
-        public static Energy FromKilojoules(long kilojoules)
-        {
-            return new Energy((kilojoules) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from Kilojoules of type decimal.
-        /// </summary>
-        public static Energy FromKilojoules(decimal kilojoules)
-        {
-            return new Energy((Convert.ToDouble(kilojoules)) * 1e3d);
+            double value = (double) kilojoules;
+            return new Energy(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from KilowattHours.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromKilowattHours(double kilowatthours)
         {
-            return new Energy((kilowatthours*3600d) * 1e3d);
+            double value = (double) kilowatthours;
+            return new Energy((value*3600d) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Energy from KilowattHours.
-        /// </summary>
-        public static Energy FromKilowattHours(int kilowatthours)
+#else
+        public static Energy FromKilowattHours(QuantityValue kilowatthours)
         {
-            return new Energy((kilowatthours*3600d) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Energy from KilowattHours.
-        /// </summary>
-        public static Energy FromKilowattHours(long kilowatthours)
-        {
-            return new Energy((kilowatthours*3600d) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from KilowattHours of type decimal.
-        /// </summary>
-        public static Energy FromKilowattHours(decimal kilowatthours)
-        {
-            return new Energy((Convert.ToDouble(kilowatthours)*3600d) * 1e3d);
+            double value = (double) kilowatthours;
+            return new Energy(((value*3600d) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromMegabritishThermalUnits(double megabritishthermalunits)
         {
-            return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
+            double value = (double) megabritishthermalunits;
+            return new Energy((value*1055.05585262) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Energy from MegabritishThermalUnits.
-        /// </summary>
-        public static Energy FromMegabritishThermalUnits(int megabritishthermalunits)
+#else
+        public static Energy FromMegabritishThermalUnits(QuantityValue megabritishthermalunits)
         {
-            return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Energy from MegabritishThermalUnits.
-        /// </summary>
-        public static Energy FromMegabritishThermalUnits(long megabritishthermalunits)
-        {
-            return new Energy((megabritishthermalunits*1055.05585262) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from MegabritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy FromMegabritishThermalUnits(decimal megabritishthermalunits)
-        {
-            return new Energy((Convert.ToDouble(megabritishthermalunits)*1055.05585262) * 1e6d);
+            double value = (double) megabritishthermalunits;
+            return new Energy(((value*1055.05585262) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from Megajoules.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromMegajoules(double megajoules)
         {
-            return new Energy((megajoules) * 1e6d);
+            double value = (double) megajoules;
+            return new Energy((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Energy from Megajoules.
-        /// </summary>
-        public static Energy FromMegajoules(int megajoules)
+#else
+        public static Energy FromMegajoules(QuantityValue megajoules)
         {
-            return new Energy((megajoules) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Energy from Megajoules.
-        /// </summary>
-        public static Energy FromMegajoules(long megajoules)
-        {
-            return new Energy((megajoules) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from Megajoules of type decimal.
-        /// </summary>
-        public static Energy FromMegajoules(decimal megajoules)
-        {
-            return new Energy((Convert.ToDouble(megajoules)) * 1e6d);
+            double value = (double) megajoules;
+            return new Energy(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromMegawattHours(double megawatthours)
         {
-            return new Energy((megawatthours*3600d) * 1e6d);
+            double value = (double) megawatthours;
+            return new Energy((value*3600d) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Energy from MegawattHours.
-        /// </summary>
-        public static Energy FromMegawattHours(int megawatthours)
+#else
+        public static Energy FromMegawattHours(QuantityValue megawatthours)
         {
-            return new Energy((megawatthours*3600d) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Energy from MegawattHours.
-        /// </summary>
-        public static Energy FromMegawattHours(long megawatthours)
-        {
-            return new Energy((megawatthours*3600d) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from MegawattHours of type decimal.
-        /// </summary>
-        public static Energy FromMegawattHours(decimal megawatthours)
-        {
-            return new Energy((Convert.ToDouble(megawatthours)*3600d) * 1e6d);
+            double value = (double) megawatthours;
+            return new Energy(((value*3600d) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from ThermsEc.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromThermsEc(double thermsec)
         {
-            return new Energy(thermsec*105505585.262);
+            double value = (double) thermsec;
+            return new Energy(value*105505585.262);
         }
-
-        /// <summary>
-        ///     Get Energy from ThermsEc.
-        /// </summary>
-        public static Energy FromThermsEc(int thermsec)
+#else
+        public static Energy FromThermsEc(QuantityValue thermsec)
         {
-            return new Energy(thermsec*105505585.262);
-        }
-
-        /// <summary>
-        ///     Get Energy from ThermsEc.
-        /// </summary>
-        public static Energy FromThermsEc(long thermsec)
-        {
-            return new Energy(thermsec*105505585.262);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from ThermsEc of type decimal.
-        /// </summary>
-        public static Energy FromThermsEc(decimal thermsec)
-        {
-            return new Energy(Convert.ToDouble(thermsec)*105505585.262);
+            double value = (double) thermsec;
+            return new Energy((value*105505585.262));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromThermsImperial(double thermsimperial)
         {
-            return new Energy(thermsimperial*1.05505585257348e+14);
+            double value = (double) thermsimperial;
+            return new Energy(value*1.05505585257348e+14);
         }
-
-        /// <summary>
-        ///     Get Energy from ThermsImperial.
-        /// </summary>
-        public static Energy FromThermsImperial(int thermsimperial)
+#else
+        public static Energy FromThermsImperial(QuantityValue thermsimperial)
         {
-            return new Energy(thermsimperial*1.05505585257348e+14);
-        }
-
-        /// <summary>
-        ///     Get Energy from ThermsImperial.
-        /// </summary>
-        public static Energy FromThermsImperial(long thermsimperial)
-        {
-            return new Energy(thermsimperial*1.05505585257348e+14);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from ThermsImperial of type decimal.
-        /// </summary>
-        public static Energy FromThermsImperial(decimal thermsimperial)
-        {
-            return new Energy(Convert.ToDouble(thermsimperial)*1.05505585257348e+14);
+            double value = (double) thermsimperial;
+            return new Energy((value*1.05505585257348e+14));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from ThermsUs.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromThermsUs(double thermsus)
         {
-            return new Energy(thermsus*1.054804e+8);
+            double value = (double) thermsus;
+            return new Energy(value*1.054804e+8);
         }
-
-        /// <summary>
-        ///     Get Energy from ThermsUs.
-        /// </summary>
-        public static Energy FromThermsUs(int thermsus)
+#else
+        public static Energy FromThermsUs(QuantityValue thermsus)
         {
-            return new Energy(thermsus*1.054804e+8);
-        }
-
-        /// <summary>
-        ///     Get Energy from ThermsUs.
-        /// </summary>
-        public static Energy FromThermsUs(long thermsus)
-        {
-            return new Energy(thermsus*1.054804e+8);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from ThermsUs of type decimal.
-        /// </summary>
-        public static Energy FromThermsUs(decimal thermsus)
-        {
-            return new Energy(Convert.ToDouble(thermsus)*1.054804e+8);
+            double value = (double) thermsus;
+            return new Energy((value*1.054804e+8));
         }
 #endif
 
         /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Energy FromWattHours(double watthours)
         {
-            return new Energy(watthours*3600d);
+            double value = (double) watthours;
+            return new Energy(value*3600d);
         }
-
-        /// <summary>
-        ///     Get Energy from WattHours.
-        /// </summary>
-        public static Energy FromWattHours(int watthours)
+#else
+        public static Energy FromWattHours(QuantityValue watthours)
         {
-            return new Energy(watthours*3600d);
-        }
-
-        /// <summary>
-        ///     Get Energy from WattHours.
-        /// </summary>
-        public static Energy FromWattHours(long watthours)
-        {
-            return new Energy(watthours*3600d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Energy from WattHours of type decimal.
-        /// </summary>
-        public static Energy FromWattHours(decimal watthours)
-        {
-            return new Energy(Convert.ToDouble(watthours)*3600d);
+            double value = (double) watthours;
+            return new Energy((value*3600d));
         }
 #endif
 
@@ -1155,52 +715,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable BritishThermalUnits.
         /// </summary>
-        public static Energy? FromBritishThermalUnits(double? britishthermalunits)
-        {
-            if (britishthermalunits.HasValue)
-            {
-                return FromBritishThermalUnits(britishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable BritishThermalUnits.
-        /// </summary>
-        public static Energy? FromBritishThermalUnits(int? britishthermalunits)
-        {
-            if (britishthermalunits.HasValue)
-            {
-                return FromBritishThermalUnits(britishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable BritishThermalUnits.
-        /// </summary>
-        public static Energy? FromBritishThermalUnits(long? britishthermalunits)
-        {
-            if (britishthermalunits.HasValue)
-            {
-                return FromBritishThermalUnits(britishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from BritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy? FromBritishThermalUnits(decimal? britishthermalunits)
+        public static Energy? FromBritishThermalUnits(QuantityValue? britishthermalunits)
         {
             if (britishthermalunits.HasValue)
             {
@@ -1215,52 +730,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable Calories.
         /// </summary>
-        public static Energy? FromCalories(double? calories)
-        {
-            if (calories.HasValue)
-            {
-                return FromCalories(calories.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Calories.
-        /// </summary>
-        public static Energy? FromCalories(int? calories)
-        {
-            if (calories.HasValue)
-            {
-                return FromCalories(calories.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Calories.
-        /// </summary>
-        public static Energy? FromCalories(long? calories)
-        {
-            if (calories.HasValue)
-            {
-                return FromCalories(calories.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from Calories of type decimal.
-        /// </summary>
-        public static Energy? FromCalories(decimal? calories)
+        public static Energy? FromCalories(QuantityValue? calories)
         {
             if (calories.HasValue)
             {
@@ -1275,52 +745,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable DecathermsEc.
         /// </summary>
-        public static Energy? FromDecathermsEc(double? decathermsec)
-        {
-            if (decathermsec.HasValue)
-            {
-                return FromDecathermsEc(decathermsec.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable DecathermsEc.
-        /// </summary>
-        public static Energy? FromDecathermsEc(int? decathermsec)
-        {
-            if (decathermsec.HasValue)
-            {
-                return FromDecathermsEc(decathermsec.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable DecathermsEc.
-        /// </summary>
-        public static Energy? FromDecathermsEc(long? decathermsec)
-        {
-            if (decathermsec.HasValue)
-            {
-                return FromDecathermsEc(decathermsec.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from DecathermsEc of type decimal.
-        /// </summary>
-        public static Energy? FromDecathermsEc(decimal? decathermsec)
+        public static Energy? FromDecathermsEc(QuantityValue? decathermsec)
         {
             if (decathermsec.HasValue)
             {
@@ -1335,52 +760,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable DecathermsImperial.
         /// </summary>
-        public static Energy? FromDecathermsImperial(double? decathermsimperial)
-        {
-            if (decathermsimperial.HasValue)
-            {
-                return FromDecathermsImperial(decathermsimperial.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable DecathermsImperial.
-        /// </summary>
-        public static Energy? FromDecathermsImperial(int? decathermsimperial)
-        {
-            if (decathermsimperial.HasValue)
-            {
-                return FromDecathermsImperial(decathermsimperial.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable DecathermsImperial.
-        /// </summary>
-        public static Energy? FromDecathermsImperial(long? decathermsimperial)
-        {
-            if (decathermsimperial.HasValue)
-            {
-                return FromDecathermsImperial(decathermsimperial.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from DecathermsImperial of type decimal.
-        /// </summary>
-        public static Energy? FromDecathermsImperial(decimal? decathermsimperial)
+        public static Energy? FromDecathermsImperial(QuantityValue? decathermsimperial)
         {
             if (decathermsimperial.HasValue)
             {
@@ -1395,52 +775,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable DecathermsUs.
         /// </summary>
-        public static Energy? FromDecathermsUs(double? decathermsus)
-        {
-            if (decathermsus.HasValue)
-            {
-                return FromDecathermsUs(decathermsus.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable DecathermsUs.
-        /// </summary>
-        public static Energy? FromDecathermsUs(int? decathermsus)
-        {
-            if (decathermsus.HasValue)
-            {
-                return FromDecathermsUs(decathermsus.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable DecathermsUs.
-        /// </summary>
-        public static Energy? FromDecathermsUs(long? decathermsus)
-        {
-            if (decathermsus.HasValue)
-            {
-                return FromDecathermsUs(decathermsus.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from DecathermsUs of type decimal.
-        /// </summary>
-        public static Energy? FromDecathermsUs(decimal? decathermsus)
+        public static Energy? FromDecathermsUs(QuantityValue? decathermsus)
         {
             if (decathermsus.HasValue)
             {
@@ -1455,52 +790,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable ElectronVolts.
         /// </summary>
-        public static Energy? FromElectronVolts(double? electronvolts)
-        {
-            if (electronvolts.HasValue)
-            {
-                return FromElectronVolts(electronvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ElectronVolts.
-        /// </summary>
-        public static Energy? FromElectronVolts(int? electronvolts)
-        {
-            if (electronvolts.HasValue)
-            {
-                return FromElectronVolts(electronvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ElectronVolts.
-        /// </summary>
-        public static Energy? FromElectronVolts(long? electronvolts)
-        {
-            if (electronvolts.HasValue)
-            {
-                return FromElectronVolts(electronvolts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from ElectronVolts of type decimal.
-        /// </summary>
-        public static Energy? FromElectronVolts(decimal? electronvolts)
+        public static Energy? FromElectronVolts(QuantityValue? electronvolts)
         {
             if (electronvolts.HasValue)
             {
@@ -1515,52 +805,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable Ergs.
         /// </summary>
-        public static Energy? FromErgs(double? ergs)
-        {
-            if (ergs.HasValue)
-            {
-                return FromErgs(ergs.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Ergs.
-        /// </summary>
-        public static Energy? FromErgs(int? ergs)
-        {
-            if (ergs.HasValue)
-            {
-                return FromErgs(ergs.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Ergs.
-        /// </summary>
-        public static Energy? FromErgs(long? ergs)
-        {
-            if (ergs.HasValue)
-            {
-                return FromErgs(ergs.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from Ergs of type decimal.
-        /// </summary>
-        public static Energy? FromErgs(decimal? ergs)
+        public static Energy? FromErgs(QuantityValue? ergs)
         {
             if (ergs.HasValue)
             {
@@ -1575,52 +820,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable FootPounds.
         /// </summary>
-        public static Energy? FromFootPounds(double? footpounds)
-        {
-            if (footpounds.HasValue)
-            {
-                return FromFootPounds(footpounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable FootPounds.
-        /// </summary>
-        public static Energy? FromFootPounds(int? footpounds)
-        {
-            if (footpounds.HasValue)
-            {
-                return FromFootPounds(footpounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable FootPounds.
-        /// </summary>
-        public static Energy? FromFootPounds(long? footpounds)
-        {
-            if (footpounds.HasValue)
-            {
-                return FromFootPounds(footpounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from FootPounds of type decimal.
-        /// </summary>
-        public static Energy? FromFootPounds(decimal? footpounds)
+        public static Energy? FromFootPounds(QuantityValue? footpounds)
         {
             if (footpounds.HasValue)
             {
@@ -1635,52 +835,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable GigabritishThermalUnits.
         /// </summary>
-        public static Energy? FromGigabritishThermalUnits(double? gigabritishthermalunits)
-        {
-            if (gigabritishthermalunits.HasValue)
-            {
-                return FromGigabritishThermalUnits(gigabritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable GigabritishThermalUnits.
-        /// </summary>
-        public static Energy? FromGigabritishThermalUnits(int? gigabritishthermalunits)
-        {
-            if (gigabritishthermalunits.HasValue)
-            {
-                return FromGigabritishThermalUnits(gigabritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable GigabritishThermalUnits.
-        /// </summary>
-        public static Energy? FromGigabritishThermalUnits(long? gigabritishthermalunits)
-        {
-            if (gigabritishthermalunits.HasValue)
-            {
-                return FromGigabritishThermalUnits(gigabritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from GigabritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy? FromGigabritishThermalUnits(decimal? gigabritishthermalunits)
+        public static Energy? FromGigabritishThermalUnits(QuantityValue? gigabritishthermalunits)
         {
             if (gigabritishthermalunits.HasValue)
             {
@@ -1695,52 +850,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable GigawattHours.
         /// </summary>
-        public static Energy? FromGigawattHours(double? gigawatthours)
-        {
-            if (gigawatthours.HasValue)
-            {
-                return FromGigawattHours(gigawatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable GigawattHours.
-        /// </summary>
-        public static Energy? FromGigawattHours(int? gigawatthours)
-        {
-            if (gigawatthours.HasValue)
-            {
-                return FromGigawattHours(gigawatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable GigawattHours.
-        /// </summary>
-        public static Energy? FromGigawattHours(long? gigawatthours)
-        {
-            if (gigawatthours.HasValue)
-            {
-                return FromGigawattHours(gigawatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from GigawattHours of type decimal.
-        /// </summary>
-        public static Energy? FromGigawattHours(decimal? gigawatthours)
+        public static Energy? FromGigawattHours(QuantityValue? gigawatthours)
         {
             if (gigawatthours.HasValue)
             {
@@ -1755,52 +865,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable Joules.
         /// </summary>
-        public static Energy? FromJoules(double? joules)
-        {
-            if (joules.HasValue)
-            {
-                return FromJoules(joules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Joules.
-        /// </summary>
-        public static Energy? FromJoules(int? joules)
-        {
-            if (joules.HasValue)
-            {
-                return FromJoules(joules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Joules.
-        /// </summary>
-        public static Energy? FromJoules(long? joules)
-        {
-            if (joules.HasValue)
-            {
-                return FromJoules(joules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from Joules of type decimal.
-        /// </summary>
-        public static Energy? FromJoules(decimal? joules)
+        public static Energy? FromJoules(QuantityValue? joules)
         {
             if (joules.HasValue)
             {
@@ -1815,52 +880,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable KilobritishThermalUnits.
         /// </summary>
-        public static Energy? FromKilobritishThermalUnits(double? kilobritishthermalunits)
-        {
-            if (kilobritishthermalunits.HasValue)
-            {
-                return FromKilobritishThermalUnits(kilobritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable KilobritishThermalUnits.
-        /// </summary>
-        public static Energy? FromKilobritishThermalUnits(int? kilobritishthermalunits)
-        {
-            if (kilobritishthermalunits.HasValue)
-            {
-                return FromKilobritishThermalUnits(kilobritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable KilobritishThermalUnits.
-        /// </summary>
-        public static Energy? FromKilobritishThermalUnits(long? kilobritishthermalunits)
-        {
-            if (kilobritishthermalunits.HasValue)
-            {
-                return FromKilobritishThermalUnits(kilobritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from KilobritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy? FromKilobritishThermalUnits(decimal? kilobritishthermalunits)
+        public static Energy? FromKilobritishThermalUnits(QuantityValue? kilobritishthermalunits)
         {
             if (kilobritishthermalunits.HasValue)
             {
@@ -1875,52 +895,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable Kilocalories.
         /// </summary>
-        public static Energy? FromKilocalories(double? kilocalories)
-        {
-            if (kilocalories.HasValue)
-            {
-                return FromKilocalories(kilocalories.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Kilocalories.
-        /// </summary>
-        public static Energy? FromKilocalories(int? kilocalories)
-        {
-            if (kilocalories.HasValue)
-            {
-                return FromKilocalories(kilocalories.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Kilocalories.
-        /// </summary>
-        public static Energy? FromKilocalories(long? kilocalories)
-        {
-            if (kilocalories.HasValue)
-            {
-                return FromKilocalories(kilocalories.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from Kilocalories of type decimal.
-        /// </summary>
-        public static Energy? FromKilocalories(decimal? kilocalories)
+        public static Energy? FromKilocalories(QuantityValue? kilocalories)
         {
             if (kilocalories.HasValue)
             {
@@ -1935,52 +910,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable Kilojoules.
         /// </summary>
-        public static Energy? FromKilojoules(double? kilojoules)
-        {
-            if (kilojoules.HasValue)
-            {
-                return FromKilojoules(kilojoules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Kilojoules.
-        /// </summary>
-        public static Energy? FromKilojoules(int? kilojoules)
-        {
-            if (kilojoules.HasValue)
-            {
-                return FromKilojoules(kilojoules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Kilojoules.
-        /// </summary>
-        public static Energy? FromKilojoules(long? kilojoules)
-        {
-            if (kilojoules.HasValue)
-            {
-                return FromKilojoules(kilojoules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from Kilojoules of type decimal.
-        /// </summary>
-        public static Energy? FromKilojoules(decimal? kilojoules)
+        public static Energy? FromKilojoules(QuantityValue? kilojoules)
         {
             if (kilojoules.HasValue)
             {
@@ -1995,52 +925,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable KilowattHours.
         /// </summary>
-        public static Energy? FromKilowattHours(double? kilowatthours)
-        {
-            if (kilowatthours.HasValue)
-            {
-                return FromKilowattHours(kilowatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable KilowattHours.
-        /// </summary>
-        public static Energy? FromKilowattHours(int? kilowatthours)
-        {
-            if (kilowatthours.HasValue)
-            {
-                return FromKilowattHours(kilowatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable KilowattHours.
-        /// </summary>
-        public static Energy? FromKilowattHours(long? kilowatthours)
-        {
-            if (kilowatthours.HasValue)
-            {
-                return FromKilowattHours(kilowatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from KilowattHours of type decimal.
-        /// </summary>
-        public static Energy? FromKilowattHours(decimal? kilowatthours)
+        public static Energy? FromKilowattHours(QuantityValue? kilowatthours)
         {
             if (kilowatthours.HasValue)
             {
@@ -2055,52 +940,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable MegabritishThermalUnits.
         /// </summary>
-        public static Energy? FromMegabritishThermalUnits(double? megabritishthermalunits)
-        {
-            if (megabritishthermalunits.HasValue)
-            {
-                return FromMegabritishThermalUnits(megabritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable MegabritishThermalUnits.
-        /// </summary>
-        public static Energy? FromMegabritishThermalUnits(int? megabritishthermalunits)
-        {
-            if (megabritishthermalunits.HasValue)
-            {
-                return FromMegabritishThermalUnits(megabritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable MegabritishThermalUnits.
-        /// </summary>
-        public static Energy? FromMegabritishThermalUnits(long? megabritishthermalunits)
-        {
-            if (megabritishthermalunits.HasValue)
-            {
-                return FromMegabritishThermalUnits(megabritishthermalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from MegabritishThermalUnits of type decimal.
-        /// </summary>
-        public static Energy? FromMegabritishThermalUnits(decimal? megabritishthermalunits)
+        public static Energy? FromMegabritishThermalUnits(QuantityValue? megabritishthermalunits)
         {
             if (megabritishthermalunits.HasValue)
             {
@@ -2115,52 +955,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable Megajoules.
         /// </summary>
-        public static Energy? FromMegajoules(double? megajoules)
-        {
-            if (megajoules.HasValue)
-            {
-                return FromMegajoules(megajoules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Megajoules.
-        /// </summary>
-        public static Energy? FromMegajoules(int? megajoules)
-        {
-            if (megajoules.HasValue)
-            {
-                return FromMegajoules(megajoules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable Megajoules.
-        /// </summary>
-        public static Energy? FromMegajoules(long? megajoules)
-        {
-            if (megajoules.HasValue)
-            {
-                return FromMegajoules(megajoules.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from Megajoules of type decimal.
-        /// </summary>
-        public static Energy? FromMegajoules(decimal? megajoules)
+        public static Energy? FromMegajoules(QuantityValue? megajoules)
         {
             if (megajoules.HasValue)
             {
@@ -2175,52 +970,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable MegawattHours.
         /// </summary>
-        public static Energy? FromMegawattHours(double? megawatthours)
-        {
-            if (megawatthours.HasValue)
-            {
-                return FromMegawattHours(megawatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable MegawattHours.
-        /// </summary>
-        public static Energy? FromMegawattHours(int? megawatthours)
-        {
-            if (megawatthours.HasValue)
-            {
-                return FromMegawattHours(megawatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable MegawattHours.
-        /// </summary>
-        public static Energy? FromMegawattHours(long? megawatthours)
-        {
-            if (megawatthours.HasValue)
-            {
-                return FromMegawattHours(megawatthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from MegawattHours of type decimal.
-        /// </summary>
-        public static Energy? FromMegawattHours(decimal? megawatthours)
+        public static Energy? FromMegawattHours(QuantityValue? megawatthours)
         {
             if (megawatthours.HasValue)
             {
@@ -2235,52 +985,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable ThermsEc.
         /// </summary>
-        public static Energy? FromThermsEc(double? thermsec)
-        {
-            if (thermsec.HasValue)
-            {
-                return FromThermsEc(thermsec.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ThermsEc.
-        /// </summary>
-        public static Energy? FromThermsEc(int? thermsec)
-        {
-            if (thermsec.HasValue)
-            {
-                return FromThermsEc(thermsec.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ThermsEc.
-        /// </summary>
-        public static Energy? FromThermsEc(long? thermsec)
-        {
-            if (thermsec.HasValue)
-            {
-                return FromThermsEc(thermsec.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from ThermsEc of type decimal.
-        /// </summary>
-        public static Energy? FromThermsEc(decimal? thermsec)
+        public static Energy? FromThermsEc(QuantityValue? thermsec)
         {
             if (thermsec.HasValue)
             {
@@ -2295,52 +1000,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable ThermsImperial.
         /// </summary>
-        public static Energy? FromThermsImperial(double? thermsimperial)
-        {
-            if (thermsimperial.HasValue)
-            {
-                return FromThermsImperial(thermsimperial.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ThermsImperial.
-        /// </summary>
-        public static Energy? FromThermsImperial(int? thermsimperial)
-        {
-            if (thermsimperial.HasValue)
-            {
-                return FromThermsImperial(thermsimperial.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ThermsImperial.
-        /// </summary>
-        public static Energy? FromThermsImperial(long? thermsimperial)
-        {
-            if (thermsimperial.HasValue)
-            {
-                return FromThermsImperial(thermsimperial.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from ThermsImperial of type decimal.
-        /// </summary>
-        public static Energy? FromThermsImperial(decimal? thermsimperial)
+        public static Energy? FromThermsImperial(QuantityValue? thermsimperial)
         {
             if (thermsimperial.HasValue)
             {
@@ -2355,52 +1015,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable ThermsUs.
         /// </summary>
-        public static Energy? FromThermsUs(double? thermsus)
-        {
-            if (thermsus.HasValue)
-            {
-                return FromThermsUs(thermsus.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ThermsUs.
-        /// </summary>
-        public static Energy? FromThermsUs(int? thermsus)
-        {
-            if (thermsus.HasValue)
-            {
-                return FromThermsUs(thermsus.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable ThermsUs.
-        /// </summary>
-        public static Energy? FromThermsUs(long? thermsus)
-        {
-            if (thermsus.HasValue)
-            {
-                return FromThermsUs(thermsus.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from ThermsUs of type decimal.
-        /// </summary>
-        public static Energy? FromThermsUs(decimal? thermsus)
+        public static Energy? FromThermsUs(QuantityValue? thermsus)
         {
             if (thermsus.HasValue)
             {
@@ -2415,52 +1030,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Energy from nullable WattHours.
         /// </summary>
-        public static Energy? FromWattHours(double? watthours)
-        {
-            if (watthours.HasValue)
-            {
-                return FromWattHours(watthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable WattHours.
-        /// </summary>
-        public static Energy? FromWattHours(int? watthours)
-        {
-            if (watthours.HasValue)
-            {
-                return FromWattHours(watthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from nullable WattHours.
-        /// </summary>
-        public static Energy? FromWattHours(long? watthours)
-        {
-            if (watthours.HasValue)
-            {
-                return FromWattHours(watthours.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Energy from WattHours of type decimal.
-        /// </summary>
-        public static Energy? FromWattHours(decimal? watthours)
+        public static Energy? FromWattHours(QuantityValue? watthours)
         {
             if (watthours.HasValue)
             {
@@ -2477,57 +1047,63 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="EnergyUnit" /> to <see cref="Energy" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Energy unit value.</returns>
-        public static Energy From(double val, EnergyUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Energy From(double value, EnergyUnit fromUnit)
+#else
+        public static Energy From(QuantityValue value, EnergyUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case EnergyUnit.BritishThermalUnit:
-                    return FromBritishThermalUnits(val);
+                    return FromBritishThermalUnits(value);
                 case EnergyUnit.Calorie:
-                    return FromCalories(val);
+                    return FromCalories(value);
                 case EnergyUnit.DecathermEc:
-                    return FromDecathermsEc(val);
+                    return FromDecathermsEc(value);
                 case EnergyUnit.DecathermImperial:
-                    return FromDecathermsImperial(val);
+                    return FromDecathermsImperial(value);
                 case EnergyUnit.DecathermUs:
-                    return FromDecathermsUs(val);
+                    return FromDecathermsUs(value);
                 case EnergyUnit.ElectronVolt:
-                    return FromElectronVolts(val);
+                    return FromElectronVolts(value);
                 case EnergyUnit.Erg:
-                    return FromErgs(val);
+                    return FromErgs(value);
                 case EnergyUnit.FootPound:
-                    return FromFootPounds(val);
+                    return FromFootPounds(value);
                 case EnergyUnit.GigabritishThermalUnit:
-                    return FromGigabritishThermalUnits(val);
+                    return FromGigabritishThermalUnits(value);
                 case EnergyUnit.GigawattHour:
-                    return FromGigawattHours(val);
+                    return FromGigawattHours(value);
                 case EnergyUnit.Joule:
-                    return FromJoules(val);
+                    return FromJoules(value);
                 case EnergyUnit.KilobritishThermalUnit:
-                    return FromKilobritishThermalUnits(val);
+                    return FromKilobritishThermalUnits(value);
                 case EnergyUnit.Kilocalorie:
-                    return FromKilocalories(val);
+                    return FromKilocalories(value);
                 case EnergyUnit.Kilojoule:
-                    return FromKilojoules(val);
+                    return FromKilojoules(value);
                 case EnergyUnit.KilowattHour:
-                    return FromKilowattHours(val);
+                    return FromKilowattHours(value);
                 case EnergyUnit.MegabritishThermalUnit:
-                    return FromMegabritishThermalUnits(val);
+                    return FromMegabritishThermalUnits(value);
                 case EnergyUnit.Megajoule:
-                    return FromMegajoules(val);
+                    return FromMegajoules(value);
                 case EnergyUnit.MegawattHour:
-                    return FromMegawattHours(val);
+                    return FromMegawattHours(value);
                 case EnergyUnit.ThermEc:
-                    return FromThermsEc(val);
+                    return FromThermsEc(value);
                 case EnergyUnit.ThermImperial:
-                    return FromThermsImperial(val);
+                    return FromThermsImperial(value);
                 case EnergyUnit.ThermUs:
-                    return FromThermsUs(val);
+                    return FromThermsUs(value);
                 case EnergyUnit.WattHour:
-                    return FromWattHours(val);
+                    return FromWattHours(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2542,7 +1118,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Energy unit value.</returns>
-        public static Energy? From(double? value, EnergyUnit fromUnit)
+        public static Energy? From(QuantityValue? value, EnergyUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -197,266 +197,126 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from CaloriesPerKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromCaloriesPerKelvin(double caloriesperkelvin)
         {
-            return new Entropy(caloriesperkelvin*4.184);
+            double value = (double) caloriesperkelvin;
+            return new Entropy(value*4.184);
         }
-
-        /// <summary>
-        ///     Get Entropy from CaloriesPerKelvin.
-        /// </summary>
-        public static Entropy FromCaloriesPerKelvin(int caloriesperkelvin)
+#else
+        public static Entropy FromCaloriesPerKelvin(QuantityValue caloriesperkelvin)
         {
-            return new Entropy(caloriesperkelvin*4.184);
-        }
-
-        /// <summary>
-        ///     Get Entropy from CaloriesPerKelvin.
-        /// </summary>
-        public static Entropy FromCaloriesPerKelvin(long caloriesperkelvin)
-        {
-            return new Entropy(caloriesperkelvin*4.184);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from CaloriesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy FromCaloriesPerKelvin(decimal caloriesperkelvin)
-        {
-            return new Entropy(Convert.ToDouble(caloriesperkelvin)*4.184);
+            double value = (double) caloriesperkelvin;
+            return new Entropy((value*4.184));
         }
 #endif
 
         /// <summary>
         ///     Get Entropy from JoulesPerDegreeCelsius.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromJoulesPerDegreeCelsius(double joulesperdegreecelsius)
         {
-            return new Entropy(joulesperdegreecelsius);
+            double value = (double) joulesperdegreecelsius;
+            return new Entropy(value);
         }
-
-        /// <summary>
-        ///     Get Entropy from JoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy FromJoulesPerDegreeCelsius(int joulesperdegreecelsius)
+#else
+        public static Entropy FromJoulesPerDegreeCelsius(QuantityValue joulesperdegreecelsius)
         {
-            return new Entropy(joulesperdegreecelsius);
-        }
-
-        /// <summary>
-        ///     Get Entropy from JoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy FromJoulesPerDegreeCelsius(long joulesperdegreecelsius)
-        {
-            return new Entropy(joulesperdegreecelsius);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from JoulesPerDegreeCelsius of type decimal.
-        /// </summary>
-        public static Entropy FromJoulesPerDegreeCelsius(decimal joulesperdegreecelsius)
-        {
-            return new Entropy(Convert.ToDouble(joulesperdegreecelsius));
+            double value = (double) joulesperdegreecelsius;
+            return new Entropy((value));
         }
 #endif
 
         /// <summary>
         ///     Get Entropy from JoulesPerKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromJoulesPerKelvin(double joulesperkelvin)
         {
-            return new Entropy(joulesperkelvin);
+            double value = (double) joulesperkelvin;
+            return new Entropy(value);
         }
-
-        /// <summary>
-        ///     Get Entropy from JoulesPerKelvin.
-        /// </summary>
-        public static Entropy FromJoulesPerKelvin(int joulesperkelvin)
+#else
+        public static Entropy FromJoulesPerKelvin(QuantityValue joulesperkelvin)
         {
-            return new Entropy(joulesperkelvin);
-        }
-
-        /// <summary>
-        ///     Get Entropy from JoulesPerKelvin.
-        /// </summary>
-        public static Entropy FromJoulesPerKelvin(long joulesperkelvin)
-        {
-            return new Entropy(joulesperkelvin);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from JoulesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy FromJoulesPerKelvin(decimal joulesperkelvin)
-        {
-            return new Entropy(Convert.ToDouble(joulesperkelvin));
+            double value = (double) joulesperkelvin;
+            return new Entropy((value));
         }
 #endif
 
         /// <summary>
         ///     Get Entropy from KilocaloriesPerKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromKilocaloriesPerKelvin(double kilocaloriesperkelvin)
         {
-            return new Entropy((kilocaloriesperkelvin*4.184) * 1e3d);
+            double value = (double) kilocaloriesperkelvin;
+            return new Entropy((value*4.184) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Entropy from KilocaloriesPerKelvin.
-        /// </summary>
-        public static Entropy FromKilocaloriesPerKelvin(int kilocaloriesperkelvin)
+#else
+        public static Entropy FromKilocaloriesPerKelvin(QuantityValue kilocaloriesperkelvin)
         {
-            return new Entropy((kilocaloriesperkelvin*4.184) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Entropy from KilocaloriesPerKelvin.
-        /// </summary>
-        public static Entropy FromKilocaloriesPerKelvin(long kilocaloriesperkelvin)
-        {
-            return new Entropy((kilocaloriesperkelvin*4.184) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from KilocaloriesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy FromKilocaloriesPerKelvin(decimal kilocaloriesperkelvin)
-        {
-            return new Entropy((Convert.ToDouble(kilocaloriesperkelvin)*4.184) * 1e3d);
+            double value = (double) kilocaloriesperkelvin;
+            return new Entropy(((value*4.184) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Entropy from KilojoulesPerDegreeCelsius.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromKilojoulesPerDegreeCelsius(double kilojoulesperdegreecelsius)
         {
-            return new Entropy((kilojoulesperdegreecelsius) * 1e3d);
+            double value = (double) kilojoulesperdegreecelsius;
+            return new Entropy((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Entropy from KilojoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy FromKilojoulesPerDegreeCelsius(int kilojoulesperdegreecelsius)
+#else
+        public static Entropy FromKilojoulesPerDegreeCelsius(QuantityValue kilojoulesperdegreecelsius)
         {
-            return new Entropy((kilojoulesperdegreecelsius) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Entropy from KilojoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy FromKilojoulesPerDegreeCelsius(long kilojoulesperdegreecelsius)
-        {
-            return new Entropy((kilojoulesperdegreecelsius) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from KilojoulesPerDegreeCelsius of type decimal.
-        /// </summary>
-        public static Entropy FromKilojoulesPerDegreeCelsius(decimal kilojoulesperdegreecelsius)
-        {
-            return new Entropy((Convert.ToDouble(kilojoulesperdegreecelsius)) * 1e3d);
+            double value = (double) kilojoulesperdegreecelsius;
+            return new Entropy(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Entropy from KilojoulesPerKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromKilojoulesPerKelvin(double kilojoulesperkelvin)
         {
-            return new Entropy((kilojoulesperkelvin) * 1e3d);
+            double value = (double) kilojoulesperkelvin;
+            return new Entropy((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Entropy from KilojoulesPerKelvin.
-        /// </summary>
-        public static Entropy FromKilojoulesPerKelvin(int kilojoulesperkelvin)
+#else
+        public static Entropy FromKilojoulesPerKelvin(QuantityValue kilojoulesperkelvin)
         {
-            return new Entropy((kilojoulesperkelvin) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Entropy from KilojoulesPerKelvin.
-        /// </summary>
-        public static Entropy FromKilojoulesPerKelvin(long kilojoulesperkelvin)
-        {
-            return new Entropy((kilojoulesperkelvin) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from KilojoulesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy FromKilojoulesPerKelvin(decimal kilojoulesperkelvin)
-        {
-            return new Entropy((Convert.ToDouble(kilojoulesperkelvin)) * 1e3d);
+            double value = (double) kilojoulesperkelvin;
+            return new Entropy(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Entropy from MegajoulesPerKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Entropy FromMegajoulesPerKelvin(double megajoulesperkelvin)
         {
-            return new Entropy((megajoulesperkelvin) * 1e6d);
+            double value = (double) megajoulesperkelvin;
+            return new Entropy((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Entropy from MegajoulesPerKelvin.
-        /// </summary>
-        public static Entropy FromMegajoulesPerKelvin(int megajoulesperkelvin)
+#else
+        public static Entropy FromMegajoulesPerKelvin(QuantityValue megajoulesperkelvin)
         {
-            return new Entropy((megajoulesperkelvin) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Entropy from MegajoulesPerKelvin.
-        /// </summary>
-        public static Entropy FromMegajoulesPerKelvin(long megajoulesperkelvin)
-        {
-            return new Entropy((megajoulesperkelvin) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Entropy from MegajoulesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy FromMegajoulesPerKelvin(decimal megajoulesperkelvin)
-        {
-            return new Entropy((Convert.ToDouble(megajoulesperkelvin)) * 1e6d);
+            double value = (double) megajoulesperkelvin;
+            return new Entropy(((value) * 1e6d));
         }
 #endif
 
@@ -465,52 +325,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable CaloriesPerKelvin.
         /// </summary>
-        public static Entropy? FromCaloriesPerKelvin(double? caloriesperkelvin)
-        {
-            if (caloriesperkelvin.HasValue)
-            {
-                return FromCaloriesPerKelvin(caloriesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable CaloriesPerKelvin.
-        /// </summary>
-        public static Entropy? FromCaloriesPerKelvin(int? caloriesperkelvin)
-        {
-            if (caloriesperkelvin.HasValue)
-            {
-                return FromCaloriesPerKelvin(caloriesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable CaloriesPerKelvin.
-        /// </summary>
-        public static Entropy? FromCaloriesPerKelvin(long? caloriesperkelvin)
-        {
-            if (caloriesperkelvin.HasValue)
-            {
-                return FromCaloriesPerKelvin(caloriesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from CaloriesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy? FromCaloriesPerKelvin(decimal? caloriesperkelvin)
+        public static Entropy? FromCaloriesPerKelvin(QuantityValue? caloriesperkelvin)
         {
             if (caloriesperkelvin.HasValue)
             {
@@ -525,52 +340,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable JoulesPerDegreeCelsius.
         /// </summary>
-        public static Entropy? FromJoulesPerDegreeCelsius(double? joulesperdegreecelsius)
-        {
-            if (joulesperdegreecelsius.HasValue)
-            {
-                return FromJoulesPerDegreeCelsius(joulesperdegreecelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable JoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy? FromJoulesPerDegreeCelsius(int? joulesperdegreecelsius)
-        {
-            if (joulesperdegreecelsius.HasValue)
-            {
-                return FromJoulesPerDegreeCelsius(joulesperdegreecelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable JoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy? FromJoulesPerDegreeCelsius(long? joulesperdegreecelsius)
-        {
-            if (joulesperdegreecelsius.HasValue)
-            {
-                return FromJoulesPerDegreeCelsius(joulesperdegreecelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from JoulesPerDegreeCelsius of type decimal.
-        /// </summary>
-        public static Entropy? FromJoulesPerDegreeCelsius(decimal? joulesperdegreecelsius)
+        public static Entropy? FromJoulesPerDegreeCelsius(QuantityValue? joulesperdegreecelsius)
         {
             if (joulesperdegreecelsius.HasValue)
             {
@@ -585,52 +355,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable JoulesPerKelvin.
         /// </summary>
-        public static Entropy? FromJoulesPerKelvin(double? joulesperkelvin)
-        {
-            if (joulesperkelvin.HasValue)
-            {
-                return FromJoulesPerKelvin(joulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable JoulesPerKelvin.
-        /// </summary>
-        public static Entropy? FromJoulesPerKelvin(int? joulesperkelvin)
-        {
-            if (joulesperkelvin.HasValue)
-            {
-                return FromJoulesPerKelvin(joulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable JoulesPerKelvin.
-        /// </summary>
-        public static Entropy? FromJoulesPerKelvin(long? joulesperkelvin)
-        {
-            if (joulesperkelvin.HasValue)
-            {
-                return FromJoulesPerKelvin(joulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from JoulesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy? FromJoulesPerKelvin(decimal? joulesperkelvin)
+        public static Entropy? FromJoulesPerKelvin(QuantityValue? joulesperkelvin)
         {
             if (joulesperkelvin.HasValue)
             {
@@ -645,52 +370,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable KilocaloriesPerKelvin.
         /// </summary>
-        public static Entropy? FromKilocaloriesPerKelvin(double? kilocaloriesperkelvin)
-        {
-            if (kilocaloriesperkelvin.HasValue)
-            {
-                return FromKilocaloriesPerKelvin(kilocaloriesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable KilocaloriesPerKelvin.
-        /// </summary>
-        public static Entropy? FromKilocaloriesPerKelvin(int? kilocaloriesperkelvin)
-        {
-            if (kilocaloriesperkelvin.HasValue)
-            {
-                return FromKilocaloriesPerKelvin(kilocaloriesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable KilocaloriesPerKelvin.
-        /// </summary>
-        public static Entropy? FromKilocaloriesPerKelvin(long? kilocaloriesperkelvin)
-        {
-            if (kilocaloriesperkelvin.HasValue)
-            {
-                return FromKilocaloriesPerKelvin(kilocaloriesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from KilocaloriesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy? FromKilocaloriesPerKelvin(decimal? kilocaloriesperkelvin)
+        public static Entropy? FromKilocaloriesPerKelvin(QuantityValue? kilocaloriesperkelvin)
         {
             if (kilocaloriesperkelvin.HasValue)
             {
@@ -705,52 +385,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable KilojoulesPerDegreeCelsius.
         /// </summary>
-        public static Entropy? FromKilojoulesPerDegreeCelsius(double? kilojoulesperdegreecelsius)
-        {
-            if (kilojoulesperdegreecelsius.HasValue)
-            {
-                return FromKilojoulesPerDegreeCelsius(kilojoulesperdegreecelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable KilojoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy? FromKilojoulesPerDegreeCelsius(int? kilojoulesperdegreecelsius)
-        {
-            if (kilojoulesperdegreecelsius.HasValue)
-            {
-                return FromKilojoulesPerDegreeCelsius(kilojoulesperdegreecelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable KilojoulesPerDegreeCelsius.
-        /// </summary>
-        public static Entropy? FromKilojoulesPerDegreeCelsius(long? kilojoulesperdegreecelsius)
-        {
-            if (kilojoulesperdegreecelsius.HasValue)
-            {
-                return FromKilojoulesPerDegreeCelsius(kilojoulesperdegreecelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from KilojoulesPerDegreeCelsius of type decimal.
-        /// </summary>
-        public static Entropy? FromKilojoulesPerDegreeCelsius(decimal? kilojoulesperdegreecelsius)
+        public static Entropy? FromKilojoulesPerDegreeCelsius(QuantityValue? kilojoulesperdegreecelsius)
         {
             if (kilojoulesperdegreecelsius.HasValue)
             {
@@ -765,52 +400,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable KilojoulesPerKelvin.
         /// </summary>
-        public static Entropy? FromKilojoulesPerKelvin(double? kilojoulesperkelvin)
-        {
-            if (kilojoulesperkelvin.HasValue)
-            {
-                return FromKilojoulesPerKelvin(kilojoulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable KilojoulesPerKelvin.
-        /// </summary>
-        public static Entropy? FromKilojoulesPerKelvin(int? kilojoulesperkelvin)
-        {
-            if (kilojoulesperkelvin.HasValue)
-            {
-                return FromKilojoulesPerKelvin(kilojoulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable KilojoulesPerKelvin.
-        /// </summary>
-        public static Entropy? FromKilojoulesPerKelvin(long? kilojoulesperkelvin)
-        {
-            if (kilojoulesperkelvin.HasValue)
-            {
-                return FromKilojoulesPerKelvin(kilojoulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from KilojoulesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy? FromKilojoulesPerKelvin(decimal? kilojoulesperkelvin)
+        public static Entropy? FromKilojoulesPerKelvin(QuantityValue? kilojoulesperkelvin)
         {
             if (kilojoulesperkelvin.HasValue)
             {
@@ -825,52 +415,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Entropy from nullable MegajoulesPerKelvin.
         /// </summary>
-        public static Entropy? FromMegajoulesPerKelvin(double? megajoulesperkelvin)
-        {
-            if (megajoulesperkelvin.HasValue)
-            {
-                return FromMegajoulesPerKelvin(megajoulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable MegajoulesPerKelvin.
-        /// </summary>
-        public static Entropy? FromMegajoulesPerKelvin(int? megajoulesperkelvin)
-        {
-            if (megajoulesperkelvin.HasValue)
-            {
-                return FromMegajoulesPerKelvin(megajoulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from nullable MegajoulesPerKelvin.
-        /// </summary>
-        public static Entropy? FromMegajoulesPerKelvin(long? megajoulesperkelvin)
-        {
-            if (megajoulesperkelvin.HasValue)
-            {
-                return FromMegajoulesPerKelvin(megajoulesperkelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Entropy from MegajoulesPerKelvin of type decimal.
-        /// </summary>
-        public static Entropy? FromMegajoulesPerKelvin(decimal? megajoulesperkelvin)
+        public static Entropy? FromMegajoulesPerKelvin(QuantityValue? megajoulesperkelvin)
         {
             if (megajoulesperkelvin.HasValue)
             {
@@ -887,27 +432,33 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="EntropyUnit" /> to <see cref="Entropy" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Entropy unit value.</returns>
-        public static Entropy From(double val, EntropyUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Entropy From(double value, EntropyUnit fromUnit)
+#else
+        public static Entropy From(QuantityValue value, EntropyUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case EntropyUnit.CaloriePerKelvin:
-                    return FromCaloriesPerKelvin(val);
+                    return FromCaloriesPerKelvin(value);
                 case EntropyUnit.JoulePerDegreeCelsius:
-                    return FromJoulesPerDegreeCelsius(val);
+                    return FromJoulesPerDegreeCelsius(value);
                 case EntropyUnit.JoulePerKelvin:
-                    return FromJoulesPerKelvin(val);
+                    return FromJoulesPerKelvin(value);
                 case EntropyUnit.KilocaloriePerKelvin:
-                    return FromKilocaloriesPerKelvin(val);
+                    return FromKilocaloriesPerKelvin(value);
                 case EntropyUnit.KilojoulePerDegreeCelsius:
-                    return FromKilojoulesPerDegreeCelsius(val);
+                    return FromKilojoulesPerDegreeCelsius(value);
                 case EntropyUnit.KilojoulePerKelvin:
-                    return FromKilojoulesPerKelvin(val);
+                    return FromKilojoulesPerKelvin(value);
                 case EntropyUnit.MegajoulePerKelvin:
-                    return FromMegajoulesPerKelvin(val);
+                    return FromMegajoulesPerKelvin(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -922,7 +473,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Entropy unit value.</returns>
-        public static Entropy? From(double? value, EntropyUnit fromUnit)
+        public static Entropy? From(QuantityValue? value, EntropyUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -277,646 +277,306 @@ namespace UnitsNet
         /// <summary>
         ///     Get Flow from CentilitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromCentilitersPerMinute(double centilitersperminute)
         {
-            return new Flow((centilitersperminute/60000.00000) * 1e-2d);
+            double value = (double) centilitersperminute;
+            return new Flow((value/60000.00000) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Flow from CentilitersPerMinute.
-        /// </summary>
-        public static Flow FromCentilitersPerMinute(int centilitersperminute)
+#else
+        public static Flow FromCentilitersPerMinute(QuantityValue centilitersperminute)
         {
-            return new Flow((centilitersperminute/60000.00000) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Flow from CentilitersPerMinute.
-        /// </summary>
-        public static Flow FromCentilitersPerMinute(long centilitersperminute)
-        {
-            return new Flow((centilitersperminute/60000.00000) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from CentilitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromCentilitersPerMinute(decimal centilitersperminute)
-        {
-            return new Flow((Convert.ToDouble(centilitersperminute)/60000.00000) * 1e-2d);
+            double value = (double) centilitersperminute;
+            return new Flow(((value/60000.00000) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from CubicDecimetersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromCubicDecimetersPerMinute(double cubicdecimetersperminute)
         {
-            return new Flow(cubicdecimetersperminute/60000.00000);
+            double value = (double) cubicdecimetersperminute;
+            return new Flow(value/60000.00000);
         }
-
-        /// <summary>
-        ///     Get Flow from CubicDecimetersPerMinute.
-        /// </summary>
-        public static Flow FromCubicDecimetersPerMinute(int cubicdecimetersperminute)
+#else
+        public static Flow FromCubicDecimetersPerMinute(QuantityValue cubicdecimetersperminute)
         {
-            return new Flow(cubicdecimetersperminute/60000.00000);
-        }
-
-        /// <summary>
-        ///     Get Flow from CubicDecimetersPerMinute.
-        /// </summary>
-        public static Flow FromCubicDecimetersPerMinute(long cubicdecimetersperminute)
-        {
-            return new Flow(cubicdecimetersperminute/60000.00000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from CubicDecimetersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromCubicDecimetersPerMinute(decimal cubicdecimetersperminute)
-        {
-            return new Flow(Convert.ToDouble(cubicdecimetersperminute)/60000.00000);
+            double value = (double) cubicdecimetersperminute;
+            return new Flow((value/60000.00000));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from CubicFeetPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromCubicFeetPerHour(double cubicfeetperhour)
         {
-            return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
+            double value = (double) cubicfeetperhour;
+            return new Flow(value*7.8657907199999087346816086183876e-6);
         }
-
-        /// <summary>
-        ///     Get Flow from CubicFeetPerHour.
-        /// </summary>
-        public static Flow FromCubicFeetPerHour(int cubicfeetperhour)
+#else
+        public static Flow FromCubicFeetPerHour(QuantityValue cubicfeetperhour)
         {
-            return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
-        }
-
-        /// <summary>
-        ///     Get Flow from CubicFeetPerHour.
-        /// </summary>
-        public static Flow FromCubicFeetPerHour(long cubicfeetperhour)
-        {
-            return new Flow(cubicfeetperhour*7.8657907199999087346816086183876e-6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from CubicFeetPerHour of type decimal.
-        /// </summary>
-        public static Flow FromCubicFeetPerHour(decimal cubicfeetperhour)
-        {
-            return new Flow(Convert.ToDouble(cubicfeetperhour)*7.8657907199999087346816086183876e-6);
+            double value = (double) cubicfeetperhour;
+            return new Flow((value*7.8657907199999087346816086183876e-6));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from CubicFeetPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromCubicFeetPerSecond(double cubicfeetpersecond)
         {
-            return new Flow(cubicfeetpersecond/35.314666721);
+            double value = (double) cubicfeetpersecond;
+            return new Flow(value/35.314666721);
         }
-
-        /// <summary>
-        ///     Get Flow from CubicFeetPerSecond.
-        /// </summary>
-        public static Flow FromCubicFeetPerSecond(int cubicfeetpersecond)
+#else
+        public static Flow FromCubicFeetPerSecond(QuantityValue cubicfeetpersecond)
         {
-            return new Flow(cubicfeetpersecond/35.314666721);
-        }
-
-        /// <summary>
-        ///     Get Flow from CubicFeetPerSecond.
-        /// </summary>
-        public static Flow FromCubicFeetPerSecond(long cubicfeetpersecond)
-        {
-            return new Flow(cubicfeetpersecond/35.314666721);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from CubicFeetPerSecond of type decimal.
-        /// </summary>
-        public static Flow FromCubicFeetPerSecond(decimal cubicfeetpersecond)
-        {
-            return new Flow(Convert.ToDouble(cubicfeetpersecond)/35.314666721);
+            double value = (double) cubicfeetpersecond;
+            return new Flow((value/35.314666721));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from CubicMetersPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromCubicMetersPerHour(double cubicmetersperhour)
         {
-            return new Flow(cubicmetersperhour/3600);
+            double value = (double) cubicmetersperhour;
+            return new Flow(value/3600);
         }
-
-        /// <summary>
-        ///     Get Flow from CubicMetersPerHour.
-        /// </summary>
-        public static Flow FromCubicMetersPerHour(int cubicmetersperhour)
+#else
+        public static Flow FromCubicMetersPerHour(QuantityValue cubicmetersperhour)
         {
-            return new Flow(cubicmetersperhour/3600);
-        }
-
-        /// <summary>
-        ///     Get Flow from CubicMetersPerHour.
-        /// </summary>
-        public static Flow FromCubicMetersPerHour(long cubicmetersperhour)
-        {
-            return new Flow(cubicmetersperhour/3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from CubicMetersPerHour of type decimal.
-        /// </summary>
-        public static Flow FromCubicMetersPerHour(decimal cubicmetersperhour)
-        {
-            return new Flow(Convert.ToDouble(cubicmetersperhour)/3600);
+            double value = (double) cubicmetersperhour;
+            return new Flow((value/3600));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from CubicMetersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromCubicMetersPerSecond(double cubicmeterspersecond)
         {
-            return new Flow(cubicmeterspersecond);
+            double value = (double) cubicmeterspersecond;
+            return new Flow(value);
         }
-
-        /// <summary>
-        ///     Get Flow from CubicMetersPerSecond.
-        /// </summary>
-        public static Flow FromCubicMetersPerSecond(int cubicmeterspersecond)
+#else
+        public static Flow FromCubicMetersPerSecond(QuantityValue cubicmeterspersecond)
         {
-            return new Flow(cubicmeterspersecond);
-        }
-
-        /// <summary>
-        ///     Get Flow from CubicMetersPerSecond.
-        /// </summary>
-        public static Flow FromCubicMetersPerSecond(long cubicmeterspersecond)
-        {
-            return new Flow(cubicmeterspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from CubicMetersPerSecond of type decimal.
-        /// </summary>
-        public static Flow FromCubicMetersPerSecond(decimal cubicmeterspersecond)
-        {
-            return new Flow(Convert.ToDouble(cubicmeterspersecond));
+            double value = (double) cubicmeterspersecond;
+            return new Flow((value));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from DecilitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromDecilitersPerMinute(double decilitersperminute)
         {
-            return new Flow((decilitersperminute/60000.00000) * 1e-1d);
+            double value = (double) decilitersperminute;
+            return new Flow((value/60000.00000) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Flow from DecilitersPerMinute.
-        /// </summary>
-        public static Flow FromDecilitersPerMinute(int decilitersperminute)
+#else
+        public static Flow FromDecilitersPerMinute(QuantityValue decilitersperminute)
         {
-            return new Flow((decilitersperminute/60000.00000) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Flow from DecilitersPerMinute.
-        /// </summary>
-        public static Flow FromDecilitersPerMinute(long decilitersperminute)
-        {
-            return new Flow((decilitersperminute/60000.00000) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from DecilitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromDecilitersPerMinute(decimal decilitersperminute)
-        {
-            return new Flow((Convert.ToDouble(decilitersperminute)/60000.00000) * 1e-1d);
+            double value = (double) decilitersperminute;
+            return new Flow(((value/60000.00000) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from KilolitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromKilolitersPerMinute(double kilolitersperminute)
         {
-            return new Flow((kilolitersperminute/60000.00000) * 1e3d);
+            double value = (double) kilolitersperminute;
+            return new Flow((value/60000.00000) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Flow from KilolitersPerMinute.
-        /// </summary>
-        public static Flow FromKilolitersPerMinute(int kilolitersperminute)
+#else
+        public static Flow FromKilolitersPerMinute(QuantityValue kilolitersperminute)
         {
-            return new Flow((kilolitersperminute/60000.00000) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Flow from KilolitersPerMinute.
-        /// </summary>
-        public static Flow FromKilolitersPerMinute(long kilolitersperminute)
-        {
-            return new Flow((kilolitersperminute/60000.00000) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from KilolitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromKilolitersPerMinute(decimal kilolitersperminute)
-        {
-            return new Flow((Convert.ToDouble(kilolitersperminute)/60000.00000) * 1e3d);
+            double value = (double) kilolitersperminute;
+            return new Flow(((value/60000.00000) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from LitersPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromLitersPerHour(double litersperhour)
         {
-            return new Flow(litersperhour/3600000.000);
+            double value = (double) litersperhour;
+            return new Flow(value/3600000.000);
         }
-
-        /// <summary>
-        ///     Get Flow from LitersPerHour.
-        /// </summary>
-        public static Flow FromLitersPerHour(int litersperhour)
+#else
+        public static Flow FromLitersPerHour(QuantityValue litersperhour)
         {
-            return new Flow(litersperhour/3600000.000);
-        }
-
-        /// <summary>
-        ///     Get Flow from LitersPerHour.
-        /// </summary>
-        public static Flow FromLitersPerHour(long litersperhour)
-        {
-            return new Flow(litersperhour/3600000.000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from LitersPerHour of type decimal.
-        /// </summary>
-        public static Flow FromLitersPerHour(decimal litersperhour)
-        {
-            return new Flow(Convert.ToDouble(litersperhour)/3600000.000);
+            double value = (double) litersperhour;
+            return new Flow((value/3600000.000));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from LitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromLitersPerMinute(double litersperminute)
         {
-            return new Flow(litersperminute/60000.00000);
+            double value = (double) litersperminute;
+            return new Flow(value/60000.00000);
         }
-
-        /// <summary>
-        ///     Get Flow from LitersPerMinute.
-        /// </summary>
-        public static Flow FromLitersPerMinute(int litersperminute)
+#else
+        public static Flow FromLitersPerMinute(QuantityValue litersperminute)
         {
-            return new Flow(litersperminute/60000.00000);
-        }
-
-        /// <summary>
-        ///     Get Flow from LitersPerMinute.
-        /// </summary>
-        public static Flow FromLitersPerMinute(long litersperminute)
-        {
-            return new Flow(litersperminute/60000.00000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from LitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromLitersPerMinute(decimal litersperminute)
-        {
-            return new Flow(Convert.ToDouble(litersperminute)/60000.00000);
+            double value = (double) litersperminute;
+            return new Flow((value/60000.00000));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from LitersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromLitersPerSecond(double literspersecond)
         {
-            return new Flow(literspersecond/1000);
+            double value = (double) literspersecond;
+            return new Flow(value/1000);
         }
-
-        /// <summary>
-        ///     Get Flow from LitersPerSecond.
-        /// </summary>
-        public static Flow FromLitersPerSecond(int literspersecond)
+#else
+        public static Flow FromLitersPerSecond(QuantityValue literspersecond)
         {
-            return new Flow(literspersecond/1000);
-        }
-
-        /// <summary>
-        ///     Get Flow from LitersPerSecond.
-        /// </summary>
-        public static Flow FromLitersPerSecond(long literspersecond)
-        {
-            return new Flow(literspersecond/1000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from LitersPerSecond of type decimal.
-        /// </summary>
-        public static Flow FromLitersPerSecond(decimal literspersecond)
-        {
-            return new Flow(Convert.ToDouble(literspersecond)/1000);
+            double value = (double) literspersecond;
+            return new Flow((value/1000));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from MicrolitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromMicrolitersPerMinute(double microlitersperminute)
         {
-            return new Flow((microlitersperminute/60000.00000) * 1e-6d);
+            double value = (double) microlitersperminute;
+            return new Flow((value/60000.00000) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Flow from MicrolitersPerMinute.
-        /// </summary>
-        public static Flow FromMicrolitersPerMinute(int microlitersperminute)
+#else
+        public static Flow FromMicrolitersPerMinute(QuantityValue microlitersperminute)
         {
-            return new Flow((microlitersperminute/60000.00000) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Flow from MicrolitersPerMinute.
-        /// </summary>
-        public static Flow FromMicrolitersPerMinute(long microlitersperminute)
-        {
-            return new Flow((microlitersperminute/60000.00000) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from MicrolitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromMicrolitersPerMinute(decimal microlitersperminute)
-        {
-            return new Flow((Convert.ToDouble(microlitersperminute)/60000.00000) * 1e-6d);
+            double value = (double) microlitersperminute;
+            return new Flow(((value/60000.00000) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from MillilitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromMillilitersPerMinute(double millilitersperminute)
         {
-            return new Flow((millilitersperminute/60000.00000) * 1e-3d);
+            double value = (double) millilitersperminute;
+            return new Flow((value/60000.00000) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Flow from MillilitersPerMinute.
-        /// </summary>
-        public static Flow FromMillilitersPerMinute(int millilitersperminute)
+#else
+        public static Flow FromMillilitersPerMinute(QuantityValue millilitersperminute)
         {
-            return new Flow((millilitersperminute/60000.00000) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Flow from MillilitersPerMinute.
-        /// </summary>
-        public static Flow FromMillilitersPerMinute(long millilitersperminute)
-        {
-            return new Flow((millilitersperminute/60000.00000) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from MillilitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromMillilitersPerMinute(decimal millilitersperminute)
-        {
-            return new Flow((Convert.ToDouble(millilitersperminute)/60000.00000) * 1e-3d);
+            double value = (double) millilitersperminute;
+            return new Flow(((value/60000.00000) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from MillionUsGallonsPerDay.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromMillionUsGallonsPerDay(double millionusgallonsperday)
         {
-            return new Flow(millionusgallonsperday/22.824465227);
+            double value = (double) millionusgallonsperday;
+            return new Flow(value/22.824465227);
         }
-
-        /// <summary>
-        ///     Get Flow from MillionUsGallonsPerDay.
-        /// </summary>
-        public static Flow FromMillionUsGallonsPerDay(int millionusgallonsperday)
+#else
+        public static Flow FromMillionUsGallonsPerDay(QuantityValue millionusgallonsperday)
         {
-            return new Flow(millionusgallonsperday/22.824465227);
-        }
-
-        /// <summary>
-        ///     Get Flow from MillionUsGallonsPerDay.
-        /// </summary>
-        public static Flow FromMillionUsGallonsPerDay(long millionusgallonsperday)
-        {
-            return new Flow(millionusgallonsperday/22.824465227);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from MillionUsGallonsPerDay of type decimal.
-        /// </summary>
-        public static Flow FromMillionUsGallonsPerDay(decimal millionusgallonsperday)
-        {
-            return new Flow(Convert.ToDouble(millionusgallonsperday)/22.824465227);
+            double value = (double) millionusgallonsperday;
+            return new Flow((value/22.824465227));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from NanolitersPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromNanolitersPerMinute(double nanolitersperminute)
         {
-            return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
+            double value = (double) nanolitersperminute;
+            return new Flow((value/60000.00000) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Flow from NanolitersPerMinute.
-        /// </summary>
-        public static Flow FromNanolitersPerMinute(int nanolitersperminute)
+#else
+        public static Flow FromNanolitersPerMinute(QuantityValue nanolitersperminute)
         {
-            return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Flow from NanolitersPerMinute.
-        /// </summary>
-        public static Flow FromNanolitersPerMinute(long nanolitersperminute)
-        {
-            return new Flow((nanolitersperminute/60000.00000) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from NanolitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromNanolitersPerMinute(decimal nanolitersperminute)
-        {
-            return new Flow((Convert.ToDouble(nanolitersperminute)/60000.00000) * 1e-9d);
+            double value = (double) nanolitersperminute;
+            return new Flow(((value/60000.00000) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from OilBarrelsPerDay.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromOilBarrelsPerDay(double oilbarrelsperday)
         {
-            return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
+            double value = (double) oilbarrelsperday;
+            return new Flow(value*1.8401307283333333333333333333333e-6);
         }
-
-        /// <summary>
-        ///     Get Flow from OilBarrelsPerDay.
-        /// </summary>
-        public static Flow FromOilBarrelsPerDay(int oilbarrelsperday)
+#else
+        public static Flow FromOilBarrelsPerDay(QuantityValue oilbarrelsperday)
         {
-            return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
-        }
-
-        /// <summary>
-        ///     Get Flow from OilBarrelsPerDay.
-        /// </summary>
-        public static Flow FromOilBarrelsPerDay(long oilbarrelsperday)
-        {
-            return new Flow(oilbarrelsperday*1.8401307283333333333333333333333e-6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from OilBarrelsPerDay of type decimal.
-        /// </summary>
-        public static Flow FromOilBarrelsPerDay(decimal oilbarrelsperday)
-        {
-            return new Flow(Convert.ToDouble(oilbarrelsperday)*1.8401307283333333333333333333333e-6);
+            double value = (double) oilbarrelsperday;
+            return new Flow((value*1.8401307283333333333333333333333e-6));
         }
 #endif
 
         /// <summary>
         ///     Get Flow from UsGallonsPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Flow FromUsGallonsPerMinute(double usgallonsperminute)
         {
-            return new Flow(usgallonsperminute/15850.323141489);
+            double value = (double) usgallonsperminute;
+            return new Flow(value/15850.323141489);
         }
-
-        /// <summary>
-        ///     Get Flow from UsGallonsPerMinute.
-        /// </summary>
-        public static Flow FromUsGallonsPerMinute(int usgallonsperminute)
+#else
+        public static Flow FromUsGallonsPerMinute(QuantityValue usgallonsperminute)
         {
-            return new Flow(usgallonsperminute/15850.323141489);
-        }
-
-        /// <summary>
-        ///     Get Flow from UsGallonsPerMinute.
-        /// </summary>
-        public static Flow FromUsGallonsPerMinute(long usgallonsperminute)
-        {
-            return new Flow(usgallonsperminute/15850.323141489);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Flow from UsGallonsPerMinute of type decimal.
-        /// </summary>
-        public static Flow FromUsGallonsPerMinute(decimal usgallonsperminute)
-        {
-            return new Flow(Convert.ToDouble(usgallonsperminute)/15850.323141489);
+            double value = (double) usgallonsperminute;
+            return new Flow((value/15850.323141489));
         }
 #endif
 
@@ -925,52 +585,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable CentilitersPerMinute.
         /// </summary>
-        public static Flow? FromCentilitersPerMinute(double? centilitersperminute)
-        {
-            if (centilitersperminute.HasValue)
-            {
-                return FromCentilitersPerMinute(centilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CentilitersPerMinute.
-        /// </summary>
-        public static Flow? FromCentilitersPerMinute(int? centilitersperminute)
-        {
-            if (centilitersperminute.HasValue)
-            {
-                return FromCentilitersPerMinute(centilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CentilitersPerMinute.
-        /// </summary>
-        public static Flow? FromCentilitersPerMinute(long? centilitersperminute)
-        {
-            if (centilitersperminute.HasValue)
-            {
-                return FromCentilitersPerMinute(centilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from CentilitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromCentilitersPerMinute(decimal? centilitersperminute)
+        public static Flow? FromCentilitersPerMinute(QuantityValue? centilitersperminute)
         {
             if (centilitersperminute.HasValue)
             {
@@ -985,52 +600,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
         /// </summary>
-        public static Flow? FromCubicDecimetersPerMinute(double? cubicdecimetersperminute)
-        {
-            if (cubicdecimetersperminute.HasValue)
-            {
-                return FromCubicDecimetersPerMinute(cubicdecimetersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
-        /// </summary>
-        public static Flow? FromCubicDecimetersPerMinute(int? cubicdecimetersperminute)
-        {
-            if (cubicdecimetersperminute.HasValue)
-            {
-                return FromCubicDecimetersPerMinute(cubicdecimetersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicDecimetersPerMinute.
-        /// </summary>
-        public static Flow? FromCubicDecimetersPerMinute(long? cubicdecimetersperminute)
-        {
-            if (cubicdecimetersperminute.HasValue)
-            {
-                return FromCubicDecimetersPerMinute(cubicdecimetersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from CubicDecimetersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromCubicDecimetersPerMinute(decimal? cubicdecimetersperminute)
+        public static Flow? FromCubicDecimetersPerMinute(QuantityValue? cubicdecimetersperminute)
         {
             if (cubicdecimetersperminute.HasValue)
             {
@@ -1045,52 +615,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerHour.
         /// </summary>
-        public static Flow? FromCubicFeetPerHour(double? cubicfeetperhour)
-        {
-            if (cubicfeetperhour.HasValue)
-            {
-                return FromCubicFeetPerHour(cubicfeetperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicFeetPerHour.
-        /// </summary>
-        public static Flow? FromCubicFeetPerHour(int? cubicfeetperhour)
-        {
-            if (cubicfeetperhour.HasValue)
-            {
-                return FromCubicFeetPerHour(cubicfeetperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicFeetPerHour.
-        /// </summary>
-        public static Flow? FromCubicFeetPerHour(long? cubicfeetperhour)
-        {
-            if (cubicfeetperhour.HasValue)
-            {
-                return FromCubicFeetPerHour(cubicfeetperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from CubicFeetPerHour of type decimal.
-        /// </summary>
-        public static Flow? FromCubicFeetPerHour(decimal? cubicfeetperhour)
+        public static Flow? FromCubicFeetPerHour(QuantityValue? cubicfeetperhour)
         {
             if (cubicfeetperhour.HasValue)
             {
@@ -1105,52 +630,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable CubicFeetPerSecond.
         /// </summary>
-        public static Flow? FromCubicFeetPerSecond(double? cubicfeetpersecond)
-        {
-            if (cubicfeetpersecond.HasValue)
-            {
-                return FromCubicFeetPerSecond(cubicfeetpersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicFeetPerSecond.
-        /// </summary>
-        public static Flow? FromCubicFeetPerSecond(int? cubicfeetpersecond)
-        {
-            if (cubicfeetpersecond.HasValue)
-            {
-                return FromCubicFeetPerSecond(cubicfeetpersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicFeetPerSecond.
-        /// </summary>
-        public static Flow? FromCubicFeetPerSecond(long? cubicfeetpersecond)
-        {
-            if (cubicfeetpersecond.HasValue)
-            {
-                return FromCubicFeetPerSecond(cubicfeetpersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from CubicFeetPerSecond of type decimal.
-        /// </summary>
-        public static Flow? FromCubicFeetPerSecond(decimal? cubicfeetpersecond)
+        public static Flow? FromCubicFeetPerSecond(QuantityValue? cubicfeetpersecond)
         {
             if (cubicfeetpersecond.HasValue)
             {
@@ -1165,52 +645,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerHour.
         /// </summary>
-        public static Flow? FromCubicMetersPerHour(double? cubicmetersperhour)
-        {
-            if (cubicmetersperhour.HasValue)
-            {
-                return FromCubicMetersPerHour(cubicmetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicMetersPerHour.
-        /// </summary>
-        public static Flow? FromCubicMetersPerHour(int? cubicmetersperhour)
-        {
-            if (cubicmetersperhour.HasValue)
-            {
-                return FromCubicMetersPerHour(cubicmetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicMetersPerHour.
-        /// </summary>
-        public static Flow? FromCubicMetersPerHour(long? cubicmetersperhour)
-        {
-            if (cubicmetersperhour.HasValue)
-            {
-                return FromCubicMetersPerHour(cubicmetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from CubicMetersPerHour of type decimal.
-        /// </summary>
-        public static Flow? FromCubicMetersPerHour(decimal? cubicmetersperhour)
+        public static Flow? FromCubicMetersPerHour(QuantityValue? cubicmetersperhour)
         {
             if (cubicmetersperhour.HasValue)
             {
@@ -1225,52 +660,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable CubicMetersPerSecond.
         /// </summary>
-        public static Flow? FromCubicMetersPerSecond(double? cubicmeterspersecond)
-        {
-            if (cubicmeterspersecond.HasValue)
-            {
-                return FromCubicMetersPerSecond(cubicmeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicMetersPerSecond.
-        /// </summary>
-        public static Flow? FromCubicMetersPerSecond(int? cubicmeterspersecond)
-        {
-            if (cubicmeterspersecond.HasValue)
-            {
-                return FromCubicMetersPerSecond(cubicmeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable CubicMetersPerSecond.
-        /// </summary>
-        public static Flow? FromCubicMetersPerSecond(long? cubicmeterspersecond)
-        {
-            if (cubicmeterspersecond.HasValue)
-            {
-                return FromCubicMetersPerSecond(cubicmeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from CubicMetersPerSecond of type decimal.
-        /// </summary>
-        public static Flow? FromCubicMetersPerSecond(decimal? cubicmeterspersecond)
+        public static Flow? FromCubicMetersPerSecond(QuantityValue? cubicmeterspersecond)
         {
             if (cubicmeterspersecond.HasValue)
             {
@@ -1285,52 +675,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable DecilitersPerMinute.
         /// </summary>
-        public static Flow? FromDecilitersPerMinute(double? decilitersperminute)
-        {
-            if (decilitersperminute.HasValue)
-            {
-                return FromDecilitersPerMinute(decilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable DecilitersPerMinute.
-        /// </summary>
-        public static Flow? FromDecilitersPerMinute(int? decilitersperminute)
-        {
-            if (decilitersperminute.HasValue)
-            {
-                return FromDecilitersPerMinute(decilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable DecilitersPerMinute.
-        /// </summary>
-        public static Flow? FromDecilitersPerMinute(long? decilitersperminute)
-        {
-            if (decilitersperminute.HasValue)
-            {
-                return FromDecilitersPerMinute(decilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from DecilitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromDecilitersPerMinute(decimal? decilitersperminute)
+        public static Flow? FromDecilitersPerMinute(QuantityValue? decilitersperminute)
         {
             if (decilitersperminute.HasValue)
             {
@@ -1345,52 +690,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable KilolitersPerMinute.
         /// </summary>
-        public static Flow? FromKilolitersPerMinute(double? kilolitersperminute)
-        {
-            if (kilolitersperminute.HasValue)
-            {
-                return FromKilolitersPerMinute(kilolitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable KilolitersPerMinute.
-        /// </summary>
-        public static Flow? FromKilolitersPerMinute(int? kilolitersperminute)
-        {
-            if (kilolitersperminute.HasValue)
-            {
-                return FromKilolitersPerMinute(kilolitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable KilolitersPerMinute.
-        /// </summary>
-        public static Flow? FromKilolitersPerMinute(long? kilolitersperminute)
-        {
-            if (kilolitersperminute.HasValue)
-            {
-                return FromKilolitersPerMinute(kilolitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from KilolitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromKilolitersPerMinute(decimal? kilolitersperminute)
+        public static Flow? FromKilolitersPerMinute(QuantityValue? kilolitersperminute)
         {
             if (kilolitersperminute.HasValue)
             {
@@ -1405,52 +705,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable LitersPerHour.
         /// </summary>
-        public static Flow? FromLitersPerHour(double? litersperhour)
-        {
-            if (litersperhour.HasValue)
-            {
-                return FromLitersPerHour(litersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable LitersPerHour.
-        /// </summary>
-        public static Flow? FromLitersPerHour(int? litersperhour)
-        {
-            if (litersperhour.HasValue)
-            {
-                return FromLitersPerHour(litersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable LitersPerHour.
-        /// </summary>
-        public static Flow? FromLitersPerHour(long? litersperhour)
-        {
-            if (litersperhour.HasValue)
-            {
-                return FromLitersPerHour(litersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from LitersPerHour of type decimal.
-        /// </summary>
-        public static Flow? FromLitersPerHour(decimal? litersperhour)
+        public static Flow? FromLitersPerHour(QuantityValue? litersperhour)
         {
             if (litersperhour.HasValue)
             {
@@ -1465,52 +720,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable LitersPerMinute.
         /// </summary>
-        public static Flow? FromLitersPerMinute(double? litersperminute)
-        {
-            if (litersperminute.HasValue)
-            {
-                return FromLitersPerMinute(litersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable LitersPerMinute.
-        /// </summary>
-        public static Flow? FromLitersPerMinute(int? litersperminute)
-        {
-            if (litersperminute.HasValue)
-            {
-                return FromLitersPerMinute(litersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable LitersPerMinute.
-        /// </summary>
-        public static Flow? FromLitersPerMinute(long? litersperminute)
-        {
-            if (litersperminute.HasValue)
-            {
-                return FromLitersPerMinute(litersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from LitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromLitersPerMinute(decimal? litersperminute)
+        public static Flow? FromLitersPerMinute(QuantityValue? litersperminute)
         {
             if (litersperminute.HasValue)
             {
@@ -1525,52 +735,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable LitersPerSecond.
         /// </summary>
-        public static Flow? FromLitersPerSecond(double? literspersecond)
-        {
-            if (literspersecond.HasValue)
-            {
-                return FromLitersPerSecond(literspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable LitersPerSecond.
-        /// </summary>
-        public static Flow? FromLitersPerSecond(int? literspersecond)
-        {
-            if (literspersecond.HasValue)
-            {
-                return FromLitersPerSecond(literspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable LitersPerSecond.
-        /// </summary>
-        public static Flow? FromLitersPerSecond(long? literspersecond)
-        {
-            if (literspersecond.HasValue)
-            {
-                return FromLitersPerSecond(literspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from LitersPerSecond of type decimal.
-        /// </summary>
-        public static Flow? FromLitersPerSecond(decimal? literspersecond)
+        public static Flow? FromLitersPerSecond(QuantityValue? literspersecond)
         {
             if (literspersecond.HasValue)
             {
@@ -1585,52 +750,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable MicrolitersPerMinute.
         /// </summary>
-        public static Flow? FromMicrolitersPerMinute(double? microlitersperminute)
-        {
-            if (microlitersperminute.HasValue)
-            {
-                return FromMicrolitersPerMinute(microlitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable MicrolitersPerMinute.
-        /// </summary>
-        public static Flow? FromMicrolitersPerMinute(int? microlitersperminute)
-        {
-            if (microlitersperminute.HasValue)
-            {
-                return FromMicrolitersPerMinute(microlitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable MicrolitersPerMinute.
-        /// </summary>
-        public static Flow? FromMicrolitersPerMinute(long? microlitersperminute)
-        {
-            if (microlitersperminute.HasValue)
-            {
-                return FromMicrolitersPerMinute(microlitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from MicrolitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromMicrolitersPerMinute(decimal? microlitersperminute)
+        public static Flow? FromMicrolitersPerMinute(QuantityValue? microlitersperminute)
         {
             if (microlitersperminute.HasValue)
             {
@@ -1645,52 +765,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable MillilitersPerMinute.
         /// </summary>
-        public static Flow? FromMillilitersPerMinute(double? millilitersperminute)
-        {
-            if (millilitersperminute.HasValue)
-            {
-                return FromMillilitersPerMinute(millilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable MillilitersPerMinute.
-        /// </summary>
-        public static Flow? FromMillilitersPerMinute(int? millilitersperminute)
-        {
-            if (millilitersperminute.HasValue)
-            {
-                return FromMillilitersPerMinute(millilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable MillilitersPerMinute.
-        /// </summary>
-        public static Flow? FromMillilitersPerMinute(long? millilitersperminute)
-        {
-            if (millilitersperminute.HasValue)
-            {
-                return FromMillilitersPerMinute(millilitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from MillilitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromMillilitersPerMinute(decimal? millilitersperminute)
+        public static Flow? FromMillilitersPerMinute(QuantityValue? millilitersperminute)
         {
             if (millilitersperminute.HasValue)
             {
@@ -1705,52 +780,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
         /// </summary>
-        public static Flow? FromMillionUsGallonsPerDay(double? millionusgallonsperday)
-        {
-            if (millionusgallonsperday.HasValue)
-            {
-                return FromMillionUsGallonsPerDay(millionusgallonsperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
-        /// </summary>
-        public static Flow? FromMillionUsGallonsPerDay(int? millionusgallonsperday)
-        {
-            if (millionusgallonsperday.HasValue)
-            {
-                return FromMillionUsGallonsPerDay(millionusgallonsperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable MillionUsGallonsPerDay.
-        /// </summary>
-        public static Flow? FromMillionUsGallonsPerDay(long? millionusgallonsperday)
-        {
-            if (millionusgallonsperday.HasValue)
-            {
-                return FromMillionUsGallonsPerDay(millionusgallonsperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from MillionUsGallonsPerDay of type decimal.
-        /// </summary>
-        public static Flow? FromMillionUsGallonsPerDay(decimal? millionusgallonsperday)
+        public static Flow? FromMillionUsGallonsPerDay(QuantityValue? millionusgallonsperday)
         {
             if (millionusgallonsperday.HasValue)
             {
@@ -1765,52 +795,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable NanolitersPerMinute.
         /// </summary>
-        public static Flow? FromNanolitersPerMinute(double? nanolitersperminute)
-        {
-            if (nanolitersperminute.HasValue)
-            {
-                return FromNanolitersPerMinute(nanolitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable NanolitersPerMinute.
-        /// </summary>
-        public static Flow? FromNanolitersPerMinute(int? nanolitersperminute)
-        {
-            if (nanolitersperminute.HasValue)
-            {
-                return FromNanolitersPerMinute(nanolitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable NanolitersPerMinute.
-        /// </summary>
-        public static Flow? FromNanolitersPerMinute(long? nanolitersperminute)
-        {
-            if (nanolitersperminute.HasValue)
-            {
-                return FromNanolitersPerMinute(nanolitersperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from NanolitersPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromNanolitersPerMinute(decimal? nanolitersperminute)
+        public static Flow? FromNanolitersPerMinute(QuantityValue? nanolitersperminute)
         {
             if (nanolitersperminute.HasValue)
             {
@@ -1825,52 +810,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable OilBarrelsPerDay.
         /// </summary>
-        public static Flow? FromOilBarrelsPerDay(double? oilbarrelsperday)
-        {
-            if (oilbarrelsperday.HasValue)
-            {
-                return FromOilBarrelsPerDay(oilbarrelsperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable OilBarrelsPerDay.
-        /// </summary>
-        public static Flow? FromOilBarrelsPerDay(int? oilbarrelsperday)
-        {
-            if (oilbarrelsperday.HasValue)
-            {
-                return FromOilBarrelsPerDay(oilbarrelsperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable OilBarrelsPerDay.
-        /// </summary>
-        public static Flow? FromOilBarrelsPerDay(long? oilbarrelsperday)
-        {
-            if (oilbarrelsperday.HasValue)
-            {
-                return FromOilBarrelsPerDay(oilbarrelsperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from OilBarrelsPerDay of type decimal.
-        /// </summary>
-        public static Flow? FromOilBarrelsPerDay(decimal? oilbarrelsperday)
+        public static Flow? FromOilBarrelsPerDay(QuantityValue? oilbarrelsperday)
         {
             if (oilbarrelsperday.HasValue)
             {
@@ -1885,52 +825,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Flow from nullable UsGallonsPerMinute.
         /// </summary>
-        public static Flow? FromUsGallonsPerMinute(double? usgallonsperminute)
-        {
-            if (usgallonsperminute.HasValue)
-            {
-                return FromUsGallonsPerMinute(usgallonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable UsGallonsPerMinute.
-        /// </summary>
-        public static Flow? FromUsGallonsPerMinute(int? usgallonsperminute)
-        {
-            if (usgallonsperminute.HasValue)
-            {
-                return FromUsGallonsPerMinute(usgallonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from nullable UsGallonsPerMinute.
-        /// </summary>
-        public static Flow? FromUsGallonsPerMinute(long? usgallonsperminute)
-        {
-            if (usgallonsperminute.HasValue)
-            {
-                return FromUsGallonsPerMinute(usgallonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Flow from UsGallonsPerMinute of type decimal.
-        /// </summary>
-        public static Flow? FromUsGallonsPerMinute(decimal? usgallonsperminute)
+        public static Flow? FromUsGallonsPerMinute(QuantityValue? usgallonsperminute)
         {
             if (usgallonsperminute.HasValue)
             {
@@ -1947,47 +842,53 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="FlowUnit" /> to <see cref="Flow" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Flow unit value.</returns>
-        public static Flow From(double val, FlowUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Flow From(double value, FlowUnit fromUnit)
+#else
+        public static Flow From(QuantityValue value, FlowUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case FlowUnit.CentilitersPerMinute:
-                    return FromCentilitersPerMinute(val);
+                    return FromCentilitersPerMinute(value);
                 case FlowUnit.CubicDecimeterPerMinute:
-                    return FromCubicDecimetersPerMinute(val);
+                    return FromCubicDecimetersPerMinute(value);
                 case FlowUnit.CubicFootPerHour:
-                    return FromCubicFeetPerHour(val);
+                    return FromCubicFeetPerHour(value);
                 case FlowUnit.CubicFootPerSecond:
-                    return FromCubicFeetPerSecond(val);
+                    return FromCubicFeetPerSecond(value);
                 case FlowUnit.CubicMeterPerHour:
-                    return FromCubicMetersPerHour(val);
+                    return FromCubicMetersPerHour(value);
                 case FlowUnit.CubicMeterPerSecond:
-                    return FromCubicMetersPerSecond(val);
+                    return FromCubicMetersPerSecond(value);
                 case FlowUnit.DecilitersPerMinute:
-                    return FromDecilitersPerMinute(val);
+                    return FromDecilitersPerMinute(value);
                 case FlowUnit.KilolitersPerMinute:
-                    return FromKilolitersPerMinute(val);
+                    return FromKilolitersPerMinute(value);
                 case FlowUnit.LitersPerHour:
-                    return FromLitersPerHour(val);
+                    return FromLitersPerHour(value);
                 case FlowUnit.LitersPerMinute:
-                    return FromLitersPerMinute(val);
+                    return FromLitersPerMinute(value);
                 case FlowUnit.LitersPerSecond:
-                    return FromLitersPerSecond(val);
+                    return FromLitersPerSecond(value);
                 case FlowUnit.MicrolitersPerMinute:
-                    return FromMicrolitersPerMinute(val);
+                    return FromMicrolitersPerMinute(value);
                 case FlowUnit.MillilitersPerMinute:
-                    return FromMillilitersPerMinute(val);
+                    return FromMillilitersPerMinute(value);
                 case FlowUnit.MillionUsGallonsPerDay:
-                    return FromMillionUsGallonsPerDay(val);
+                    return FromMillionUsGallonsPerDay(value);
                 case FlowUnit.NanolitersPerMinute:
-                    return FromNanolitersPerMinute(val);
+                    return FromNanolitersPerMinute(value);
                 case FlowUnit.OilBarrelsPerDay:
-                    return FromOilBarrelsPerDay(val);
+                    return FromOilBarrelsPerDay(value);
                 case FlowUnit.UsGallonsPerMinute:
-                    return FromUsGallonsPerMinute(val);
+                    return FromUsGallonsPerMinute(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2002,7 +903,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Flow unit value.</returns>
-        public static Flow? From(double? value, FlowUnit fromUnit)
+        public static Flow? From(QuantityValue? value, FlowUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -213,342 +213,162 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Decanewtons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromDecanewtons(double decanewtons)
         {
-            return new Force((decanewtons) * 1e1d);
+            double value = (double) decanewtons;
+            return new Force((value) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get Force from Decanewtons.
-        /// </summary>
-        public static Force FromDecanewtons(int decanewtons)
+#else
+        public static Force FromDecanewtons(QuantityValue decanewtons)
         {
-            return new Force((decanewtons) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get Force from Decanewtons.
-        /// </summary>
-        public static Force FromDecanewtons(long decanewtons)
-        {
-            return new Force((decanewtons) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from Decanewtons of type decimal.
-        /// </summary>
-        public static Force FromDecanewtons(decimal decanewtons)
-        {
-            return new Force((Convert.ToDouble(decanewtons)) * 1e1d);
+            double value = (double) decanewtons;
+            return new Force(((value) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromDyne(double dyne)
         {
-            return new Force(dyne/1e5);
+            double value = (double) dyne;
+            return new Force(value/1e5);
         }
-
-        /// <summary>
-        ///     Get Force from Dyne.
-        /// </summary>
-        public static Force FromDyne(int dyne)
+#else
+        public static Force FromDyne(QuantityValue dyne)
         {
-            return new Force(dyne/1e5);
-        }
-
-        /// <summary>
-        ///     Get Force from Dyne.
-        /// </summary>
-        public static Force FromDyne(long dyne)
-        {
-            return new Force(dyne/1e5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from Dyne of type decimal.
-        /// </summary>
-        public static Force FromDyne(decimal dyne)
-        {
-            return new Force(Convert.ToDouble(dyne)/1e5);
+            double value = (double) dyne;
+            return new Force((value/1e5));
         }
 #endif
 
         /// <summary>
         ///     Get Force from KilogramsForce.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromKilogramsForce(double kilogramsforce)
         {
-            return new Force(kilogramsforce*9.80665002864);
+            double value = (double) kilogramsforce;
+            return new Force(value*9.80665002864);
         }
-
-        /// <summary>
-        ///     Get Force from KilogramsForce.
-        /// </summary>
-        public static Force FromKilogramsForce(int kilogramsforce)
+#else
+        public static Force FromKilogramsForce(QuantityValue kilogramsforce)
         {
-            return new Force(kilogramsforce*9.80665002864);
-        }
-
-        /// <summary>
-        ///     Get Force from KilogramsForce.
-        /// </summary>
-        public static Force FromKilogramsForce(long kilogramsforce)
-        {
-            return new Force(kilogramsforce*9.80665002864);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from KilogramsForce of type decimal.
-        /// </summary>
-        public static Force FromKilogramsForce(decimal kilogramsforce)
-        {
-            return new Force(Convert.ToDouble(kilogramsforce)*9.80665002864);
+            double value = (double) kilogramsforce;
+            return new Force((value*9.80665002864));
         }
 #endif
 
         /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromKilonewtons(double kilonewtons)
         {
-            return new Force((kilonewtons) * 1e3d);
+            double value = (double) kilonewtons;
+            return new Force((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Force from Kilonewtons.
-        /// </summary>
-        public static Force FromKilonewtons(int kilonewtons)
+#else
+        public static Force FromKilonewtons(QuantityValue kilonewtons)
         {
-            return new Force((kilonewtons) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Force from Kilonewtons.
-        /// </summary>
-        public static Force FromKilonewtons(long kilonewtons)
-        {
-            return new Force((kilonewtons) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from Kilonewtons of type decimal.
-        /// </summary>
-        public static Force FromKilonewtons(decimal kilonewtons)
-        {
-            return new Force((Convert.ToDouble(kilonewtons)) * 1e3d);
+            double value = (double) kilonewtons;
+            return new Force(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Force from KiloPonds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromKiloPonds(double kiloponds)
         {
-            return new Force(kiloponds*9.80665002864);
+            double value = (double) kiloponds;
+            return new Force(value*9.80665002864);
         }
-
-        /// <summary>
-        ///     Get Force from KiloPonds.
-        /// </summary>
-        public static Force FromKiloPonds(int kiloponds)
+#else
+        public static Force FromKiloPonds(QuantityValue kiloponds)
         {
-            return new Force(kiloponds*9.80665002864);
-        }
-
-        /// <summary>
-        ///     Get Force from KiloPonds.
-        /// </summary>
-        public static Force FromKiloPonds(long kiloponds)
-        {
-            return new Force(kiloponds*9.80665002864);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from KiloPonds of type decimal.
-        /// </summary>
-        public static Force FromKiloPonds(decimal kiloponds)
-        {
-            return new Force(Convert.ToDouble(kiloponds)*9.80665002864);
+            double value = (double) kiloponds;
+            return new Force((value*9.80665002864));
         }
 #endif
 
         /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromNewtons(double newtons)
         {
-            return new Force(newtons);
+            double value = (double) newtons;
+            return new Force(value);
         }
-
-        /// <summary>
-        ///     Get Force from Newtons.
-        /// </summary>
-        public static Force FromNewtons(int newtons)
+#else
+        public static Force FromNewtons(QuantityValue newtons)
         {
-            return new Force(newtons);
-        }
-
-        /// <summary>
-        ///     Get Force from Newtons.
-        /// </summary>
-        public static Force FromNewtons(long newtons)
-        {
-            return new Force(newtons);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from Newtons of type decimal.
-        /// </summary>
-        public static Force FromNewtons(decimal newtons)
-        {
-            return new Force(Convert.ToDouble(newtons));
+            double value = (double) newtons;
+            return new Force((value));
         }
 #endif
 
         /// <summary>
         ///     Get Force from Poundals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromPoundals(double poundals)
         {
-            return new Force(poundals*0.13825502798973041652092282466083);
+            double value = (double) poundals;
+            return new Force(value*0.13825502798973041652092282466083);
         }
-
-        /// <summary>
-        ///     Get Force from Poundals.
-        /// </summary>
-        public static Force FromPoundals(int poundals)
+#else
+        public static Force FromPoundals(QuantityValue poundals)
         {
-            return new Force(poundals*0.13825502798973041652092282466083);
-        }
-
-        /// <summary>
-        ///     Get Force from Poundals.
-        /// </summary>
-        public static Force FromPoundals(long poundals)
-        {
-            return new Force(poundals*0.13825502798973041652092282466083);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from Poundals of type decimal.
-        /// </summary>
-        public static Force FromPoundals(decimal poundals)
-        {
-            return new Force(Convert.ToDouble(poundals)*0.13825502798973041652092282466083);
+            double value = (double) poundals;
+            return new Force((value*0.13825502798973041652092282466083));
         }
 #endif
 
         /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromPoundsForce(double poundsforce)
         {
-            return new Force(poundsforce*4.4482216152605095551842641431421);
+            double value = (double) poundsforce;
+            return new Force(value*4.4482216152605095551842641431421);
         }
-
-        /// <summary>
-        ///     Get Force from PoundsForce.
-        /// </summary>
-        public static Force FromPoundsForce(int poundsforce)
+#else
+        public static Force FromPoundsForce(QuantityValue poundsforce)
         {
-            return new Force(poundsforce*4.4482216152605095551842641431421);
-        }
-
-        /// <summary>
-        ///     Get Force from PoundsForce.
-        /// </summary>
-        public static Force FromPoundsForce(long poundsforce)
-        {
-            return new Force(poundsforce*4.4482216152605095551842641431421);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from PoundsForce of type decimal.
-        /// </summary>
-        public static Force FromPoundsForce(decimal poundsforce)
-        {
-            return new Force(Convert.ToDouble(poundsforce)*4.4482216152605095551842641431421);
+            double value = (double) poundsforce;
+            return new Force((value*4.4482216152605095551842641431421));
         }
 #endif
 
         /// <summary>
         ///     Get Force from TonnesForce.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Force FromTonnesForce(double tonnesforce)
         {
-            return new Force(tonnesforce*9.80665002864*1000);
+            double value = (double) tonnesforce;
+            return new Force(value*9.80665002864*1000);
         }
-
-        /// <summary>
-        ///     Get Force from TonnesForce.
-        /// </summary>
-        public static Force FromTonnesForce(int tonnesforce)
+#else
+        public static Force FromTonnesForce(QuantityValue tonnesforce)
         {
-            return new Force(tonnesforce*9.80665002864*1000);
-        }
-
-        /// <summary>
-        ///     Get Force from TonnesForce.
-        /// </summary>
-        public static Force FromTonnesForce(long tonnesforce)
-        {
-            return new Force(tonnesforce*9.80665002864*1000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Force from TonnesForce of type decimal.
-        /// </summary>
-        public static Force FromTonnesForce(decimal tonnesforce)
-        {
-            return new Force(Convert.ToDouble(tonnesforce)*9.80665002864*1000);
+            double value = (double) tonnesforce;
+            return new Force((value*9.80665002864*1000));
         }
 #endif
 
@@ -557,52 +377,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable Decanewtons.
         /// </summary>
-        public static Force? FromDecanewtons(double? decanewtons)
-        {
-            if (decanewtons.HasValue)
-            {
-                return FromDecanewtons(decanewtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Decanewtons.
-        /// </summary>
-        public static Force? FromDecanewtons(int? decanewtons)
-        {
-            if (decanewtons.HasValue)
-            {
-                return FromDecanewtons(decanewtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Decanewtons.
-        /// </summary>
-        public static Force? FromDecanewtons(long? decanewtons)
-        {
-            if (decanewtons.HasValue)
-            {
-                return FromDecanewtons(decanewtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from Decanewtons of type decimal.
-        /// </summary>
-        public static Force? FromDecanewtons(decimal? decanewtons)
+        public static Force? FromDecanewtons(QuantityValue? decanewtons)
         {
             if (decanewtons.HasValue)
             {
@@ -617,52 +392,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable Dyne.
         /// </summary>
-        public static Force? FromDyne(double? dyne)
-        {
-            if (dyne.HasValue)
-            {
-                return FromDyne(dyne.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Dyne.
-        /// </summary>
-        public static Force? FromDyne(int? dyne)
-        {
-            if (dyne.HasValue)
-            {
-                return FromDyne(dyne.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Dyne.
-        /// </summary>
-        public static Force? FromDyne(long? dyne)
-        {
-            if (dyne.HasValue)
-            {
-                return FromDyne(dyne.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from Dyne of type decimal.
-        /// </summary>
-        public static Force? FromDyne(decimal? dyne)
+        public static Force? FromDyne(QuantityValue? dyne)
         {
             if (dyne.HasValue)
             {
@@ -677,52 +407,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable KilogramsForce.
         /// </summary>
-        public static Force? FromKilogramsForce(double? kilogramsforce)
-        {
-            if (kilogramsforce.HasValue)
-            {
-                return FromKilogramsForce(kilogramsforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable KilogramsForce.
-        /// </summary>
-        public static Force? FromKilogramsForce(int? kilogramsforce)
-        {
-            if (kilogramsforce.HasValue)
-            {
-                return FromKilogramsForce(kilogramsforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable KilogramsForce.
-        /// </summary>
-        public static Force? FromKilogramsForce(long? kilogramsforce)
-        {
-            if (kilogramsforce.HasValue)
-            {
-                return FromKilogramsForce(kilogramsforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from KilogramsForce of type decimal.
-        /// </summary>
-        public static Force? FromKilogramsForce(decimal? kilogramsforce)
+        public static Force? FromKilogramsForce(QuantityValue? kilogramsforce)
         {
             if (kilogramsforce.HasValue)
             {
@@ -737,52 +422,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable Kilonewtons.
         /// </summary>
-        public static Force? FromKilonewtons(double? kilonewtons)
-        {
-            if (kilonewtons.HasValue)
-            {
-                return FromKilonewtons(kilonewtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Kilonewtons.
-        /// </summary>
-        public static Force? FromKilonewtons(int? kilonewtons)
-        {
-            if (kilonewtons.HasValue)
-            {
-                return FromKilonewtons(kilonewtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Kilonewtons.
-        /// </summary>
-        public static Force? FromKilonewtons(long? kilonewtons)
-        {
-            if (kilonewtons.HasValue)
-            {
-                return FromKilonewtons(kilonewtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from Kilonewtons of type decimal.
-        /// </summary>
-        public static Force? FromKilonewtons(decimal? kilonewtons)
+        public static Force? FromKilonewtons(QuantityValue? kilonewtons)
         {
             if (kilonewtons.HasValue)
             {
@@ -797,52 +437,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable KiloPonds.
         /// </summary>
-        public static Force? FromKiloPonds(double? kiloponds)
-        {
-            if (kiloponds.HasValue)
-            {
-                return FromKiloPonds(kiloponds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable KiloPonds.
-        /// </summary>
-        public static Force? FromKiloPonds(int? kiloponds)
-        {
-            if (kiloponds.HasValue)
-            {
-                return FromKiloPonds(kiloponds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable KiloPonds.
-        /// </summary>
-        public static Force? FromKiloPonds(long? kiloponds)
-        {
-            if (kiloponds.HasValue)
-            {
-                return FromKiloPonds(kiloponds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from KiloPonds of type decimal.
-        /// </summary>
-        public static Force? FromKiloPonds(decimal? kiloponds)
+        public static Force? FromKiloPonds(QuantityValue? kiloponds)
         {
             if (kiloponds.HasValue)
             {
@@ -857,52 +452,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable Newtons.
         /// </summary>
-        public static Force? FromNewtons(double? newtons)
-        {
-            if (newtons.HasValue)
-            {
-                return FromNewtons(newtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Newtons.
-        /// </summary>
-        public static Force? FromNewtons(int? newtons)
-        {
-            if (newtons.HasValue)
-            {
-                return FromNewtons(newtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Newtons.
-        /// </summary>
-        public static Force? FromNewtons(long? newtons)
-        {
-            if (newtons.HasValue)
-            {
-                return FromNewtons(newtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from Newtons of type decimal.
-        /// </summary>
-        public static Force? FromNewtons(decimal? newtons)
+        public static Force? FromNewtons(QuantityValue? newtons)
         {
             if (newtons.HasValue)
             {
@@ -917,52 +467,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable Poundals.
         /// </summary>
-        public static Force? FromPoundals(double? poundals)
-        {
-            if (poundals.HasValue)
-            {
-                return FromPoundals(poundals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Poundals.
-        /// </summary>
-        public static Force? FromPoundals(int? poundals)
-        {
-            if (poundals.HasValue)
-            {
-                return FromPoundals(poundals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable Poundals.
-        /// </summary>
-        public static Force? FromPoundals(long? poundals)
-        {
-            if (poundals.HasValue)
-            {
-                return FromPoundals(poundals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from Poundals of type decimal.
-        /// </summary>
-        public static Force? FromPoundals(decimal? poundals)
+        public static Force? FromPoundals(QuantityValue? poundals)
         {
             if (poundals.HasValue)
             {
@@ -977,52 +482,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable PoundsForce.
         /// </summary>
-        public static Force? FromPoundsForce(double? poundsforce)
-        {
-            if (poundsforce.HasValue)
-            {
-                return FromPoundsForce(poundsforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable PoundsForce.
-        /// </summary>
-        public static Force? FromPoundsForce(int? poundsforce)
-        {
-            if (poundsforce.HasValue)
-            {
-                return FromPoundsForce(poundsforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable PoundsForce.
-        /// </summary>
-        public static Force? FromPoundsForce(long? poundsforce)
-        {
-            if (poundsforce.HasValue)
-            {
-                return FromPoundsForce(poundsforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from PoundsForce of type decimal.
-        /// </summary>
-        public static Force? FromPoundsForce(decimal? poundsforce)
+        public static Force? FromPoundsForce(QuantityValue? poundsforce)
         {
             if (poundsforce.HasValue)
             {
@@ -1037,52 +497,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Force from nullable TonnesForce.
         /// </summary>
-        public static Force? FromTonnesForce(double? tonnesforce)
-        {
-            if (tonnesforce.HasValue)
-            {
-                return FromTonnesForce(tonnesforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable TonnesForce.
-        /// </summary>
-        public static Force? FromTonnesForce(int? tonnesforce)
-        {
-            if (tonnesforce.HasValue)
-            {
-                return FromTonnesForce(tonnesforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from nullable TonnesForce.
-        /// </summary>
-        public static Force? FromTonnesForce(long? tonnesforce)
-        {
-            if (tonnesforce.HasValue)
-            {
-                return FromTonnesForce(tonnesforce.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Force from TonnesForce of type decimal.
-        /// </summary>
-        public static Force? FromTonnesForce(decimal? tonnesforce)
+        public static Force? FromTonnesForce(QuantityValue? tonnesforce)
         {
             if (tonnesforce.HasValue)
             {
@@ -1099,31 +514,37 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ForceUnit" /> to <see cref="Force" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Force unit value.</returns>
-        public static Force From(double val, ForceUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Force From(double value, ForceUnit fromUnit)
+#else
+        public static Force From(QuantityValue value, ForceUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ForceUnit.Decanewton:
-                    return FromDecanewtons(val);
+                    return FromDecanewtons(value);
                 case ForceUnit.Dyn:
-                    return FromDyne(val);
+                    return FromDyne(value);
                 case ForceUnit.KilogramForce:
-                    return FromKilogramsForce(val);
+                    return FromKilogramsForce(value);
                 case ForceUnit.Kilonewton:
-                    return FromKilonewtons(val);
+                    return FromKilonewtons(value);
                 case ForceUnit.KiloPond:
-                    return FromKiloPonds(val);
+                    return FromKiloPonds(value);
                 case ForceUnit.Newton:
-                    return FromNewtons(val);
+                    return FromNewtons(value);
                 case ForceUnit.Poundal:
-                    return FromPoundals(val);
+                    return FromPoundals(value);
                 case ForceUnit.PoundForce:
-                    return FromPoundsForce(val);
+                    return FromPoundsForce(value);
                 case ForceUnit.TonneForce:
-                    return FromTonnesForce(val);
+                    return FromTonnesForce(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1138,7 +559,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Force unit value.</returns>
-        public static Force? From(double? value, ForceUnit fromUnit)
+        public static Force? From(QuantityValue? value, ForceUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -229,418 +229,198 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromCentinewtonsPerSecond(double centinewtonspersecond)
         {
-            return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
+            double value = (double) centinewtonspersecond;
+            return new ForceChangeRate((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from CentinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromCentinewtonsPerSecond(int centinewtonspersecond)
+#else
+        public static ForceChangeRate FromCentinewtonsPerSecond(QuantityValue centinewtonspersecond)
         {
-            return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from CentinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromCentinewtonsPerSecond(long centinewtonspersecond)
-        {
-            return new ForceChangeRate((centinewtonspersecond) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from CentinewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromCentinewtonsPerSecond(decimal centinewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(centinewtonspersecond)) * 1e-2d);
+            double value = (double) centinewtonspersecond;
+            return new ForceChangeRate(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromDecanewtonsPerMinute(double decanewtonsperminute)
         {
-            return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
+            double value = (double) decanewtonsperminute;
+            return new ForceChangeRate((value/60) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from DecanewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate FromDecanewtonsPerMinute(int decanewtonsperminute)
+#else
+        public static ForceChangeRate FromDecanewtonsPerMinute(QuantityValue decanewtonsperminute)
         {
-            return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from DecanewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate FromDecanewtonsPerMinute(long decanewtonsperminute)
-        {
-            return new ForceChangeRate((decanewtonsperminute/60) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from DecanewtonsPerMinute of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromDecanewtonsPerMinute(decimal decanewtonsperminute)
-        {
-            return new ForceChangeRate((Convert.ToDouble(decanewtonsperminute)/60) * 1e1d);
+            double value = (double) decanewtonsperminute;
+            return new ForceChangeRate(((value/60) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromDecanewtonsPerSecond(double decanewtonspersecond)
         {
-            return new ForceChangeRate((decanewtonspersecond) * 1e1d);
+            double value = (double) decanewtonspersecond;
+            return new ForceChangeRate((value) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from DecanewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromDecanewtonsPerSecond(int decanewtonspersecond)
+#else
+        public static ForceChangeRate FromDecanewtonsPerSecond(QuantityValue decanewtonspersecond)
         {
-            return new ForceChangeRate((decanewtonspersecond) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from DecanewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromDecanewtonsPerSecond(long decanewtonspersecond)
-        {
-            return new ForceChangeRate((decanewtonspersecond) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from DecanewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromDecanewtonsPerSecond(decimal decanewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(decanewtonspersecond)) * 1e1d);
+            double value = (double) decanewtonspersecond;
+            return new ForceChangeRate(((value) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromDecinewtonsPerSecond(double decinewtonspersecond)
         {
-            return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
+            double value = (double) decinewtonspersecond;
+            return new ForceChangeRate((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from DecinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromDecinewtonsPerSecond(int decinewtonspersecond)
+#else
+        public static ForceChangeRate FromDecinewtonsPerSecond(QuantityValue decinewtonspersecond)
         {
-            return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from DecinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromDecinewtonsPerSecond(long decinewtonspersecond)
-        {
-            return new ForceChangeRate((decinewtonspersecond) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from DecinewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromDecinewtonsPerSecond(decimal decinewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(decinewtonspersecond)) * 1e-1d);
+            double value = (double) decinewtonspersecond;
+            return new ForceChangeRate(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromKilonewtonsPerMinute(double kilonewtonsperminute)
         {
-            return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
+            double value = (double) kilonewtonsperminute;
+            return new ForceChangeRate((value/60) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from KilonewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate FromKilonewtonsPerMinute(int kilonewtonsperminute)
+#else
+        public static ForceChangeRate FromKilonewtonsPerMinute(QuantityValue kilonewtonsperminute)
         {
-            return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from KilonewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate FromKilonewtonsPerMinute(long kilonewtonsperminute)
-        {
-            return new ForceChangeRate((kilonewtonsperminute/60) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from KilonewtonsPerMinute of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromKilonewtonsPerMinute(decimal kilonewtonsperminute)
-        {
-            return new ForceChangeRate((Convert.ToDouble(kilonewtonsperminute)/60) * 1e3d);
+            double value = (double) kilonewtonsperminute;
+            return new ForceChangeRate(((value/60) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromKilonewtonsPerSecond(double kilonewtonspersecond)
         {
-            return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
+            double value = (double) kilonewtonspersecond;
+            return new ForceChangeRate((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from KilonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromKilonewtonsPerSecond(int kilonewtonspersecond)
+#else
+        public static ForceChangeRate FromKilonewtonsPerSecond(QuantityValue kilonewtonspersecond)
         {
-            return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from KilonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromKilonewtonsPerSecond(long kilonewtonspersecond)
-        {
-            return new ForceChangeRate((kilonewtonspersecond) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from KilonewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromKilonewtonsPerSecond(decimal kilonewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(kilonewtonspersecond)) * 1e3d);
+            double value = (double) kilonewtonspersecond;
+            return new ForceChangeRate(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromMicronewtonsPerSecond(double micronewtonspersecond)
         {
-            return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
+            double value = (double) micronewtonspersecond;
+            return new ForceChangeRate((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from MicronewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromMicronewtonsPerSecond(int micronewtonspersecond)
+#else
+        public static ForceChangeRate FromMicronewtonsPerSecond(QuantityValue micronewtonspersecond)
         {
-            return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from MicronewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromMicronewtonsPerSecond(long micronewtonspersecond)
-        {
-            return new ForceChangeRate((micronewtonspersecond) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from MicronewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromMicronewtonsPerSecond(decimal micronewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(micronewtonspersecond)) * 1e-6d);
+            double value = (double) micronewtonspersecond;
+            return new ForceChangeRate(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromMillinewtonsPerSecond(double millinewtonspersecond)
         {
-            return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
+            double value = (double) millinewtonspersecond;
+            return new ForceChangeRate((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from MillinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromMillinewtonsPerSecond(int millinewtonspersecond)
+#else
+        public static ForceChangeRate FromMillinewtonsPerSecond(QuantityValue millinewtonspersecond)
         {
-            return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from MillinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromMillinewtonsPerSecond(long millinewtonspersecond)
-        {
-            return new ForceChangeRate((millinewtonspersecond) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from MillinewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromMillinewtonsPerSecond(decimal millinewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(millinewtonspersecond)) * 1e-3d);
+            double value = (double) millinewtonspersecond;
+            return new ForceChangeRate(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromNanonewtonsPerSecond(double nanonewtonspersecond)
         {
-            return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
+            double value = (double) nanonewtonspersecond;
+            return new ForceChangeRate((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from NanonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromNanonewtonsPerSecond(int nanonewtonspersecond)
+#else
+        public static ForceChangeRate FromNanonewtonsPerSecond(QuantityValue nanonewtonspersecond)
         {
-            return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from NanonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromNanonewtonsPerSecond(long nanonewtonspersecond)
-        {
-            return new ForceChangeRate((nanonewtonspersecond) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from NanonewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromNanonewtonsPerSecond(decimal nanonewtonspersecond)
-        {
-            return new ForceChangeRate((Convert.ToDouble(nanonewtonspersecond)) * 1e-9d);
+            double value = (double) nanonewtonspersecond;
+            return new ForceChangeRate(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromNewtonsPerMinute(double newtonsperminute)
         {
-            return new ForceChangeRate(newtonsperminute/60);
+            double value = (double) newtonsperminute;
+            return new ForceChangeRate(value/60);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from NewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate FromNewtonsPerMinute(int newtonsperminute)
+#else
+        public static ForceChangeRate FromNewtonsPerMinute(QuantityValue newtonsperminute)
         {
-            return new ForceChangeRate(newtonsperminute/60);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from NewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate FromNewtonsPerMinute(long newtonsperminute)
-        {
-            return new ForceChangeRate(newtonsperminute/60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from NewtonsPerMinute of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromNewtonsPerMinute(decimal newtonsperminute)
-        {
-            return new ForceChangeRate(Convert.ToDouble(newtonsperminute)/60);
+            double value = (double) newtonsperminute;
+            return new ForceChangeRate((value/60));
         }
 #endif
 
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForceChangeRate FromNewtonsPerSecond(double newtonspersecond)
         {
-            return new ForceChangeRate(newtonspersecond);
+            double value = (double) newtonspersecond;
+            return new ForceChangeRate(value);
         }
-
-        /// <summary>
-        ///     Get ForceChangeRate from NewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromNewtonsPerSecond(int newtonspersecond)
+#else
+        public static ForceChangeRate FromNewtonsPerSecond(QuantityValue newtonspersecond)
         {
-            return new ForceChangeRate(newtonspersecond);
-        }
-
-        /// <summary>
-        ///     Get ForceChangeRate from NewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate FromNewtonsPerSecond(long newtonspersecond)
-        {
-            return new ForceChangeRate(newtonspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForceChangeRate from NewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate FromNewtonsPerSecond(decimal newtonspersecond)
-        {
-            return new ForceChangeRate(Convert.ToDouble(newtonspersecond));
+            double value = (double) newtonspersecond;
+            return new ForceChangeRate((value));
         }
 #endif
 
@@ -649,52 +429,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromCentinewtonsPerSecond(double? centinewtonspersecond)
-        {
-            if (centinewtonspersecond.HasValue)
-            {
-                return FromCentinewtonsPerSecond(centinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromCentinewtonsPerSecond(int? centinewtonspersecond)
-        {
-            if (centinewtonspersecond.HasValue)
-            {
-                return FromCentinewtonsPerSecond(centinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable CentinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromCentinewtonsPerSecond(long? centinewtonspersecond)
-        {
-            if (centinewtonspersecond.HasValue)
-            {
-                return FromCentinewtonsPerSecond(centinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from CentinewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromCentinewtonsPerSecond(decimal? centinewtonspersecond)
+        public static ForceChangeRate? FromCentinewtonsPerSecond(QuantityValue? centinewtonspersecond)
         {
             if (centinewtonspersecond.HasValue)
             {
@@ -709,52 +444,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
         /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerMinute(double? decanewtonsperminute)
-        {
-            if (decanewtonsperminute.HasValue)
-            {
-                return FromDecanewtonsPerMinute(decanewtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerMinute(int? decanewtonsperminute)
-        {
-            if (decanewtonsperminute.HasValue)
-            {
-                return FromDecanewtonsPerMinute(decanewtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerMinute(long? decanewtonsperminute)
-        {
-            if (decanewtonsperminute.HasValue)
-            {
-                return FromDecanewtonsPerMinute(decanewtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from DecanewtonsPerMinute of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerMinute(decimal? decanewtonsperminute)
+        public static ForceChangeRate? FromDecanewtonsPerMinute(QuantityValue? decanewtonsperminute)
         {
             if (decanewtonsperminute.HasValue)
             {
@@ -769,52 +459,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerSecond(double? decanewtonspersecond)
-        {
-            if (decanewtonspersecond.HasValue)
-            {
-                return FromDecanewtonsPerSecond(decanewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerSecond(int? decanewtonspersecond)
-        {
-            if (decanewtonspersecond.HasValue)
-            {
-                return FromDecanewtonsPerSecond(decanewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable DecanewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerSecond(long? decanewtonspersecond)
-        {
-            if (decanewtonspersecond.HasValue)
-            {
-                return FromDecanewtonsPerSecond(decanewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from DecanewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromDecanewtonsPerSecond(decimal? decanewtonspersecond)
+        public static ForceChangeRate? FromDecanewtonsPerSecond(QuantityValue? decanewtonspersecond)
         {
             if (decanewtonspersecond.HasValue)
             {
@@ -829,52 +474,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromDecinewtonsPerSecond(double? decinewtonspersecond)
-        {
-            if (decinewtonspersecond.HasValue)
-            {
-                return FromDecinewtonsPerSecond(decinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromDecinewtonsPerSecond(int? decinewtonspersecond)
-        {
-            if (decinewtonspersecond.HasValue)
-            {
-                return FromDecinewtonsPerSecond(decinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable DecinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromDecinewtonsPerSecond(long? decinewtonspersecond)
-        {
-            if (decinewtonspersecond.HasValue)
-            {
-                return FromDecinewtonsPerSecond(decinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from DecinewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromDecinewtonsPerSecond(decimal? decinewtonspersecond)
+        public static ForceChangeRate? FromDecinewtonsPerSecond(QuantityValue? decinewtonspersecond)
         {
             if (decinewtonspersecond.HasValue)
             {
@@ -889,52 +489,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
         /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerMinute(double? kilonewtonsperminute)
-        {
-            if (kilonewtonsperminute.HasValue)
-            {
-                return FromKilonewtonsPerMinute(kilonewtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerMinute(int? kilonewtonsperminute)
-        {
-            if (kilonewtonsperminute.HasValue)
-            {
-                return FromKilonewtonsPerMinute(kilonewtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerMinute(long? kilonewtonsperminute)
-        {
-            if (kilonewtonsperminute.HasValue)
-            {
-                return FromKilonewtonsPerMinute(kilonewtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from KilonewtonsPerMinute of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerMinute(decimal? kilonewtonsperminute)
+        public static ForceChangeRate? FromKilonewtonsPerMinute(QuantityValue? kilonewtonsperminute)
         {
             if (kilonewtonsperminute.HasValue)
             {
@@ -949,52 +504,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerSecond(double? kilonewtonspersecond)
-        {
-            if (kilonewtonspersecond.HasValue)
-            {
-                return FromKilonewtonsPerSecond(kilonewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerSecond(int? kilonewtonspersecond)
-        {
-            if (kilonewtonspersecond.HasValue)
-            {
-                return FromKilonewtonsPerSecond(kilonewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable KilonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerSecond(long? kilonewtonspersecond)
-        {
-            if (kilonewtonspersecond.HasValue)
-            {
-                return FromKilonewtonsPerSecond(kilonewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from KilonewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromKilonewtonsPerSecond(decimal? kilonewtonspersecond)
+        public static ForceChangeRate? FromKilonewtonsPerSecond(QuantityValue? kilonewtonspersecond)
         {
             if (kilonewtonspersecond.HasValue)
             {
@@ -1009,52 +519,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromMicronewtonsPerSecond(double? micronewtonspersecond)
-        {
-            if (micronewtonspersecond.HasValue)
-            {
-                return FromMicronewtonsPerSecond(micronewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromMicronewtonsPerSecond(int? micronewtonspersecond)
-        {
-            if (micronewtonspersecond.HasValue)
-            {
-                return FromMicronewtonsPerSecond(micronewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable MicronewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromMicronewtonsPerSecond(long? micronewtonspersecond)
-        {
-            if (micronewtonspersecond.HasValue)
-            {
-                return FromMicronewtonsPerSecond(micronewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from MicronewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromMicronewtonsPerSecond(decimal? micronewtonspersecond)
+        public static ForceChangeRate? FromMicronewtonsPerSecond(QuantityValue? micronewtonspersecond)
         {
             if (micronewtonspersecond.HasValue)
             {
@@ -1069,52 +534,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromMillinewtonsPerSecond(double? millinewtonspersecond)
-        {
-            if (millinewtonspersecond.HasValue)
-            {
-                return FromMillinewtonsPerSecond(millinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromMillinewtonsPerSecond(int? millinewtonspersecond)
-        {
-            if (millinewtonspersecond.HasValue)
-            {
-                return FromMillinewtonsPerSecond(millinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable MillinewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromMillinewtonsPerSecond(long? millinewtonspersecond)
-        {
-            if (millinewtonspersecond.HasValue)
-            {
-                return FromMillinewtonsPerSecond(millinewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from MillinewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromMillinewtonsPerSecond(decimal? millinewtonspersecond)
+        public static ForceChangeRate? FromMillinewtonsPerSecond(QuantityValue? millinewtonspersecond)
         {
             if (millinewtonspersecond.HasValue)
             {
@@ -1129,52 +549,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromNanonewtonsPerSecond(double? nanonewtonspersecond)
-        {
-            if (nanonewtonspersecond.HasValue)
-            {
-                return FromNanonewtonsPerSecond(nanonewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromNanonewtonsPerSecond(int? nanonewtonspersecond)
-        {
-            if (nanonewtonspersecond.HasValue)
-            {
-                return FromNanonewtonsPerSecond(nanonewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable NanonewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromNanonewtonsPerSecond(long? nanonewtonspersecond)
-        {
-            if (nanonewtonspersecond.HasValue)
-            {
-                return FromNanonewtonsPerSecond(nanonewtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from NanonewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromNanonewtonsPerSecond(decimal? nanonewtonspersecond)
+        public static ForceChangeRate? FromNanonewtonsPerSecond(QuantityValue? nanonewtonspersecond)
         {
             if (nanonewtonspersecond.HasValue)
             {
@@ -1189,52 +564,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
         /// </summary>
-        public static ForceChangeRate? FromNewtonsPerMinute(double? newtonsperminute)
-        {
-            if (newtonsperminute.HasValue)
-            {
-                return FromNewtonsPerMinute(newtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate? FromNewtonsPerMinute(int? newtonsperminute)
-        {
-            if (newtonsperminute.HasValue)
-            {
-                return FromNewtonsPerMinute(newtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable NewtonsPerMinute.
-        /// </summary>
-        public static ForceChangeRate? FromNewtonsPerMinute(long? newtonsperminute)
-        {
-            if (newtonsperminute.HasValue)
-            {
-                return FromNewtonsPerMinute(newtonsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from NewtonsPerMinute of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromNewtonsPerMinute(decimal? newtonsperminute)
+        public static ForceChangeRate? FromNewtonsPerMinute(QuantityValue? newtonsperminute)
         {
             if (newtonsperminute.HasValue)
             {
@@ -1249,52 +579,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
         /// </summary>
-        public static ForceChangeRate? FromNewtonsPerSecond(double? newtonspersecond)
-        {
-            if (newtonspersecond.HasValue)
-            {
-                return FromNewtonsPerSecond(newtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromNewtonsPerSecond(int? newtonspersecond)
-        {
-            if (newtonspersecond.HasValue)
-            {
-                return FromNewtonsPerSecond(newtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from nullable NewtonsPerSecond.
-        /// </summary>
-        public static ForceChangeRate? FromNewtonsPerSecond(long? newtonspersecond)
-        {
-            if (newtonspersecond.HasValue)
-            {
-                return FromNewtonsPerSecond(newtonspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForceChangeRate from NewtonsPerSecond of type decimal.
-        /// </summary>
-        public static ForceChangeRate? FromNewtonsPerSecond(decimal? newtonspersecond)
+        public static ForceChangeRate? FromNewtonsPerSecond(QuantityValue? newtonspersecond)
         {
             if (newtonspersecond.HasValue)
             {
@@ -1311,35 +596,41 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ForceChangeRateUnit" /> to <see cref="ForceChangeRate" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ForceChangeRate unit value.</returns>
-        public static ForceChangeRate From(double val, ForceChangeRateUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ForceChangeRate From(double value, ForceChangeRateUnit fromUnit)
+#else
+        public static ForceChangeRate From(QuantityValue value, ForceChangeRateUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ForceChangeRateUnit.CentinewtonPerSecond:
-                    return FromCentinewtonsPerSecond(val);
+                    return FromCentinewtonsPerSecond(value);
                 case ForceChangeRateUnit.DecanewtonPerMinute:
-                    return FromDecanewtonsPerMinute(val);
+                    return FromDecanewtonsPerMinute(value);
                 case ForceChangeRateUnit.DecanewtonPerSecond:
-                    return FromDecanewtonsPerSecond(val);
+                    return FromDecanewtonsPerSecond(value);
                 case ForceChangeRateUnit.DecinewtonPerSecond:
-                    return FromDecinewtonsPerSecond(val);
+                    return FromDecinewtonsPerSecond(value);
                 case ForceChangeRateUnit.KilonewtonPerMinute:
-                    return FromKilonewtonsPerMinute(val);
+                    return FromKilonewtonsPerMinute(value);
                 case ForceChangeRateUnit.KilonewtonPerSecond:
-                    return FromKilonewtonsPerSecond(val);
+                    return FromKilonewtonsPerSecond(value);
                 case ForceChangeRateUnit.MicronewtonPerSecond:
-                    return FromMicronewtonsPerSecond(val);
+                    return FromMicronewtonsPerSecond(value);
                 case ForceChangeRateUnit.MillinewtonPerSecond:
-                    return FromMillinewtonsPerSecond(val);
+                    return FromMillinewtonsPerSecond(value);
                 case ForceChangeRateUnit.NanonewtonPerSecond:
-                    return FromNanonewtonsPerSecond(val);
+                    return FromNanonewtonsPerSecond(value);
                 case ForceChangeRateUnit.NewtonPerMinute:
-                    return FromNewtonsPerMinute(val);
+                    return FromNewtonsPerMinute(value);
                 case ForceChangeRateUnit.NewtonPerSecond:
-                    return FromNewtonsPerSecond(val);
+                    return FromNewtonsPerSecond(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1354,7 +645,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ForceChangeRate unit value.</returns>
-        public static ForceChangeRate? From(double? value, ForceChangeRateUnit fromUnit)
+        public static ForceChangeRate? From(QuantityValue? value, ForceChangeRateUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromCentinewtonsPerMeter(double centinewtonspermeter)
         {
-            return new ForcePerLength((centinewtonspermeter) * 1e-2d);
+            double value = (double) centinewtonspermeter;
+            return new ForcePerLength((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from CentinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromCentinewtonsPerMeter(int centinewtonspermeter)
+#else
+        public static ForcePerLength FromCentinewtonsPerMeter(QuantityValue centinewtonspermeter)
         {
-            return new ForcePerLength((centinewtonspermeter) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from CentinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromCentinewtonsPerMeter(long centinewtonspermeter)
-        {
-            return new ForcePerLength((centinewtonspermeter) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from CentinewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromCentinewtonsPerMeter(decimal centinewtonspermeter)
-        {
-            return new ForcePerLength((Convert.ToDouble(centinewtonspermeter)) * 1e-2d);
+            double value = (double) centinewtonspermeter;
+            return new ForcePerLength(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromDecinewtonsPerMeter(double decinewtonspermeter)
         {
-            return new ForcePerLength((decinewtonspermeter) * 1e-1d);
+            double value = (double) decinewtonspermeter;
+            return new ForcePerLength((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from DecinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromDecinewtonsPerMeter(int decinewtonspermeter)
+#else
+        public static ForcePerLength FromDecinewtonsPerMeter(QuantityValue decinewtonspermeter)
         {
-            return new ForcePerLength((decinewtonspermeter) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from DecinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromDecinewtonsPerMeter(long decinewtonspermeter)
-        {
-            return new ForcePerLength((decinewtonspermeter) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from DecinewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromDecinewtonsPerMeter(decimal decinewtonspermeter)
-        {
-            return new ForcePerLength((Convert.ToDouble(decinewtonspermeter)) * 1e-1d);
+            double value = (double) decinewtonspermeter;
+            return new ForcePerLength(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromKilogramsForcePerMeter(double kilogramsforcepermeter)
         {
-            return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
+            double value = (double) kilogramsforcepermeter;
+            return new ForcePerLength(value*9.80665002864);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from KilogramsForcePerMeter.
-        /// </summary>
-        public static ForcePerLength FromKilogramsForcePerMeter(int kilogramsforcepermeter)
+#else
+        public static ForcePerLength FromKilogramsForcePerMeter(QuantityValue kilogramsforcepermeter)
         {
-            return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from KilogramsForcePerMeter.
-        /// </summary>
-        public static ForcePerLength FromKilogramsForcePerMeter(long kilogramsforcepermeter)
-        {
-            return new ForcePerLength(kilogramsforcepermeter*9.80665002864);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from KilogramsForcePerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromKilogramsForcePerMeter(decimal kilogramsforcepermeter)
-        {
-            return new ForcePerLength(Convert.ToDouble(kilogramsforcepermeter)*9.80665002864);
+            double value = (double) kilogramsforcepermeter;
+            return new ForcePerLength((value*9.80665002864));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromKilonewtonsPerMeter(double kilonewtonspermeter)
         {
-            return new ForcePerLength((kilonewtonspermeter) * 1e3d);
+            double value = (double) kilonewtonspermeter;
+            return new ForcePerLength((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from KilonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromKilonewtonsPerMeter(int kilonewtonspermeter)
+#else
+        public static ForcePerLength FromKilonewtonsPerMeter(QuantityValue kilonewtonspermeter)
         {
-            return new ForcePerLength((kilonewtonspermeter) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from KilonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromKilonewtonsPerMeter(long kilonewtonspermeter)
-        {
-            return new ForcePerLength((kilonewtonspermeter) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from KilonewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromKilonewtonsPerMeter(decimal kilonewtonspermeter)
-        {
-            return new ForcePerLength((Convert.ToDouble(kilonewtonspermeter)) * 1e3d);
+            double value = (double) kilonewtonspermeter;
+            return new ForcePerLength(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromMicronewtonsPerMeter(double micronewtonspermeter)
         {
-            return new ForcePerLength((micronewtonspermeter) * 1e-6d);
+            double value = (double) micronewtonspermeter;
+            return new ForcePerLength((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from MicronewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromMicronewtonsPerMeter(int micronewtonspermeter)
+#else
+        public static ForcePerLength FromMicronewtonsPerMeter(QuantityValue micronewtonspermeter)
         {
-            return new ForcePerLength((micronewtonspermeter) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from MicronewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromMicronewtonsPerMeter(long micronewtonspermeter)
-        {
-            return new ForcePerLength((micronewtonspermeter) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from MicronewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromMicronewtonsPerMeter(decimal micronewtonspermeter)
-        {
-            return new ForcePerLength((Convert.ToDouble(micronewtonspermeter)) * 1e-6d);
+            double value = (double) micronewtonspermeter;
+            return new ForcePerLength(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromMillinewtonsPerMeter(double millinewtonspermeter)
         {
-            return new ForcePerLength((millinewtonspermeter) * 1e-3d);
+            double value = (double) millinewtonspermeter;
+            return new ForcePerLength((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from MillinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromMillinewtonsPerMeter(int millinewtonspermeter)
+#else
+        public static ForcePerLength FromMillinewtonsPerMeter(QuantityValue millinewtonspermeter)
         {
-            return new ForcePerLength((millinewtonspermeter) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from MillinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromMillinewtonsPerMeter(long millinewtonspermeter)
-        {
-            return new ForcePerLength((millinewtonspermeter) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from MillinewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromMillinewtonsPerMeter(decimal millinewtonspermeter)
-        {
-            return new ForcePerLength((Convert.ToDouble(millinewtonspermeter)) * 1e-3d);
+            double value = (double) millinewtonspermeter;
+            return new ForcePerLength(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromNanonewtonsPerMeter(double nanonewtonspermeter)
         {
-            return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
+            double value = (double) nanonewtonspermeter;
+            return new ForcePerLength((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from NanonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromNanonewtonsPerMeter(int nanonewtonspermeter)
+#else
+        public static ForcePerLength FromNanonewtonsPerMeter(QuantityValue nanonewtonspermeter)
         {
-            return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from NanonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromNanonewtonsPerMeter(long nanonewtonspermeter)
-        {
-            return new ForcePerLength((nanonewtonspermeter) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from NanonewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromNanonewtonsPerMeter(decimal nanonewtonspermeter)
-        {
-            return new ForcePerLength((Convert.ToDouble(nanonewtonspermeter)) * 1e-9d);
+            double value = (double) nanonewtonspermeter;
+            return new ForcePerLength(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ForcePerLength FromNewtonsPerMeter(double newtonspermeter)
         {
-            return new ForcePerLength(newtonspermeter);
+            double value = (double) newtonspermeter;
+            return new ForcePerLength(value);
         }
-
-        /// <summary>
-        ///     Get ForcePerLength from NewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromNewtonsPerMeter(int newtonspermeter)
+#else
+        public static ForcePerLength FromNewtonsPerMeter(QuantityValue newtonspermeter)
         {
-            return new ForcePerLength(newtonspermeter);
-        }
-
-        /// <summary>
-        ///     Get ForcePerLength from NewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength FromNewtonsPerMeter(long newtonspermeter)
-        {
-            return new ForcePerLength(newtonspermeter);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ForcePerLength from NewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength FromNewtonsPerMeter(decimal newtonspermeter)
-        {
-            return new ForcePerLength(Convert.ToDouble(newtonspermeter));
+            double value = (double) newtonspermeter;
+            return new ForcePerLength((value));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromCentinewtonsPerMeter(double? centinewtonspermeter)
-        {
-            if (centinewtonspermeter.HasValue)
-            {
-                return FromCentinewtonsPerMeter(centinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromCentinewtonsPerMeter(int? centinewtonspermeter)
-        {
-            if (centinewtonspermeter.HasValue)
-            {
-                return FromCentinewtonsPerMeter(centinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable CentinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromCentinewtonsPerMeter(long? centinewtonspermeter)
-        {
-            if (centinewtonspermeter.HasValue)
-            {
-                return FromCentinewtonsPerMeter(centinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from CentinewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromCentinewtonsPerMeter(decimal? centinewtonspermeter)
+        public static ForcePerLength? FromCentinewtonsPerMeter(QuantityValue? centinewtonspermeter)
         {
             if (centinewtonspermeter.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromDecinewtonsPerMeter(double? decinewtonspermeter)
-        {
-            if (decinewtonspermeter.HasValue)
-            {
-                return FromDecinewtonsPerMeter(decinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromDecinewtonsPerMeter(int? decinewtonspermeter)
-        {
-            if (decinewtonspermeter.HasValue)
-            {
-                return FromDecinewtonsPerMeter(decinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable DecinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromDecinewtonsPerMeter(long? decinewtonspermeter)
-        {
-            if (decinewtonspermeter.HasValue)
-            {
-                return FromDecinewtonsPerMeter(decinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from DecinewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromDecinewtonsPerMeter(decimal? decinewtonspermeter)
+        public static ForcePerLength? FromDecinewtonsPerMeter(QuantityValue? decinewtonspermeter)
         {
             if (decinewtonspermeter.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
         /// </summary>
-        public static ForcePerLength? FromKilogramsForcePerMeter(double? kilogramsforcepermeter)
-        {
-            if (kilogramsforcepermeter.HasValue)
-            {
-                return FromKilogramsForcePerMeter(kilogramsforcepermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
-        /// </summary>
-        public static ForcePerLength? FromKilogramsForcePerMeter(int? kilogramsforcepermeter)
-        {
-            if (kilogramsforcepermeter.HasValue)
-            {
-                return FromKilogramsForcePerMeter(kilogramsforcepermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable KilogramsForcePerMeter.
-        /// </summary>
-        public static ForcePerLength? FromKilogramsForcePerMeter(long? kilogramsforcepermeter)
-        {
-            if (kilogramsforcepermeter.HasValue)
-            {
-                return FromKilogramsForcePerMeter(kilogramsforcepermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from KilogramsForcePerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromKilogramsForcePerMeter(decimal? kilogramsforcepermeter)
+        public static ForcePerLength? FromKilogramsForcePerMeter(QuantityValue? kilogramsforcepermeter)
         {
             if (kilogramsforcepermeter.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromKilonewtonsPerMeter(double? kilonewtonspermeter)
-        {
-            if (kilonewtonspermeter.HasValue)
-            {
-                return FromKilonewtonsPerMeter(kilonewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromKilonewtonsPerMeter(int? kilonewtonspermeter)
-        {
-            if (kilonewtonspermeter.HasValue)
-            {
-                return FromKilonewtonsPerMeter(kilonewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable KilonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromKilonewtonsPerMeter(long? kilonewtonspermeter)
-        {
-            if (kilonewtonspermeter.HasValue)
-            {
-                return FromKilonewtonsPerMeter(kilonewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from KilonewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromKilonewtonsPerMeter(decimal? kilonewtonspermeter)
+        public static ForcePerLength? FromKilonewtonsPerMeter(QuantityValue? kilonewtonspermeter)
         {
             if (kilonewtonspermeter.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromMicronewtonsPerMeter(double? micronewtonspermeter)
-        {
-            if (micronewtonspermeter.HasValue)
-            {
-                return FromMicronewtonsPerMeter(micronewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromMicronewtonsPerMeter(int? micronewtonspermeter)
-        {
-            if (micronewtonspermeter.HasValue)
-            {
-                return FromMicronewtonsPerMeter(micronewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromMicronewtonsPerMeter(long? micronewtonspermeter)
-        {
-            if (micronewtonspermeter.HasValue)
-            {
-                return FromMicronewtonsPerMeter(micronewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from MicronewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromMicronewtonsPerMeter(decimal? micronewtonspermeter)
+        public static ForcePerLength? FromMicronewtonsPerMeter(QuantityValue? micronewtonspermeter)
         {
             if (micronewtonspermeter.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromMillinewtonsPerMeter(double? millinewtonspermeter)
-        {
-            if (millinewtonspermeter.HasValue)
-            {
-                return FromMillinewtonsPerMeter(millinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromMillinewtonsPerMeter(int? millinewtonspermeter)
-        {
-            if (millinewtonspermeter.HasValue)
-            {
-                return FromMillinewtonsPerMeter(millinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable MillinewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromMillinewtonsPerMeter(long? millinewtonspermeter)
-        {
-            if (millinewtonspermeter.HasValue)
-            {
-                return FromMillinewtonsPerMeter(millinewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from MillinewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromMillinewtonsPerMeter(decimal? millinewtonspermeter)
+        public static ForcePerLength? FromMillinewtonsPerMeter(QuantityValue? millinewtonspermeter)
         {
             if (millinewtonspermeter.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromNanonewtonsPerMeter(double? nanonewtonspermeter)
-        {
-            if (nanonewtonspermeter.HasValue)
-            {
-                return FromNanonewtonsPerMeter(nanonewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromNanonewtonsPerMeter(int? nanonewtonspermeter)
-        {
-            if (nanonewtonspermeter.HasValue)
-            {
-                return FromNanonewtonsPerMeter(nanonewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable NanonewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromNanonewtonsPerMeter(long? nanonewtonspermeter)
-        {
-            if (nanonewtonspermeter.HasValue)
-            {
-                return FromNanonewtonsPerMeter(nanonewtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from NanonewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromNanonewtonsPerMeter(decimal? nanonewtonspermeter)
+        public static ForcePerLength? FromNanonewtonsPerMeter(QuantityValue? nanonewtonspermeter)
         {
             if (nanonewtonspermeter.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
         /// </summary>
-        public static ForcePerLength? FromNewtonsPerMeter(double? newtonspermeter)
-        {
-            if (newtonspermeter.HasValue)
-            {
-                return FromNewtonsPerMeter(newtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromNewtonsPerMeter(int? newtonspermeter)
-        {
-            if (newtonspermeter.HasValue)
-            {
-                return FromNewtonsPerMeter(newtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from nullable NewtonsPerMeter.
-        /// </summary>
-        public static ForcePerLength? FromNewtonsPerMeter(long? newtonspermeter)
-        {
-            if (newtonspermeter.HasValue)
-            {
-                return FromNewtonsPerMeter(newtonspermeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ForcePerLength from NewtonsPerMeter of type decimal.
-        /// </summary>
-        public static ForcePerLength? FromNewtonsPerMeter(decimal? newtonspermeter)
+        public static ForcePerLength? FromNewtonsPerMeter(QuantityValue? newtonspermeter)
         {
             if (newtonspermeter.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ForcePerLengthUnit" /> to <see cref="ForcePerLength" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ForcePerLength unit value.</returns>
-        public static ForcePerLength From(double val, ForcePerLengthUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ForcePerLength From(double value, ForcePerLengthUnit fromUnit)
+#else
+        public static ForcePerLength From(QuantityValue value, ForcePerLengthUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ForcePerLengthUnit.CentinewtonPerMeter:
-                    return FromCentinewtonsPerMeter(val);
+                    return FromCentinewtonsPerMeter(value);
                 case ForcePerLengthUnit.DecinewtonPerMeter:
-                    return FromDecinewtonsPerMeter(val);
+                    return FromDecinewtonsPerMeter(value);
                 case ForcePerLengthUnit.KilogramForcePerMeter:
-                    return FromKilogramsForcePerMeter(val);
+                    return FromKilogramsForcePerMeter(value);
                 case ForcePerLengthUnit.KilonewtonPerMeter:
-                    return FromKilonewtonsPerMeter(val);
+                    return FromKilonewtonsPerMeter(value);
                 case ForcePerLengthUnit.MicronewtonPerMeter:
-                    return FromMicronewtonsPerMeter(val);
+                    return FromMicronewtonsPerMeter(value);
                 case ForcePerLengthUnit.MillinewtonPerMeter:
-                    return FromMillinewtonsPerMeter(val);
+                    return FromMillinewtonsPerMeter(value);
                 case ForcePerLengthUnit.NanonewtonPerMeter:
-                    return FromNanonewtonsPerMeter(val);
+                    return FromNanonewtonsPerMeter(value);
                 case ForcePerLengthUnit.NewtonPerMeter:
-                    return FromNewtonsPerMeter(val);
+                    return FromNewtonsPerMeter(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ForcePerLength unit value.</returns>
-        public static ForcePerLength? From(double? value, ForcePerLengthUnit fromUnit)
+        public static ForcePerLength? From(QuantityValue? value, ForcePerLengthUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromCyclesPerHour(double cyclesperhour)
         {
-            return new Frequency(cyclesperhour/3600);
+            double value = (double) cyclesperhour;
+            return new Frequency(value/3600);
         }
-
-        /// <summary>
-        ///     Get Frequency from CyclesPerHour.
-        /// </summary>
-        public static Frequency FromCyclesPerHour(int cyclesperhour)
+#else
+        public static Frequency FromCyclesPerHour(QuantityValue cyclesperhour)
         {
-            return new Frequency(cyclesperhour/3600);
-        }
-
-        /// <summary>
-        ///     Get Frequency from CyclesPerHour.
-        /// </summary>
-        public static Frequency FromCyclesPerHour(long cyclesperhour)
-        {
-            return new Frequency(cyclesperhour/3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from CyclesPerHour of type decimal.
-        /// </summary>
-        public static Frequency FromCyclesPerHour(decimal cyclesperhour)
-        {
-            return new Frequency(Convert.ToDouble(cyclesperhour)/3600);
+            double value = (double) cyclesperhour;
+            return new Frequency((value/3600));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromCyclesPerMinute(double cyclesperminute)
         {
-            return new Frequency(cyclesperminute/60);
+            double value = (double) cyclesperminute;
+            return new Frequency(value/60);
         }
-
-        /// <summary>
-        ///     Get Frequency from CyclesPerMinute.
-        /// </summary>
-        public static Frequency FromCyclesPerMinute(int cyclesperminute)
+#else
+        public static Frequency FromCyclesPerMinute(QuantityValue cyclesperminute)
         {
-            return new Frequency(cyclesperminute/60);
-        }
-
-        /// <summary>
-        ///     Get Frequency from CyclesPerMinute.
-        /// </summary>
-        public static Frequency FromCyclesPerMinute(long cyclesperminute)
-        {
-            return new Frequency(cyclesperminute/60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from CyclesPerMinute of type decimal.
-        /// </summary>
-        public static Frequency FromCyclesPerMinute(decimal cyclesperminute)
-        {
-            return new Frequency(Convert.ToDouble(cyclesperminute)/60);
+            double value = (double) cyclesperminute;
+            return new Frequency((value/60));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from Gigahertz.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromGigahertz(double gigahertz)
         {
-            return new Frequency((gigahertz) * 1e9d);
+            double value = (double) gigahertz;
+            return new Frequency((value) * 1e9d);
         }
-
-        /// <summary>
-        ///     Get Frequency from Gigahertz.
-        /// </summary>
-        public static Frequency FromGigahertz(int gigahertz)
+#else
+        public static Frequency FromGigahertz(QuantityValue gigahertz)
         {
-            return new Frequency((gigahertz) * 1e9d);
-        }
-
-        /// <summary>
-        ///     Get Frequency from Gigahertz.
-        /// </summary>
-        public static Frequency FromGigahertz(long gigahertz)
-        {
-            return new Frequency((gigahertz) * 1e9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from Gigahertz of type decimal.
-        /// </summary>
-        public static Frequency FromGigahertz(decimal gigahertz)
-        {
-            return new Frequency((Convert.ToDouble(gigahertz)) * 1e9d);
+            double value = (double) gigahertz;
+            return new Frequency(((value) * 1e9d));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromHertz(double hertz)
         {
-            return new Frequency(hertz);
+            double value = (double) hertz;
+            return new Frequency(value);
         }
-
-        /// <summary>
-        ///     Get Frequency from Hertz.
-        /// </summary>
-        public static Frequency FromHertz(int hertz)
+#else
+        public static Frequency FromHertz(QuantityValue hertz)
         {
-            return new Frequency(hertz);
-        }
-
-        /// <summary>
-        ///     Get Frequency from Hertz.
-        /// </summary>
-        public static Frequency FromHertz(long hertz)
-        {
-            return new Frequency(hertz);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from Hertz of type decimal.
-        /// </summary>
-        public static Frequency FromHertz(decimal hertz)
-        {
-            return new Frequency(Convert.ToDouble(hertz));
+            double value = (double) hertz;
+            return new Frequency((value));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from Kilohertz.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromKilohertz(double kilohertz)
         {
-            return new Frequency((kilohertz) * 1e3d);
+            double value = (double) kilohertz;
+            return new Frequency((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Frequency from Kilohertz.
-        /// </summary>
-        public static Frequency FromKilohertz(int kilohertz)
+#else
+        public static Frequency FromKilohertz(QuantityValue kilohertz)
         {
-            return new Frequency((kilohertz) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Frequency from Kilohertz.
-        /// </summary>
-        public static Frequency FromKilohertz(long kilohertz)
-        {
-            return new Frequency((kilohertz) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from Kilohertz of type decimal.
-        /// </summary>
-        public static Frequency FromKilohertz(decimal kilohertz)
-        {
-            return new Frequency((Convert.ToDouble(kilohertz)) * 1e3d);
+            double value = (double) kilohertz;
+            return new Frequency(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromMegahertz(double megahertz)
         {
-            return new Frequency((megahertz) * 1e6d);
+            double value = (double) megahertz;
+            return new Frequency((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Frequency from Megahertz.
-        /// </summary>
-        public static Frequency FromMegahertz(int megahertz)
+#else
+        public static Frequency FromMegahertz(QuantityValue megahertz)
         {
-            return new Frequency((megahertz) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Frequency from Megahertz.
-        /// </summary>
-        public static Frequency FromMegahertz(long megahertz)
-        {
-            return new Frequency((megahertz) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from Megahertz of type decimal.
-        /// </summary>
-        public static Frequency FromMegahertz(decimal megahertz)
-        {
-            return new Frequency((Convert.ToDouble(megahertz)) * 1e6d);
+            double value = (double) megahertz;
+            return new Frequency(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromRadiansPerSecond(double radianspersecond)
         {
-            return new Frequency(radianspersecond/6.2831853072);
+            double value = (double) radianspersecond;
+            return new Frequency(value/6.2831853072);
         }
-
-        /// <summary>
-        ///     Get Frequency from RadiansPerSecond.
-        /// </summary>
-        public static Frequency FromRadiansPerSecond(int radianspersecond)
+#else
+        public static Frequency FromRadiansPerSecond(QuantityValue radianspersecond)
         {
-            return new Frequency(radianspersecond/6.2831853072);
-        }
-
-        /// <summary>
-        ///     Get Frequency from RadiansPerSecond.
-        /// </summary>
-        public static Frequency FromRadiansPerSecond(long radianspersecond)
-        {
-            return new Frequency(radianspersecond/6.2831853072);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from RadiansPerSecond of type decimal.
-        /// </summary>
-        public static Frequency FromRadiansPerSecond(decimal radianspersecond)
-        {
-            return new Frequency(Convert.ToDouble(radianspersecond)/6.2831853072);
+            double value = (double) radianspersecond;
+            return new Frequency((value/6.2831853072));
         }
 #endif
 
         /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Frequency FromTerahertz(double terahertz)
         {
-            return new Frequency((terahertz) * 1e12d);
+            double value = (double) terahertz;
+            return new Frequency((value) * 1e12d);
         }
-
-        /// <summary>
-        ///     Get Frequency from Terahertz.
-        /// </summary>
-        public static Frequency FromTerahertz(int terahertz)
+#else
+        public static Frequency FromTerahertz(QuantityValue terahertz)
         {
-            return new Frequency((terahertz) * 1e12d);
-        }
-
-        /// <summary>
-        ///     Get Frequency from Terahertz.
-        /// </summary>
-        public static Frequency FromTerahertz(long terahertz)
-        {
-            return new Frequency((terahertz) * 1e12d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Frequency from Terahertz of type decimal.
-        /// </summary>
-        public static Frequency FromTerahertz(decimal terahertz)
-        {
-            return new Frequency((Convert.ToDouble(terahertz)) * 1e12d);
+            double value = (double) terahertz;
+            return new Frequency(((value) * 1e12d));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerHour.
         /// </summary>
-        public static Frequency? FromCyclesPerHour(double? cyclesperhour)
-        {
-            if (cyclesperhour.HasValue)
-            {
-                return FromCyclesPerHour(cyclesperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable CyclesPerHour.
-        /// </summary>
-        public static Frequency? FromCyclesPerHour(int? cyclesperhour)
-        {
-            if (cyclesperhour.HasValue)
-            {
-                return FromCyclesPerHour(cyclesperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable CyclesPerHour.
-        /// </summary>
-        public static Frequency? FromCyclesPerHour(long? cyclesperhour)
-        {
-            if (cyclesperhour.HasValue)
-            {
-                return FromCyclesPerHour(cyclesperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from CyclesPerHour of type decimal.
-        /// </summary>
-        public static Frequency? FromCyclesPerHour(decimal? cyclesperhour)
+        public static Frequency? FromCyclesPerHour(QuantityValue? cyclesperhour)
         {
             if (cyclesperhour.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable CyclesPerMinute.
         /// </summary>
-        public static Frequency? FromCyclesPerMinute(double? cyclesperminute)
-        {
-            if (cyclesperminute.HasValue)
-            {
-                return FromCyclesPerMinute(cyclesperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable CyclesPerMinute.
-        /// </summary>
-        public static Frequency? FromCyclesPerMinute(int? cyclesperminute)
-        {
-            if (cyclesperminute.HasValue)
-            {
-                return FromCyclesPerMinute(cyclesperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable CyclesPerMinute.
-        /// </summary>
-        public static Frequency? FromCyclesPerMinute(long? cyclesperminute)
-        {
-            if (cyclesperminute.HasValue)
-            {
-                return FromCyclesPerMinute(cyclesperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from CyclesPerMinute of type decimal.
-        /// </summary>
-        public static Frequency? FromCyclesPerMinute(decimal? cyclesperminute)
+        public static Frequency? FromCyclesPerMinute(QuantityValue? cyclesperminute)
         {
             if (cyclesperminute.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable Gigahertz.
         /// </summary>
-        public static Frequency? FromGigahertz(double? gigahertz)
-        {
-            if (gigahertz.HasValue)
-            {
-                return FromGigahertz(gigahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Gigahertz.
-        /// </summary>
-        public static Frequency? FromGigahertz(int? gigahertz)
-        {
-            if (gigahertz.HasValue)
-            {
-                return FromGigahertz(gigahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Gigahertz.
-        /// </summary>
-        public static Frequency? FromGigahertz(long? gigahertz)
-        {
-            if (gigahertz.HasValue)
-            {
-                return FromGigahertz(gigahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from Gigahertz of type decimal.
-        /// </summary>
-        public static Frequency? FromGigahertz(decimal? gigahertz)
+        public static Frequency? FromGigahertz(QuantityValue? gigahertz)
         {
             if (gigahertz.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable Hertz.
         /// </summary>
-        public static Frequency? FromHertz(double? hertz)
-        {
-            if (hertz.HasValue)
-            {
-                return FromHertz(hertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Hertz.
-        /// </summary>
-        public static Frequency? FromHertz(int? hertz)
-        {
-            if (hertz.HasValue)
-            {
-                return FromHertz(hertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Hertz.
-        /// </summary>
-        public static Frequency? FromHertz(long? hertz)
-        {
-            if (hertz.HasValue)
-            {
-                return FromHertz(hertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from Hertz of type decimal.
-        /// </summary>
-        public static Frequency? FromHertz(decimal? hertz)
+        public static Frequency? FromHertz(QuantityValue? hertz)
         {
             if (hertz.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable Kilohertz.
         /// </summary>
-        public static Frequency? FromKilohertz(double? kilohertz)
-        {
-            if (kilohertz.HasValue)
-            {
-                return FromKilohertz(kilohertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Kilohertz.
-        /// </summary>
-        public static Frequency? FromKilohertz(int? kilohertz)
-        {
-            if (kilohertz.HasValue)
-            {
-                return FromKilohertz(kilohertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Kilohertz.
-        /// </summary>
-        public static Frequency? FromKilohertz(long? kilohertz)
-        {
-            if (kilohertz.HasValue)
-            {
-                return FromKilohertz(kilohertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from Kilohertz of type decimal.
-        /// </summary>
-        public static Frequency? FromKilohertz(decimal? kilohertz)
+        public static Frequency? FromKilohertz(QuantityValue? kilohertz)
         {
             if (kilohertz.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable Megahertz.
         /// </summary>
-        public static Frequency? FromMegahertz(double? megahertz)
-        {
-            if (megahertz.HasValue)
-            {
-                return FromMegahertz(megahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Megahertz.
-        /// </summary>
-        public static Frequency? FromMegahertz(int? megahertz)
-        {
-            if (megahertz.HasValue)
-            {
-                return FromMegahertz(megahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Megahertz.
-        /// </summary>
-        public static Frequency? FromMegahertz(long? megahertz)
-        {
-            if (megahertz.HasValue)
-            {
-                return FromMegahertz(megahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from Megahertz of type decimal.
-        /// </summary>
-        public static Frequency? FromMegahertz(decimal? megahertz)
+        public static Frequency? FromMegahertz(QuantityValue? megahertz)
         {
             if (megahertz.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable RadiansPerSecond.
         /// </summary>
-        public static Frequency? FromRadiansPerSecond(double? radianspersecond)
-        {
-            if (radianspersecond.HasValue)
-            {
-                return FromRadiansPerSecond(radianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable RadiansPerSecond.
-        /// </summary>
-        public static Frequency? FromRadiansPerSecond(int? radianspersecond)
-        {
-            if (radianspersecond.HasValue)
-            {
-                return FromRadiansPerSecond(radianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable RadiansPerSecond.
-        /// </summary>
-        public static Frequency? FromRadiansPerSecond(long? radianspersecond)
-        {
-            if (radianspersecond.HasValue)
-            {
-                return FromRadiansPerSecond(radianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from RadiansPerSecond of type decimal.
-        /// </summary>
-        public static Frequency? FromRadiansPerSecond(decimal? radianspersecond)
+        public static Frequency? FromRadiansPerSecond(QuantityValue? radianspersecond)
         {
             if (radianspersecond.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Frequency from nullable Terahertz.
         /// </summary>
-        public static Frequency? FromTerahertz(double? terahertz)
-        {
-            if (terahertz.HasValue)
-            {
-                return FromTerahertz(terahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Terahertz.
-        /// </summary>
-        public static Frequency? FromTerahertz(int? terahertz)
-        {
-            if (terahertz.HasValue)
-            {
-                return FromTerahertz(terahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from nullable Terahertz.
-        /// </summary>
-        public static Frequency? FromTerahertz(long? terahertz)
-        {
-            if (terahertz.HasValue)
-            {
-                return FromTerahertz(terahertz.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Frequency from Terahertz of type decimal.
-        /// </summary>
-        public static Frequency? FromTerahertz(decimal? terahertz)
+        public static Frequency? FromTerahertz(QuantityValue? terahertz)
         {
             if (terahertz.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="FrequencyUnit" /> to <see cref="Frequency" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Frequency unit value.</returns>
-        public static Frequency From(double val, FrequencyUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Frequency From(double value, FrequencyUnit fromUnit)
+#else
+        public static Frequency From(QuantityValue value, FrequencyUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case FrequencyUnit.CyclePerHour:
-                    return FromCyclesPerHour(val);
+                    return FromCyclesPerHour(value);
                 case FrequencyUnit.CyclePerMinute:
-                    return FromCyclesPerMinute(val);
+                    return FromCyclesPerMinute(value);
                 case FrequencyUnit.Gigahertz:
-                    return FromGigahertz(val);
+                    return FromGigahertz(value);
                 case FrequencyUnit.Hertz:
-                    return FromHertz(val);
+                    return FromHertz(value);
                 case FrequencyUnit.Kilohertz:
-                    return FromKilohertz(val);
+                    return FromKilohertz(value);
                 case FrequencyUnit.Megahertz:
-                    return FromMegahertz(val);
+                    return FromMegahertz(value);
                 case FrequencyUnit.RadianPerSecond:
-                    return FromRadiansPerSecond(val);
+                    return FromRadiansPerSecond(value);
                 case FrequencyUnit.Terahertz:
-                    return FromTerahertz(val);
+                    return FromTerahertz(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Frequency unit value.</returns>
-        public static Frequency? From(double? value, FrequencyUnit fromUnit)
+        public static Frequency? From(QuantityValue? value, FrequencyUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -349,988 +349,468 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromBits(double bits)
         {
-            return new Information(Convert.ToDecimal(bits));
+            double value = (double) bits;
+            return new Information(Convert.ToDecimal(value));
         }
-
-        /// <summary>
-        ///     Get Information from Bits.
-        /// </summary>
-        public static Information FromBits(int bits)
+#else
+        public static Information FromBits(QuantityValue bits)
         {
-            return new Information(Convert.ToDecimal(bits));
-        }
-
-        /// <summary>
-        ///     Get Information from Bits.
-        /// </summary>
-        public static Information FromBits(long bits)
-        {
-            return new Information(Convert.ToDecimal(bits));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Bits of type decimal.
-        /// </summary>
-        public static Information FromBits(decimal bits)
-        {
-            return new Information(Convert.ToDecimal(Convert.ToDouble(bits)));
+            double value = (double) bits;
+            return new Information((Convert.ToDecimal(value)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromBytes(double bytes)
         {
-            return new Information(Convert.ToDecimal(bytes*8d));
+            double value = (double) bytes;
+            return new Information(Convert.ToDecimal(value*8d));
         }
-
-        /// <summary>
-        ///     Get Information from Bytes.
-        /// </summary>
-        public static Information FromBytes(int bytes)
+#else
+        public static Information FromBytes(QuantityValue bytes)
         {
-            return new Information(Convert.ToDecimal(bytes*8d));
-        }
-
-        /// <summary>
-        ///     Get Information from Bytes.
-        /// </summary>
-        public static Information FromBytes(long bytes)
-        {
-            return new Information(Convert.ToDecimal(bytes*8d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Bytes of type decimal.
-        /// </summary>
-        public static Information FromBytes(decimal bytes)
-        {
-            return new Information(Convert.ToDecimal(Convert.ToDouble(bytes)*8d));
+            double value = (double) bytes;
+            return new Information((Convert.ToDecimal(value*8d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Exabits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromExabits(double exabits)
         {
-            return new Information(Convert.ToDecimal((exabits) * 1e18d));
+            double value = (double) exabits;
+            return new Information(Convert.ToDecimal((value) * 1e18d));
         }
-
-        /// <summary>
-        ///     Get Information from Exabits.
-        /// </summary>
-        public static Information FromExabits(int exabits)
+#else
+        public static Information FromExabits(QuantityValue exabits)
         {
-            return new Information(Convert.ToDecimal((exabits) * 1e18d));
-        }
-
-        /// <summary>
-        ///     Get Information from Exabits.
-        /// </summary>
-        public static Information FromExabits(long exabits)
-        {
-            return new Information(Convert.ToDecimal((exabits) * 1e18d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Exabits of type decimal.
-        /// </summary>
-        public static Information FromExabits(decimal exabits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(exabits)) * 1e18d));
+            double value = (double) exabits;
+            return new Information((Convert.ToDecimal((value) * 1e18d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromExabytes(double exabytes)
         {
-            return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
+            double value = (double) exabytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1e18d));
         }
-
-        /// <summary>
-        ///     Get Information from Exabytes.
-        /// </summary>
-        public static Information FromExabytes(int exabytes)
+#else
+        public static Information FromExabytes(QuantityValue exabytes)
         {
-            return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
-        }
-
-        /// <summary>
-        ///     Get Information from Exabytes.
-        /// </summary>
-        public static Information FromExabytes(long exabytes)
-        {
-            return new Information(Convert.ToDecimal((exabytes*8d) * 1e18d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Exabytes of type decimal.
-        /// </summary>
-        public static Information FromExabytes(decimal exabytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(exabytes)*8d) * 1e18d));
+            double value = (double) exabytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1e18d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromExbibits(double exbibits)
         {
-            return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) exbibits;
+            return new Information(Convert.ToDecimal((value) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Exbibits.
-        /// </summary>
-        public static Information FromExbibits(int exbibits)
+#else
+        public static Information FromExbibits(QuantityValue exbibits)
         {
-            return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Exbibits.
-        /// </summary>
-        public static Information FromExbibits(long exbibits)
-        {
-            return new Information(Convert.ToDecimal((exbibits) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Exbibits of type decimal.
-        /// </summary>
-        public static Information FromExbibits(decimal exbibits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(exbibits)) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) exbibits;
+            return new Information((Convert.ToDecimal((value) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromExbibytes(double exbibytes)
         {
-            return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) exbibytes;
+            return new Information(Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Exbibytes.
-        /// </summary>
-        public static Information FromExbibytes(int exbibytes)
+#else
+        public static Information FromExbibytes(QuantityValue exbibytes)
         {
-            return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Exbibytes.
-        /// </summary>
-        public static Information FromExbibytes(long exbibytes)
-        {
-            return new Information(Convert.ToDecimal((exbibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Exbibytes of type decimal.
-        /// </summary>
-        public static Information FromExbibytes(decimal exbibytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(exbibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) exbibytes;
+            return new Information((Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024 * 1024 * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Gibibits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromGibibits(double gibibits)
         {
-            return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
+            double value = (double) gibibits;
+            return new Information(Convert.ToDecimal((value) * (1024d * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Gibibits.
-        /// </summary>
-        public static Information FromGibibits(int gibibits)
+#else
+        public static Information FromGibibits(QuantityValue gibibits)
         {
-            return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Gibibits.
-        /// </summary>
-        public static Information FromGibibits(long gibibits)
-        {
-            return new Information(Convert.ToDecimal((gibibits) * (1024d * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Gibibits of type decimal.
-        /// </summary>
-        public static Information FromGibibits(decimal gibibits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(gibibits)) * (1024d * 1024 * 1024)));
+            double value = (double) gibibits;
+            return new Information((Convert.ToDecimal((value) * (1024d * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromGibibytes(double gibibytes)
         {
-            return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
+            double value = (double) gibibytes;
+            return new Information(Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Gibibytes.
-        /// </summary>
-        public static Information FromGibibytes(int gibibytes)
+#else
+        public static Information FromGibibytes(QuantityValue gibibytes)
         {
-            return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Gibibytes.
-        /// </summary>
-        public static Information FromGibibytes(long gibibytes)
-        {
-            return new Information(Convert.ToDecimal((gibibytes*8d) * (1024d * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Gibibytes of type decimal.
-        /// </summary>
-        public static Information FromGibibytes(decimal gibibytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(gibibytes)*8d) * (1024d * 1024 * 1024)));
+            double value = (double) gibibytes;
+            return new Information((Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Gigabits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromGigabits(double gigabits)
         {
-            return new Information(Convert.ToDecimal((gigabits) * 1e9d));
+            double value = (double) gigabits;
+            return new Information(Convert.ToDecimal((value) * 1e9d));
         }
-
-        /// <summary>
-        ///     Get Information from Gigabits.
-        /// </summary>
-        public static Information FromGigabits(int gigabits)
+#else
+        public static Information FromGigabits(QuantityValue gigabits)
         {
-            return new Information(Convert.ToDecimal((gigabits) * 1e9d));
-        }
-
-        /// <summary>
-        ///     Get Information from Gigabits.
-        /// </summary>
-        public static Information FromGigabits(long gigabits)
-        {
-            return new Information(Convert.ToDecimal((gigabits) * 1e9d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Gigabits of type decimal.
-        /// </summary>
-        public static Information FromGigabits(decimal gigabits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(gigabits)) * 1e9d));
+            double value = (double) gigabits;
+            return new Information((Convert.ToDecimal((value) * 1e9d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromGigabytes(double gigabytes)
         {
-            return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
+            double value = (double) gigabytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1e9d));
         }
-
-        /// <summary>
-        ///     Get Information from Gigabytes.
-        /// </summary>
-        public static Information FromGigabytes(int gigabytes)
+#else
+        public static Information FromGigabytes(QuantityValue gigabytes)
         {
-            return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
-        }
-
-        /// <summary>
-        ///     Get Information from Gigabytes.
-        /// </summary>
-        public static Information FromGigabytes(long gigabytes)
-        {
-            return new Information(Convert.ToDecimal((gigabytes*8d) * 1e9d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Gigabytes of type decimal.
-        /// </summary>
-        public static Information FromGigabytes(decimal gigabytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(gigabytes)*8d) * 1e9d));
+            double value = (double) gigabytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1e9d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Kibibits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromKibibits(double kibibits)
         {
-            return new Information(Convert.ToDecimal((kibibits) * 1024d));
+            double value = (double) kibibits;
+            return new Information(Convert.ToDecimal((value) * 1024d));
         }
-
-        /// <summary>
-        ///     Get Information from Kibibits.
-        /// </summary>
-        public static Information FromKibibits(int kibibits)
+#else
+        public static Information FromKibibits(QuantityValue kibibits)
         {
-            return new Information(Convert.ToDecimal((kibibits) * 1024d));
-        }
-
-        /// <summary>
-        ///     Get Information from Kibibits.
-        /// </summary>
-        public static Information FromKibibits(long kibibits)
-        {
-            return new Information(Convert.ToDecimal((kibibits) * 1024d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Kibibits of type decimal.
-        /// </summary>
-        public static Information FromKibibits(decimal kibibits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(kibibits)) * 1024d));
+            double value = (double) kibibits;
+            return new Information((Convert.ToDecimal((value) * 1024d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromKibibytes(double kibibytes)
         {
-            return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
+            double value = (double) kibibytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1024d));
         }
-
-        /// <summary>
-        ///     Get Information from Kibibytes.
-        /// </summary>
-        public static Information FromKibibytes(int kibibytes)
+#else
+        public static Information FromKibibytes(QuantityValue kibibytes)
         {
-            return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
-        }
-
-        /// <summary>
-        ///     Get Information from Kibibytes.
-        /// </summary>
-        public static Information FromKibibytes(long kibibytes)
-        {
-            return new Information(Convert.ToDecimal((kibibytes*8d) * 1024d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Kibibytes of type decimal.
-        /// </summary>
-        public static Information FromKibibytes(decimal kibibytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(kibibytes)*8d) * 1024d));
+            double value = (double) kibibytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1024d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Kilobits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromKilobits(double kilobits)
         {
-            return new Information(Convert.ToDecimal((kilobits) * 1e3d));
+            double value = (double) kilobits;
+            return new Information(Convert.ToDecimal((value) * 1e3d));
         }
-
-        /// <summary>
-        ///     Get Information from Kilobits.
-        /// </summary>
-        public static Information FromKilobits(int kilobits)
+#else
+        public static Information FromKilobits(QuantityValue kilobits)
         {
-            return new Information(Convert.ToDecimal((kilobits) * 1e3d));
-        }
-
-        /// <summary>
-        ///     Get Information from Kilobits.
-        /// </summary>
-        public static Information FromKilobits(long kilobits)
-        {
-            return new Information(Convert.ToDecimal((kilobits) * 1e3d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Kilobits of type decimal.
-        /// </summary>
-        public static Information FromKilobits(decimal kilobits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(kilobits)) * 1e3d));
+            double value = (double) kilobits;
+            return new Information((Convert.ToDecimal((value) * 1e3d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromKilobytes(double kilobytes)
         {
-            return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
+            double value = (double) kilobytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1e3d));
         }
-
-        /// <summary>
-        ///     Get Information from Kilobytes.
-        /// </summary>
-        public static Information FromKilobytes(int kilobytes)
+#else
+        public static Information FromKilobytes(QuantityValue kilobytes)
         {
-            return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
-        }
-
-        /// <summary>
-        ///     Get Information from Kilobytes.
-        /// </summary>
-        public static Information FromKilobytes(long kilobytes)
-        {
-            return new Information(Convert.ToDecimal((kilobytes*8d) * 1e3d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Kilobytes of type decimal.
-        /// </summary>
-        public static Information FromKilobytes(decimal kilobytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(kilobytes)*8d) * 1e3d));
+            double value = (double) kilobytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1e3d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Mebibits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromMebibits(double mebibits)
         {
-            return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
+            double value = (double) mebibits;
+            return new Information(Convert.ToDecimal((value) * (1024d * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Mebibits.
-        /// </summary>
-        public static Information FromMebibits(int mebibits)
+#else
+        public static Information FromMebibits(QuantityValue mebibits)
         {
-            return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Mebibits.
-        /// </summary>
-        public static Information FromMebibits(long mebibits)
-        {
-            return new Information(Convert.ToDecimal((mebibits) * (1024d * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Mebibits of type decimal.
-        /// </summary>
-        public static Information FromMebibits(decimal mebibits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(mebibits)) * (1024d * 1024)));
+            double value = (double) mebibits;
+            return new Information((Convert.ToDecimal((value) * (1024d * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromMebibytes(double mebibytes)
         {
-            return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
+            double value = (double) mebibytes;
+            return new Information(Convert.ToDecimal((value*8d) * (1024d * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Mebibytes.
-        /// </summary>
-        public static Information FromMebibytes(int mebibytes)
+#else
+        public static Information FromMebibytes(QuantityValue mebibytes)
         {
-            return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Mebibytes.
-        /// </summary>
-        public static Information FromMebibytes(long mebibytes)
-        {
-            return new Information(Convert.ToDecimal((mebibytes*8d) * (1024d * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Mebibytes of type decimal.
-        /// </summary>
-        public static Information FromMebibytes(decimal mebibytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(mebibytes)*8d) * (1024d * 1024)));
+            double value = (double) mebibytes;
+            return new Information((Convert.ToDecimal((value*8d) * (1024d * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Megabits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromMegabits(double megabits)
         {
-            return new Information(Convert.ToDecimal((megabits) * 1e6d));
+            double value = (double) megabits;
+            return new Information(Convert.ToDecimal((value) * 1e6d));
         }
-
-        /// <summary>
-        ///     Get Information from Megabits.
-        /// </summary>
-        public static Information FromMegabits(int megabits)
+#else
+        public static Information FromMegabits(QuantityValue megabits)
         {
-            return new Information(Convert.ToDecimal((megabits) * 1e6d));
-        }
-
-        /// <summary>
-        ///     Get Information from Megabits.
-        /// </summary>
-        public static Information FromMegabits(long megabits)
-        {
-            return new Information(Convert.ToDecimal((megabits) * 1e6d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Megabits of type decimal.
-        /// </summary>
-        public static Information FromMegabits(decimal megabits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(megabits)) * 1e6d));
+            double value = (double) megabits;
+            return new Information((Convert.ToDecimal((value) * 1e6d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromMegabytes(double megabytes)
         {
-            return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
+            double value = (double) megabytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1e6d));
         }
-
-        /// <summary>
-        ///     Get Information from Megabytes.
-        /// </summary>
-        public static Information FromMegabytes(int megabytes)
+#else
+        public static Information FromMegabytes(QuantityValue megabytes)
         {
-            return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
-        }
-
-        /// <summary>
-        ///     Get Information from Megabytes.
-        /// </summary>
-        public static Information FromMegabytes(long megabytes)
-        {
-            return new Information(Convert.ToDecimal((megabytes*8d) * 1e6d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Megabytes of type decimal.
-        /// </summary>
-        public static Information FromMegabytes(decimal megabytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(megabytes)*8d) * 1e6d));
+            double value = (double) megabytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1e6d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Pebibits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromPebibits(double pebibits)
         {
-            return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) pebibits;
+            return new Information(Convert.ToDecimal((value) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Pebibits.
-        /// </summary>
-        public static Information FromPebibits(int pebibits)
+#else
+        public static Information FromPebibits(QuantityValue pebibits)
         {
-            return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Pebibits.
-        /// </summary>
-        public static Information FromPebibits(long pebibits)
-        {
-            return new Information(Convert.ToDecimal((pebibits) * (1024d * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Pebibits of type decimal.
-        /// </summary>
-        public static Information FromPebibits(decimal pebibits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(pebibits)) * (1024d * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) pebibits;
+            return new Information((Convert.ToDecimal((value) * (1024d * 1024 * 1024 * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromPebibytes(double pebibytes)
         {
-            return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) pebibytes;
+            return new Information(Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Pebibytes.
-        /// </summary>
-        public static Information FromPebibytes(int pebibytes)
+#else
+        public static Information FromPebibytes(QuantityValue pebibytes)
         {
-            return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Pebibytes.
-        /// </summary>
-        public static Information FromPebibytes(long pebibytes)
-        {
-            return new Information(Convert.ToDecimal((pebibytes*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Pebibytes of type decimal.
-        /// </summary>
-        public static Information FromPebibytes(decimal pebibytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(pebibytes)*8d) * (1024d * 1024 * 1024 * 1024 * 1024)));
+            double value = (double) pebibytes;
+            return new Information((Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024 * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Petabits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromPetabits(double petabits)
         {
-            return new Information(Convert.ToDecimal((petabits) * 1e15d));
+            double value = (double) petabits;
+            return new Information(Convert.ToDecimal((value) * 1e15d));
         }
-
-        /// <summary>
-        ///     Get Information from Petabits.
-        /// </summary>
-        public static Information FromPetabits(int petabits)
+#else
+        public static Information FromPetabits(QuantityValue petabits)
         {
-            return new Information(Convert.ToDecimal((petabits) * 1e15d));
-        }
-
-        /// <summary>
-        ///     Get Information from Petabits.
-        /// </summary>
-        public static Information FromPetabits(long petabits)
-        {
-            return new Information(Convert.ToDecimal((petabits) * 1e15d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Petabits of type decimal.
-        /// </summary>
-        public static Information FromPetabits(decimal petabits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(petabits)) * 1e15d));
+            double value = (double) petabits;
+            return new Information((Convert.ToDecimal((value) * 1e15d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromPetabytes(double petabytes)
         {
-            return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
+            double value = (double) petabytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1e15d));
         }
-
-        /// <summary>
-        ///     Get Information from Petabytes.
-        /// </summary>
-        public static Information FromPetabytes(int petabytes)
+#else
+        public static Information FromPetabytes(QuantityValue petabytes)
         {
-            return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
-        }
-
-        /// <summary>
-        ///     Get Information from Petabytes.
-        /// </summary>
-        public static Information FromPetabytes(long petabytes)
-        {
-            return new Information(Convert.ToDecimal((petabytes*8d) * 1e15d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Petabytes of type decimal.
-        /// </summary>
-        public static Information FromPetabytes(decimal petabytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(petabytes)*8d) * 1e15d));
+            double value = (double) petabytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1e15d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Tebibits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromTebibits(double tebibits)
         {
-            return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
+            double value = (double) tebibits;
+            return new Information(Convert.ToDecimal((value) * (1024d * 1024 * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Tebibits.
-        /// </summary>
-        public static Information FromTebibits(int tebibits)
+#else
+        public static Information FromTebibits(QuantityValue tebibits)
         {
-            return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Tebibits.
-        /// </summary>
-        public static Information FromTebibits(long tebibits)
-        {
-            return new Information(Convert.ToDecimal((tebibits) * (1024d * 1024 * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Tebibits of type decimal.
-        /// </summary>
-        public static Information FromTebibits(decimal tebibits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(tebibits)) * (1024d * 1024 * 1024 * 1024)));
+            double value = (double) tebibits;
+            return new Information((Convert.ToDecimal((value) * (1024d * 1024 * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromTebibytes(double tebibytes)
         {
-            return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
+            double value = (double) tebibytes;
+            return new Information(Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024 * 1024)));
         }
-
-        /// <summary>
-        ///     Get Information from Tebibytes.
-        /// </summary>
-        public static Information FromTebibytes(int tebibytes)
+#else
+        public static Information FromTebibytes(QuantityValue tebibytes)
         {
-            return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
-        }
-
-        /// <summary>
-        ///     Get Information from Tebibytes.
-        /// </summary>
-        public static Information FromTebibytes(long tebibytes)
-        {
-            return new Information(Convert.ToDecimal((tebibytes*8d) * (1024d * 1024 * 1024 * 1024)));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Tebibytes of type decimal.
-        /// </summary>
-        public static Information FromTebibytes(decimal tebibytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(tebibytes)*8d) * (1024d * 1024 * 1024 * 1024)));
+            double value = (double) tebibytes;
+            return new Information((Convert.ToDecimal((value*8d) * (1024d * 1024 * 1024 * 1024))));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Terabits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromTerabits(double terabits)
         {
-            return new Information(Convert.ToDecimal((terabits) * 1e12d));
+            double value = (double) terabits;
+            return new Information(Convert.ToDecimal((value) * 1e12d));
         }
-
-        /// <summary>
-        ///     Get Information from Terabits.
-        /// </summary>
-        public static Information FromTerabits(int terabits)
+#else
+        public static Information FromTerabits(QuantityValue terabits)
         {
-            return new Information(Convert.ToDecimal((terabits) * 1e12d));
-        }
-
-        /// <summary>
-        ///     Get Information from Terabits.
-        /// </summary>
-        public static Information FromTerabits(long terabits)
-        {
-            return new Information(Convert.ToDecimal((terabits) * 1e12d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Terabits of type decimal.
-        /// </summary>
-        public static Information FromTerabits(decimal terabits)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(terabits)) * 1e12d));
+            double value = (double) terabits;
+            return new Information((Convert.ToDecimal((value) * 1e12d)));
         }
 #endif
 
         /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Information FromTerabytes(double terabytes)
         {
-            return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
+            double value = (double) terabytes;
+            return new Information(Convert.ToDecimal((value*8d) * 1e12d));
         }
-
-        /// <summary>
-        ///     Get Information from Terabytes.
-        /// </summary>
-        public static Information FromTerabytes(int terabytes)
+#else
+        public static Information FromTerabytes(QuantityValue terabytes)
         {
-            return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
-        }
-
-        /// <summary>
-        ///     Get Information from Terabytes.
-        /// </summary>
-        public static Information FromTerabytes(long terabytes)
-        {
-            return new Information(Convert.ToDecimal((terabytes*8d) * 1e12d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Information from Terabytes of type decimal.
-        /// </summary>
-        public static Information FromTerabytes(decimal terabytes)
-        {
-            return new Information(Convert.ToDecimal((Convert.ToDouble(terabytes)*8d) * 1e12d));
+            double value = (double) terabytes;
+            return new Information((Convert.ToDecimal((value*8d) * 1e12d)));
         }
 #endif
 
@@ -1339,52 +819,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Bits.
         /// </summary>
-        public static Information? FromBits(double? bits)
-        {
-            if (bits.HasValue)
-            {
-                return FromBits(bits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Bits.
-        /// </summary>
-        public static Information? FromBits(int? bits)
-        {
-            if (bits.HasValue)
-            {
-                return FromBits(bits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Bits.
-        /// </summary>
-        public static Information? FromBits(long? bits)
-        {
-            if (bits.HasValue)
-            {
-                return FromBits(bits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Bits of type decimal.
-        /// </summary>
-        public static Information? FromBits(decimal? bits)
+        public static Information? FromBits(QuantityValue? bits)
         {
             if (bits.HasValue)
             {
@@ -1399,52 +834,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Bytes.
         /// </summary>
-        public static Information? FromBytes(double? bytes)
-        {
-            if (bytes.HasValue)
-            {
-                return FromBytes(bytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Bytes.
-        /// </summary>
-        public static Information? FromBytes(int? bytes)
-        {
-            if (bytes.HasValue)
-            {
-                return FromBytes(bytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Bytes.
-        /// </summary>
-        public static Information? FromBytes(long? bytes)
-        {
-            if (bytes.HasValue)
-            {
-                return FromBytes(bytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Bytes of type decimal.
-        /// </summary>
-        public static Information? FromBytes(decimal? bytes)
+        public static Information? FromBytes(QuantityValue? bytes)
         {
             if (bytes.HasValue)
             {
@@ -1459,52 +849,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Exabits.
         /// </summary>
-        public static Information? FromExabits(double? exabits)
-        {
-            if (exabits.HasValue)
-            {
-                return FromExabits(exabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exabits.
-        /// </summary>
-        public static Information? FromExabits(int? exabits)
-        {
-            if (exabits.HasValue)
-            {
-                return FromExabits(exabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exabits.
-        /// </summary>
-        public static Information? FromExabits(long? exabits)
-        {
-            if (exabits.HasValue)
-            {
-                return FromExabits(exabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Exabits of type decimal.
-        /// </summary>
-        public static Information? FromExabits(decimal? exabits)
+        public static Information? FromExabits(QuantityValue? exabits)
         {
             if (exabits.HasValue)
             {
@@ -1519,52 +864,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Exabytes.
         /// </summary>
-        public static Information? FromExabytes(double? exabytes)
-        {
-            if (exabytes.HasValue)
-            {
-                return FromExabytes(exabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exabytes.
-        /// </summary>
-        public static Information? FromExabytes(int? exabytes)
-        {
-            if (exabytes.HasValue)
-            {
-                return FromExabytes(exabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exabytes.
-        /// </summary>
-        public static Information? FromExabytes(long? exabytes)
-        {
-            if (exabytes.HasValue)
-            {
-                return FromExabytes(exabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Exabytes of type decimal.
-        /// </summary>
-        public static Information? FromExabytes(decimal? exabytes)
+        public static Information? FromExabytes(QuantityValue? exabytes)
         {
             if (exabytes.HasValue)
             {
@@ -1579,52 +879,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Exbibits.
         /// </summary>
-        public static Information? FromExbibits(double? exbibits)
-        {
-            if (exbibits.HasValue)
-            {
-                return FromExbibits(exbibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exbibits.
-        /// </summary>
-        public static Information? FromExbibits(int? exbibits)
-        {
-            if (exbibits.HasValue)
-            {
-                return FromExbibits(exbibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exbibits.
-        /// </summary>
-        public static Information? FromExbibits(long? exbibits)
-        {
-            if (exbibits.HasValue)
-            {
-                return FromExbibits(exbibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Exbibits of type decimal.
-        /// </summary>
-        public static Information? FromExbibits(decimal? exbibits)
+        public static Information? FromExbibits(QuantityValue? exbibits)
         {
             if (exbibits.HasValue)
             {
@@ -1639,52 +894,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Exbibytes.
         /// </summary>
-        public static Information? FromExbibytes(double? exbibytes)
-        {
-            if (exbibytes.HasValue)
-            {
-                return FromExbibytes(exbibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exbibytes.
-        /// </summary>
-        public static Information? FromExbibytes(int? exbibytes)
-        {
-            if (exbibytes.HasValue)
-            {
-                return FromExbibytes(exbibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Exbibytes.
-        /// </summary>
-        public static Information? FromExbibytes(long? exbibytes)
-        {
-            if (exbibytes.HasValue)
-            {
-                return FromExbibytes(exbibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Exbibytes of type decimal.
-        /// </summary>
-        public static Information? FromExbibytes(decimal? exbibytes)
+        public static Information? FromExbibytes(QuantityValue? exbibytes)
         {
             if (exbibytes.HasValue)
             {
@@ -1699,52 +909,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Gibibits.
         /// </summary>
-        public static Information? FromGibibits(double? gibibits)
-        {
-            if (gibibits.HasValue)
-            {
-                return FromGibibits(gibibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gibibits.
-        /// </summary>
-        public static Information? FromGibibits(int? gibibits)
-        {
-            if (gibibits.HasValue)
-            {
-                return FromGibibits(gibibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gibibits.
-        /// </summary>
-        public static Information? FromGibibits(long? gibibits)
-        {
-            if (gibibits.HasValue)
-            {
-                return FromGibibits(gibibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Gibibits of type decimal.
-        /// </summary>
-        public static Information? FromGibibits(decimal? gibibits)
+        public static Information? FromGibibits(QuantityValue? gibibits)
         {
             if (gibibits.HasValue)
             {
@@ -1759,52 +924,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Gibibytes.
         /// </summary>
-        public static Information? FromGibibytes(double? gibibytes)
-        {
-            if (gibibytes.HasValue)
-            {
-                return FromGibibytes(gibibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gibibytes.
-        /// </summary>
-        public static Information? FromGibibytes(int? gibibytes)
-        {
-            if (gibibytes.HasValue)
-            {
-                return FromGibibytes(gibibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gibibytes.
-        /// </summary>
-        public static Information? FromGibibytes(long? gibibytes)
-        {
-            if (gibibytes.HasValue)
-            {
-                return FromGibibytes(gibibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Gibibytes of type decimal.
-        /// </summary>
-        public static Information? FromGibibytes(decimal? gibibytes)
+        public static Information? FromGibibytes(QuantityValue? gibibytes)
         {
             if (gibibytes.HasValue)
             {
@@ -1819,52 +939,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Gigabits.
         /// </summary>
-        public static Information? FromGigabits(double? gigabits)
-        {
-            if (gigabits.HasValue)
-            {
-                return FromGigabits(gigabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gigabits.
-        /// </summary>
-        public static Information? FromGigabits(int? gigabits)
-        {
-            if (gigabits.HasValue)
-            {
-                return FromGigabits(gigabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gigabits.
-        /// </summary>
-        public static Information? FromGigabits(long? gigabits)
-        {
-            if (gigabits.HasValue)
-            {
-                return FromGigabits(gigabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Gigabits of type decimal.
-        /// </summary>
-        public static Information? FromGigabits(decimal? gigabits)
+        public static Information? FromGigabits(QuantityValue? gigabits)
         {
             if (gigabits.HasValue)
             {
@@ -1879,52 +954,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Gigabytes.
         /// </summary>
-        public static Information? FromGigabytes(double? gigabytes)
-        {
-            if (gigabytes.HasValue)
-            {
-                return FromGigabytes(gigabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gigabytes.
-        /// </summary>
-        public static Information? FromGigabytes(int? gigabytes)
-        {
-            if (gigabytes.HasValue)
-            {
-                return FromGigabytes(gigabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Gigabytes.
-        /// </summary>
-        public static Information? FromGigabytes(long? gigabytes)
-        {
-            if (gigabytes.HasValue)
-            {
-                return FromGigabytes(gigabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Gigabytes of type decimal.
-        /// </summary>
-        public static Information? FromGigabytes(decimal? gigabytes)
+        public static Information? FromGigabytes(QuantityValue? gigabytes)
         {
             if (gigabytes.HasValue)
             {
@@ -1939,52 +969,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Kibibits.
         /// </summary>
-        public static Information? FromKibibits(double? kibibits)
-        {
-            if (kibibits.HasValue)
-            {
-                return FromKibibits(kibibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kibibits.
-        /// </summary>
-        public static Information? FromKibibits(int? kibibits)
-        {
-            if (kibibits.HasValue)
-            {
-                return FromKibibits(kibibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kibibits.
-        /// </summary>
-        public static Information? FromKibibits(long? kibibits)
-        {
-            if (kibibits.HasValue)
-            {
-                return FromKibibits(kibibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Kibibits of type decimal.
-        /// </summary>
-        public static Information? FromKibibits(decimal? kibibits)
+        public static Information? FromKibibits(QuantityValue? kibibits)
         {
             if (kibibits.HasValue)
             {
@@ -1999,52 +984,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Kibibytes.
         /// </summary>
-        public static Information? FromKibibytes(double? kibibytes)
-        {
-            if (kibibytes.HasValue)
-            {
-                return FromKibibytes(kibibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kibibytes.
-        /// </summary>
-        public static Information? FromKibibytes(int? kibibytes)
-        {
-            if (kibibytes.HasValue)
-            {
-                return FromKibibytes(kibibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kibibytes.
-        /// </summary>
-        public static Information? FromKibibytes(long? kibibytes)
-        {
-            if (kibibytes.HasValue)
-            {
-                return FromKibibytes(kibibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Kibibytes of type decimal.
-        /// </summary>
-        public static Information? FromKibibytes(decimal? kibibytes)
+        public static Information? FromKibibytes(QuantityValue? kibibytes)
         {
             if (kibibytes.HasValue)
             {
@@ -2059,52 +999,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Kilobits.
         /// </summary>
-        public static Information? FromKilobits(double? kilobits)
-        {
-            if (kilobits.HasValue)
-            {
-                return FromKilobits(kilobits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kilobits.
-        /// </summary>
-        public static Information? FromKilobits(int? kilobits)
-        {
-            if (kilobits.HasValue)
-            {
-                return FromKilobits(kilobits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kilobits.
-        /// </summary>
-        public static Information? FromKilobits(long? kilobits)
-        {
-            if (kilobits.HasValue)
-            {
-                return FromKilobits(kilobits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Kilobits of type decimal.
-        /// </summary>
-        public static Information? FromKilobits(decimal? kilobits)
+        public static Information? FromKilobits(QuantityValue? kilobits)
         {
             if (kilobits.HasValue)
             {
@@ -2119,52 +1014,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Kilobytes.
         /// </summary>
-        public static Information? FromKilobytes(double? kilobytes)
-        {
-            if (kilobytes.HasValue)
-            {
-                return FromKilobytes(kilobytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kilobytes.
-        /// </summary>
-        public static Information? FromKilobytes(int? kilobytes)
-        {
-            if (kilobytes.HasValue)
-            {
-                return FromKilobytes(kilobytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Kilobytes.
-        /// </summary>
-        public static Information? FromKilobytes(long? kilobytes)
-        {
-            if (kilobytes.HasValue)
-            {
-                return FromKilobytes(kilobytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Kilobytes of type decimal.
-        /// </summary>
-        public static Information? FromKilobytes(decimal? kilobytes)
+        public static Information? FromKilobytes(QuantityValue? kilobytes)
         {
             if (kilobytes.HasValue)
             {
@@ -2179,52 +1029,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Mebibits.
         /// </summary>
-        public static Information? FromMebibits(double? mebibits)
-        {
-            if (mebibits.HasValue)
-            {
-                return FromMebibits(mebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Mebibits.
-        /// </summary>
-        public static Information? FromMebibits(int? mebibits)
-        {
-            if (mebibits.HasValue)
-            {
-                return FromMebibits(mebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Mebibits.
-        /// </summary>
-        public static Information? FromMebibits(long? mebibits)
-        {
-            if (mebibits.HasValue)
-            {
-                return FromMebibits(mebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Mebibits of type decimal.
-        /// </summary>
-        public static Information? FromMebibits(decimal? mebibits)
+        public static Information? FromMebibits(QuantityValue? mebibits)
         {
             if (mebibits.HasValue)
             {
@@ -2239,52 +1044,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Mebibytes.
         /// </summary>
-        public static Information? FromMebibytes(double? mebibytes)
-        {
-            if (mebibytes.HasValue)
-            {
-                return FromMebibytes(mebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Mebibytes.
-        /// </summary>
-        public static Information? FromMebibytes(int? mebibytes)
-        {
-            if (mebibytes.HasValue)
-            {
-                return FromMebibytes(mebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Mebibytes.
-        /// </summary>
-        public static Information? FromMebibytes(long? mebibytes)
-        {
-            if (mebibytes.HasValue)
-            {
-                return FromMebibytes(mebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Mebibytes of type decimal.
-        /// </summary>
-        public static Information? FromMebibytes(decimal? mebibytes)
+        public static Information? FromMebibytes(QuantityValue? mebibytes)
         {
             if (mebibytes.HasValue)
             {
@@ -2299,52 +1059,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Megabits.
         /// </summary>
-        public static Information? FromMegabits(double? megabits)
-        {
-            if (megabits.HasValue)
-            {
-                return FromMegabits(megabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Megabits.
-        /// </summary>
-        public static Information? FromMegabits(int? megabits)
-        {
-            if (megabits.HasValue)
-            {
-                return FromMegabits(megabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Megabits.
-        /// </summary>
-        public static Information? FromMegabits(long? megabits)
-        {
-            if (megabits.HasValue)
-            {
-                return FromMegabits(megabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Megabits of type decimal.
-        /// </summary>
-        public static Information? FromMegabits(decimal? megabits)
+        public static Information? FromMegabits(QuantityValue? megabits)
         {
             if (megabits.HasValue)
             {
@@ -2359,52 +1074,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Megabytes.
         /// </summary>
-        public static Information? FromMegabytes(double? megabytes)
-        {
-            if (megabytes.HasValue)
-            {
-                return FromMegabytes(megabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Megabytes.
-        /// </summary>
-        public static Information? FromMegabytes(int? megabytes)
-        {
-            if (megabytes.HasValue)
-            {
-                return FromMegabytes(megabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Megabytes.
-        /// </summary>
-        public static Information? FromMegabytes(long? megabytes)
-        {
-            if (megabytes.HasValue)
-            {
-                return FromMegabytes(megabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Megabytes of type decimal.
-        /// </summary>
-        public static Information? FromMegabytes(decimal? megabytes)
+        public static Information? FromMegabytes(QuantityValue? megabytes)
         {
             if (megabytes.HasValue)
             {
@@ -2419,52 +1089,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Pebibits.
         /// </summary>
-        public static Information? FromPebibits(double? pebibits)
-        {
-            if (pebibits.HasValue)
-            {
-                return FromPebibits(pebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Pebibits.
-        /// </summary>
-        public static Information? FromPebibits(int? pebibits)
-        {
-            if (pebibits.HasValue)
-            {
-                return FromPebibits(pebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Pebibits.
-        /// </summary>
-        public static Information? FromPebibits(long? pebibits)
-        {
-            if (pebibits.HasValue)
-            {
-                return FromPebibits(pebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Pebibits of type decimal.
-        /// </summary>
-        public static Information? FromPebibits(decimal? pebibits)
+        public static Information? FromPebibits(QuantityValue? pebibits)
         {
             if (pebibits.HasValue)
             {
@@ -2479,52 +1104,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Pebibytes.
         /// </summary>
-        public static Information? FromPebibytes(double? pebibytes)
-        {
-            if (pebibytes.HasValue)
-            {
-                return FromPebibytes(pebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Pebibytes.
-        /// </summary>
-        public static Information? FromPebibytes(int? pebibytes)
-        {
-            if (pebibytes.HasValue)
-            {
-                return FromPebibytes(pebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Pebibytes.
-        /// </summary>
-        public static Information? FromPebibytes(long? pebibytes)
-        {
-            if (pebibytes.HasValue)
-            {
-                return FromPebibytes(pebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Pebibytes of type decimal.
-        /// </summary>
-        public static Information? FromPebibytes(decimal? pebibytes)
+        public static Information? FromPebibytes(QuantityValue? pebibytes)
         {
             if (pebibytes.HasValue)
             {
@@ -2539,52 +1119,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Petabits.
         /// </summary>
-        public static Information? FromPetabits(double? petabits)
-        {
-            if (petabits.HasValue)
-            {
-                return FromPetabits(petabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Petabits.
-        /// </summary>
-        public static Information? FromPetabits(int? petabits)
-        {
-            if (petabits.HasValue)
-            {
-                return FromPetabits(petabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Petabits.
-        /// </summary>
-        public static Information? FromPetabits(long? petabits)
-        {
-            if (petabits.HasValue)
-            {
-                return FromPetabits(petabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Petabits of type decimal.
-        /// </summary>
-        public static Information? FromPetabits(decimal? petabits)
+        public static Information? FromPetabits(QuantityValue? petabits)
         {
             if (petabits.HasValue)
             {
@@ -2599,52 +1134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Petabytes.
         /// </summary>
-        public static Information? FromPetabytes(double? petabytes)
-        {
-            if (petabytes.HasValue)
-            {
-                return FromPetabytes(petabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Petabytes.
-        /// </summary>
-        public static Information? FromPetabytes(int? petabytes)
-        {
-            if (petabytes.HasValue)
-            {
-                return FromPetabytes(petabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Petabytes.
-        /// </summary>
-        public static Information? FromPetabytes(long? petabytes)
-        {
-            if (petabytes.HasValue)
-            {
-                return FromPetabytes(petabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Petabytes of type decimal.
-        /// </summary>
-        public static Information? FromPetabytes(decimal? petabytes)
+        public static Information? FromPetabytes(QuantityValue? petabytes)
         {
             if (petabytes.HasValue)
             {
@@ -2659,52 +1149,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Tebibits.
         /// </summary>
-        public static Information? FromTebibits(double? tebibits)
-        {
-            if (tebibits.HasValue)
-            {
-                return FromTebibits(tebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Tebibits.
-        /// </summary>
-        public static Information? FromTebibits(int? tebibits)
-        {
-            if (tebibits.HasValue)
-            {
-                return FromTebibits(tebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Tebibits.
-        /// </summary>
-        public static Information? FromTebibits(long? tebibits)
-        {
-            if (tebibits.HasValue)
-            {
-                return FromTebibits(tebibits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Tebibits of type decimal.
-        /// </summary>
-        public static Information? FromTebibits(decimal? tebibits)
+        public static Information? FromTebibits(QuantityValue? tebibits)
         {
             if (tebibits.HasValue)
             {
@@ -2719,52 +1164,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Tebibytes.
         /// </summary>
-        public static Information? FromTebibytes(double? tebibytes)
-        {
-            if (tebibytes.HasValue)
-            {
-                return FromTebibytes(tebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Tebibytes.
-        /// </summary>
-        public static Information? FromTebibytes(int? tebibytes)
-        {
-            if (tebibytes.HasValue)
-            {
-                return FromTebibytes(tebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Tebibytes.
-        /// </summary>
-        public static Information? FromTebibytes(long? tebibytes)
-        {
-            if (tebibytes.HasValue)
-            {
-                return FromTebibytes(tebibytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Tebibytes of type decimal.
-        /// </summary>
-        public static Information? FromTebibytes(decimal? tebibytes)
+        public static Information? FromTebibytes(QuantityValue? tebibytes)
         {
             if (tebibytes.HasValue)
             {
@@ -2779,52 +1179,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Terabits.
         /// </summary>
-        public static Information? FromTerabits(double? terabits)
-        {
-            if (terabits.HasValue)
-            {
-                return FromTerabits(terabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Terabits.
-        /// </summary>
-        public static Information? FromTerabits(int? terabits)
-        {
-            if (terabits.HasValue)
-            {
-                return FromTerabits(terabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Terabits.
-        /// </summary>
-        public static Information? FromTerabits(long? terabits)
-        {
-            if (terabits.HasValue)
-            {
-                return FromTerabits(terabits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Terabits of type decimal.
-        /// </summary>
-        public static Information? FromTerabits(decimal? terabits)
+        public static Information? FromTerabits(QuantityValue? terabits)
         {
             if (terabits.HasValue)
             {
@@ -2839,52 +1194,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Information from nullable Terabytes.
         /// </summary>
-        public static Information? FromTerabytes(double? terabytes)
-        {
-            if (terabytes.HasValue)
-            {
-                return FromTerabytes(terabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Terabytes.
-        /// </summary>
-        public static Information? FromTerabytes(int? terabytes)
-        {
-            if (terabytes.HasValue)
-            {
-                return FromTerabytes(terabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from nullable Terabytes.
-        /// </summary>
-        public static Information? FromTerabytes(long? terabytes)
-        {
-            if (terabytes.HasValue)
-            {
-                return FromTerabytes(terabytes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Information from Terabytes of type decimal.
-        /// </summary>
-        public static Information? FromTerabytes(decimal? terabytes)
+        public static Information? FromTerabytes(QuantityValue? terabytes)
         {
             if (terabytes.HasValue)
             {
@@ -2901,65 +1211,71 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="InformationUnit" /> to <see cref="Information" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Information unit value.</returns>
-        public static Information From(double val, InformationUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Information From(double value, InformationUnit fromUnit)
+#else
+        public static Information From(QuantityValue value, InformationUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case InformationUnit.Bit:
-                    return FromBits(val);
+                    return FromBits(value);
                 case InformationUnit.Byte:
-                    return FromBytes(val);
+                    return FromBytes(value);
                 case InformationUnit.Exabit:
-                    return FromExabits(val);
+                    return FromExabits(value);
                 case InformationUnit.Exabyte:
-                    return FromExabytes(val);
+                    return FromExabytes(value);
                 case InformationUnit.Exbibit:
-                    return FromExbibits(val);
+                    return FromExbibits(value);
                 case InformationUnit.Exbibyte:
-                    return FromExbibytes(val);
+                    return FromExbibytes(value);
                 case InformationUnit.Gibibit:
-                    return FromGibibits(val);
+                    return FromGibibits(value);
                 case InformationUnit.Gibibyte:
-                    return FromGibibytes(val);
+                    return FromGibibytes(value);
                 case InformationUnit.Gigabit:
-                    return FromGigabits(val);
+                    return FromGigabits(value);
                 case InformationUnit.Gigabyte:
-                    return FromGigabytes(val);
+                    return FromGigabytes(value);
                 case InformationUnit.Kibibit:
-                    return FromKibibits(val);
+                    return FromKibibits(value);
                 case InformationUnit.Kibibyte:
-                    return FromKibibytes(val);
+                    return FromKibibytes(value);
                 case InformationUnit.Kilobit:
-                    return FromKilobits(val);
+                    return FromKilobits(value);
                 case InformationUnit.Kilobyte:
-                    return FromKilobytes(val);
+                    return FromKilobytes(value);
                 case InformationUnit.Mebibit:
-                    return FromMebibits(val);
+                    return FromMebibits(value);
                 case InformationUnit.Mebibyte:
-                    return FromMebibytes(val);
+                    return FromMebibytes(value);
                 case InformationUnit.Megabit:
-                    return FromMegabits(val);
+                    return FromMegabits(value);
                 case InformationUnit.Megabyte:
-                    return FromMegabytes(val);
+                    return FromMegabytes(value);
                 case InformationUnit.Pebibit:
-                    return FromPebibits(val);
+                    return FromPebibits(value);
                 case InformationUnit.Pebibyte:
-                    return FromPebibytes(val);
+                    return FromPebibytes(value);
                 case InformationUnit.Petabit:
-                    return FromPetabits(val);
+                    return FromPetabits(value);
                 case InformationUnit.Petabyte:
-                    return FromPetabytes(val);
+                    return FromPetabytes(value);
                 case InformationUnit.Tebibit:
-                    return FromTebibits(val);
+                    return FromTebibits(value);
                 case InformationUnit.Tebibyte:
-                    return FromTebibytes(val);
+                    return FromTebibytes(value);
                 case InformationUnit.Terabit:
-                    return FromTerabits(val);
+                    return FromTerabits(value);
                 case InformationUnit.Terabyte:
-                    return FromTerabytes(val);
+                    return FromTerabytes(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2974,7 +1290,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Information unit value.</returns>
-        public static Information? From(double? value, InformationUnit fromUnit)
+        public static Information? From(QuantityValue? value, InformationUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Centistokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromCentistokes(double centistokes)
         {
-            return new KinematicViscosity((centistokes/1e4) * 1e-2d);
+            double value = (double) centistokes;
+            return new KinematicViscosity((value/1e4) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Centistokes.
-        /// </summary>
-        public static KinematicViscosity FromCentistokes(int centistokes)
+#else
+        public static KinematicViscosity FromCentistokes(QuantityValue centistokes)
         {
-            return new KinematicViscosity((centistokes/1e4) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Centistokes.
-        /// </summary>
-        public static KinematicViscosity FromCentistokes(long centistokes)
-        {
-            return new KinematicViscosity((centistokes/1e4) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Centistokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromCentistokes(decimal centistokes)
-        {
-            return new KinematicViscosity((Convert.ToDouble(centistokes)/1e4) * 1e-2d);
+            double value = (double) centistokes;
+            return new KinematicViscosity(((value/1e4) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromDecistokes(double decistokes)
         {
-            return new KinematicViscosity((decistokes/1e4) * 1e-1d);
+            double value = (double) decistokes;
+            return new KinematicViscosity((value/1e4) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Decistokes.
-        /// </summary>
-        public static KinematicViscosity FromDecistokes(int decistokes)
+#else
+        public static KinematicViscosity FromDecistokes(QuantityValue decistokes)
         {
-            return new KinematicViscosity((decistokes/1e4) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Decistokes.
-        /// </summary>
-        public static KinematicViscosity FromDecistokes(long decistokes)
-        {
-            return new KinematicViscosity((decistokes/1e4) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Decistokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromDecistokes(decimal decistokes)
-        {
-            return new KinematicViscosity((Convert.ToDouble(decistokes)/1e4) * 1e-1d);
+            double value = (double) decistokes;
+            return new KinematicViscosity(((value/1e4) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromKilostokes(double kilostokes)
         {
-            return new KinematicViscosity((kilostokes/1e4) * 1e3d);
+            double value = (double) kilostokes;
+            return new KinematicViscosity((value/1e4) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Kilostokes.
-        /// </summary>
-        public static KinematicViscosity FromKilostokes(int kilostokes)
+#else
+        public static KinematicViscosity FromKilostokes(QuantityValue kilostokes)
         {
-            return new KinematicViscosity((kilostokes/1e4) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Kilostokes.
-        /// </summary>
-        public static KinematicViscosity FromKilostokes(long kilostokes)
-        {
-            return new KinematicViscosity((kilostokes/1e4) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Kilostokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromKilostokes(decimal kilostokes)
-        {
-            return new KinematicViscosity((Convert.ToDouble(kilostokes)/1e4) * 1e3d);
+            double value = (double) kilostokes;
+            return new KinematicViscosity(((value/1e4) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromMicrostokes(double microstokes)
         {
-            return new KinematicViscosity((microstokes/1e4) * 1e-6d);
+            double value = (double) microstokes;
+            return new KinematicViscosity((value/1e4) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Microstokes.
-        /// </summary>
-        public static KinematicViscosity FromMicrostokes(int microstokes)
+#else
+        public static KinematicViscosity FromMicrostokes(QuantityValue microstokes)
         {
-            return new KinematicViscosity((microstokes/1e4) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Microstokes.
-        /// </summary>
-        public static KinematicViscosity FromMicrostokes(long microstokes)
-        {
-            return new KinematicViscosity((microstokes/1e4) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Microstokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromMicrostokes(decimal microstokes)
-        {
-            return new KinematicViscosity((Convert.ToDouble(microstokes)/1e4) * 1e-6d);
+            double value = (double) microstokes;
+            return new KinematicViscosity(((value/1e4) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from Millistokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromMillistokes(double millistokes)
         {
-            return new KinematicViscosity((millistokes/1e4) * 1e-3d);
+            double value = (double) millistokes;
+            return new KinematicViscosity((value/1e4) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Millistokes.
-        /// </summary>
-        public static KinematicViscosity FromMillistokes(int millistokes)
+#else
+        public static KinematicViscosity FromMillistokes(QuantityValue millistokes)
         {
-            return new KinematicViscosity((millistokes/1e4) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Millistokes.
-        /// </summary>
-        public static KinematicViscosity FromMillistokes(long millistokes)
-        {
-            return new KinematicViscosity((millistokes/1e4) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Millistokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromMillistokes(decimal millistokes)
-        {
-            return new KinematicViscosity((Convert.ToDouble(millistokes)/1e4) * 1e-3d);
+            double value = (double) millistokes;
+            return new KinematicViscosity(((value/1e4) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromNanostokes(double nanostokes)
         {
-            return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
+            double value = (double) nanostokes;
+            return new KinematicViscosity((value/1e4) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Nanostokes.
-        /// </summary>
-        public static KinematicViscosity FromNanostokes(int nanostokes)
+#else
+        public static KinematicViscosity FromNanostokes(QuantityValue nanostokes)
         {
-            return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Nanostokes.
-        /// </summary>
-        public static KinematicViscosity FromNanostokes(long nanostokes)
-        {
-            return new KinematicViscosity((nanostokes/1e4) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Nanostokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromNanostokes(decimal nanostokes)
-        {
-            return new KinematicViscosity((Convert.ToDouble(nanostokes)/1e4) * 1e-9d);
+            double value = (double) nanostokes;
+            return new KinematicViscosity(((value/1e4) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromSquareMetersPerSecond(double squaremeterspersecond)
         {
-            return new KinematicViscosity(squaremeterspersecond);
+            double value = (double) squaremeterspersecond;
+            return new KinematicViscosity(value);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from SquareMetersPerSecond.
-        /// </summary>
-        public static KinematicViscosity FromSquareMetersPerSecond(int squaremeterspersecond)
+#else
+        public static KinematicViscosity FromSquareMetersPerSecond(QuantityValue squaremeterspersecond)
         {
-            return new KinematicViscosity(squaremeterspersecond);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from SquareMetersPerSecond.
-        /// </summary>
-        public static KinematicViscosity FromSquareMetersPerSecond(long squaremeterspersecond)
-        {
-            return new KinematicViscosity(squaremeterspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from SquareMetersPerSecond of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromSquareMetersPerSecond(decimal squaremeterspersecond)
-        {
-            return new KinematicViscosity(Convert.ToDouble(squaremeterspersecond));
+            double value = (double) squaremeterspersecond;
+            return new KinematicViscosity((value));
         }
 #endif
 
         /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static KinematicViscosity FromStokes(double stokes)
         {
-            return new KinematicViscosity(stokes/1e4);
+            double value = (double) stokes;
+            return new KinematicViscosity(value/1e4);
         }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Stokes.
-        /// </summary>
-        public static KinematicViscosity FromStokes(int stokes)
+#else
+        public static KinematicViscosity FromStokes(QuantityValue stokes)
         {
-            return new KinematicViscosity(stokes/1e4);
-        }
-
-        /// <summary>
-        ///     Get KinematicViscosity from Stokes.
-        /// </summary>
-        public static KinematicViscosity FromStokes(long stokes)
-        {
-            return new KinematicViscosity(stokes/1e4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get KinematicViscosity from Stokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity FromStokes(decimal stokes)
-        {
-            return new KinematicViscosity(Convert.ToDouble(stokes)/1e4);
+            double value = (double) stokes;
+            return new KinematicViscosity((value/1e4));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Centistokes.
         /// </summary>
-        public static KinematicViscosity? FromCentistokes(double? centistokes)
-        {
-            if (centistokes.HasValue)
-            {
-                return FromCentistokes(centistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Centistokes.
-        /// </summary>
-        public static KinematicViscosity? FromCentistokes(int? centistokes)
-        {
-            if (centistokes.HasValue)
-            {
-                return FromCentistokes(centistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Centistokes.
-        /// </summary>
-        public static KinematicViscosity? FromCentistokes(long? centistokes)
-        {
-            if (centistokes.HasValue)
-            {
-                return FromCentistokes(centistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Centistokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromCentistokes(decimal? centistokes)
+        public static KinematicViscosity? FromCentistokes(QuantityValue? centistokes)
         {
             if (centistokes.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Decistokes.
         /// </summary>
-        public static KinematicViscosity? FromDecistokes(double? decistokes)
-        {
-            if (decistokes.HasValue)
-            {
-                return FromDecistokes(decistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Decistokes.
-        /// </summary>
-        public static KinematicViscosity? FromDecistokes(int? decistokes)
-        {
-            if (decistokes.HasValue)
-            {
-                return FromDecistokes(decistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Decistokes.
-        /// </summary>
-        public static KinematicViscosity? FromDecistokes(long? decistokes)
-        {
-            if (decistokes.HasValue)
-            {
-                return FromDecistokes(decistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Decistokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromDecistokes(decimal? decistokes)
+        public static KinematicViscosity? FromDecistokes(QuantityValue? decistokes)
         {
             if (decistokes.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Kilostokes.
         /// </summary>
-        public static KinematicViscosity? FromKilostokes(double? kilostokes)
-        {
-            if (kilostokes.HasValue)
-            {
-                return FromKilostokes(kilostokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Kilostokes.
-        /// </summary>
-        public static KinematicViscosity? FromKilostokes(int? kilostokes)
-        {
-            if (kilostokes.HasValue)
-            {
-                return FromKilostokes(kilostokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Kilostokes.
-        /// </summary>
-        public static KinematicViscosity? FromKilostokes(long? kilostokes)
-        {
-            if (kilostokes.HasValue)
-            {
-                return FromKilostokes(kilostokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Kilostokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromKilostokes(decimal? kilostokes)
+        public static KinematicViscosity? FromKilostokes(QuantityValue? kilostokes)
         {
             if (kilostokes.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Microstokes.
         /// </summary>
-        public static KinematicViscosity? FromMicrostokes(double? microstokes)
-        {
-            if (microstokes.HasValue)
-            {
-                return FromMicrostokes(microstokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Microstokes.
-        /// </summary>
-        public static KinematicViscosity? FromMicrostokes(int? microstokes)
-        {
-            if (microstokes.HasValue)
-            {
-                return FromMicrostokes(microstokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Microstokes.
-        /// </summary>
-        public static KinematicViscosity? FromMicrostokes(long? microstokes)
-        {
-            if (microstokes.HasValue)
-            {
-                return FromMicrostokes(microstokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Microstokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromMicrostokes(decimal? microstokes)
+        public static KinematicViscosity? FromMicrostokes(QuantityValue? microstokes)
         {
             if (microstokes.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Millistokes.
         /// </summary>
-        public static KinematicViscosity? FromMillistokes(double? millistokes)
-        {
-            if (millistokes.HasValue)
-            {
-                return FromMillistokes(millistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Millistokes.
-        /// </summary>
-        public static KinematicViscosity? FromMillistokes(int? millistokes)
-        {
-            if (millistokes.HasValue)
-            {
-                return FromMillistokes(millistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Millistokes.
-        /// </summary>
-        public static KinematicViscosity? FromMillistokes(long? millistokes)
-        {
-            if (millistokes.HasValue)
-            {
-                return FromMillistokes(millistokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Millistokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromMillistokes(decimal? millistokes)
+        public static KinematicViscosity? FromMillistokes(QuantityValue? millistokes)
         {
             if (millistokes.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Nanostokes.
         /// </summary>
-        public static KinematicViscosity? FromNanostokes(double? nanostokes)
-        {
-            if (nanostokes.HasValue)
-            {
-                return FromNanostokes(nanostokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Nanostokes.
-        /// </summary>
-        public static KinematicViscosity? FromNanostokes(int? nanostokes)
-        {
-            if (nanostokes.HasValue)
-            {
-                return FromNanostokes(nanostokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Nanostokes.
-        /// </summary>
-        public static KinematicViscosity? FromNanostokes(long? nanostokes)
-        {
-            if (nanostokes.HasValue)
-            {
-                return FromNanostokes(nanostokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Nanostokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromNanostokes(decimal? nanostokes)
+        public static KinematicViscosity? FromNanostokes(QuantityValue? nanostokes)
         {
             if (nanostokes.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
         /// </summary>
-        public static KinematicViscosity? FromSquareMetersPerSecond(double? squaremeterspersecond)
-        {
-            if (squaremeterspersecond.HasValue)
-            {
-                return FromSquareMetersPerSecond(squaremeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
-        /// </summary>
-        public static KinematicViscosity? FromSquareMetersPerSecond(int? squaremeterspersecond)
-        {
-            if (squaremeterspersecond.HasValue)
-            {
-                return FromSquareMetersPerSecond(squaremeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable SquareMetersPerSecond.
-        /// </summary>
-        public static KinematicViscosity? FromSquareMetersPerSecond(long? squaremeterspersecond)
-        {
-            if (squaremeterspersecond.HasValue)
-            {
-                return FromSquareMetersPerSecond(squaremeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from SquareMetersPerSecond of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromSquareMetersPerSecond(decimal? squaremeterspersecond)
+        public static KinematicViscosity? FromSquareMetersPerSecond(QuantityValue? squaremeterspersecond)
         {
             if (squaremeterspersecond.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable KinematicViscosity from nullable Stokes.
         /// </summary>
-        public static KinematicViscosity? FromStokes(double? stokes)
-        {
-            if (stokes.HasValue)
-            {
-                return FromStokes(stokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Stokes.
-        /// </summary>
-        public static KinematicViscosity? FromStokes(int? stokes)
-        {
-            if (stokes.HasValue)
-            {
-                return FromStokes(stokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from nullable Stokes.
-        /// </summary>
-        public static KinematicViscosity? FromStokes(long? stokes)
-        {
-            if (stokes.HasValue)
-            {
-                return FromStokes(stokes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable KinematicViscosity from Stokes of type decimal.
-        /// </summary>
-        public static KinematicViscosity? FromStokes(decimal? stokes)
+        public static KinematicViscosity? FromStokes(QuantityValue? stokes)
         {
             if (stokes.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="KinematicViscosityUnit" /> to <see cref="KinematicViscosity" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>KinematicViscosity unit value.</returns>
-        public static KinematicViscosity From(double val, KinematicViscosityUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static KinematicViscosity From(double value, KinematicViscosityUnit fromUnit)
+#else
+        public static KinematicViscosity From(QuantityValue value, KinematicViscosityUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case KinematicViscosityUnit.Centistokes:
-                    return FromCentistokes(val);
+                    return FromCentistokes(value);
                 case KinematicViscosityUnit.Decistokes:
-                    return FromDecistokes(val);
+                    return FromDecistokes(value);
                 case KinematicViscosityUnit.Kilostokes:
-                    return FromKilostokes(val);
+                    return FromKilostokes(value);
                 case KinematicViscosityUnit.Microstokes:
-                    return FromMicrostokes(val);
+                    return FromMicrostokes(value);
                 case KinematicViscosityUnit.Millistokes:
-                    return FromMillistokes(val);
+                    return FromMillistokes(value);
                 case KinematicViscosityUnit.Nanostokes:
-                    return FromNanostokes(val);
+                    return FromNanostokes(value);
                 case KinematicViscosityUnit.SquareMeterPerSecond:
-                    return FromSquareMetersPerSecond(val);
+                    return FromSquareMetersPerSecond(value);
                 case KinematicViscosityUnit.Stokes:
-                    return FromStokes(val);
+                    return FromStokes(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>KinematicViscosity unit value.</returns>
-        public static KinematicViscosity? From(double? value, KinematicViscosityUnit fromUnit)
+        public static KinematicViscosity? From(QuantityValue? value, KinematicViscosityUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
@@ -149,38 +149,18 @@ namespace UnitsNet
         /// <summary>
         ///     Get LapseRate from DegreesCelciusPerKilometer.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static LapseRate FromDegreesCelciusPerKilometer(double degreescelciusperkilometer)
         {
-            return new LapseRate(degreescelciusperkilometer);
+            double value = (double) degreescelciusperkilometer;
+            return new LapseRate(value);
         }
-
-        /// <summary>
-        ///     Get LapseRate from DegreesCelciusPerKilometer.
-        /// </summary>
-        public static LapseRate FromDegreesCelciusPerKilometer(int degreescelciusperkilometer)
+#else
+        public static LapseRate FromDegreesCelciusPerKilometer(QuantityValue degreescelciusperkilometer)
         {
-            return new LapseRate(degreescelciusperkilometer);
-        }
-
-        /// <summary>
-        ///     Get LapseRate from DegreesCelciusPerKilometer.
-        /// </summary>
-        public static LapseRate FromDegreesCelciusPerKilometer(long degreescelciusperkilometer)
-        {
-            return new LapseRate(degreescelciusperkilometer);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get LapseRate from DegreesCelciusPerKilometer of type decimal.
-        /// </summary>
-        public static LapseRate FromDegreesCelciusPerKilometer(decimal degreescelciusperkilometer)
-        {
-            return new LapseRate(Convert.ToDouble(degreescelciusperkilometer));
+            double value = (double) degreescelciusperkilometer;
+            return new LapseRate((value));
         }
 #endif
 
@@ -189,52 +169,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable LapseRate from nullable DegreesCelciusPerKilometer.
         /// </summary>
-        public static LapseRate? FromDegreesCelciusPerKilometer(double? degreescelciusperkilometer)
-        {
-            if (degreescelciusperkilometer.HasValue)
-            {
-                return FromDegreesCelciusPerKilometer(degreescelciusperkilometer.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable LapseRate from nullable DegreesCelciusPerKilometer.
-        /// </summary>
-        public static LapseRate? FromDegreesCelciusPerKilometer(int? degreescelciusperkilometer)
-        {
-            if (degreescelciusperkilometer.HasValue)
-            {
-                return FromDegreesCelciusPerKilometer(degreescelciusperkilometer.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable LapseRate from nullable DegreesCelciusPerKilometer.
-        /// </summary>
-        public static LapseRate? FromDegreesCelciusPerKilometer(long? degreescelciusperkilometer)
-        {
-            if (degreescelciusperkilometer.HasValue)
-            {
-                return FromDegreesCelciusPerKilometer(degreescelciusperkilometer.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable LapseRate from DegreesCelciusPerKilometer of type decimal.
-        /// </summary>
-        public static LapseRate? FromDegreesCelciusPerKilometer(decimal? degreescelciusperkilometer)
+        public static LapseRate? FromDegreesCelciusPerKilometer(QuantityValue? degreescelciusperkilometer)
         {
             if (degreescelciusperkilometer.HasValue)
             {
@@ -251,15 +186,21 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="LapseRateUnit" /> to <see cref="LapseRate" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>LapseRate unit value.</returns>
-        public static LapseRate From(double val, LapseRateUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static LapseRate From(double value, LapseRateUnit fromUnit)
+#else
+        public static LapseRate From(QuantityValue value, LapseRateUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case LapseRateUnit.DegreeCelsiusPerKilometer:
-                    return FromDegreesCelciusPerKilometer(val);
+                    return FromDegreesCelciusPerKilometer(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -274,7 +215,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>LapseRate unit value.</returns>
-        public static LapseRate? From(double? value, LapseRateUnit fromUnit)
+        public static LapseRate? From(QuantityValue? value, LapseRateUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -317,836 +317,396 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Centimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromCentimeters(double centimeters)
         {
-            return new Length((centimeters) * 1e-2d);
+            double value = (double) centimeters;
+            return new Length((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Length from Centimeters.
-        /// </summary>
-        public static Length FromCentimeters(int centimeters)
+#else
+        public static Length FromCentimeters(QuantityValue centimeters)
         {
-            return new Length((centimeters) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Length from Centimeters.
-        /// </summary>
-        public static Length FromCentimeters(long centimeters)
-        {
-            return new Length((centimeters) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Centimeters of type decimal.
-        /// </summary>
-        public static Length FromCentimeters(decimal centimeters)
-        {
-            return new Length((Convert.ToDouble(centimeters)) * 1e-2d);
+            double value = (double) centimeters;
+            return new Length(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromDecimeters(double decimeters)
         {
-            return new Length((decimeters) * 1e-1d);
+            double value = (double) decimeters;
+            return new Length((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Length from Decimeters.
-        /// </summary>
-        public static Length FromDecimeters(int decimeters)
+#else
+        public static Length FromDecimeters(QuantityValue decimeters)
         {
-            return new Length((decimeters) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Length from Decimeters.
-        /// </summary>
-        public static Length FromDecimeters(long decimeters)
-        {
-            return new Length((decimeters) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Decimeters of type decimal.
-        /// </summary>
-        public static Length FromDecimeters(decimal decimeters)
-        {
-            return new Length((Convert.ToDouble(decimeters)) * 1e-1d);
+            double value = (double) decimeters;
+            return new Length(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Length from DtpPicas.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromDtpPicas(double dtppicas)
         {
-            return new Length(dtppicas/236.220472441);
+            double value = (double) dtppicas;
+            return new Length(value/236.220472441);
         }
-
-        /// <summary>
-        ///     Get Length from DtpPicas.
-        /// </summary>
-        public static Length FromDtpPicas(int dtppicas)
+#else
+        public static Length FromDtpPicas(QuantityValue dtppicas)
         {
-            return new Length(dtppicas/236.220472441);
-        }
-
-        /// <summary>
-        ///     Get Length from DtpPicas.
-        /// </summary>
-        public static Length FromDtpPicas(long dtppicas)
-        {
-            return new Length(dtppicas/236.220472441);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from DtpPicas of type decimal.
-        /// </summary>
-        public static Length FromDtpPicas(decimal dtppicas)
-        {
-            return new Length(Convert.ToDouble(dtppicas)/236.220472441);
+            double value = (double) dtppicas;
+            return new Length((value/236.220472441));
         }
 #endif
 
         /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromDtpPoints(double dtppoints)
         {
-            return new Length((dtppoints/72)*2.54e-2);
+            double value = (double) dtppoints;
+            return new Length((value/72)*2.54e-2);
         }
-
-        /// <summary>
-        ///     Get Length from DtpPoints.
-        /// </summary>
-        public static Length FromDtpPoints(int dtppoints)
+#else
+        public static Length FromDtpPoints(QuantityValue dtppoints)
         {
-            return new Length((dtppoints/72)*2.54e-2);
-        }
-
-        /// <summary>
-        ///     Get Length from DtpPoints.
-        /// </summary>
-        public static Length FromDtpPoints(long dtppoints)
-        {
-            return new Length((dtppoints/72)*2.54e-2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from DtpPoints of type decimal.
-        /// </summary>
-        public static Length FromDtpPoints(decimal dtppoints)
-        {
-            return new Length((Convert.ToDouble(dtppoints)/72)*2.54e-2);
+            double value = (double) dtppoints;
+            return new Length(((value/72)*2.54e-2));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Fathoms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromFathoms(double fathoms)
         {
-            return new Length(fathoms*1.8288);
+            double value = (double) fathoms;
+            return new Length(value*1.8288);
         }
-
-        /// <summary>
-        ///     Get Length from Fathoms.
-        /// </summary>
-        public static Length FromFathoms(int fathoms)
+#else
+        public static Length FromFathoms(QuantityValue fathoms)
         {
-            return new Length(fathoms*1.8288);
-        }
-
-        /// <summary>
-        ///     Get Length from Fathoms.
-        /// </summary>
-        public static Length FromFathoms(long fathoms)
-        {
-            return new Length(fathoms*1.8288);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Fathoms of type decimal.
-        /// </summary>
-        public static Length FromFathoms(decimal fathoms)
-        {
-            return new Length(Convert.ToDouble(fathoms)*1.8288);
+            double value = (double) fathoms;
+            return new Length((value*1.8288));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Feet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromFeet(double feet)
         {
-            return new Length(feet*0.3048);
+            double value = (double) feet;
+            return new Length(value*0.3048);
         }
-
-        /// <summary>
-        ///     Get Length from Feet.
-        /// </summary>
-        public static Length FromFeet(int feet)
+#else
+        public static Length FromFeet(QuantityValue feet)
         {
-            return new Length(feet*0.3048);
-        }
-
-        /// <summary>
-        ///     Get Length from Feet.
-        /// </summary>
-        public static Length FromFeet(long feet)
-        {
-            return new Length(feet*0.3048);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Feet of type decimal.
-        /// </summary>
-        public static Length FromFeet(decimal feet)
-        {
-            return new Length(Convert.ToDouble(feet)*0.3048);
+            double value = (double) feet;
+            return new Length((value*0.3048));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Inches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromInches(double inches)
         {
-            return new Length(inches*2.54e-2);
+            double value = (double) inches;
+            return new Length(value*2.54e-2);
         }
-
-        /// <summary>
-        ///     Get Length from Inches.
-        /// </summary>
-        public static Length FromInches(int inches)
+#else
+        public static Length FromInches(QuantityValue inches)
         {
-            return new Length(inches*2.54e-2);
-        }
-
-        /// <summary>
-        ///     Get Length from Inches.
-        /// </summary>
-        public static Length FromInches(long inches)
-        {
-            return new Length(inches*2.54e-2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Inches of type decimal.
-        /// </summary>
-        public static Length FromInches(decimal inches)
-        {
-            return new Length(Convert.ToDouble(inches)*2.54e-2);
+            double value = (double) inches;
+            return new Length((value*2.54e-2));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromKilometers(double kilometers)
         {
-            return new Length((kilometers) * 1e3d);
+            double value = (double) kilometers;
+            return new Length((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Length from Kilometers.
-        /// </summary>
-        public static Length FromKilometers(int kilometers)
+#else
+        public static Length FromKilometers(QuantityValue kilometers)
         {
-            return new Length((kilometers) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Length from Kilometers.
-        /// </summary>
-        public static Length FromKilometers(long kilometers)
-        {
-            return new Length((kilometers) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Kilometers of type decimal.
-        /// </summary>
-        public static Length FromKilometers(decimal kilometers)
-        {
-            return new Length((Convert.ToDouble(kilometers)) * 1e3d);
+            double value = (double) kilometers;
+            return new Length(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Meters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromMeters(double meters)
         {
-            return new Length(meters);
+            double value = (double) meters;
+            return new Length(value);
         }
-
-        /// <summary>
-        ///     Get Length from Meters.
-        /// </summary>
-        public static Length FromMeters(int meters)
+#else
+        public static Length FromMeters(QuantityValue meters)
         {
-            return new Length(meters);
-        }
-
-        /// <summary>
-        ///     Get Length from Meters.
-        /// </summary>
-        public static Length FromMeters(long meters)
-        {
-            return new Length(meters);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Meters of type decimal.
-        /// </summary>
-        public static Length FromMeters(decimal meters)
-        {
-            return new Length(Convert.ToDouble(meters));
+            double value = (double) meters;
+            return new Length((value));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromMicroinches(double microinches)
         {
-            return new Length(microinches*2.54e-8);
+            double value = (double) microinches;
+            return new Length(value*2.54e-8);
         }
-
-        /// <summary>
-        ///     Get Length from Microinches.
-        /// </summary>
-        public static Length FromMicroinches(int microinches)
+#else
+        public static Length FromMicroinches(QuantityValue microinches)
         {
-            return new Length(microinches*2.54e-8);
-        }
-
-        /// <summary>
-        ///     Get Length from Microinches.
-        /// </summary>
-        public static Length FromMicroinches(long microinches)
-        {
-            return new Length(microinches*2.54e-8);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Microinches of type decimal.
-        /// </summary>
-        public static Length FromMicroinches(decimal microinches)
-        {
-            return new Length(Convert.ToDouble(microinches)*2.54e-8);
+            double value = (double) microinches;
+            return new Length((value*2.54e-8));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Micrometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromMicrometers(double micrometers)
         {
-            return new Length((micrometers) * 1e-6d);
+            double value = (double) micrometers;
+            return new Length((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Length from Micrometers.
-        /// </summary>
-        public static Length FromMicrometers(int micrometers)
+#else
+        public static Length FromMicrometers(QuantityValue micrometers)
         {
-            return new Length((micrometers) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Length from Micrometers.
-        /// </summary>
-        public static Length FromMicrometers(long micrometers)
-        {
-            return new Length((micrometers) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Micrometers of type decimal.
-        /// </summary>
-        public static Length FromMicrometers(decimal micrometers)
-        {
-            return new Length((Convert.ToDouble(micrometers)) * 1e-6d);
+            double value = (double) micrometers;
+            return new Length(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Mils.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromMils(double mils)
         {
-            return new Length(mils*2.54e-5);
+            double value = (double) mils;
+            return new Length(value*2.54e-5);
         }
-
-        /// <summary>
-        ///     Get Length from Mils.
-        /// </summary>
-        public static Length FromMils(int mils)
+#else
+        public static Length FromMils(QuantityValue mils)
         {
-            return new Length(mils*2.54e-5);
-        }
-
-        /// <summary>
-        ///     Get Length from Mils.
-        /// </summary>
-        public static Length FromMils(long mils)
-        {
-            return new Length(mils*2.54e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Mils of type decimal.
-        /// </summary>
-        public static Length FromMils(decimal mils)
-        {
-            return new Length(Convert.ToDouble(mils)*2.54e-5);
+            double value = (double) mils;
+            return new Length((value*2.54e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Miles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromMiles(double miles)
         {
-            return new Length(miles*1609.34);
+            double value = (double) miles;
+            return new Length(value*1609.34);
         }
-
-        /// <summary>
-        ///     Get Length from Miles.
-        /// </summary>
-        public static Length FromMiles(int miles)
+#else
+        public static Length FromMiles(QuantityValue miles)
         {
-            return new Length(miles*1609.34);
-        }
-
-        /// <summary>
-        ///     Get Length from Miles.
-        /// </summary>
-        public static Length FromMiles(long miles)
-        {
-            return new Length(miles*1609.34);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Miles of type decimal.
-        /// </summary>
-        public static Length FromMiles(decimal miles)
-        {
-            return new Length(Convert.ToDouble(miles)*1609.34);
+            double value = (double) miles;
+            return new Length((value*1609.34));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromMillimeters(double millimeters)
         {
-            return new Length((millimeters) * 1e-3d);
+            double value = (double) millimeters;
+            return new Length((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Length from Millimeters.
-        /// </summary>
-        public static Length FromMillimeters(int millimeters)
+#else
+        public static Length FromMillimeters(QuantityValue millimeters)
         {
-            return new Length((millimeters) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Length from Millimeters.
-        /// </summary>
-        public static Length FromMillimeters(long millimeters)
-        {
-            return new Length((millimeters) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Millimeters of type decimal.
-        /// </summary>
-        public static Length FromMillimeters(decimal millimeters)
-        {
-            return new Length((Convert.ToDouble(millimeters)) * 1e-3d);
+            double value = (double) millimeters;
+            return new Length(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Nanometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromNanometers(double nanometers)
         {
-            return new Length((nanometers) * 1e-9d);
+            double value = (double) nanometers;
+            return new Length((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Length from Nanometers.
-        /// </summary>
-        public static Length FromNanometers(int nanometers)
+#else
+        public static Length FromNanometers(QuantityValue nanometers)
         {
-            return new Length((nanometers) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Length from Nanometers.
-        /// </summary>
-        public static Length FromNanometers(long nanometers)
-        {
-            return new Length((nanometers) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Nanometers of type decimal.
-        /// </summary>
-        public static Length FromNanometers(decimal nanometers)
-        {
-            return new Length((Convert.ToDouble(nanometers)) * 1e-9d);
+            double value = (double) nanometers;
+            return new Length(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromNauticalMiles(double nauticalmiles)
         {
-            return new Length(nauticalmiles*1852);
+            double value = (double) nauticalmiles;
+            return new Length(value*1852);
         }
-
-        /// <summary>
-        ///     Get Length from NauticalMiles.
-        /// </summary>
-        public static Length FromNauticalMiles(int nauticalmiles)
+#else
+        public static Length FromNauticalMiles(QuantityValue nauticalmiles)
         {
-            return new Length(nauticalmiles*1852);
-        }
-
-        /// <summary>
-        ///     Get Length from NauticalMiles.
-        /// </summary>
-        public static Length FromNauticalMiles(long nauticalmiles)
-        {
-            return new Length(nauticalmiles*1852);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from NauticalMiles of type decimal.
-        /// </summary>
-        public static Length FromNauticalMiles(decimal nauticalmiles)
-        {
-            return new Length(Convert.ToDouble(nauticalmiles)*1852);
+            double value = (double) nauticalmiles;
+            return new Length((value*1852));
         }
 #endif
 
         /// <summary>
         ///     Get Length from PrinterPicas.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromPrinterPicas(double printerpicas)
         {
-            return new Length(printerpicas/237.106301584);
+            double value = (double) printerpicas;
+            return new Length(value/237.106301584);
         }
-
-        /// <summary>
-        ///     Get Length from PrinterPicas.
-        /// </summary>
-        public static Length FromPrinterPicas(int printerpicas)
+#else
+        public static Length FromPrinterPicas(QuantityValue printerpicas)
         {
-            return new Length(printerpicas/237.106301584);
-        }
-
-        /// <summary>
-        ///     Get Length from PrinterPicas.
-        /// </summary>
-        public static Length FromPrinterPicas(long printerpicas)
-        {
-            return new Length(printerpicas/237.106301584);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from PrinterPicas of type decimal.
-        /// </summary>
-        public static Length FromPrinterPicas(decimal printerpicas)
-        {
-            return new Length(Convert.ToDouble(printerpicas)/237.106301584);
+            double value = (double) printerpicas;
+            return new Length((value/237.106301584));
         }
 #endif
 
         /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromPrinterPoints(double printerpoints)
         {
-            return new Length((printerpoints/72.27)*2.54e-2);
+            double value = (double) printerpoints;
+            return new Length((value/72.27)*2.54e-2);
         }
-
-        /// <summary>
-        ///     Get Length from PrinterPoints.
-        /// </summary>
-        public static Length FromPrinterPoints(int printerpoints)
+#else
+        public static Length FromPrinterPoints(QuantityValue printerpoints)
         {
-            return new Length((printerpoints/72.27)*2.54e-2);
-        }
-
-        /// <summary>
-        ///     Get Length from PrinterPoints.
-        /// </summary>
-        public static Length FromPrinterPoints(long printerpoints)
-        {
-            return new Length((printerpoints/72.27)*2.54e-2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from PrinterPoints of type decimal.
-        /// </summary>
-        public static Length FromPrinterPoints(decimal printerpoints)
-        {
-            return new Length((Convert.ToDouble(printerpoints)/72.27)*2.54e-2);
+            double value = (double) printerpoints;
+            return new Length(((value/72.27)*2.54e-2));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Shackles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromShackles(double shackles)
         {
-            return new Length(shackles*27.432);
+            double value = (double) shackles;
+            return new Length(value*27.432);
         }
-
-        /// <summary>
-        ///     Get Length from Shackles.
-        /// </summary>
-        public static Length FromShackles(int shackles)
+#else
+        public static Length FromShackles(QuantityValue shackles)
         {
-            return new Length(shackles*27.432);
-        }
-
-        /// <summary>
-        ///     Get Length from Shackles.
-        /// </summary>
-        public static Length FromShackles(long shackles)
-        {
-            return new Length(shackles*27.432);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Shackles of type decimal.
-        /// </summary>
-        public static Length FromShackles(decimal shackles)
-        {
-            return new Length(Convert.ToDouble(shackles)*27.432);
+            double value = (double) shackles;
+            return new Length((value*27.432));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Twips.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromTwips(double twips)
         {
-            return new Length(twips/56692.913385826);
+            double value = (double) twips;
+            return new Length(value/56692.913385826);
         }
-
-        /// <summary>
-        ///     Get Length from Twips.
-        /// </summary>
-        public static Length FromTwips(int twips)
+#else
+        public static Length FromTwips(QuantityValue twips)
         {
-            return new Length(twips/56692.913385826);
-        }
-
-        /// <summary>
-        ///     Get Length from Twips.
-        /// </summary>
-        public static Length FromTwips(long twips)
-        {
-            return new Length(twips/56692.913385826);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Twips of type decimal.
-        /// </summary>
-        public static Length FromTwips(decimal twips)
-        {
-            return new Length(Convert.ToDouble(twips)/56692.913385826);
+            double value = (double) twips;
+            return new Length((value/56692.913385826));
         }
 #endif
 
         /// <summary>
         ///     Get Length from UsSurveyFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromUsSurveyFeet(double ussurveyfeet)
         {
-            return new Length(ussurveyfeet*1200/3937);
+            double value = (double) ussurveyfeet;
+            return new Length(value*1200/3937);
         }
-
-        /// <summary>
-        ///     Get Length from UsSurveyFeet.
-        /// </summary>
-        public static Length FromUsSurveyFeet(int ussurveyfeet)
+#else
+        public static Length FromUsSurveyFeet(QuantityValue ussurveyfeet)
         {
-            return new Length(ussurveyfeet*1200/3937);
-        }
-
-        /// <summary>
-        ///     Get Length from UsSurveyFeet.
-        /// </summary>
-        public static Length FromUsSurveyFeet(long ussurveyfeet)
-        {
-            return new Length(ussurveyfeet*1200/3937);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from UsSurveyFeet of type decimal.
-        /// </summary>
-        public static Length FromUsSurveyFeet(decimal ussurveyfeet)
-        {
-            return new Length(Convert.ToDouble(ussurveyfeet)*1200/3937);
+            double value = (double) ussurveyfeet;
+            return new Length((value*1200/3937));
         }
 #endif
 
         /// <summary>
         ///     Get Length from Yards.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Length FromYards(double yards)
         {
-            return new Length(yards*0.9144);
+            double value = (double) yards;
+            return new Length(value*0.9144);
         }
-
-        /// <summary>
-        ///     Get Length from Yards.
-        /// </summary>
-        public static Length FromYards(int yards)
+#else
+        public static Length FromYards(QuantityValue yards)
         {
-            return new Length(yards*0.9144);
-        }
-
-        /// <summary>
-        ///     Get Length from Yards.
-        /// </summary>
-        public static Length FromYards(long yards)
-        {
-            return new Length(yards*0.9144);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Length from Yards of type decimal.
-        /// </summary>
-        public static Length FromYards(decimal yards)
-        {
-            return new Length(Convert.ToDouble(yards)*0.9144);
+            double value = (double) yards;
+            return new Length((value*0.9144));
         }
 #endif
 
@@ -1155,52 +715,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Centimeters.
         /// </summary>
-        public static Length? FromCentimeters(double? centimeters)
-        {
-            if (centimeters.HasValue)
-            {
-                return FromCentimeters(centimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Centimeters.
-        /// </summary>
-        public static Length? FromCentimeters(int? centimeters)
-        {
-            if (centimeters.HasValue)
-            {
-                return FromCentimeters(centimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Centimeters.
-        /// </summary>
-        public static Length? FromCentimeters(long? centimeters)
-        {
-            if (centimeters.HasValue)
-            {
-                return FromCentimeters(centimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Centimeters of type decimal.
-        /// </summary>
-        public static Length? FromCentimeters(decimal? centimeters)
+        public static Length? FromCentimeters(QuantityValue? centimeters)
         {
             if (centimeters.HasValue)
             {
@@ -1215,52 +730,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Decimeters.
         /// </summary>
-        public static Length? FromDecimeters(double? decimeters)
-        {
-            if (decimeters.HasValue)
-            {
-                return FromDecimeters(decimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Decimeters.
-        /// </summary>
-        public static Length? FromDecimeters(int? decimeters)
-        {
-            if (decimeters.HasValue)
-            {
-                return FromDecimeters(decimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Decimeters.
-        /// </summary>
-        public static Length? FromDecimeters(long? decimeters)
-        {
-            if (decimeters.HasValue)
-            {
-                return FromDecimeters(decimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Decimeters of type decimal.
-        /// </summary>
-        public static Length? FromDecimeters(decimal? decimeters)
+        public static Length? FromDecimeters(QuantityValue? decimeters)
         {
             if (decimeters.HasValue)
             {
@@ -1275,52 +745,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable DtpPicas.
         /// </summary>
-        public static Length? FromDtpPicas(double? dtppicas)
-        {
-            if (dtppicas.HasValue)
-            {
-                return FromDtpPicas(dtppicas.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable DtpPicas.
-        /// </summary>
-        public static Length? FromDtpPicas(int? dtppicas)
-        {
-            if (dtppicas.HasValue)
-            {
-                return FromDtpPicas(dtppicas.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable DtpPicas.
-        /// </summary>
-        public static Length? FromDtpPicas(long? dtppicas)
-        {
-            if (dtppicas.HasValue)
-            {
-                return FromDtpPicas(dtppicas.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from DtpPicas of type decimal.
-        /// </summary>
-        public static Length? FromDtpPicas(decimal? dtppicas)
+        public static Length? FromDtpPicas(QuantityValue? dtppicas)
         {
             if (dtppicas.HasValue)
             {
@@ -1335,52 +760,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable DtpPoints.
         /// </summary>
-        public static Length? FromDtpPoints(double? dtppoints)
-        {
-            if (dtppoints.HasValue)
-            {
-                return FromDtpPoints(dtppoints.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable DtpPoints.
-        /// </summary>
-        public static Length? FromDtpPoints(int? dtppoints)
-        {
-            if (dtppoints.HasValue)
-            {
-                return FromDtpPoints(dtppoints.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable DtpPoints.
-        /// </summary>
-        public static Length? FromDtpPoints(long? dtppoints)
-        {
-            if (dtppoints.HasValue)
-            {
-                return FromDtpPoints(dtppoints.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from DtpPoints of type decimal.
-        /// </summary>
-        public static Length? FromDtpPoints(decimal? dtppoints)
+        public static Length? FromDtpPoints(QuantityValue? dtppoints)
         {
             if (dtppoints.HasValue)
             {
@@ -1395,52 +775,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Fathoms.
         /// </summary>
-        public static Length? FromFathoms(double? fathoms)
-        {
-            if (fathoms.HasValue)
-            {
-                return FromFathoms(fathoms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Fathoms.
-        /// </summary>
-        public static Length? FromFathoms(int? fathoms)
-        {
-            if (fathoms.HasValue)
-            {
-                return FromFathoms(fathoms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Fathoms.
-        /// </summary>
-        public static Length? FromFathoms(long? fathoms)
-        {
-            if (fathoms.HasValue)
-            {
-                return FromFathoms(fathoms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Fathoms of type decimal.
-        /// </summary>
-        public static Length? FromFathoms(decimal? fathoms)
+        public static Length? FromFathoms(QuantityValue? fathoms)
         {
             if (fathoms.HasValue)
             {
@@ -1455,52 +790,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Feet.
         /// </summary>
-        public static Length? FromFeet(double? feet)
-        {
-            if (feet.HasValue)
-            {
-                return FromFeet(feet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Feet.
-        /// </summary>
-        public static Length? FromFeet(int? feet)
-        {
-            if (feet.HasValue)
-            {
-                return FromFeet(feet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Feet.
-        /// </summary>
-        public static Length? FromFeet(long? feet)
-        {
-            if (feet.HasValue)
-            {
-                return FromFeet(feet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Feet of type decimal.
-        /// </summary>
-        public static Length? FromFeet(decimal? feet)
+        public static Length? FromFeet(QuantityValue? feet)
         {
             if (feet.HasValue)
             {
@@ -1515,52 +805,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Inches.
         /// </summary>
-        public static Length? FromInches(double? inches)
-        {
-            if (inches.HasValue)
-            {
-                return FromInches(inches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Inches.
-        /// </summary>
-        public static Length? FromInches(int? inches)
-        {
-            if (inches.HasValue)
-            {
-                return FromInches(inches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Inches.
-        /// </summary>
-        public static Length? FromInches(long? inches)
-        {
-            if (inches.HasValue)
-            {
-                return FromInches(inches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Inches of type decimal.
-        /// </summary>
-        public static Length? FromInches(decimal? inches)
+        public static Length? FromInches(QuantityValue? inches)
         {
             if (inches.HasValue)
             {
@@ -1575,52 +820,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Kilometers.
         /// </summary>
-        public static Length? FromKilometers(double? kilometers)
-        {
-            if (kilometers.HasValue)
-            {
-                return FromKilometers(kilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Kilometers.
-        /// </summary>
-        public static Length? FromKilometers(int? kilometers)
-        {
-            if (kilometers.HasValue)
-            {
-                return FromKilometers(kilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Kilometers.
-        /// </summary>
-        public static Length? FromKilometers(long? kilometers)
-        {
-            if (kilometers.HasValue)
-            {
-                return FromKilometers(kilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Kilometers of type decimal.
-        /// </summary>
-        public static Length? FromKilometers(decimal? kilometers)
+        public static Length? FromKilometers(QuantityValue? kilometers)
         {
             if (kilometers.HasValue)
             {
@@ -1635,52 +835,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Meters.
         /// </summary>
-        public static Length? FromMeters(double? meters)
-        {
-            if (meters.HasValue)
-            {
-                return FromMeters(meters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Meters.
-        /// </summary>
-        public static Length? FromMeters(int? meters)
-        {
-            if (meters.HasValue)
-            {
-                return FromMeters(meters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Meters.
-        /// </summary>
-        public static Length? FromMeters(long? meters)
-        {
-            if (meters.HasValue)
-            {
-                return FromMeters(meters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Meters of type decimal.
-        /// </summary>
-        public static Length? FromMeters(decimal? meters)
+        public static Length? FromMeters(QuantityValue? meters)
         {
             if (meters.HasValue)
             {
@@ -1695,52 +850,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Microinches.
         /// </summary>
-        public static Length? FromMicroinches(double? microinches)
-        {
-            if (microinches.HasValue)
-            {
-                return FromMicroinches(microinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Microinches.
-        /// </summary>
-        public static Length? FromMicroinches(int? microinches)
-        {
-            if (microinches.HasValue)
-            {
-                return FromMicroinches(microinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Microinches.
-        /// </summary>
-        public static Length? FromMicroinches(long? microinches)
-        {
-            if (microinches.HasValue)
-            {
-                return FromMicroinches(microinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Microinches of type decimal.
-        /// </summary>
-        public static Length? FromMicroinches(decimal? microinches)
+        public static Length? FromMicroinches(QuantityValue? microinches)
         {
             if (microinches.HasValue)
             {
@@ -1755,52 +865,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Micrometers.
         /// </summary>
-        public static Length? FromMicrometers(double? micrometers)
-        {
-            if (micrometers.HasValue)
-            {
-                return FromMicrometers(micrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Micrometers.
-        /// </summary>
-        public static Length? FromMicrometers(int? micrometers)
-        {
-            if (micrometers.HasValue)
-            {
-                return FromMicrometers(micrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Micrometers.
-        /// </summary>
-        public static Length? FromMicrometers(long? micrometers)
-        {
-            if (micrometers.HasValue)
-            {
-                return FromMicrometers(micrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Micrometers of type decimal.
-        /// </summary>
-        public static Length? FromMicrometers(decimal? micrometers)
+        public static Length? FromMicrometers(QuantityValue? micrometers)
         {
             if (micrometers.HasValue)
             {
@@ -1815,52 +880,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Mils.
         /// </summary>
-        public static Length? FromMils(double? mils)
-        {
-            if (mils.HasValue)
-            {
-                return FromMils(mils.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Mils.
-        /// </summary>
-        public static Length? FromMils(int? mils)
-        {
-            if (mils.HasValue)
-            {
-                return FromMils(mils.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Mils.
-        /// </summary>
-        public static Length? FromMils(long? mils)
-        {
-            if (mils.HasValue)
-            {
-                return FromMils(mils.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Mils of type decimal.
-        /// </summary>
-        public static Length? FromMils(decimal? mils)
+        public static Length? FromMils(QuantityValue? mils)
         {
             if (mils.HasValue)
             {
@@ -1875,52 +895,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Miles.
         /// </summary>
-        public static Length? FromMiles(double? miles)
-        {
-            if (miles.HasValue)
-            {
-                return FromMiles(miles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Miles.
-        /// </summary>
-        public static Length? FromMiles(int? miles)
-        {
-            if (miles.HasValue)
-            {
-                return FromMiles(miles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Miles.
-        /// </summary>
-        public static Length? FromMiles(long? miles)
-        {
-            if (miles.HasValue)
-            {
-                return FromMiles(miles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Miles of type decimal.
-        /// </summary>
-        public static Length? FromMiles(decimal? miles)
+        public static Length? FromMiles(QuantityValue? miles)
         {
             if (miles.HasValue)
             {
@@ -1935,52 +910,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Millimeters.
         /// </summary>
-        public static Length? FromMillimeters(double? millimeters)
-        {
-            if (millimeters.HasValue)
-            {
-                return FromMillimeters(millimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Millimeters.
-        /// </summary>
-        public static Length? FromMillimeters(int? millimeters)
-        {
-            if (millimeters.HasValue)
-            {
-                return FromMillimeters(millimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Millimeters.
-        /// </summary>
-        public static Length? FromMillimeters(long? millimeters)
-        {
-            if (millimeters.HasValue)
-            {
-                return FromMillimeters(millimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Millimeters of type decimal.
-        /// </summary>
-        public static Length? FromMillimeters(decimal? millimeters)
+        public static Length? FromMillimeters(QuantityValue? millimeters)
         {
             if (millimeters.HasValue)
             {
@@ -1995,52 +925,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Nanometers.
         /// </summary>
-        public static Length? FromNanometers(double? nanometers)
-        {
-            if (nanometers.HasValue)
-            {
-                return FromNanometers(nanometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Nanometers.
-        /// </summary>
-        public static Length? FromNanometers(int? nanometers)
-        {
-            if (nanometers.HasValue)
-            {
-                return FromNanometers(nanometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Nanometers.
-        /// </summary>
-        public static Length? FromNanometers(long? nanometers)
-        {
-            if (nanometers.HasValue)
-            {
-                return FromNanometers(nanometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Nanometers of type decimal.
-        /// </summary>
-        public static Length? FromNanometers(decimal? nanometers)
+        public static Length? FromNanometers(QuantityValue? nanometers)
         {
             if (nanometers.HasValue)
             {
@@ -2055,52 +940,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable NauticalMiles.
         /// </summary>
-        public static Length? FromNauticalMiles(double? nauticalmiles)
-        {
-            if (nauticalmiles.HasValue)
-            {
-                return FromNauticalMiles(nauticalmiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable NauticalMiles.
-        /// </summary>
-        public static Length? FromNauticalMiles(int? nauticalmiles)
-        {
-            if (nauticalmiles.HasValue)
-            {
-                return FromNauticalMiles(nauticalmiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable NauticalMiles.
-        /// </summary>
-        public static Length? FromNauticalMiles(long? nauticalmiles)
-        {
-            if (nauticalmiles.HasValue)
-            {
-                return FromNauticalMiles(nauticalmiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from NauticalMiles of type decimal.
-        /// </summary>
-        public static Length? FromNauticalMiles(decimal? nauticalmiles)
+        public static Length? FromNauticalMiles(QuantityValue? nauticalmiles)
         {
             if (nauticalmiles.HasValue)
             {
@@ -2115,52 +955,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable PrinterPicas.
         /// </summary>
-        public static Length? FromPrinterPicas(double? printerpicas)
-        {
-            if (printerpicas.HasValue)
-            {
-                return FromPrinterPicas(printerpicas.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable PrinterPicas.
-        /// </summary>
-        public static Length? FromPrinterPicas(int? printerpicas)
-        {
-            if (printerpicas.HasValue)
-            {
-                return FromPrinterPicas(printerpicas.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable PrinterPicas.
-        /// </summary>
-        public static Length? FromPrinterPicas(long? printerpicas)
-        {
-            if (printerpicas.HasValue)
-            {
-                return FromPrinterPicas(printerpicas.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from PrinterPicas of type decimal.
-        /// </summary>
-        public static Length? FromPrinterPicas(decimal? printerpicas)
+        public static Length? FromPrinterPicas(QuantityValue? printerpicas)
         {
             if (printerpicas.HasValue)
             {
@@ -2175,52 +970,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable PrinterPoints.
         /// </summary>
-        public static Length? FromPrinterPoints(double? printerpoints)
-        {
-            if (printerpoints.HasValue)
-            {
-                return FromPrinterPoints(printerpoints.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable PrinterPoints.
-        /// </summary>
-        public static Length? FromPrinterPoints(int? printerpoints)
-        {
-            if (printerpoints.HasValue)
-            {
-                return FromPrinterPoints(printerpoints.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable PrinterPoints.
-        /// </summary>
-        public static Length? FromPrinterPoints(long? printerpoints)
-        {
-            if (printerpoints.HasValue)
-            {
-                return FromPrinterPoints(printerpoints.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from PrinterPoints of type decimal.
-        /// </summary>
-        public static Length? FromPrinterPoints(decimal? printerpoints)
+        public static Length? FromPrinterPoints(QuantityValue? printerpoints)
         {
             if (printerpoints.HasValue)
             {
@@ -2235,52 +985,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Shackles.
         /// </summary>
-        public static Length? FromShackles(double? shackles)
-        {
-            if (shackles.HasValue)
-            {
-                return FromShackles(shackles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Shackles.
-        /// </summary>
-        public static Length? FromShackles(int? shackles)
-        {
-            if (shackles.HasValue)
-            {
-                return FromShackles(shackles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Shackles.
-        /// </summary>
-        public static Length? FromShackles(long? shackles)
-        {
-            if (shackles.HasValue)
-            {
-                return FromShackles(shackles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Shackles of type decimal.
-        /// </summary>
-        public static Length? FromShackles(decimal? shackles)
+        public static Length? FromShackles(QuantityValue? shackles)
         {
             if (shackles.HasValue)
             {
@@ -2295,52 +1000,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Twips.
         /// </summary>
-        public static Length? FromTwips(double? twips)
-        {
-            if (twips.HasValue)
-            {
-                return FromTwips(twips.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Twips.
-        /// </summary>
-        public static Length? FromTwips(int? twips)
-        {
-            if (twips.HasValue)
-            {
-                return FromTwips(twips.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Twips.
-        /// </summary>
-        public static Length? FromTwips(long? twips)
-        {
-            if (twips.HasValue)
-            {
-                return FromTwips(twips.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Twips of type decimal.
-        /// </summary>
-        public static Length? FromTwips(decimal? twips)
+        public static Length? FromTwips(QuantityValue? twips)
         {
             if (twips.HasValue)
             {
@@ -2355,52 +1015,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable UsSurveyFeet.
         /// </summary>
-        public static Length? FromUsSurveyFeet(double? ussurveyfeet)
-        {
-            if (ussurveyfeet.HasValue)
-            {
-                return FromUsSurveyFeet(ussurveyfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable UsSurveyFeet.
-        /// </summary>
-        public static Length? FromUsSurveyFeet(int? ussurveyfeet)
-        {
-            if (ussurveyfeet.HasValue)
-            {
-                return FromUsSurveyFeet(ussurveyfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable UsSurveyFeet.
-        /// </summary>
-        public static Length? FromUsSurveyFeet(long? ussurveyfeet)
-        {
-            if (ussurveyfeet.HasValue)
-            {
-                return FromUsSurveyFeet(ussurveyfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from UsSurveyFeet of type decimal.
-        /// </summary>
-        public static Length? FromUsSurveyFeet(decimal? ussurveyfeet)
+        public static Length? FromUsSurveyFeet(QuantityValue? ussurveyfeet)
         {
             if (ussurveyfeet.HasValue)
             {
@@ -2415,52 +1030,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Length from nullable Yards.
         /// </summary>
-        public static Length? FromYards(double? yards)
-        {
-            if (yards.HasValue)
-            {
-                return FromYards(yards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Yards.
-        /// </summary>
-        public static Length? FromYards(int? yards)
-        {
-            if (yards.HasValue)
-            {
-                return FromYards(yards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from nullable Yards.
-        /// </summary>
-        public static Length? FromYards(long? yards)
-        {
-            if (yards.HasValue)
-            {
-                return FromYards(yards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Length from Yards of type decimal.
-        /// </summary>
-        public static Length? FromYards(decimal? yards)
+        public static Length? FromYards(QuantityValue? yards)
         {
             if (yards.HasValue)
             {
@@ -2477,57 +1047,63 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="LengthUnit" /> to <see cref="Length" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Length unit value.</returns>
-        public static Length From(double val, LengthUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Length From(double value, LengthUnit fromUnit)
+#else
+        public static Length From(QuantityValue value, LengthUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case LengthUnit.Centimeter:
-                    return FromCentimeters(val);
+                    return FromCentimeters(value);
                 case LengthUnit.Decimeter:
-                    return FromDecimeters(val);
+                    return FromDecimeters(value);
                 case LengthUnit.DtpPica:
-                    return FromDtpPicas(val);
+                    return FromDtpPicas(value);
                 case LengthUnit.DtpPoint:
-                    return FromDtpPoints(val);
+                    return FromDtpPoints(value);
                 case LengthUnit.Fathom:
-                    return FromFathoms(val);
+                    return FromFathoms(value);
                 case LengthUnit.Foot:
-                    return FromFeet(val);
+                    return FromFeet(value);
                 case LengthUnit.Inch:
-                    return FromInches(val);
+                    return FromInches(value);
                 case LengthUnit.Kilometer:
-                    return FromKilometers(val);
+                    return FromKilometers(value);
                 case LengthUnit.Meter:
-                    return FromMeters(val);
+                    return FromMeters(value);
                 case LengthUnit.Microinch:
-                    return FromMicroinches(val);
+                    return FromMicroinches(value);
                 case LengthUnit.Micrometer:
-                    return FromMicrometers(val);
+                    return FromMicrometers(value);
                 case LengthUnit.Mil:
-                    return FromMils(val);
+                    return FromMils(value);
                 case LengthUnit.Mile:
-                    return FromMiles(val);
+                    return FromMiles(value);
                 case LengthUnit.Millimeter:
-                    return FromMillimeters(val);
+                    return FromMillimeters(value);
                 case LengthUnit.Nanometer:
-                    return FromNanometers(val);
+                    return FromNanometers(value);
                 case LengthUnit.NauticalMile:
-                    return FromNauticalMiles(val);
+                    return FromNauticalMiles(value);
                 case LengthUnit.PrinterPica:
-                    return FromPrinterPicas(val);
+                    return FromPrinterPicas(value);
                 case LengthUnit.PrinterPoint:
-                    return FromPrinterPoints(val);
+                    return FromPrinterPoints(value);
                 case LengthUnit.Shackle:
-                    return FromShackles(val);
+                    return FromShackles(value);
                 case LengthUnit.Twip:
-                    return FromTwips(val);
+                    return FromTwips(value);
                 case LengthUnit.UsSurveyFoot:
-                    return FromUsSurveyFeet(val);
+                    return FromUsSurveyFeet(value);
                 case LengthUnit.Yard:
-                    return FromYards(val);
+                    return FromYards(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2542,7 +1118,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Length unit value.</returns>
-        public static Length? From(double? value, LengthUnit fromUnit)
+        public static Length? From(QuantityValue? value, LengthUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -157,76 +157,36 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Decibels.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Level FromDecibels(double decibels)
         {
-            return new Level(decibels);
+            double value = (double) decibels;
+            return new Level(value);
         }
-
-        /// <summary>
-        ///     Get Level from Decibels.
-        /// </summary>
-        public static Level FromDecibels(int decibels)
+#else
+        public static Level FromDecibels(QuantityValue decibels)
         {
-            return new Level(decibels);
-        }
-
-        /// <summary>
-        ///     Get Level from Decibels.
-        /// </summary>
-        public static Level FromDecibels(long decibels)
-        {
-            return new Level(decibels);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Level from Decibels of type decimal.
-        /// </summary>
-        public static Level FromDecibels(decimal decibels)
-        {
-            return new Level(Convert.ToDouble(decibels));
+            double value = (double) decibels;
+            return new Level((value));
         }
 #endif
 
         /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Level FromNepers(double nepers)
         {
-            return new Level((1/0.115129254)*nepers);
+            double value = (double) nepers;
+            return new Level((1/0.115129254)*value);
         }
-
-        /// <summary>
-        ///     Get Level from Nepers.
-        /// </summary>
-        public static Level FromNepers(int nepers)
+#else
+        public static Level FromNepers(QuantityValue nepers)
         {
-            return new Level((1/0.115129254)*nepers);
-        }
-
-        /// <summary>
-        ///     Get Level from Nepers.
-        /// </summary>
-        public static Level FromNepers(long nepers)
-        {
-            return new Level((1/0.115129254)*nepers);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Level from Nepers of type decimal.
-        /// </summary>
-        public static Level FromNepers(decimal nepers)
-        {
-            return new Level((1/0.115129254)*Convert.ToDouble(nepers));
+            double value = (double) nepers;
+            return new Level(((1/0.115129254)*value));
         }
 #endif
 
@@ -235,52 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Level from nullable Decibels.
         /// </summary>
-        public static Level? FromDecibels(double? decibels)
-        {
-            if (decibels.HasValue)
-            {
-                return FromDecibels(decibels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Level from nullable Decibels.
-        /// </summary>
-        public static Level? FromDecibels(int? decibels)
-        {
-            if (decibels.HasValue)
-            {
-                return FromDecibels(decibels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Level from nullable Decibels.
-        /// </summary>
-        public static Level? FromDecibels(long? decibels)
-        {
-            if (decibels.HasValue)
-            {
-                return FromDecibels(decibels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Level from Decibels of type decimal.
-        /// </summary>
-        public static Level? FromDecibels(decimal? decibels)
+        public static Level? FromDecibels(QuantityValue? decibels)
         {
             if (decibels.HasValue)
             {
@@ -295,52 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Level from nullable Nepers.
         /// </summary>
-        public static Level? FromNepers(double? nepers)
-        {
-            if (nepers.HasValue)
-            {
-                return FromNepers(nepers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Level from nullable Nepers.
-        /// </summary>
-        public static Level? FromNepers(int? nepers)
-        {
-            if (nepers.HasValue)
-            {
-                return FromNepers(nepers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Level from nullable Nepers.
-        /// </summary>
-        public static Level? FromNepers(long? nepers)
-        {
-            if (nepers.HasValue)
-            {
-                return FromNepers(nepers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Level from Nepers of type decimal.
-        /// </summary>
-        public static Level? FromNepers(decimal? nepers)
+        public static Level? FromNepers(QuantityValue? nepers)
         {
             if (nepers.HasValue)
             {
@@ -357,17 +227,23 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="LevelUnit" /> to <see cref="Level" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Level unit value.</returns>
-        public static Level From(double val, LevelUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Level From(double value, LevelUnit fromUnit)
+#else
+        public static Level From(QuantityValue value, LevelUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case LevelUnit.Decibel:
-                    return FromDecibels(val);
+                    return FromDecibels(value);
                 case LevelUnit.Neper:
-                    return FromNepers(val);
+                    return FromNepers(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -382,7 +258,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Level unit value.</returns>
-        public static Level? From(double? value, LevelUnit fromUnit)
+        public static Level? From(QuantityValue? value, LevelUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -309,798 +309,378 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Centigrams.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromCentigrams(double centigrams)
         {
-            return new Mass((centigrams/1e3) * 1e-2d);
+            double value = (double) centigrams;
+            return new Mass((value/1e3) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Mass from Centigrams.
-        /// </summary>
-        public static Mass FromCentigrams(int centigrams)
+#else
+        public static Mass FromCentigrams(QuantityValue centigrams)
         {
-            return new Mass((centigrams/1e3) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Centigrams.
-        /// </summary>
-        public static Mass FromCentigrams(long centigrams)
-        {
-            return new Mass((centigrams/1e3) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Centigrams of type decimal.
-        /// </summary>
-        public static Mass FromCentigrams(decimal centigrams)
-        {
-            return new Mass((Convert.ToDouble(centigrams)/1e3) * 1e-2d);
+            double value = (double) centigrams;
+            return new Mass(((value/1e3) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromDecagrams(double decagrams)
         {
-            return new Mass((decagrams/1e3) * 1e1d);
+            double value = (double) decagrams;
+            return new Mass((value/1e3) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get Mass from Decagrams.
-        /// </summary>
-        public static Mass FromDecagrams(int decagrams)
+#else
+        public static Mass FromDecagrams(QuantityValue decagrams)
         {
-            return new Mass((decagrams/1e3) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Decagrams.
-        /// </summary>
-        public static Mass FromDecagrams(long decagrams)
-        {
-            return new Mass((decagrams/1e3) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Decagrams of type decimal.
-        /// </summary>
-        public static Mass FromDecagrams(decimal decagrams)
-        {
-            return new Mass((Convert.ToDouble(decagrams)/1e3) * 1e1d);
+            double value = (double) decagrams;
+            return new Mass(((value/1e3) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Decigrams.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromDecigrams(double decigrams)
         {
-            return new Mass((decigrams/1e3) * 1e-1d);
+            double value = (double) decigrams;
+            return new Mass((value/1e3) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Mass from Decigrams.
-        /// </summary>
-        public static Mass FromDecigrams(int decigrams)
+#else
+        public static Mass FromDecigrams(QuantityValue decigrams)
         {
-            return new Mass((decigrams/1e3) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Decigrams.
-        /// </summary>
-        public static Mass FromDecigrams(long decigrams)
-        {
-            return new Mass((decigrams/1e3) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Decigrams of type decimal.
-        /// </summary>
-        public static Mass FromDecigrams(decimal decigrams)
-        {
-            return new Mass((Convert.ToDouble(decigrams)/1e3) * 1e-1d);
+            double value = (double) decigrams;
+            return new Mass(((value/1e3) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromGrams(double grams)
         {
-            return new Mass(grams/1e3);
+            double value = (double) grams;
+            return new Mass(value/1e3);
         }
-
-        /// <summary>
-        ///     Get Mass from Grams.
-        /// </summary>
-        public static Mass FromGrams(int grams)
+#else
+        public static Mass FromGrams(QuantityValue grams)
         {
-            return new Mass(grams/1e3);
-        }
-
-        /// <summary>
-        ///     Get Mass from Grams.
-        /// </summary>
-        public static Mass FromGrams(long grams)
-        {
-            return new Mass(grams/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Grams of type decimal.
-        /// </summary>
-        public static Mass FromGrams(decimal grams)
-        {
-            return new Mass(Convert.ToDouble(grams)/1e3);
+            double value = (double) grams;
+            return new Mass((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Hectograms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromHectograms(double hectograms)
         {
-            return new Mass((hectograms/1e3) * 1e2d);
+            double value = (double) hectograms;
+            return new Mass((value/1e3) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get Mass from Hectograms.
-        /// </summary>
-        public static Mass FromHectograms(int hectograms)
+#else
+        public static Mass FromHectograms(QuantityValue hectograms)
         {
-            return new Mass((hectograms/1e3) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Hectograms.
-        /// </summary>
-        public static Mass FromHectograms(long hectograms)
-        {
-            return new Mass((hectograms/1e3) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Hectograms of type decimal.
-        /// </summary>
-        public static Mass FromHectograms(decimal hectograms)
-        {
-            return new Mass((Convert.ToDouble(hectograms)/1e3) * 1e2d);
+            double value = (double) hectograms;
+            return new Mass(((value/1e3) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromKilograms(double kilograms)
         {
-            return new Mass((kilograms/1e3) * 1e3d);
+            double value = (double) kilograms;
+            return new Mass((value/1e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Mass from Kilograms.
-        /// </summary>
-        public static Mass FromKilograms(int kilograms)
+#else
+        public static Mass FromKilograms(QuantityValue kilograms)
         {
-            return new Mass((kilograms/1e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Kilograms.
-        /// </summary>
-        public static Mass FromKilograms(long kilograms)
-        {
-            return new Mass((kilograms/1e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Kilograms of type decimal.
-        /// </summary>
-        public static Mass FromKilograms(decimal kilograms)
-        {
-            return new Mass((Convert.ToDouble(kilograms)/1e3) * 1e3d);
+            double value = (double) kilograms;
+            return new Mass(((value/1e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Kilopounds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromKilopounds(double kilopounds)
         {
-            return new Mass((kilopounds*0.45359237) * 1e3d);
+            double value = (double) kilopounds;
+            return new Mass((value*0.45359237) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Mass from Kilopounds.
-        /// </summary>
-        public static Mass FromKilopounds(int kilopounds)
+#else
+        public static Mass FromKilopounds(QuantityValue kilopounds)
         {
-            return new Mass((kilopounds*0.45359237) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Kilopounds.
-        /// </summary>
-        public static Mass FromKilopounds(long kilopounds)
-        {
-            return new Mass((kilopounds*0.45359237) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Kilopounds of type decimal.
-        /// </summary>
-        public static Mass FromKilopounds(decimal kilopounds)
-        {
-            return new Mass((Convert.ToDouble(kilopounds)*0.45359237) * 1e3d);
+            double value = (double) kilopounds;
+            return new Mass(((value*0.45359237) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromKilotonnes(double kilotonnes)
         {
-            return new Mass((kilotonnes*1e3) * 1e3d);
+            double value = (double) kilotonnes;
+            return new Mass((value*1e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Mass from Kilotonnes.
-        /// </summary>
-        public static Mass FromKilotonnes(int kilotonnes)
+#else
+        public static Mass FromKilotonnes(QuantityValue kilotonnes)
         {
-            return new Mass((kilotonnes*1e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Kilotonnes.
-        /// </summary>
-        public static Mass FromKilotonnes(long kilotonnes)
-        {
-            return new Mass((kilotonnes*1e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Kilotonnes of type decimal.
-        /// </summary>
-        public static Mass FromKilotonnes(decimal kilotonnes)
-        {
-            return new Mass((Convert.ToDouble(kilotonnes)*1e3) * 1e3d);
+            double value = (double) kilotonnes;
+            return new Mass(((value*1e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from LongHundredweight.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromLongHundredweight(double longhundredweight)
         {
-            return new Mass(longhundredweight/0.01968413055222121);
+            double value = (double) longhundredweight;
+            return new Mass(value/0.01968413055222121);
         }
-
-        /// <summary>
-        ///     Get Mass from LongHundredweight.
-        /// </summary>
-        public static Mass FromLongHundredweight(int longhundredweight)
+#else
+        public static Mass FromLongHundredweight(QuantityValue longhundredweight)
         {
-            return new Mass(longhundredweight/0.01968413055222121);
-        }
-
-        /// <summary>
-        ///     Get Mass from LongHundredweight.
-        /// </summary>
-        public static Mass FromLongHundredweight(long longhundredweight)
-        {
-            return new Mass(longhundredweight/0.01968413055222121);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from LongHundredweight of type decimal.
-        /// </summary>
-        public static Mass FromLongHundredweight(decimal longhundredweight)
-        {
-            return new Mass(Convert.ToDouble(longhundredweight)/0.01968413055222121);
+            double value = (double) longhundredweight;
+            return new Mass((value/0.01968413055222121));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromLongTons(double longtons)
         {
-            return new Mass(longtons*1016.0469088);
+            double value = (double) longtons;
+            return new Mass(value*1016.0469088);
         }
-
-        /// <summary>
-        ///     Get Mass from LongTons.
-        /// </summary>
-        public static Mass FromLongTons(int longtons)
+#else
+        public static Mass FromLongTons(QuantityValue longtons)
         {
-            return new Mass(longtons*1016.0469088);
-        }
-
-        /// <summary>
-        ///     Get Mass from LongTons.
-        /// </summary>
-        public static Mass FromLongTons(long longtons)
-        {
-            return new Mass(longtons*1016.0469088);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from LongTons of type decimal.
-        /// </summary>
-        public static Mass FromLongTons(decimal longtons)
-        {
-            return new Mass(Convert.ToDouble(longtons)*1016.0469088);
+            double value = (double) longtons;
+            return new Mass((value*1016.0469088));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Megapounds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromMegapounds(double megapounds)
         {
-            return new Mass((megapounds*0.45359237) * 1e6d);
+            double value = (double) megapounds;
+            return new Mass((value*0.45359237) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Mass from Megapounds.
-        /// </summary>
-        public static Mass FromMegapounds(int megapounds)
+#else
+        public static Mass FromMegapounds(QuantityValue megapounds)
         {
-            return new Mass((megapounds*0.45359237) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Megapounds.
-        /// </summary>
-        public static Mass FromMegapounds(long megapounds)
-        {
-            return new Mass((megapounds*0.45359237) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Megapounds of type decimal.
-        /// </summary>
-        public static Mass FromMegapounds(decimal megapounds)
-        {
-            return new Mass((Convert.ToDouble(megapounds)*0.45359237) * 1e6d);
+            double value = (double) megapounds;
+            return new Mass(((value*0.45359237) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromMegatonnes(double megatonnes)
         {
-            return new Mass((megatonnes*1e3) * 1e6d);
+            double value = (double) megatonnes;
+            return new Mass((value*1e3) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Mass from Megatonnes.
-        /// </summary>
-        public static Mass FromMegatonnes(int megatonnes)
+#else
+        public static Mass FromMegatonnes(QuantityValue megatonnes)
         {
-            return new Mass((megatonnes*1e3) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Megatonnes.
-        /// </summary>
-        public static Mass FromMegatonnes(long megatonnes)
-        {
-            return new Mass((megatonnes*1e3) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Megatonnes of type decimal.
-        /// </summary>
-        public static Mass FromMegatonnes(decimal megatonnes)
-        {
-            return new Mass((Convert.ToDouble(megatonnes)*1e3) * 1e6d);
+            double value = (double) megatonnes;
+            return new Mass(((value*1e3) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Micrograms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromMicrograms(double micrograms)
         {
-            return new Mass((micrograms/1e3) * 1e-6d);
+            double value = (double) micrograms;
+            return new Mass((value/1e3) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Mass from Micrograms.
-        /// </summary>
-        public static Mass FromMicrograms(int micrograms)
+#else
+        public static Mass FromMicrograms(QuantityValue micrograms)
         {
-            return new Mass((micrograms/1e3) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Micrograms.
-        /// </summary>
-        public static Mass FromMicrograms(long micrograms)
-        {
-            return new Mass((micrograms/1e3) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Micrograms of type decimal.
-        /// </summary>
-        public static Mass FromMicrograms(decimal micrograms)
-        {
-            return new Mass((Convert.ToDouble(micrograms)/1e3) * 1e-6d);
+            double value = (double) micrograms;
+            return new Mass(((value/1e3) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromMilligrams(double milligrams)
         {
-            return new Mass((milligrams/1e3) * 1e-3d);
+            double value = (double) milligrams;
+            return new Mass((value/1e3) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Mass from Milligrams.
-        /// </summary>
-        public static Mass FromMilligrams(int milligrams)
+#else
+        public static Mass FromMilligrams(QuantityValue milligrams)
         {
-            return new Mass((milligrams/1e3) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Milligrams.
-        /// </summary>
-        public static Mass FromMilligrams(long milligrams)
-        {
-            return new Mass((milligrams/1e3) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Milligrams of type decimal.
-        /// </summary>
-        public static Mass FromMilligrams(decimal milligrams)
-        {
-            return new Mass((Convert.ToDouble(milligrams)/1e3) * 1e-3d);
+            double value = (double) milligrams;
+            return new Mass(((value/1e3) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Nanograms.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromNanograms(double nanograms)
         {
-            return new Mass((nanograms/1e3) * 1e-9d);
+            double value = (double) nanograms;
+            return new Mass((value/1e3) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Mass from Nanograms.
-        /// </summary>
-        public static Mass FromNanograms(int nanograms)
+#else
+        public static Mass FromNanograms(QuantityValue nanograms)
         {
-            return new Mass((nanograms/1e3) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Mass from Nanograms.
-        /// </summary>
-        public static Mass FromNanograms(long nanograms)
-        {
-            return new Mass((nanograms/1e3) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Nanograms of type decimal.
-        /// </summary>
-        public static Mass FromNanograms(decimal nanograms)
-        {
-            return new Mass((Convert.ToDouble(nanograms)/1e3) * 1e-9d);
+            double value = (double) nanograms;
+            return new Mass(((value/1e3) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromOunces(double ounces)
         {
-            return new Mass(ounces/35.2739619);
+            double value = (double) ounces;
+            return new Mass(value/35.2739619);
         }
-
-        /// <summary>
-        ///     Get Mass from Ounces.
-        /// </summary>
-        public static Mass FromOunces(int ounces)
+#else
+        public static Mass FromOunces(QuantityValue ounces)
         {
-            return new Mass(ounces/35.2739619);
-        }
-
-        /// <summary>
-        ///     Get Mass from Ounces.
-        /// </summary>
-        public static Mass FromOunces(long ounces)
-        {
-            return new Mass(ounces/35.2739619);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Ounces of type decimal.
-        /// </summary>
-        public static Mass FromOunces(decimal ounces)
-        {
-            return new Mass(Convert.ToDouble(ounces)/35.2739619);
+            double value = (double) ounces;
+            return new Mass((value/35.2739619));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Pounds.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromPounds(double pounds)
         {
-            return new Mass(pounds*0.45359237);
+            double value = (double) pounds;
+            return new Mass(value*0.45359237);
         }
-
-        /// <summary>
-        ///     Get Mass from Pounds.
-        /// </summary>
-        public static Mass FromPounds(int pounds)
+#else
+        public static Mass FromPounds(QuantityValue pounds)
         {
-            return new Mass(pounds*0.45359237);
-        }
-
-        /// <summary>
-        ///     Get Mass from Pounds.
-        /// </summary>
-        public static Mass FromPounds(long pounds)
-        {
-            return new Mass(pounds*0.45359237);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Pounds of type decimal.
-        /// </summary>
-        public static Mass FromPounds(decimal pounds)
-        {
-            return new Mass(Convert.ToDouble(pounds)*0.45359237);
+            double value = (double) pounds;
+            return new Mass((value*0.45359237));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromShortHundredweight(double shorthundredweight)
         {
-            return new Mass(shorthundredweight/0.022046226218487758);
+            double value = (double) shorthundredweight;
+            return new Mass(value/0.022046226218487758);
         }
-
-        /// <summary>
-        ///     Get Mass from ShortHundredweight.
-        /// </summary>
-        public static Mass FromShortHundredweight(int shorthundredweight)
+#else
+        public static Mass FromShortHundredweight(QuantityValue shorthundredweight)
         {
-            return new Mass(shorthundredweight/0.022046226218487758);
-        }
-
-        /// <summary>
-        ///     Get Mass from ShortHundredweight.
-        /// </summary>
-        public static Mass FromShortHundredweight(long shorthundredweight)
-        {
-            return new Mass(shorthundredweight/0.022046226218487758);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from ShortHundredweight of type decimal.
-        /// </summary>
-        public static Mass FromShortHundredweight(decimal shorthundredweight)
-        {
-            return new Mass(Convert.ToDouble(shorthundredweight)/0.022046226218487758);
+            double value = (double) shorthundredweight;
+            return new Mass((value/0.022046226218487758));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from ShortTons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromShortTons(double shorttons)
         {
-            return new Mass(shorttons*907.18474);
+            double value = (double) shorttons;
+            return new Mass(value*907.18474);
         }
-
-        /// <summary>
-        ///     Get Mass from ShortTons.
-        /// </summary>
-        public static Mass FromShortTons(int shorttons)
+#else
+        public static Mass FromShortTons(QuantityValue shorttons)
         {
-            return new Mass(shorttons*907.18474);
-        }
-
-        /// <summary>
-        ///     Get Mass from ShortTons.
-        /// </summary>
-        public static Mass FromShortTons(long shorttons)
-        {
-            return new Mass(shorttons*907.18474);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from ShortTons of type decimal.
-        /// </summary>
-        public static Mass FromShortTons(decimal shorttons)
-        {
-            return new Mass(Convert.ToDouble(shorttons)*907.18474);
+            double value = (double) shorttons;
+            return new Mass((value*907.18474));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromStone(double stone)
         {
-            return new Mass(stone/0.1574731728702698);
+            double value = (double) stone;
+            return new Mass(value/0.1574731728702698);
         }
-
-        /// <summary>
-        ///     Get Mass from Stone.
-        /// </summary>
-        public static Mass FromStone(int stone)
+#else
+        public static Mass FromStone(QuantityValue stone)
         {
-            return new Mass(stone/0.1574731728702698);
-        }
-
-        /// <summary>
-        ///     Get Mass from Stone.
-        /// </summary>
-        public static Mass FromStone(long stone)
-        {
-            return new Mass(stone/0.1574731728702698);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Stone of type decimal.
-        /// </summary>
-        public static Mass FromStone(decimal stone)
-        {
-            return new Mass(Convert.ToDouble(stone)/0.1574731728702698);
+            double value = (double) stone;
+            return new Mass((value/0.1574731728702698));
         }
 #endif
 
         /// <summary>
         ///     Get Mass from Tonnes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Mass FromTonnes(double tonnes)
         {
-            return new Mass(tonnes*1e3);
+            double value = (double) tonnes;
+            return new Mass(value*1e3);
         }
-
-        /// <summary>
-        ///     Get Mass from Tonnes.
-        /// </summary>
-        public static Mass FromTonnes(int tonnes)
+#else
+        public static Mass FromTonnes(QuantityValue tonnes)
         {
-            return new Mass(tonnes*1e3);
-        }
-
-        /// <summary>
-        ///     Get Mass from Tonnes.
-        /// </summary>
-        public static Mass FromTonnes(long tonnes)
-        {
-            return new Mass(tonnes*1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Mass from Tonnes of type decimal.
-        /// </summary>
-        public static Mass FromTonnes(decimal tonnes)
-        {
-            return new Mass(Convert.ToDouble(tonnes)*1e3);
+            double value = (double) tonnes;
+            return new Mass((value*1e3));
         }
 #endif
 
@@ -1109,52 +689,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Centigrams.
         /// </summary>
-        public static Mass? FromCentigrams(double? centigrams)
-        {
-            if (centigrams.HasValue)
-            {
-                return FromCentigrams(centigrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Centigrams.
-        /// </summary>
-        public static Mass? FromCentigrams(int? centigrams)
-        {
-            if (centigrams.HasValue)
-            {
-                return FromCentigrams(centigrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Centigrams.
-        /// </summary>
-        public static Mass? FromCentigrams(long? centigrams)
-        {
-            if (centigrams.HasValue)
-            {
-                return FromCentigrams(centigrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Centigrams of type decimal.
-        /// </summary>
-        public static Mass? FromCentigrams(decimal? centigrams)
+        public static Mass? FromCentigrams(QuantityValue? centigrams)
         {
             if (centigrams.HasValue)
             {
@@ -1169,52 +704,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Decagrams.
         /// </summary>
-        public static Mass? FromDecagrams(double? decagrams)
-        {
-            if (decagrams.HasValue)
-            {
-                return FromDecagrams(decagrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Decagrams.
-        /// </summary>
-        public static Mass? FromDecagrams(int? decagrams)
-        {
-            if (decagrams.HasValue)
-            {
-                return FromDecagrams(decagrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Decagrams.
-        /// </summary>
-        public static Mass? FromDecagrams(long? decagrams)
-        {
-            if (decagrams.HasValue)
-            {
-                return FromDecagrams(decagrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Decagrams of type decimal.
-        /// </summary>
-        public static Mass? FromDecagrams(decimal? decagrams)
+        public static Mass? FromDecagrams(QuantityValue? decagrams)
         {
             if (decagrams.HasValue)
             {
@@ -1229,52 +719,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Decigrams.
         /// </summary>
-        public static Mass? FromDecigrams(double? decigrams)
-        {
-            if (decigrams.HasValue)
-            {
-                return FromDecigrams(decigrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Decigrams.
-        /// </summary>
-        public static Mass? FromDecigrams(int? decigrams)
-        {
-            if (decigrams.HasValue)
-            {
-                return FromDecigrams(decigrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Decigrams.
-        /// </summary>
-        public static Mass? FromDecigrams(long? decigrams)
-        {
-            if (decigrams.HasValue)
-            {
-                return FromDecigrams(decigrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Decigrams of type decimal.
-        /// </summary>
-        public static Mass? FromDecigrams(decimal? decigrams)
+        public static Mass? FromDecigrams(QuantityValue? decigrams)
         {
             if (decigrams.HasValue)
             {
@@ -1289,52 +734,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Grams.
         /// </summary>
-        public static Mass? FromGrams(double? grams)
-        {
-            if (grams.HasValue)
-            {
-                return FromGrams(grams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Grams.
-        /// </summary>
-        public static Mass? FromGrams(int? grams)
-        {
-            if (grams.HasValue)
-            {
-                return FromGrams(grams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Grams.
-        /// </summary>
-        public static Mass? FromGrams(long? grams)
-        {
-            if (grams.HasValue)
-            {
-                return FromGrams(grams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Grams of type decimal.
-        /// </summary>
-        public static Mass? FromGrams(decimal? grams)
+        public static Mass? FromGrams(QuantityValue? grams)
         {
             if (grams.HasValue)
             {
@@ -1349,52 +749,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Hectograms.
         /// </summary>
-        public static Mass? FromHectograms(double? hectograms)
-        {
-            if (hectograms.HasValue)
-            {
-                return FromHectograms(hectograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Hectograms.
-        /// </summary>
-        public static Mass? FromHectograms(int? hectograms)
-        {
-            if (hectograms.HasValue)
-            {
-                return FromHectograms(hectograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Hectograms.
-        /// </summary>
-        public static Mass? FromHectograms(long? hectograms)
-        {
-            if (hectograms.HasValue)
-            {
-                return FromHectograms(hectograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Hectograms of type decimal.
-        /// </summary>
-        public static Mass? FromHectograms(decimal? hectograms)
+        public static Mass? FromHectograms(QuantityValue? hectograms)
         {
             if (hectograms.HasValue)
             {
@@ -1409,52 +764,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Kilograms.
         /// </summary>
-        public static Mass? FromKilograms(double? kilograms)
-        {
-            if (kilograms.HasValue)
-            {
-                return FromKilograms(kilograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Kilograms.
-        /// </summary>
-        public static Mass? FromKilograms(int? kilograms)
-        {
-            if (kilograms.HasValue)
-            {
-                return FromKilograms(kilograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Kilograms.
-        /// </summary>
-        public static Mass? FromKilograms(long? kilograms)
-        {
-            if (kilograms.HasValue)
-            {
-                return FromKilograms(kilograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Kilograms of type decimal.
-        /// </summary>
-        public static Mass? FromKilograms(decimal? kilograms)
+        public static Mass? FromKilograms(QuantityValue? kilograms)
         {
             if (kilograms.HasValue)
             {
@@ -1469,52 +779,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Kilopounds.
         /// </summary>
-        public static Mass? FromKilopounds(double? kilopounds)
-        {
-            if (kilopounds.HasValue)
-            {
-                return FromKilopounds(kilopounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Kilopounds.
-        /// </summary>
-        public static Mass? FromKilopounds(int? kilopounds)
-        {
-            if (kilopounds.HasValue)
-            {
-                return FromKilopounds(kilopounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Kilopounds.
-        /// </summary>
-        public static Mass? FromKilopounds(long? kilopounds)
-        {
-            if (kilopounds.HasValue)
-            {
-                return FromKilopounds(kilopounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Kilopounds of type decimal.
-        /// </summary>
-        public static Mass? FromKilopounds(decimal? kilopounds)
+        public static Mass? FromKilopounds(QuantityValue? kilopounds)
         {
             if (kilopounds.HasValue)
             {
@@ -1529,52 +794,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Kilotonnes.
         /// </summary>
-        public static Mass? FromKilotonnes(double? kilotonnes)
-        {
-            if (kilotonnes.HasValue)
-            {
-                return FromKilotonnes(kilotonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Kilotonnes.
-        /// </summary>
-        public static Mass? FromKilotonnes(int? kilotonnes)
-        {
-            if (kilotonnes.HasValue)
-            {
-                return FromKilotonnes(kilotonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Kilotonnes.
-        /// </summary>
-        public static Mass? FromKilotonnes(long? kilotonnes)
-        {
-            if (kilotonnes.HasValue)
-            {
-                return FromKilotonnes(kilotonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Kilotonnes of type decimal.
-        /// </summary>
-        public static Mass? FromKilotonnes(decimal? kilotonnes)
+        public static Mass? FromKilotonnes(QuantityValue? kilotonnes)
         {
             if (kilotonnes.HasValue)
             {
@@ -1589,52 +809,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable LongHundredweight.
         /// </summary>
-        public static Mass? FromLongHundredweight(double? longhundredweight)
-        {
-            if (longhundredweight.HasValue)
-            {
-                return FromLongHundredweight(longhundredweight.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable LongHundredweight.
-        /// </summary>
-        public static Mass? FromLongHundredweight(int? longhundredweight)
-        {
-            if (longhundredweight.HasValue)
-            {
-                return FromLongHundredweight(longhundredweight.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable LongHundredweight.
-        /// </summary>
-        public static Mass? FromLongHundredweight(long? longhundredweight)
-        {
-            if (longhundredweight.HasValue)
-            {
-                return FromLongHundredweight(longhundredweight.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from LongHundredweight of type decimal.
-        /// </summary>
-        public static Mass? FromLongHundredweight(decimal? longhundredweight)
+        public static Mass? FromLongHundredweight(QuantityValue? longhundredweight)
         {
             if (longhundredweight.HasValue)
             {
@@ -1649,52 +824,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable LongTons.
         /// </summary>
-        public static Mass? FromLongTons(double? longtons)
-        {
-            if (longtons.HasValue)
-            {
-                return FromLongTons(longtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable LongTons.
-        /// </summary>
-        public static Mass? FromLongTons(int? longtons)
-        {
-            if (longtons.HasValue)
-            {
-                return FromLongTons(longtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable LongTons.
-        /// </summary>
-        public static Mass? FromLongTons(long? longtons)
-        {
-            if (longtons.HasValue)
-            {
-                return FromLongTons(longtons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from LongTons of type decimal.
-        /// </summary>
-        public static Mass? FromLongTons(decimal? longtons)
+        public static Mass? FromLongTons(QuantityValue? longtons)
         {
             if (longtons.HasValue)
             {
@@ -1709,52 +839,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Megapounds.
         /// </summary>
-        public static Mass? FromMegapounds(double? megapounds)
-        {
-            if (megapounds.HasValue)
-            {
-                return FromMegapounds(megapounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Megapounds.
-        /// </summary>
-        public static Mass? FromMegapounds(int? megapounds)
-        {
-            if (megapounds.HasValue)
-            {
-                return FromMegapounds(megapounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Megapounds.
-        /// </summary>
-        public static Mass? FromMegapounds(long? megapounds)
-        {
-            if (megapounds.HasValue)
-            {
-                return FromMegapounds(megapounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Megapounds of type decimal.
-        /// </summary>
-        public static Mass? FromMegapounds(decimal? megapounds)
+        public static Mass? FromMegapounds(QuantityValue? megapounds)
         {
             if (megapounds.HasValue)
             {
@@ -1769,52 +854,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Megatonnes.
         /// </summary>
-        public static Mass? FromMegatonnes(double? megatonnes)
-        {
-            if (megatonnes.HasValue)
-            {
-                return FromMegatonnes(megatonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Megatonnes.
-        /// </summary>
-        public static Mass? FromMegatonnes(int? megatonnes)
-        {
-            if (megatonnes.HasValue)
-            {
-                return FromMegatonnes(megatonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Megatonnes.
-        /// </summary>
-        public static Mass? FromMegatonnes(long? megatonnes)
-        {
-            if (megatonnes.HasValue)
-            {
-                return FromMegatonnes(megatonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Megatonnes of type decimal.
-        /// </summary>
-        public static Mass? FromMegatonnes(decimal? megatonnes)
+        public static Mass? FromMegatonnes(QuantityValue? megatonnes)
         {
             if (megatonnes.HasValue)
             {
@@ -1829,52 +869,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Micrograms.
         /// </summary>
-        public static Mass? FromMicrograms(double? micrograms)
-        {
-            if (micrograms.HasValue)
-            {
-                return FromMicrograms(micrograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Micrograms.
-        /// </summary>
-        public static Mass? FromMicrograms(int? micrograms)
-        {
-            if (micrograms.HasValue)
-            {
-                return FromMicrograms(micrograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Micrograms.
-        /// </summary>
-        public static Mass? FromMicrograms(long? micrograms)
-        {
-            if (micrograms.HasValue)
-            {
-                return FromMicrograms(micrograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Micrograms of type decimal.
-        /// </summary>
-        public static Mass? FromMicrograms(decimal? micrograms)
+        public static Mass? FromMicrograms(QuantityValue? micrograms)
         {
             if (micrograms.HasValue)
             {
@@ -1889,52 +884,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Milligrams.
         /// </summary>
-        public static Mass? FromMilligrams(double? milligrams)
-        {
-            if (milligrams.HasValue)
-            {
-                return FromMilligrams(milligrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Milligrams.
-        /// </summary>
-        public static Mass? FromMilligrams(int? milligrams)
-        {
-            if (milligrams.HasValue)
-            {
-                return FromMilligrams(milligrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Milligrams.
-        /// </summary>
-        public static Mass? FromMilligrams(long? milligrams)
-        {
-            if (milligrams.HasValue)
-            {
-                return FromMilligrams(milligrams.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Milligrams of type decimal.
-        /// </summary>
-        public static Mass? FromMilligrams(decimal? milligrams)
+        public static Mass? FromMilligrams(QuantityValue? milligrams)
         {
             if (milligrams.HasValue)
             {
@@ -1949,52 +899,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Nanograms.
         /// </summary>
-        public static Mass? FromNanograms(double? nanograms)
-        {
-            if (nanograms.HasValue)
-            {
-                return FromNanograms(nanograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Nanograms.
-        /// </summary>
-        public static Mass? FromNanograms(int? nanograms)
-        {
-            if (nanograms.HasValue)
-            {
-                return FromNanograms(nanograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Nanograms.
-        /// </summary>
-        public static Mass? FromNanograms(long? nanograms)
-        {
-            if (nanograms.HasValue)
-            {
-                return FromNanograms(nanograms.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Nanograms of type decimal.
-        /// </summary>
-        public static Mass? FromNanograms(decimal? nanograms)
+        public static Mass? FromNanograms(QuantityValue? nanograms)
         {
             if (nanograms.HasValue)
             {
@@ -2009,52 +914,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Ounces.
         /// </summary>
-        public static Mass? FromOunces(double? ounces)
-        {
-            if (ounces.HasValue)
-            {
-                return FromOunces(ounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Ounces.
-        /// </summary>
-        public static Mass? FromOunces(int? ounces)
-        {
-            if (ounces.HasValue)
-            {
-                return FromOunces(ounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Ounces.
-        /// </summary>
-        public static Mass? FromOunces(long? ounces)
-        {
-            if (ounces.HasValue)
-            {
-                return FromOunces(ounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Ounces of type decimal.
-        /// </summary>
-        public static Mass? FromOunces(decimal? ounces)
+        public static Mass? FromOunces(QuantityValue? ounces)
         {
             if (ounces.HasValue)
             {
@@ -2069,52 +929,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Pounds.
         /// </summary>
-        public static Mass? FromPounds(double? pounds)
-        {
-            if (pounds.HasValue)
-            {
-                return FromPounds(pounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Pounds.
-        /// </summary>
-        public static Mass? FromPounds(int? pounds)
-        {
-            if (pounds.HasValue)
-            {
-                return FromPounds(pounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Pounds.
-        /// </summary>
-        public static Mass? FromPounds(long? pounds)
-        {
-            if (pounds.HasValue)
-            {
-                return FromPounds(pounds.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Pounds of type decimal.
-        /// </summary>
-        public static Mass? FromPounds(decimal? pounds)
+        public static Mass? FromPounds(QuantityValue? pounds)
         {
             if (pounds.HasValue)
             {
@@ -2129,52 +944,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable ShortHundredweight.
         /// </summary>
-        public static Mass? FromShortHundredweight(double? shorthundredweight)
-        {
-            if (shorthundredweight.HasValue)
-            {
-                return FromShortHundredweight(shorthundredweight.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable ShortHundredweight.
-        /// </summary>
-        public static Mass? FromShortHundredweight(int? shorthundredweight)
-        {
-            if (shorthundredweight.HasValue)
-            {
-                return FromShortHundredweight(shorthundredweight.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable ShortHundredweight.
-        /// </summary>
-        public static Mass? FromShortHundredweight(long? shorthundredweight)
-        {
-            if (shorthundredweight.HasValue)
-            {
-                return FromShortHundredweight(shorthundredweight.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from ShortHundredweight of type decimal.
-        /// </summary>
-        public static Mass? FromShortHundredweight(decimal? shorthundredweight)
+        public static Mass? FromShortHundredweight(QuantityValue? shorthundredweight)
         {
             if (shorthundredweight.HasValue)
             {
@@ -2189,52 +959,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable ShortTons.
         /// </summary>
-        public static Mass? FromShortTons(double? shorttons)
-        {
-            if (shorttons.HasValue)
-            {
-                return FromShortTons(shorttons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable ShortTons.
-        /// </summary>
-        public static Mass? FromShortTons(int? shorttons)
-        {
-            if (shorttons.HasValue)
-            {
-                return FromShortTons(shorttons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable ShortTons.
-        /// </summary>
-        public static Mass? FromShortTons(long? shorttons)
-        {
-            if (shorttons.HasValue)
-            {
-                return FromShortTons(shorttons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from ShortTons of type decimal.
-        /// </summary>
-        public static Mass? FromShortTons(decimal? shorttons)
+        public static Mass? FromShortTons(QuantityValue? shorttons)
         {
             if (shorttons.HasValue)
             {
@@ -2249,52 +974,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Stone.
         /// </summary>
-        public static Mass? FromStone(double? stone)
-        {
-            if (stone.HasValue)
-            {
-                return FromStone(stone.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Stone.
-        /// </summary>
-        public static Mass? FromStone(int? stone)
-        {
-            if (stone.HasValue)
-            {
-                return FromStone(stone.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Stone.
-        /// </summary>
-        public static Mass? FromStone(long? stone)
-        {
-            if (stone.HasValue)
-            {
-                return FromStone(stone.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Stone of type decimal.
-        /// </summary>
-        public static Mass? FromStone(decimal? stone)
+        public static Mass? FromStone(QuantityValue? stone)
         {
             if (stone.HasValue)
             {
@@ -2309,52 +989,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Mass from nullable Tonnes.
         /// </summary>
-        public static Mass? FromTonnes(double? tonnes)
-        {
-            if (tonnes.HasValue)
-            {
-                return FromTonnes(tonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Tonnes.
-        /// </summary>
-        public static Mass? FromTonnes(int? tonnes)
-        {
-            if (tonnes.HasValue)
-            {
-                return FromTonnes(tonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from nullable Tonnes.
-        /// </summary>
-        public static Mass? FromTonnes(long? tonnes)
-        {
-            if (tonnes.HasValue)
-            {
-                return FromTonnes(tonnes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Mass from Tonnes of type decimal.
-        /// </summary>
-        public static Mass? FromTonnes(decimal? tonnes)
+        public static Mass? FromTonnes(QuantityValue? tonnes)
         {
             if (tonnes.HasValue)
             {
@@ -2371,55 +1006,61 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MassUnit" /> to <see cref="Mass" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Mass unit value.</returns>
-        public static Mass From(double val, MassUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Mass From(double value, MassUnit fromUnit)
+#else
+        public static Mass From(QuantityValue value, MassUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MassUnit.Centigram:
-                    return FromCentigrams(val);
+                    return FromCentigrams(value);
                 case MassUnit.Decagram:
-                    return FromDecagrams(val);
+                    return FromDecagrams(value);
                 case MassUnit.Decigram:
-                    return FromDecigrams(val);
+                    return FromDecigrams(value);
                 case MassUnit.Gram:
-                    return FromGrams(val);
+                    return FromGrams(value);
                 case MassUnit.Hectogram:
-                    return FromHectograms(val);
+                    return FromHectograms(value);
                 case MassUnit.Kilogram:
-                    return FromKilograms(val);
+                    return FromKilograms(value);
                 case MassUnit.Kilopound:
-                    return FromKilopounds(val);
+                    return FromKilopounds(value);
                 case MassUnit.Kilotonne:
-                    return FromKilotonnes(val);
+                    return FromKilotonnes(value);
                 case MassUnit.LongHundredweight:
-                    return FromLongHundredweight(val);
+                    return FromLongHundredweight(value);
                 case MassUnit.LongTon:
-                    return FromLongTons(val);
+                    return FromLongTons(value);
                 case MassUnit.Megapound:
-                    return FromMegapounds(val);
+                    return FromMegapounds(value);
                 case MassUnit.Megatonne:
-                    return FromMegatonnes(val);
+                    return FromMegatonnes(value);
                 case MassUnit.Microgram:
-                    return FromMicrograms(val);
+                    return FromMicrograms(value);
                 case MassUnit.Milligram:
-                    return FromMilligrams(val);
+                    return FromMilligrams(value);
                 case MassUnit.Nanogram:
-                    return FromNanograms(val);
+                    return FromNanograms(value);
                 case MassUnit.Ounce:
-                    return FromOunces(val);
+                    return FromOunces(value);
                 case MassUnit.Pound:
-                    return FromPounds(val);
+                    return FromPounds(value);
                 case MassUnit.ShortHundredweight:
-                    return FromShortHundredweight(val);
+                    return FromShortHundredweight(value);
                 case MassUnit.ShortTon:
-                    return FromShortTons(val);
+                    return FromShortTons(value);
                 case MassUnit.Stone:
-                    return FromStone(val);
+                    return FromStone(value);
                 case MassUnit.Tonne:
-                    return FromTonnes(val);
+                    return FromTonnes(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2434,7 +1075,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Mass unit value.</returns>
-        public static Mass? From(double? value, MassUnit fromUnit)
+        public static Mass? From(QuantityValue? value, MassUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -253,532 +253,252 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from CentigramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromCentigramsPerSecond(double centigramspersecond)
         {
-            return new MassFlow((centigramspersecond) * 1e-2d);
+            double value = (double) centigramspersecond;
+            return new MassFlow((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from CentigramsPerSecond.
-        /// </summary>
-        public static MassFlow FromCentigramsPerSecond(int centigramspersecond)
+#else
+        public static MassFlow FromCentigramsPerSecond(QuantityValue centigramspersecond)
         {
-            return new MassFlow((centigramspersecond) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from CentigramsPerSecond.
-        /// </summary>
-        public static MassFlow FromCentigramsPerSecond(long centigramspersecond)
-        {
-            return new MassFlow((centigramspersecond) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from CentigramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromCentigramsPerSecond(decimal centigramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(centigramspersecond)) * 1e-2d);
+            double value = (double) centigramspersecond;
+            return new MassFlow(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromDecagramsPerSecond(double decagramspersecond)
         {
-            return new MassFlow((decagramspersecond) * 1e1d);
+            double value = (double) decagramspersecond;
+            return new MassFlow((value) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from DecagramsPerSecond.
-        /// </summary>
-        public static MassFlow FromDecagramsPerSecond(int decagramspersecond)
+#else
+        public static MassFlow FromDecagramsPerSecond(QuantityValue decagramspersecond)
         {
-            return new MassFlow((decagramspersecond) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from DecagramsPerSecond.
-        /// </summary>
-        public static MassFlow FromDecagramsPerSecond(long decagramspersecond)
-        {
-            return new MassFlow((decagramspersecond) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from DecagramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromDecagramsPerSecond(decimal decagramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(decagramspersecond)) * 1e1d);
+            double value = (double) decagramspersecond;
+            return new MassFlow(((value) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromDecigramsPerSecond(double decigramspersecond)
         {
-            return new MassFlow((decigramspersecond) * 1e-1d);
+            double value = (double) decigramspersecond;
+            return new MassFlow((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from DecigramsPerSecond.
-        /// </summary>
-        public static MassFlow FromDecigramsPerSecond(int decigramspersecond)
+#else
+        public static MassFlow FromDecigramsPerSecond(QuantityValue decigramspersecond)
         {
-            return new MassFlow((decigramspersecond) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from DecigramsPerSecond.
-        /// </summary>
-        public static MassFlow FromDecigramsPerSecond(long decigramspersecond)
-        {
-            return new MassFlow((decigramspersecond) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from DecigramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromDecigramsPerSecond(decimal decigramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(decigramspersecond)) * 1e-1d);
+            double value = (double) decigramspersecond;
+            return new MassFlow(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromGramsPerSecond(double gramspersecond)
         {
-            return new MassFlow(gramspersecond);
+            double value = (double) gramspersecond;
+            return new MassFlow(value);
         }
-
-        /// <summary>
-        ///     Get MassFlow from GramsPerSecond.
-        /// </summary>
-        public static MassFlow FromGramsPerSecond(int gramspersecond)
+#else
+        public static MassFlow FromGramsPerSecond(QuantityValue gramspersecond)
         {
-            return new MassFlow(gramspersecond);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from GramsPerSecond.
-        /// </summary>
-        public static MassFlow FromGramsPerSecond(long gramspersecond)
-        {
-            return new MassFlow(gramspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from GramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromGramsPerSecond(decimal gramspersecond)
-        {
-            return new MassFlow(Convert.ToDouble(gramspersecond));
+            double value = (double) gramspersecond;
+            return new MassFlow((value));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromHectogramsPerSecond(double hectogramspersecond)
         {
-            return new MassFlow((hectogramspersecond) * 1e2d);
+            double value = (double) hectogramspersecond;
+            return new MassFlow((value) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from HectogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromHectogramsPerSecond(int hectogramspersecond)
+#else
+        public static MassFlow FromHectogramsPerSecond(QuantityValue hectogramspersecond)
         {
-            return new MassFlow((hectogramspersecond) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from HectogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromHectogramsPerSecond(long hectogramspersecond)
-        {
-            return new MassFlow((hectogramspersecond) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from HectogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromHectogramsPerSecond(decimal hectogramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(hectogramspersecond)) * 1e2d);
+            double value = (double) hectogramspersecond;
+            return new MassFlow(((value) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromKilogramsPerHour(double kilogramsperhour)
         {
-            return new MassFlow(kilogramsperhour/3.6);
+            double value = (double) kilogramsperhour;
+            return new MassFlow(value/3.6);
         }
-
-        /// <summary>
-        ///     Get MassFlow from KilogramsPerHour.
-        /// </summary>
-        public static MassFlow FromKilogramsPerHour(int kilogramsperhour)
+#else
+        public static MassFlow FromKilogramsPerHour(QuantityValue kilogramsperhour)
         {
-            return new MassFlow(kilogramsperhour/3.6);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from KilogramsPerHour.
-        /// </summary>
-        public static MassFlow FromKilogramsPerHour(long kilogramsperhour)
-        {
-            return new MassFlow(kilogramsperhour/3.6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from KilogramsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow FromKilogramsPerHour(decimal kilogramsperhour)
-        {
-            return new MassFlow(Convert.ToDouble(kilogramsperhour)/3.6);
+            double value = (double) kilogramsperhour;
+            return new MassFlow((value/3.6));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromKilogramsPerSecond(double kilogramspersecond)
         {
-            return new MassFlow((kilogramspersecond) * 1e3d);
+            double value = (double) kilogramspersecond;
+            return new MassFlow((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from KilogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromKilogramsPerSecond(int kilogramspersecond)
+#else
+        public static MassFlow FromKilogramsPerSecond(QuantityValue kilogramspersecond)
         {
-            return new MassFlow((kilogramspersecond) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from KilogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromKilogramsPerSecond(long kilogramspersecond)
-        {
-            return new MassFlow((kilogramspersecond) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from KilogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromKilogramsPerSecond(decimal kilogramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(kilogramspersecond)) * 1e3d);
+            double value = (double) kilogramspersecond;
+            return new MassFlow(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromMegapoundsPerHour(double megapoundsperhour)
         {
-            return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
+            double value = (double) megapoundsperhour;
+            return new MassFlow((value/7.93664) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from MegapoundsPerHour.
-        /// </summary>
-        public static MassFlow FromMegapoundsPerHour(int megapoundsperhour)
+#else
+        public static MassFlow FromMegapoundsPerHour(QuantityValue megapoundsperhour)
         {
-            return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from MegapoundsPerHour.
-        /// </summary>
-        public static MassFlow FromMegapoundsPerHour(long megapoundsperhour)
-        {
-            return new MassFlow((megapoundsperhour/7.93664) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from MegapoundsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow FromMegapoundsPerHour(decimal megapoundsperhour)
-        {
-            return new MassFlow((Convert.ToDouble(megapoundsperhour)/7.93664) * 1e6d);
+            double value = (double) megapoundsperhour;
+            return new MassFlow(((value/7.93664) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromMicrogramsPerSecond(double microgramspersecond)
         {
-            return new MassFlow((microgramspersecond) * 1e-6d);
+            double value = (double) microgramspersecond;
+            return new MassFlow((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from MicrogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromMicrogramsPerSecond(int microgramspersecond)
+#else
+        public static MassFlow FromMicrogramsPerSecond(QuantityValue microgramspersecond)
         {
-            return new MassFlow((microgramspersecond) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from MicrogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromMicrogramsPerSecond(long microgramspersecond)
-        {
-            return new MassFlow((microgramspersecond) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from MicrogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromMicrogramsPerSecond(decimal microgramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(microgramspersecond)) * 1e-6d);
+            double value = (double) microgramspersecond;
+            return new MassFlow(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromMilligramsPerSecond(double milligramspersecond)
         {
-            return new MassFlow((milligramspersecond) * 1e-3d);
+            double value = (double) milligramspersecond;
+            return new MassFlow((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from MilligramsPerSecond.
-        /// </summary>
-        public static MassFlow FromMilligramsPerSecond(int milligramspersecond)
+#else
+        public static MassFlow FromMilligramsPerSecond(QuantityValue milligramspersecond)
         {
-            return new MassFlow((milligramspersecond) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from MilligramsPerSecond.
-        /// </summary>
-        public static MassFlow FromMilligramsPerSecond(long milligramspersecond)
-        {
-            return new MassFlow((milligramspersecond) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from MilligramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromMilligramsPerSecond(decimal milligramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(milligramspersecond)) * 1e-3d);
+            double value = (double) milligramspersecond;
+            return new MassFlow(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromNanogramsPerSecond(double nanogramspersecond)
         {
-            return new MassFlow((nanogramspersecond) * 1e-9d);
+            double value = (double) nanogramspersecond;
+            return new MassFlow((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get MassFlow from NanogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromNanogramsPerSecond(int nanogramspersecond)
+#else
+        public static MassFlow FromNanogramsPerSecond(QuantityValue nanogramspersecond)
         {
-            return new MassFlow((nanogramspersecond) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from NanogramsPerSecond.
-        /// </summary>
-        public static MassFlow FromNanogramsPerSecond(long nanogramspersecond)
-        {
-            return new MassFlow((nanogramspersecond) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from NanogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow FromNanogramsPerSecond(decimal nanogramspersecond)
-        {
-            return new MassFlow((Convert.ToDouble(nanogramspersecond)) * 1e-9d);
+            double value = (double) nanogramspersecond;
+            return new MassFlow(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromPoundsPerHour(double poundsperhour)
         {
-            return new MassFlow(poundsperhour/7.93664);
+            double value = (double) poundsperhour;
+            return new MassFlow(value/7.93664);
         }
-
-        /// <summary>
-        ///     Get MassFlow from PoundsPerHour.
-        /// </summary>
-        public static MassFlow FromPoundsPerHour(int poundsperhour)
+#else
+        public static MassFlow FromPoundsPerHour(QuantityValue poundsperhour)
         {
-            return new MassFlow(poundsperhour/7.93664);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from PoundsPerHour.
-        /// </summary>
-        public static MassFlow FromPoundsPerHour(long poundsperhour)
-        {
-            return new MassFlow(poundsperhour/7.93664);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from PoundsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow FromPoundsPerHour(decimal poundsperhour)
-        {
-            return new MassFlow(Convert.ToDouble(poundsperhour)/7.93664);
+            double value = (double) poundsperhour;
+            return new MassFlow((value/7.93664));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromShortTonsPerHour(double shorttonsperhour)
         {
-            return new MassFlow(shorttonsperhour*251.9957611);
+            double value = (double) shorttonsperhour;
+            return new MassFlow(value*251.9957611);
         }
-
-        /// <summary>
-        ///     Get MassFlow from ShortTonsPerHour.
-        /// </summary>
-        public static MassFlow FromShortTonsPerHour(int shorttonsperhour)
+#else
+        public static MassFlow FromShortTonsPerHour(QuantityValue shorttonsperhour)
         {
-            return new MassFlow(shorttonsperhour*251.9957611);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from ShortTonsPerHour.
-        /// </summary>
-        public static MassFlow FromShortTonsPerHour(long shorttonsperhour)
-        {
-            return new MassFlow(shorttonsperhour*251.9957611);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from ShortTonsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow FromShortTonsPerHour(decimal shorttonsperhour)
-        {
-            return new MassFlow(Convert.ToDouble(shorttonsperhour)*251.9957611);
+            double value = (double) shorttonsperhour;
+            return new MassFlow((value*251.9957611));
         }
 #endif
 
         /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassFlow FromTonnesPerDay(double tonnesperday)
         {
-            return new MassFlow(tonnesperday/0.0864000);
+            double value = (double) tonnesperday;
+            return new MassFlow(value/0.0864000);
         }
-
-        /// <summary>
-        ///     Get MassFlow from TonnesPerDay.
-        /// </summary>
-        public static MassFlow FromTonnesPerDay(int tonnesperday)
+#else
+        public static MassFlow FromTonnesPerDay(QuantityValue tonnesperday)
         {
-            return new MassFlow(tonnesperday/0.0864000);
-        }
-
-        /// <summary>
-        ///     Get MassFlow from TonnesPerDay.
-        /// </summary>
-        public static MassFlow FromTonnesPerDay(long tonnesperday)
-        {
-            return new MassFlow(tonnesperday/0.0864000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassFlow from TonnesPerDay of type decimal.
-        /// </summary>
-        public static MassFlow FromTonnesPerDay(decimal tonnesperday)
-        {
-            return new MassFlow(Convert.ToDouble(tonnesperday)/0.0864000);
+            double value = (double) tonnesperday;
+            return new MassFlow((value/0.0864000));
         }
 #endif
 
@@ -787,52 +507,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable CentigramsPerSecond.
         /// </summary>
-        public static MassFlow? FromCentigramsPerSecond(double? centigramspersecond)
-        {
-            if (centigramspersecond.HasValue)
-            {
-                return FromCentigramsPerSecond(centigramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable CentigramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromCentigramsPerSecond(int? centigramspersecond)
-        {
-            if (centigramspersecond.HasValue)
-            {
-                return FromCentigramsPerSecond(centigramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable CentigramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromCentigramsPerSecond(long? centigramspersecond)
-        {
-            if (centigramspersecond.HasValue)
-            {
-                return FromCentigramsPerSecond(centigramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from CentigramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromCentigramsPerSecond(decimal? centigramspersecond)
+        public static MassFlow? FromCentigramsPerSecond(QuantityValue? centigramspersecond)
         {
             if (centigramspersecond.HasValue)
             {
@@ -847,52 +522,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable DecagramsPerSecond.
         /// </summary>
-        public static MassFlow? FromDecagramsPerSecond(double? decagramspersecond)
-        {
-            if (decagramspersecond.HasValue)
-            {
-                return FromDecagramsPerSecond(decagramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable DecagramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromDecagramsPerSecond(int? decagramspersecond)
-        {
-            if (decagramspersecond.HasValue)
-            {
-                return FromDecagramsPerSecond(decagramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable DecagramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromDecagramsPerSecond(long? decagramspersecond)
-        {
-            if (decagramspersecond.HasValue)
-            {
-                return FromDecagramsPerSecond(decagramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from DecagramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromDecagramsPerSecond(decimal? decagramspersecond)
+        public static MassFlow? FromDecagramsPerSecond(QuantityValue? decagramspersecond)
         {
             if (decagramspersecond.HasValue)
             {
@@ -907,52 +537,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable DecigramsPerSecond.
         /// </summary>
-        public static MassFlow? FromDecigramsPerSecond(double? decigramspersecond)
-        {
-            if (decigramspersecond.HasValue)
-            {
-                return FromDecigramsPerSecond(decigramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable DecigramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromDecigramsPerSecond(int? decigramspersecond)
-        {
-            if (decigramspersecond.HasValue)
-            {
-                return FromDecigramsPerSecond(decigramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable DecigramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromDecigramsPerSecond(long? decigramspersecond)
-        {
-            if (decigramspersecond.HasValue)
-            {
-                return FromDecigramsPerSecond(decigramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from DecigramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromDecigramsPerSecond(decimal? decigramspersecond)
+        public static MassFlow? FromDecigramsPerSecond(QuantityValue? decigramspersecond)
         {
             if (decigramspersecond.HasValue)
             {
@@ -967,52 +552,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable GramsPerSecond.
         /// </summary>
-        public static MassFlow? FromGramsPerSecond(double? gramspersecond)
-        {
-            if (gramspersecond.HasValue)
-            {
-                return FromGramsPerSecond(gramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable GramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromGramsPerSecond(int? gramspersecond)
-        {
-            if (gramspersecond.HasValue)
-            {
-                return FromGramsPerSecond(gramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable GramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromGramsPerSecond(long? gramspersecond)
-        {
-            if (gramspersecond.HasValue)
-            {
-                return FromGramsPerSecond(gramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from GramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromGramsPerSecond(decimal? gramspersecond)
+        public static MassFlow? FromGramsPerSecond(QuantityValue? gramspersecond)
         {
             if (gramspersecond.HasValue)
             {
@@ -1027,52 +567,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable HectogramsPerSecond.
         /// </summary>
-        public static MassFlow? FromHectogramsPerSecond(double? hectogramspersecond)
-        {
-            if (hectogramspersecond.HasValue)
-            {
-                return FromHectogramsPerSecond(hectogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable HectogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromHectogramsPerSecond(int? hectogramspersecond)
-        {
-            if (hectogramspersecond.HasValue)
-            {
-                return FromHectogramsPerSecond(hectogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable HectogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromHectogramsPerSecond(long? hectogramspersecond)
-        {
-            if (hectogramspersecond.HasValue)
-            {
-                return FromHectogramsPerSecond(hectogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from HectogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromHectogramsPerSecond(decimal? hectogramspersecond)
+        public static MassFlow? FromHectogramsPerSecond(QuantityValue? hectogramspersecond)
         {
             if (hectogramspersecond.HasValue)
             {
@@ -1087,52 +582,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerHour.
         /// </summary>
-        public static MassFlow? FromKilogramsPerHour(double? kilogramsperhour)
-        {
-            if (kilogramsperhour.HasValue)
-            {
-                return FromKilogramsPerHour(kilogramsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable KilogramsPerHour.
-        /// </summary>
-        public static MassFlow? FromKilogramsPerHour(int? kilogramsperhour)
-        {
-            if (kilogramsperhour.HasValue)
-            {
-                return FromKilogramsPerHour(kilogramsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable KilogramsPerHour.
-        /// </summary>
-        public static MassFlow? FromKilogramsPerHour(long? kilogramsperhour)
-        {
-            if (kilogramsperhour.HasValue)
-            {
-                return FromKilogramsPerHour(kilogramsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from KilogramsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow? FromKilogramsPerHour(decimal? kilogramsperhour)
+        public static MassFlow? FromKilogramsPerHour(QuantityValue? kilogramsperhour)
         {
             if (kilogramsperhour.HasValue)
             {
@@ -1147,52 +597,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable KilogramsPerSecond.
         /// </summary>
-        public static MassFlow? FromKilogramsPerSecond(double? kilogramspersecond)
-        {
-            if (kilogramspersecond.HasValue)
-            {
-                return FromKilogramsPerSecond(kilogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable KilogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromKilogramsPerSecond(int? kilogramspersecond)
-        {
-            if (kilogramspersecond.HasValue)
-            {
-                return FromKilogramsPerSecond(kilogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable KilogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromKilogramsPerSecond(long? kilogramspersecond)
-        {
-            if (kilogramspersecond.HasValue)
-            {
-                return FromKilogramsPerSecond(kilogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from KilogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromKilogramsPerSecond(decimal? kilogramspersecond)
+        public static MassFlow? FromKilogramsPerSecond(QuantityValue? kilogramspersecond)
         {
             if (kilogramspersecond.HasValue)
             {
@@ -1207,52 +612,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable MegapoundsPerHour.
         /// </summary>
-        public static MassFlow? FromMegapoundsPerHour(double? megapoundsperhour)
-        {
-            if (megapoundsperhour.HasValue)
-            {
-                return FromMegapoundsPerHour(megapoundsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable MegapoundsPerHour.
-        /// </summary>
-        public static MassFlow? FromMegapoundsPerHour(int? megapoundsperhour)
-        {
-            if (megapoundsperhour.HasValue)
-            {
-                return FromMegapoundsPerHour(megapoundsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable MegapoundsPerHour.
-        /// </summary>
-        public static MassFlow? FromMegapoundsPerHour(long? megapoundsperhour)
-        {
-            if (megapoundsperhour.HasValue)
-            {
-                return FromMegapoundsPerHour(megapoundsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from MegapoundsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow? FromMegapoundsPerHour(decimal? megapoundsperhour)
+        public static MassFlow? FromMegapoundsPerHour(QuantityValue? megapoundsperhour)
         {
             if (megapoundsperhour.HasValue)
             {
@@ -1267,52 +627,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
         /// </summary>
-        public static MassFlow? FromMicrogramsPerSecond(double? microgramspersecond)
-        {
-            if (microgramspersecond.HasValue)
-            {
-                return FromMicrogramsPerSecond(microgramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromMicrogramsPerSecond(int? microgramspersecond)
-        {
-            if (microgramspersecond.HasValue)
-            {
-                return FromMicrogramsPerSecond(microgramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable MicrogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromMicrogramsPerSecond(long? microgramspersecond)
-        {
-            if (microgramspersecond.HasValue)
-            {
-                return FromMicrogramsPerSecond(microgramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from MicrogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromMicrogramsPerSecond(decimal? microgramspersecond)
+        public static MassFlow? FromMicrogramsPerSecond(QuantityValue? microgramspersecond)
         {
             if (microgramspersecond.HasValue)
             {
@@ -1327,52 +642,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable MilligramsPerSecond.
         /// </summary>
-        public static MassFlow? FromMilligramsPerSecond(double? milligramspersecond)
-        {
-            if (milligramspersecond.HasValue)
-            {
-                return FromMilligramsPerSecond(milligramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable MilligramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromMilligramsPerSecond(int? milligramspersecond)
-        {
-            if (milligramspersecond.HasValue)
-            {
-                return FromMilligramsPerSecond(milligramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable MilligramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromMilligramsPerSecond(long? milligramspersecond)
-        {
-            if (milligramspersecond.HasValue)
-            {
-                return FromMilligramsPerSecond(milligramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from MilligramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromMilligramsPerSecond(decimal? milligramspersecond)
+        public static MassFlow? FromMilligramsPerSecond(QuantityValue? milligramspersecond)
         {
             if (milligramspersecond.HasValue)
             {
@@ -1387,52 +657,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable NanogramsPerSecond.
         /// </summary>
-        public static MassFlow? FromNanogramsPerSecond(double? nanogramspersecond)
-        {
-            if (nanogramspersecond.HasValue)
-            {
-                return FromNanogramsPerSecond(nanogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable NanogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromNanogramsPerSecond(int? nanogramspersecond)
-        {
-            if (nanogramspersecond.HasValue)
-            {
-                return FromNanogramsPerSecond(nanogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable NanogramsPerSecond.
-        /// </summary>
-        public static MassFlow? FromNanogramsPerSecond(long? nanogramspersecond)
-        {
-            if (nanogramspersecond.HasValue)
-            {
-                return FromNanogramsPerSecond(nanogramspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from NanogramsPerSecond of type decimal.
-        /// </summary>
-        public static MassFlow? FromNanogramsPerSecond(decimal? nanogramspersecond)
+        public static MassFlow? FromNanogramsPerSecond(QuantityValue? nanogramspersecond)
         {
             if (nanogramspersecond.HasValue)
             {
@@ -1447,52 +672,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable PoundsPerHour.
         /// </summary>
-        public static MassFlow? FromPoundsPerHour(double? poundsperhour)
-        {
-            if (poundsperhour.HasValue)
-            {
-                return FromPoundsPerHour(poundsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable PoundsPerHour.
-        /// </summary>
-        public static MassFlow? FromPoundsPerHour(int? poundsperhour)
-        {
-            if (poundsperhour.HasValue)
-            {
-                return FromPoundsPerHour(poundsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable PoundsPerHour.
-        /// </summary>
-        public static MassFlow? FromPoundsPerHour(long? poundsperhour)
-        {
-            if (poundsperhour.HasValue)
-            {
-                return FromPoundsPerHour(poundsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from PoundsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow? FromPoundsPerHour(decimal? poundsperhour)
+        public static MassFlow? FromPoundsPerHour(QuantityValue? poundsperhour)
         {
             if (poundsperhour.HasValue)
             {
@@ -1507,52 +687,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable ShortTonsPerHour.
         /// </summary>
-        public static MassFlow? FromShortTonsPerHour(double? shorttonsperhour)
-        {
-            if (shorttonsperhour.HasValue)
-            {
-                return FromShortTonsPerHour(shorttonsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable ShortTonsPerHour.
-        /// </summary>
-        public static MassFlow? FromShortTonsPerHour(int? shorttonsperhour)
-        {
-            if (shorttonsperhour.HasValue)
-            {
-                return FromShortTonsPerHour(shorttonsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable ShortTonsPerHour.
-        /// </summary>
-        public static MassFlow? FromShortTonsPerHour(long? shorttonsperhour)
-        {
-            if (shorttonsperhour.HasValue)
-            {
-                return FromShortTonsPerHour(shorttonsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from ShortTonsPerHour of type decimal.
-        /// </summary>
-        public static MassFlow? FromShortTonsPerHour(decimal? shorttonsperhour)
+        public static MassFlow? FromShortTonsPerHour(QuantityValue? shorttonsperhour)
         {
             if (shorttonsperhour.HasValue)
             {
@@ -1567,52 +702,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassFlow from nullable TonnesPerDay.
         /// </summary>
-        public static MassFlow? FromTonnesPerDay(double? tonnesperday)
-        {
-            if (tonnesperday.HasValue)
-            {
-                return FromTonnesPerDay(tonnesperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable TonnesPerDay.
-        /// </summary>
-        public static MassFlow? FromTonnesPerDay(int? tonnesperday)
-        {
-            if (tonnesperday.HasValue)
-            {
-                return FromTonnesPerDay(tonnesperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from nullable TonnesPerDay.
-        /// </summary>
-        public static MassFlow? FromTonnesPerDay(long? tonnesperday)
-        {
-            if (tonnesperday.HasValue)
-            {
-                return FromTonnesPerDay(tonnesperday.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassFlow from TonnesPerDay of type decimal.
-        /// </summary>
-        public static MassFlow? FromTonnesPerDay(decimal? tonnesperday)
+        public static MassFlow? FromTonnesPerDay(QuantityValue? tonnesperday)
         {
             if (tonnesperday.HasValue)
             {
@@ -1629,41 +719,47 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MassFlowUnit" /> to <see cref="MassFlow" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MassFlow unit value.</returns>
-        public static MassFlow From(double val, MassFlowUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static MassFlow From(double value, MassFlowUnit fromUnit)
+#else
+        public static MassFlow From(QuantityValue value, MassFlowUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MassFlowUnit.CentigramPerSecond:
-                    return FromCentigramsPerSecond(val);
+                    return FromCentigramsPerSecond(value);
                 case MassFlowUnit.DecagramPerSecond:
-                    return FromDecagramsPerSecond(val);
+                    return FromDecagramsPerSecond(value);
                 case MassFlowUnit.DecigramPerSecond:
-                    return FromDecigramsPerSecond(val);
+                    return FromDecigramsPerSecond(value);
                 case MassFlowUnit.GramPerSecond:
-                    return FromGramsPerSecond(val);
+                    return FromGramsPerSecond(value);
                 case MassFlowUnit.HectogramPerSecond:
-                    return FromHectogramsPerSecond(val);
+                    return FromHectogramsPerSecond(value);
                 case MassFlowUnit.KilogramPerHour:
-                    return FromKilogramsPerHour(val);
+                    return FromKilogramsPerHour(value);
                 case MassFlowUnit.KilogramPerSecond:
-                    return FromKilogramsPerSecond(val);
+                    return FromKilogramsPerSecond(value);
                 case MassFlowUnit.MegapoundPerHour:
-                    return FromMegapoundsPerHour(val);
+                    return FromMegapoundsPerHour(value);
                 case MassFlowUnit.MicrogramPerSecond:
-                    return FromMicrogramsPerSecond(val);
+                    return FromMicrogramsPerSecond(value);
                 case MassFlowUnit.MilligramPerSecond:
-                    return FromMilligramsPerSecond(val);
+                    return FromMilligramsPerSecond(value);
                 case MassFlowUnit.NanogramPerSecond:
-                    return FromNanogramsPerSecond(val);
+                    return FromNanogramsPerSecond(value);
                 case MassFlowUnit.PoundPerHour:
-                    return FromPoundsPerHour(val);
+                    return FromPoundsPerHour(value);
                 case MassFlowUnit.ShortTonPerHour:
-                    return FromShortTonsPerHour(val);
+                    return FromShortTonsPerHour(value);
                 case MassFlowUnit.TonnePerDay:
-                    return FromTonnesPerDay(val);
+                    return FromTonnesPerDay(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1678,7 +774,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MassFlow unit value.</returns>
-        public static MassFlow? From(double? value, MassFlowUnit fromUnit)
+        public static MassFlow? From(QuantityValue? value, MassFlowUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -349,988 +349,468 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromGramSquareCentimeters(double gramsquarecentimeters)
         {
-            return new MassMomentOfInertia(gramsquarecentimeters/1e7);
+            double value = (double) gramsquarecentimeters;
+            return new MassMomentOfInertia(value/1e7);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareCentimeters(int gramsquarecentimeters)
+#else
+        public static MassMomentOfInertia FromGramSquareCentimeters(QuantityValue gramsquarecentimeters)
         {
-            return new MassMomentOfInertia(gramsquarecentimeters/1e7);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareCentimeters(long gramsquarecentimeters)
-        {
-            return new MassMomentOfInertia(gramsquarecentimeters/1e7);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareCentimeters(decimal gramsquarecentimeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(gramsquarecentimeters)/1e7);
+            double value = (double) gramsquarecentimeters;
+            return new MassMomentOfInertia((value/1e7));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromGramSquareDecimeters(double gramsquaredecimeters)
         {
-            return new MassMomentOfInertia(gramsquaredecimeters/1e5);
+            double value = (double) gramsquaredecimeters;
+            return new MassMomentOfInertia(value/1e5);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareDecimeters(int gramsquaredecimeters)
+#else
+        public static MassMomentOfInertia FromGramSquareDecimeters(QuantityValue gramsquaredecimeters)
         {
-            return new MassMomentOfInertia(gramsquaredecimeters/1e5);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareDecimeters(long gramsquaredecimeters)
-        {
-            return new MassMomentOfInertia(gramsquaredecimeters/1e5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareDecimeters(decimal gramsquaredecimeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(gramsquaredecimeters)/1e5);
+            double value = (double) gramsquaredecimeters;
+            return new MassMomentOfInertia((value/1e5));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromGramSquareMeters(double gramsquaremeters)
         {
-            return new MassMomentOfInertia(gramsquaremeters/1e3);
+            double value = (double) gramsquaremeters;
+            return new MassMomentOfInertia(value/1e3);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareMeters(int gramsquaremeters)
+#else
+        public static MassMomentOfInertia FromGramSquareMeters(QuantityValue gramsquaremeters)
         {
-            return new MassMomentOfInertia(gramsquaremeters/1e3);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareMeters(long gramsquaremeters)
-        {
-            return new MassMomentOfInertia(gramsquaremeters/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareMeters(decimal gramsquaremeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(gramsquaremeters)/1e3);
+            double value = (double) gramsquaremeters;
+            return new MassMomentOfInertia((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromGramSquareMillimeters(double gramsquaremillimeters)
         {
-            return new MassMomentOfInertia(gramsquaremillimeters/1e9);
+            double value = (double) gramsquaremillimeters;
+            return new MassMomentOfInertia(value/1e9);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareMillimeters(int gramsquaremillimeters)
+#else
+        public static MassMomentOfInertia FromGramSquareMillimeters(QuantityValue gramsquaremillimeters)
         {
-            return new MassMomentOfInertia(gramsquaremillimeters/1e9);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareMillimeters(long gramsquaremillimeters)
-        {
-            return new MassMomentOfInertia(gramsquaremillimeters/1e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from GramSquareMillimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromGramSquareMillimeters(decimal gramsquaremillimeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(gramsquaremillimeters)/1e9);
+            double value = (double) gramsquaremillimeters;
+            return new MassMomentOfInertia((value/1e9));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilogramSquareCentimeters(double kilogramsquarecentimeters)
         {
-            return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
+            double value = (double) kilogramsquarecentimeters;
+            return new MassMomentOfInertia((value/1e7) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareCentimeters(int kilogramsquarecentimeters)
+#else
+        public static MassMomentOfInertia FromKilogramSquareCentimeters(QuantityValue kilogramsquarecentimeters)
         {
-            return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareCentimeters(long kilogramsquarecentimeters)
-        {
-            return new MassMomentOfInertia((kilogramsquarecentimeters/1e7) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareCentimeters(decimal kilogramsquarecentimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquarecentimeters)/1e7) * 1e3d);
+            double value = (double) kilogramsquarecentimeters;
+            return new MassMomentOfInertia(((value/1e7) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilogramSquareDecimeters(double kilogramsquaredecimeters)
         {
-            return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
+            double value = (double) kilogramsquaredecimeters;
+            return new MassMomentOfInertia((value/1e5) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareDecimeters(int kilogramsquaredecimeters)
+#else
+        public static MassMomentOfInertia FromKilogramSquareDecimeters(QuantityValue kilogramsquaredecimeters)
         {
-            return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareDecimeters(long kilogramsquaredecimeters)
-        {
-            return new MassMomentOfInertia((kilogramsquaredecimeters/1e5) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareDecimeters(decimal kilogramsquaredecimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaredecimeters)/1e5) * 1e3d);
+            double value = (double) kilogramsquaredecimeters;
+            return new MassMomentOfInertia(((value/1e5) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilogramSquareMeters(double kilogramsquaremeters)
         {
-            return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
+            double value = (double) kilogramsquaremeters;
+            return new MassMomentOfInertia((value/1e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareMeters(int kilogramsquaremeters)
+#else
+        public static MassMomentOfInertia FromKilogramSquareMeters(QuantityValue kilogramsquaremeters)
         {
-            return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareMeters(long kilogramsquaremeters)
-        {
-            return new MassMomentOfInertia((kilogramsquaremeters/1e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareMeters(decimal kilogramsquaremeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremeters)/1e3) * 1e3d);
+            double value = (double) kilogramsquaremeters;
+            return new MassMomentOfInertia(((value/1e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilogramSquareMillimeters(double kilogramsquaremillimeters)
         {
-            return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
+            double value = (double) kilogramsquaremillimeters;
+            return new MassMomentOfInertia((value/1e9) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareMillimeters(int kilogramsquaremillimeters)
+#else
+        public static MassMomentOfInertia FromKilogramSquareMillimeters(QuantityValue kilogramsquaremillimeters)
         {
-            return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareMillimeters(long kilogramsquaremillimeters)
-        {
-            return new MassMomentOfInertia((kilogramsquaremillimeters/1e9) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilogramSquareMillimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilogramSquareMillimeters(decimal kilogramsquaremillimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilogramsquaremillimeters)/1e9) * 1e3d);
+            double value = (double) kilogramsquaremillimeters;
+            return new MassMomentOfInertia(((value/1e9) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(double kilotonnesquarecentimeters)
         {
-            return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
+            double value = (double) kilotonnesquarecentimeters;
+            return new MassMomentOfInertia((value/1e1) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareCentimeters(int kilotonnesquarecentimeters)
+#else
+        public static MassMomentOfInertia FromKilotonneSquareCentimeters(QuantityValue kilotonnesquarecentimeters)
         {
-            return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareCentimeters(long kilotonnesquarecentimeters)
-        {
-            return new MassMomentOfInertia((kilotonnesquarecentimeters/1e1) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareCentimeters(decimal kilotonnesquarecentimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquarecentimeters)/1e1) * 1e3d);
+            double value = (double) kilotonnesquarecentimeters;
+            return new MassMomentOfInertia(((value/1e1) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(double kilotonnesquaredecimeters)
         {
-            return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
+            double value = (double) kilotonnesquaredecimeters;
+            return new MassMomentOfInertia((value/1e-1) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareDecimeters(int kilotonnesquaredecimeters)
+#else
+        public static MassMomentOfInertia FromKilotonneSquareDecimeters(QuantityValue kilotonnesquaredecimeters)
         {
-            return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareDecimeters(long kilotonnesquaredecimeters)
-        {
-            return new MassMomentOfInertia((kilotonnesquaredecimeters/1e-1) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareDecimeters(decimal kilotonnesquaredecimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaredecimeters)/1e-1) * 1e3d);
+            double value = (double) kilotonnesquaredecimeters;
+            return new MassMomentOfInertia(((value/1e-1) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilotonneSquareMeters(double kilotonnesquaremeters)
         {
-            return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
+            double value = (double) kilotonnesquaremeters;
+            return new MassMomentOfInertia((value/1e-3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareMeters(int kilotonnesquaremeters)
+#else
+        public static MassMomentOfInertia FromKilotonneSquareMeters(QuantityValue kilotonnesquaremeters)
         {
-            return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareMeters(long kilotonnesquaremeters)
-        {
-            return new MassMomentOfInertia((kilotonnesquaremeters/1e-3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareMeters(decimal kilotonnesquaremeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremeters)/1e-3) * 1e3d);
+            double value = (double) kilotonnesquaremeters;
+            return new MassMomentOfInertia(((value/1e-3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(double kilotonnesquaremilimeters)
         {
-            return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
+            double value = (double) kilotonnesquaremilimeters;
+            return new MassMomentOfInertia((value/1e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareMilimeters(int kilotonnesquaremilimeters)
+#else
+        public static MassMomentOfInertia FromKilotonneSquareMilimeters(QuantityValue kilotonnesquaremilimeters)
         {
-            return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareMilimeters(long kilotonnesquaremilimeters)
-        {
-            return new MassMomentOfInertia((kilotonnesquaremilimeters/1e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from KilotonneSquareMilimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromKilotonneSquareMilimeters(decimal kilotonnesquaremilimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(kilotonnesquaremilimeters)/1e3) * 1e3d);
+            double value = (double) kilotonnesquaremilimeters;
+            return new MassMomentOfInertia(((value/1e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(double megatonnesquarecentimeters)
         {
-            return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
+            double value = (double) megatonnesquarecentimeters;
+            return new MassMomentOfInertia((value/1e1) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareCentimeters(int megatonnesquarecentimeters)
+#else
+        public static MassMomentOfInertia FromMegatonneSquareCentimeters(QuantityValue megatonnesquarecentimeters)
         {
-            return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareCentimeters(long megatonnesquarecentimeters)
-        {
-            return new MassMomentOfInertia((megatonnesquarecentimeters/1e1) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareCentimeters(decimal megatonnesquarecentimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquarecentimeters)/1e1) * 1e6d);
+            double value = (double) megatonnesquarecentimeters;
+            return new MassMomentOfInertia(((value/1e1) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(double megatonnesquaredecimeters)
         {
-            return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
+            double value = (double) megatonnesquaredecimeters;
+            return new MassMomentOfInertia((value/1e-1) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareDecimeters(int megatonnesquaredecimeters)
+#else
+        public static MassMomentOfInertia FromMegatonneSquareDecimeters(QuantityValue megatonnesquaredecimeters)
         {
-            return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareDecimeters(long megatonnesquaredecimeters)
-        {
-            return new MassMomentOfInertia((megatonnesquaredecimeters/1e-1) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareDecimeters(decimal megatonnesquaredecimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaredecimeters)/1e-1) * 1e6d);
+            double value = (double) megatonnesquaredecimeters;
+            return new MassMomentOfInertia(((value/1e-1) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMegatonneSquareMeters(double megatonnesquaremeters)
         {
-            return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
+            double value = (double) megatonnesquaremeters;
+            return new MassMomentOfInertia((value/1e-3) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareMeters(int megatonnesquaremeters)
+#else
+        public static MassMomentOfInertia FromMegatonneSquareMeters(QuantityValue megatonnesquaremeters)
         {
-            return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareMeters(long megatonnesquaremeters)
-        {
-            return new MassMomentOfInertia((megatonnesquaremeters/1e-3) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareMeters(decimal megatonnesquaremeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremeters)/1e-3) * 1e6d);
+            double value = (double) megatonnesquaremeters;
+            return new MassMomentOfInertia(((value/1e-3) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(double megatonnesquaremilimeters)
         {
-            return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
+            double value = (double) megatonnesquaremilimeters;
+            return new MassMomentOfInertia((value/1e3) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareMilimeters(int megatonnesquaremilimeters)
+#else
+        public static MassMomentOfInertia FromMegatonneSquareMilimeters(QuantityValue megatonnesquaremilimeters)
         {
-            return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareMilimeters(long megatonnesquaremilimeters)
-        {
-            return new MassMomentOfInertia((megatonnesquaremilimeters/1e3) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MegatonneSquareMilimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMegatonneSquareMilimeters(decimal megatonnesquaremilimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(megatonnesquaremilimeters)/1e3) * 1e6d);
+            double value = (double) megatonnesquaremilimeters;
+            return new MassMomentOfInertia(((value/1e3) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMilligramSquareCentimeters(double milligramsquarecentimeters)
         {
-            return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
+            double value = (double) milligramsquarecentimeters;
+            return new MassMomentOfInertia((value/1e7) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareCentimeters(int milligramsquarecentimeters)
+#else
+        public static MassMomentOfInertia FromMilligramSquareCentimeters(QuantityValue milligramsquarecentimeters)
         {
-            return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareCentimeters(long milligramsquarecentimeters)
-        {
-            return new MassMomentOfInertia((milligramsquarecentimeters/1e7) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareCentimeters(decimal milligramsquarecentimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(milligramsquarecentimeters)/1e7) * 1e-3d);
+            double value = (double) milligramsquarecentimeters;
+            return new MassMomentOfInertia(((value/1e7) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMilligramSquareDecimeters(double milligramsquaredecimeters)
         {
-            return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
+            double value = (double) milligramsquaredecimeters;
+            return new MassMomentOfInertia((value/1e5) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareDecimeters(int milligramsquaredecimeters)
+#else
+        public static MassMomentOfInertia FromMilligramSquareDecimeters(QuantityValue milligramsquaredecimeters)
         {
-            return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareDecimeters(long milligramsquaredecimeters)
-        {
-            return new MassMomentOfInertia((milligramsquaredecimeters/1e5) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareDecimeters(decimal milligramsquaredecimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(milligramsquaredecimeters)/1e5) * 1e-3d);
+            double value = (double) milligramsquaredecimeters;
+            return new MassMomentOfInertia(((value/1e5) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMilligramSquareMeters(double milligramsquaremeters)
         {
-            return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
+            double value = (double) milligramsquaremeters;
+            return new MassMomentOfInertia((value/1e3) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareMeters(int milligramsquaremeters)
+#else
+        public static MassMomentOfInertia FromMilligramSquareMeters(QuantityValue milligramsquaremeters)
         {
-            return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareMeters(long milligramsquaremeters)
-        {
-            return new MassMomentOfInertia((milligramsquaremeters/1e3) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareMeters(decimal milligramsquaremeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremeters)/1e3) * 1e-3d);
+            double value = (double) milligramsquaremeters;
+            return new MassMomentOfInertia(((value/1e3) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromMilligramSquareMillimeters(double milligramsquaremillimeters)
         {
-            return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
+            double value = (double) milligramsquaremillimeters;
+            return new MassMomentOfInertia((value/1e9) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareMillimeters(int milligramsquaremillimeters)
+#else
+        public static MassMomentOfInertia FromMilligramSquareMillimeters(QuantityValue milligramsquaremillimeters)
         {
-            return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareMillimeters(long milligramsquaremillimeters)
-        {
-            return new MassMomentOfInertia((milligramsquaremillimeters/1e9) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from MilligramSquareMillimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromMilligramSquareMillimeters(decimal milligramsquaremillimeters)
-        {
-            return new MassMomentOfInertia((Convert.ToDouble(milligramsquaremillimeters)/1e9) * 1e-3d);
+            double value = (double) milligramsquaremillimeters;
+            return new MassMomentOfInertia(((value/1e9) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromPoundSquareFeet(double poundsquarefeet)
         {
-            return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
+            double value = (double) poundsquarefeet;
+            return new MassMomentOfInertia(value*4.21401101e-2);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from PoundSquareFeet.
-        /// </summary>
-        public static MassMomentOfInertia FromPoundSquareFeet(int poundsquarefeet)
+#else
+        public static MassMomentOfInertia FromPoundSquareFeet(QuantityValue poundsquarefeet)
         {
-            return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from PoundSquareFeet.
-        /// </summary>
-        public static MassMomentOfInertia FromPoundSquareFeet(long poundsquarefeet)
-        {
-            return new MassMomentOfInertia(poundsquarefeet*4.21401101e-2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from PoundSquareFeet of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromPoundSquareFeet(decimal poundsquarefeet)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(poundsquarefeet)*4.21401101e-2);
+            double value = (double) poundsquarefeet;
+            return new MassMomentOfInertia((value*4.21401101e-2));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromPoundSquareInches(double poundsquareinches)
         {
-            return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
+            double value = (double) poundsquareinches;
+            return new MassMomentOfInertia(value*2.9263965e-4);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from PoundSquareInches.
-        /// </summary>
-        public static MassMomentOfInertia FromPoundSquareInches(int poundsquareinches)
+#else
+        public static MassMomentOfInertia FromPoundSquareInches(QuantityValue poundsquareinches)
         {
-            return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from PoundSquareInches.
-        /// </summary>
-        public static MassMomentOfInertia FromPoundSquareInches(long poundsquareinches)
-        {
-            return new MassMomentOfInertia(poundsquareinches*2.9263965e-4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from PoundSquareInches of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromPoundSquareInches(decimal poundsquareinches)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(poundsquareinches)*2.9263965e-4);
+            double value = (double) poundsquareinches;
+            return new MassMomentOfInertia((value*2.9263965e-4));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromTonneSquareCentimeters(double tonnesquarecentimeters)
         {
-            return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
+            double value = (double) tonnesquarecentimeters;
+            return new MassMomentOfInertia(value/1e1);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareCentimeters(int tonnesquarecentimeters)
+#else
+        public static MassMomentOfInertia FromTonneSquareCentimeters(QuantityValue tonnesquarecentimeters)
         {
-            return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareCentimeters(long tonnesquarecentimeters)
-        {
-            return new MassMomentOfInertia(tonnesquarecentimeters/1e1);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareCentimeters(decimal tonnesquarecentimeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(tonnesquarecentimeters)/1e1);
+            double value = (double) tonnesquarecentimeters;
+            return new MassMomentOfInertia((value/1e1));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromTonneSquareDecimeters(double tonnesquaredecimeters)
         {
-            return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
+            double value = (double) tonnesquaredecimeters;
+            return new MassMomentOfInertia(value/1e-1);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareDecimeters(int tonnesquaredecimeters)
+#else
+        public static MassMomentOfInertia FromTonneSquareDecimeters(QuantityValue tonnesquaredecimeters)
         {
-            return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareDecimeters(long tonnesquaredecimeters)
-        {
-            return new MassMomentOfInertia(tonnesquaredecimeters/1e-1);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareDecimeters(decimal tonnesquaredecimeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(tonnesquaredecimeters)/1e-1);
+            double value = (double) tonnesquaredecimeters;
+            return new MassMomentOfInertia((value/1e-1));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromTonneSquareMeters(double tonnesquaremeters)
         {
-            return new MassMomentOfInertia(tonnesquaremeters/1e-3);
+            double value = (double) tonnesquaremeters;
+            return new MassMomentOfInertia(value/1e-3);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareMeters(int tonnesquaremeters)
+#else
+        public static MassMomentOfInertia FromTonneSquareMeters(QuantityValue tonnesquaremeters)
         {
-            return new MassMomentOfInertia(tonnesquaremeters/1e-3);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareMeters(long tonnesquaremeters)
-        {
-            return new MassMomentOfInertia(tonnesquaremeters/1e-3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareMeters(decimal tonnesquaremeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremeters)/1e-3);
+            double value = (double) tonnesquaremeters;
+            return new MassMomentOfInertia((value/1e-3));
         }
 #endif
 
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MassMomentOfInertia FromTonneSquareMilimeters(double tonnesquaremilimeters)
         {
-            return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
+            double value = (double) tonnesquaremilimeters;
+            return new MassMomentOfInertia(value/1e3);
         }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareMilimeters(int tonnesquaremilimeters)
+#else
+        public static MassMomentOfInertia FromTonneSquareMilimeters(QuantityValue tonnesquaremilimeters)
         {
-            return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
-        }
-
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareMilimeters(long tonnesquaremilimeters)
-        {
-            return new MassMomentOfInertia(tonnesquaremilimeters/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MassMomentOfInertia from TonneSquareMilimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia FromTonneSquareMilimeters(decimal tonnesquaremilimeters)
-        {
-            return new MassMomentOfInertia(Convert.ToDouble(tonnesquaremilimeters)/1e3);
+            double value = (double) tonnesquaremilimeters;
+            return new MassMomentOfInertia((value/1e3));
         }
 #endif
 
@@ -1339,52 +819,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromGramSquareCentimeters(double? gramsquarecentimeters)
-        {
-            if (gramsquarecentimeters.HasValue)
-            {
-                return FromGramSquareCentimeters(gramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareCentimeters(int? gramsquarecentimeters)
-        {
-            if (gramsquarecentimeters.HasValue)
-            {
-                return FromGramSquareCentimeters(gramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareCentimeters(long? gramsquarecentimeters)
-        {
-            if (gramsquarecentimeters.HasValue)
-            {
-                return FromGramSquareCentimeters(gramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from GramSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareCentimeters(decimal? gramsquarecentimeters)
+        public static MassMomentOfInertia? FromGramSquareCentimeters(QuantityValue? gramsquarecentimeters)
         {
             if (gramsquarecentimeters.HasValue)
             {
@@ -1399,52 +834,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromGramSquareDecimeters(double? gramsquaredecimeters)
-        {
-            if (gramsquaredecimeters.HasValue)
-            {
-                return FromGramSquareDecimeters(gramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareDecimeters(int? gramsquaredecimeters)
-        {
-            if (gramsquaredecimeters.HasValue)
-            {
-                return FromGramSquareDecimeters(gramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareDecimeters(long? gramsquaredecimeters)
-        {
-            if (gramsquaredecimeters.HasValue)
-            {
-                return FromGramSquareDecimeters(gramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from GramSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareDecimeters(decimal? gramsquaredecimeters)
+        public static MassMomentOfInertia? FromGramSquareDecimeters(QuantityValue? gramsquaredecimeters)
         {
             if (gramsquaredecimeters.HasValue)
             {
@@ -1459,52 +849,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
         /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMeters(double? gramsquaremeters)
-        {
-            if (gramsquaremeters.HasValue)
-            {
-                return FromGramSquareMeters(gramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMeters(int? gramsquaremeters)
-        {
-            if (gramsquaremeters.HasValue)
-            {
-                return FromGramSquareMeters(gramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMeters(long? gramsquaremeters)
-        {
-            if (gramsquaremeters.HasValue)
-            {
-                return FromGramSquareMeters(gramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from GramSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMeters(decimal? gramsquaremeters)
+        public static MassMomentOfInertia? FromGramSquareMeters(QuantityValue? gramsquaremeters)
         {
             if (gramsquaremeters.HasValue)
             {
@@ -1519,52 +864,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMillimeters(double? gramsquaremillimeters)
-        {
-            if (gramsquaremillimeters.HasValue)
-            {
-                return FromGramSquareMillimeters(gramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMillimeters(int? gramsquaremillimeters)
-        {
-            if (gramsquaremillimeters.HasValue)
-            {
-                return FromGramSquareMillimeters(gramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable GramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMillimeters(long? gramsquaremillimeters)
-        {
-            if (gramsquaremillimeters.HasValue)
-            {
-                return FromGramSquareMillimeters(gramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from GramSquareMillimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromGramSquareMillimeters(decimal? gramsquaremillimeters)
+        public static MassMomentOfInertia? FromGramSquareMillimeters(QuantityValue? gramsquaremillimeters)
         {
             if (gramsquaremillimeters.HasValue)
             {
@@ -1579,52 +879,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareCentimeters(double? kilogramsquarecentimeters)
-        {
-            if (kilogramsquarecentimeters.HasValue)
-            {
-                return FromKilogramSquareCentimeters(kilogramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareCentimeters(int? kilogramsquarecentimeters)
-        {
-            if (kilogramsquarecentimeters.HasValue)
-            {
-                return FromKilogramSquareCentimeters(kilogramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareCentimeters(long? kilogramsquarecentimeters)
-        {
-            if (kilogramsquarecentimeters.HasValue)
-            {
-                return FromKilogramSquareCentimeters(kilogramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilogramSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareCentimeters(decimal? kilogramsquarecentimeters)
+        public static MassMomentOfInertia? FromKilogramSquareCentimeters(QuantityValue? kilogramsquarecentimeters)
         {
             if (kilogramsquarecentimeters.HasValue)
             {
@@ -1639,52 +894,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareDecimeters(double? kilogramsquaredecimeters)
-        {
-            if (kilogramsquaredecimeters.HasValue)
-            {
-                return FromKilogramSquareDecimeters(kilogramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareDecimeters(int? kilogramsquaredecimeters)
-        {
-            if (kilogramsquaredecimeters.HasValue)
-            {
-                return FromKilogramSquareDecimeters(kilogramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareDecimeters(long? kilogramsquaredecimeters)
-        {
-            if (kilogramsquaredecimeters.HasValue)
-            {
-                return FromKilogramSquareDecimeters(kilogramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilogramSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareDecimeters(decimal? kilogramsquaredecimeters)
+        public static MassMomentOfInertia? FromKilogramSquareDecimeters(QuantityValue? kilogramsquaredecimeters)
         {
             if (kilogramsquaredecimeters.HasValue)
             {
@@ -1699,52 +909,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMeters(double? kilogramsquaremeters)
-        {
-            if (kilogramsquaremeters.HasValue)
-            {
-                return FromKilogramSquareMeters(kilogramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMeters(int? kilogramsquaremeters)
-        {
-            if (kilogramsquaremeters.HasValue)
-            {
-                return FromKilogramSquareMeters(kilogramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMeters(long? kilogramsquaremeters)
-        {
-            if (kilogramsquaremeters.HasValue)
-            {
-                return FromKilogramSquareMeters(kilogramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilogramSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMeters(decimal? kilogramsquaremeters)
+        public static MassMomentOfInertia? FromKilogramSquareMeters(QuantityValue? kilogramsquaremeters)
         {
             if (kilogramsquaremeters.HasValue)
             {
@@ -1759,52 +924,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMillimeters(double? kilogramsquaremillimeters)
-        {
-            if (kilogramsquaremillimeters.HasValue)
-            {
-                return FromKilogramSquareMillimeters(kilogramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMillimeters(int? kilogramsquaremillimeters)
-        {
-            if (kilogramsquaremillimeters.HasValue)
-            {
-                return FromKilogramSquareMillimeters(kilogramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilogramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMillimeters(long? kilogramsquaremillimeters)
-        {
-            if (kilogramsquaremillimeters.HasValue)
-            {
-                return FromKilogramSquareMillimeters(kilogramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilogramSquareMillimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilogramSquareMillimeters(decimal? kilogramsquaremillimeters)
+        public static MassMomentOfInertia? FromKilogramSquareMillimeters(QuantityValue? kilogramsquaremillimeters)
         {
             if (kilogramsquaremillimeters.HasValue)
             {
@@ -1819,52 +939,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(double? kilotonnesquarecentimeters)
-        {
-            if (kilotonnesquarecentimeters.HasValue)
-            {
-                return FromKilotonneSquareCentimeters(kilotonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(int? kilotonnesquarecentimeters)
-        {
-            if (kilotonnesquarecentimeters.HasValue)
-            {
-                return FromKilotonneSquareCentimeters(kilotonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(long? kilotonnesquarecentimeters)
-        {
-            if (kilotonnesquarecentimeters.HasValue)
-            {
-                return FromKilotonneSquareCentimeters(kilotonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilotonneSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(decimal? kilotonnesquarecentimeters)
+        public static MassMomentOfInertia? FromKilotonneSquareCentimeters(QuantityValue? kilotonnesquarecentimeters)
         {
             if (kilotonnesquarecentimeters.HasValue)
             {
@@ -1879,52 +954,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(double? kilotonnesquaredecimeters)
-        {
-            if (kilotonnesquaredecimeters.HasValue)
-            {
-                return FromKilotonneSquareDecimeters(kilotonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(int? kilotonnesquaredecimeters)
-        {
-            if (kilotonnesquaredecimeters.HasValue)
-            {
-                return FromKilotonneSquareDecimeters(kilotonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(long? kilotonnesquaredecimeters)
-        {
-            if (kilotonnesquaredecimeters.HasValue)
-            {
-                return FromKilotonneSquareDecimeters(kilotonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilotonneSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(decimal? kilotonnesquaredecimeters)
+        public static MassMomentOfInertia? FromKilotonneSquareDecimeters(QuantityValue? kilotonnesquaredecimeters)
         {
             if (kilotonnesquaredecimeters.HasValue)
             {
@@ -1939,52 +969,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMeters(double? kilotonnesquaremeters)
-        {
-            if (kilotonnesquaremeters.HasValue)
-            {
-                return FromKilotonneSquareMeters(kilotonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMeters(int? kilotonnesquaremeters)
-        {
-            if (kilotonnesquaremeters.HasValue)
-            {
-                return FromKilotonneSquareMeters(kilotonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMeters(long? kilotonnesquaremeters)
-        {
-            if (kilotonnesquaremeters.HasValue)
-            {
-                return FromKilotonneSquareMeters(kilotonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilotonneSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMeters(decimal? kilotonnesquaremeters)
+        public static MassMomentOfInertia? FromKilotonneSquareMeters(QuantityValue? kilotonnesquaremeters)
         {
             if (kilotonnesquaremeters.HasValue)
             {
@@ -1999,52 +984,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(double? kilotonnesquaremilimeters)
-        {
-            if (kilotonnesquaremilimeters.HasValue)
-            {
-                return FromKilotonneSquareMilimeters(kilotonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(int? kilotonnesquaremilimeters)
-        {
-            if (kilotonnesquaremilimeters.HasValue)
-            {
-                return FromKilotonneSquareMilimeters(kilotonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable KilotonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(long? kilotonnesquaremilimeters)
-        {
-            if (kilotonnesquaremilimeters.HasValue)
-            {
-                return FromKilotonneSquareMilimeters(kilotonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from KilotonneSquareMilimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(decimal? kilotonnesquaremilimeters)
+        public static MassMomentOfInertia? FromKilotonneSquareMilimeters(QuantityValue? kilotonnesquaremilimeters)
         {
             if (kilotonnesquaremilimeters.HasValue)
             {
@@ -2059,52 +999,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(double? megatonnesquarecentimeters)
-        {
-            if (megatonnesquarecentimeters.HasValue)
-            {
-                return FromMegatonneSquareCentimeters(megatonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(int? megatonnesquarecentimeters)
-        {
-            if (megatonnesquarecentimeters.HasValue)
-            {
-                return FromMegatonneSquareCentimeters(megatonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(long? megatonnesquarecentimeters)
-        {
-            if (megatonnesquarecentimeters.HasValue)
-            {
-                return FromMegatonneSquareCentimeters(megatonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MegatonneSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(decimal? megatonnesquarecentimeters)
+        public static MassMomentOfInertia? FromMegatonneSquareCentimeters(QuantityValue? megatonnesquarecentimeters)
         {
             if (megatonnesquarecentimeters.HasValue)
             {
@@ -2119,52 +1014,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(double? megatonnesquaredecimeters)
-        {
-            if (megatonnesquaredecimeters.HasValue)
-            {
-                return FromMegatonneSquareDecimeters(megatonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(int? megatonnesquaredecimeters)
-        {
-            if (megatonnesquaredecimeters.HasValue)
-            {
-                return FromMegatonneSquareDecimeters(megatonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(long? megatonnesquaredecimeters)
-        {
-            if (megatonnesquaredecimeters.HasValue)
-            {
-                return FromMegatonneSquareDecimeters(megatonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MegatonneSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(decimal? megatonnesquaredecimeters)
+        public static MassMomentOfInertia? FromMegatonneSquareDecimeters(QuantityValue? megatonnesquaredecimeters)
         {
             if (megatonnesquaredecimeters.HasValue)
             {
@@ -2179,52 +1029,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMeters(double? megatonnesquaremeters)
-        {
-            if (megatonnesquaremeters.HasValue)
-            {
-                return FromMegatonneSquareMeters(megatonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMeters(int? megatonnesquaremeters)
-        {
-            if (megatonnesquaremeters.HasValue)
-            {
-                return FromMegatonneSquareMeters(megatonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMeters(long? megatonnesquaremeters)
-        {
-            if (megatonnesquaremeters.HasValue)
-            {
-                return FromMegatonneSquareMeters(megatonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MegatonneSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMeters(decimal? megatonnesquaremeters)
+        public static MassMomentOfInertia? FromMegatonneSquareMeters(QuantityValue? megatonnesquaremeters)
         {
             if (megatonnesquaremeters.HasValue)
             {
@@ -2239,52 +1044,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(double? megatonnesquaremilimeters)
-        {
-            if (megatonnesquaremilimeters.HasValue)
-            {
-                return FromMegatonneSquareMilimeters(megatonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(int? megatonnesquaremilimeters)
-        {
-            if (megatonnesquaremilimeters.HasValue)
-            {
-                return FromMegatonneSquareMilimeters(megatonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MegatonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(long? megatonnesquaremilimeters)
-        {
-            if (megatonnesquaremilimeters.HasValue)
-            {
-                return FromMegatonneSquareMilimeters(megatonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MegatonneSquareMilimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(decimal? megatonnesquaremilimeters)
+        public static MassMomentOfInertia? FromMegatonneSquareMilimeters(QuantityValue? megatonnesquaremilimeters)
         {
             if (megatonnesquaremilimeters.HasValue)
             {
@@ -2299,52 +1059,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareCentimeters(double? milligramsquarecentimeters)
-        {
-            if (milligramsquarecentimeters.HasValue)
-            {
-                return FromMilligramSquareCentimeters(milligramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareCentimeters(int? milligramsquarecentimeters)
-        {
-            if (milligramsquarecentimeters.HasValue)
-            {
-                return FromMilligramSquareCentimeters(milligramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareCentimeters(long? milligramsquarecentimeters)
-        {
-            if (milligramsquarecentimeters.HasValue)
-            {
-                return FromMilligramSquareCentimeters(milligramsquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MilligramSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareCentimeters(decimal? milligramsquarecentimeters)
+        public static MassMomentOfInertia? FromMilligramSquareCentimeters(QuantityValue? milligramsquarecentimeters)
         {
             if (milligramsquarecentimeters.HasValue)
             {
@@ -2359,52 +1074,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareDecimeters(double? milligramsquaredecimeters)
-        {
-            if (milligramsquaredecimeters.HasValue)
-            {
-                return FromMilligramSquareDecimeters(milligramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareDecimeters(int? milligramsquaredecimeters)
-        {
-            if (milligramsquaredecimeters.HasValue)
-            {
-                return FromMilligramSquareDecimeters(milligramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareDecimeters(long? milligramsquaredecimeters)
-        {
-            if (milligramsquaredecimeters.HasValue)
-            {
-                return FromMilligramSquareDecimeters(milligramsquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MilligramSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareDecimeters(decimal? milligramsquaredecimeters)
+        public static MassMomentOfInertia? FromMilligramSquareDecimeters(QuantityValue? milligramsquaredecimeters)
         {
             if (milligramsquaredecimeters.HasValue)
             {
@@ -2419,52 +1089,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMeters(double? milligramsquaremeters)
-        {
-            if (milligramsquaremeters.HasValue)
-            {
-                return FromMilligramSquareMeters(milligramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMeters(int? milligramsquaremeters)
-        {
-            if (milligramsquaremeters.HasValue)
-            {
-                return FromMilligramSquareMeters(milligramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMeters(long? milligramsquaremeters)
-        {
-            if (milligramsquaremeters.HasValue)
-            {
-                return FromMilligramSquareMeters(milligramsquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MilligramSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMeters(decimal? milligramsquaremeters)
+        public static MassMomentOfInertia? FromMilligramSquareMeters(QuantityValue? milligramsquaremeters)
         {
             if (milligramsquaremeters.HasValue)
             {
@@ -2479,52 +1104,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMillimeters(double? milligramsquaremillimeters)
-        {
-            if (milligramsquaremillimeters.HasValue)
-            {
-                return FromMilligramSquareMillimeters(milligramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMillimeters(int? milligramsquaremillimeters)
-        {
-            if (milligramsquaremillimeters.HasValue)
-            {
-                return FromMilligramSquareMillimeters(milligramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable MilligramSquareMillimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMillimeters(long? milligramsquaremillimeters)
-        {
-            if (milligramsquaremillimeters.HasValue)
-            {
-                return FromMilligramSquareMillimeters(milligramsquaremillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from MilligramSquareMillimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromMilligramSquareMillimeters(decimal? milligramsquaremillimeters)
+        public static MassMomentOfInertia? FromMilligramSquareMillimeters(QuantityValue? milligramsquaremillimeters)
         {
             if (milligramsquaremillimeters.HasValue)
             {
@@ -2539,52 +1119,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
         /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareFeet(double? poundsquarefeet)
-        {
-            if (poundsquarefeet.HasValue)
-            {
-                return FromPoundSquareFeet(poundsquarefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
-        /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareFeet(int? poundsquarefeet)
-        {
-            if (poundsquarefeet.HasValue)
-            {
-                return FromPoundSquareFeet(poundsquarefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable PoundSquareFeet.
-        /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareFeet(long? poundsquarefeet)
-        {
-            if (poundsquarefeet.HasValue)
-            {
-                return FromPoundSquareFeet(poundsquarefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from PoundSquareFeet of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareFeet(decimal? poundsquarefeet)
+        public static MassMomentOfInertia? FromPoundSquareFeet(QuantityValue? poundsquarefeet)
         {
             if (poundsquarefeet.HasValue)
             {
@@ -2599,52 +1134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
         /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareInches(double? poundsquareinches)
-        {
-            if (poundsquareinches.HasValue)
-            {
-                return FromPoundSquareInches(poundsquareinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
-        /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareInches(int? poundsquareinches)
-        {
-            if (poundsquareinches.HasValue)
-            {
-                return FromPoundSquareInches(poundsquareinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable PoundSquareInches.
-        /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareInches(long? poundsquareinches)
-        {
-            if (poundsquareinches.HasValue)
-            {
-                return FromPoundSquareInches(poundsquareinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from PoundSquareInches of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromPoundSquareInches(decimal? poundsquareinches)
+        public static MassMomentOfInertia? FromPoundSquareInches(QuantityValue? poundsquareinches)
         {
             if (poundsquareinches.HasValue)
             {
@@ -2659,52 +1149,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareCentimeters(double? tonnesquarecentimeters)
-        {
-            if (tonnesquarecentimeters.HasValue)
-            {
-                return FromTonneSquareCentimeters(tonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareCentimeters(int? tonnesquarecentimeters)
-        {
-            if (tonnesquarecentimeters.HasValue)
-            {
-                return FromTonneSquareCentimeters(tonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareCentimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareCentimeters(long? tonnesquarecentimeters)
-        {
-            if (tonnesquarecentimeters.HasValue)
-            {
-                return FromTonneSquareCentimeters(tonnesquarecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from TonneSquareCentimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareCentimeters(decimal? tonnesquarecentimeters)
+        public static MassMomentOfInertia? FromTonneSquareCentimeters(QuantityValue? tonnesquarecentimeters)
         {
             if (tonnesquarecentimeters.HasValue)
             {
@@ -2719,52 +1164,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareDecimeters(double? tonnesquaredecimeters)
-        {
-            if (tonnesquaredecimeters.HasValue)
-            {
-                return FromTonneSquareDecimeters(tonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareDecimeters(int? tonnesquaredecimeters)
-        {
-            if (tonnesquaredecimeters.HasValue)
-            {
-                return FromTonneSquareDecimeters(tonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareDecimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareDecimeters(long? tonnesquaredecimeters)
-        {
-            if (tonnesquaredecimeters.HasValue)
-            {
-                return FromTonneSquareDecimeters(tonnesquaredecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from TonneSquareDecimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareDecimeters(decimal? tonnesquaredecimeters)
+        public static MassMomentOfInertia? FromTonneSquareDecimeters(QuantityValue? tonnesquaredecimeters)
         {
             if (tonnesquaredecimeters.HasValue)
             {
@@ -2779,52 +1179,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
         /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMeters(double? tonnesquaremeters)
-        {
-            if (tonnesquaremeters.HasValue)
-            {
-                return FromTonneSquareMeters(tonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMeters(int? tonnesquaremeters)
-        {
-            if (tonnesquaremeters.HasValue)
-            {
-                return FromTonneSquareMeters(tonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMeters(long? tonnesquaremeters)
-        {
-            if (tonnesquaremeters.HasValue)
-            {
-                return FromTonneSquareMeters(tonnesquaremeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from TonneSquareMeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMeters(decimal? tonnesquaremeters)
+        public static MassMomentOfInertia? FromTonneSquareMeters(QuantityValue? tonnesquaremeters)
         {
             if (tonnesquaremeters.HasValue)
             {
@@ -2839,52 +1194,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
         /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMilimeters(double? tonnesquaremilimeters)
-        {
-            if (tonnesquaremilimeters.HasValue)
-            {
-                return FromTonneSquareMilimeters(tonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMilimeters(int? tonnesquaremilimeters)
-        {
-            if (tonnesquaremilimeters.HasValue)
-            {
-                return FromTonneSquareMilimeters(tonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from nullable TonneSquareMilimeters.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMilimeters(long? tonnesquaremilimeters)
-        {
-            if (tonnesquaremilimeters.HasValue)
-            {
-                return FromTonneSquareMilimeters(tonnesquaremilimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MassMomentOfInertia from TonneSquareMilimeters of type decimal.
-        /// </summary>
-        public static MassMomentOfInertia? FromTonneSquareMilimeters(decimal? tonnesquaremilimeters)
+        public static MassMomentOfInertia? FromTonneSquareMilimeters(QuantityValue? tonnesquaremilimeters)
         {
             if (tonnesquaremilimeters.HasValue)
             {
@@ -2901,65 +1211,71 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MassMomentOfInertiaUnit" /> to <see cref="MassMomentOfInertia" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MassMomentOfInertia unit value.</returns>
-        public static MassMomentOfInertia From(double val, MassMomentOfInertiaUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static MassMomentOfInertia From(double value, MassMomentOfInertiaUnit fromUnit)
+#else
+        public static MassMomentOfInertia From(QuantityValue value, MassMomentOfInertiaUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MassMomentOfInertiaUnit.GramSquareCentimeter:
-                    return FromGramSquareCentimeters(val);
+                    return FromGramSquareCentimeters(value);
                 case MassMomentOfInertiaUnit.GramSquareDecimeter:
-                    return FromGramSquareDecimeters(val);
+                    return FromGramSquareDecimeters(value);
                 case MassMomentOfInertiaUnit.GramSquareMeter:
-                    return FromGramSquareMeters(val);
+                    return FromGramSquareMeters(value);
                 case MassMomentOfInertiaUnit.GramSquareMillimeter:
-                    return FromGramSquareMillimeters(val);
+                    return FromGramSquareMillimeters(value);
                 case MassMomentOfInertiaUnit.KilogramSquareCentimeter:
-                    return FromKilogramSquareCentimeters(val);
+                    return FromKilogramSquareCentimeters(value);
                 case MassMomentOfInertiaUnit.KilogramSquareDecimeter:
-                    return FromKilogramSquareDecimeters(val);
+                    return FromKilogramSquareDecimeters(value);
                 case MassMomentOfInertiaUnit.KilogramSquareMeter:
-                    return FromKilogramSquareMeters(val);
+                    return FromKilogramSquareMeters(value);
                 case MassMomentOfInertiaUnit.KilogramSquareMillimeter:
-                    return FromKilogramSquareMillimeters(val);
+                    return FromKilogramSquareMillimeters(value);
                 case MassMomentOfInertiaUnit.KilotonneSquareCentimeter:
-                    return FromKilotonneSquareCentimeters(val);
+                    return FromKilotonneSquareCentimeters(value);
                 case MassMomentOfInertiaUnit.KilotonneSquareDecimeter:
-                    return FromKilotonneSquareDecimeters(val);
+                    return FromKilotonneSquareDecimeters(value);
                 case MassMomentOfInertiaUnit.KilotonneSquareMeter:
-                    return FromKilotonneSquareMeters(val);
+                    return FromKilotonneSquareMeters(value);
                 case MassMomentOfInertiaUnit.KilotonneSquareMilimeter:
-                    return FromKilotonneSquareMilimeters(val);
+                    return FromKilotonneSquareMilimeters(value);
                 case MassMomentOfInertiaUnit.MegatonneSquareCentimeter:
-                    return FromMegatonneSquareCentimeters(val);
+                    return FromMegatonneSquareCentimeters(value);
                 case MassMomentOfInertiaUnit.MegatonneSquareDecimeter:
-                    return FromMegatonneSquareDecimeters(val);
+                    return FromMegatonneSquareDecimeters(value);
                 case MassMomentOfInertiaUnit.MegatonneSquareMeter:
-                    return FromMegatonneSquareMeters(val);
+                    return FromMegatonneSquareMeters(value);
                 case MassMomentOfInertiaUnit.MegatonneSquareMilimeter:
-                    return FromMegatonneSquareMilimeters(val);
+                    return FromMegatonneSquareMilimeters(value);
                 case MassMomentOfInertiaUnit.MilligramSquareCentimeter:
-                    return FromMilligramSquareCentimeters(val);
+                    return FromMilligramSquareCentimeters(value);
                 case MassMomentOfInertiaUnit.MilligramSquareDecimeter:
-                    return FromMilligramSquareDecimeters(val);
+                    return FromMilligramSquareDecimeters(value);
                 case MassMomentOfInertiaUnit.MilligramSquareMeter:
-                    return FromMilligramSquareMeters(val);
+                    return FromMilligramSquareMeters(value);
                 case MassMomentOfInertiaUnit.MilligramSquareMillimeter:
-                    return FromMilligramSquareMillimeters(val);
+                    return FromMilligramSquareMillimeters(value);
                 case MassMomentOfInertiaUnit.PoundSquareFoot:
-                    return FromPoundSquareFeet(val);
+                    return FromPoundSquareFeet(value);
                 case MassMomentOfInertiaUnit.PoundSquareInch:
-                    return FromPoundSquareInches(val);
+                    return FromPoundSquareInches(value);
                 case MassMomentOfInertiaUnit.TonneSquareCentimeter:
-                    return FromTonneSquareCentimeters(val);
+                    return FromTonneSquareCentimeters(value);
                 case MassMomentOfInertiaUnit.TonneSquareDecimeter:
-                    return FromTonneSquareDecimeters(val);
+                    return FromTonneSquareDecimeters(value);
                 case MassMomentOfInertiaUnit.TonneSquareMeter:
-                    return FromTonneSquareMeters(val);
+                    return FromTonneSquareMeters(value);
                 case MassMomentOfInertiaUnit.TonneSquareMilimeter:
-                    return FromTonneSquareMilimeters(val);
+                    return FromTonneSquareMilimeters(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2974,7 +1290,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MassMomentOfInertia unit value.</returns>
-        public static MassMomentOfInertia? From(double? value, MassMomentOfInertiaUnit fromUnit)
+        public static MassMomentOfInertia? From(QuantityValue? value, MassMomentOfInertiaUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -165,114 +165,54 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from JoulesPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarEnergy FromJoulesPerMole(double joulespermole)
         {
-            return new MolarEnergy(joulespermole);
+            double value = (double) joulespermole;
+            return new MolarEnergy(value);
         }
-
-        /// <summary>
-        ///     Get MolarEnergy from JoulesPerMole.
-        /// </summary>
-        public static MolarEnergy FromJoulesPerMole(int joulespermole)
+#else
+        public static MolarEnergy FromJoulesPerMole(QuantityValue joulespermole)
         {
-            return new MolarEnergy(joulespermole);
-        }
-
-        /// <summary>
-        ///     Get MolarEnergy from JoulesPerMole.
-        /// </summary>
-        public static MolarEnergy FromJoulesPerMole(long joulespermole)
-        {
-            return new MolarEnergy(joulespermole);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarEnergy from JoulesPerMole of type decimal.
-        /// </summary>
-        public static MolarEnergy FromJoulesPerMole(decimal joulespermole)
-        {
-            return new MolarEnergy(Convert.ToDouble(joulespermole));
+            double value = (double) joulespermole;
+            return new MolarEnergy((value));
         }
 #endif
 
         /// <summary>
         ///     Get MolarEnergy from KilojoulesPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarEnergy FromKilojoulesPerMole(double kilojoulespermole)
         {
-            return new MolarEnergy((kilojoulespermole) * 1e3d);
+            double value = (double) kilojoulespermole;
+            return new MolarEnergy((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MolarEnergy from KilojoulesPerMole.
-        /// </summary>
-        public static MolarEnergy FromKilojoulesPerMole(int kilojoulespermole)
+#else
+        public static MolarEnergy FromKilojoulesPerMole(QuantityValue kilojoulespermole)
         {
-            return new MolarEnergy((kilojoulespermole) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MolarEnergy from KilojoulesPerMole.
-        /// </summary>
-        public static MolarEnergy FromKilojoulesPerMole(long kilojoulespermole)
-        {
-            return new MolarEnergy((kilojoulespermole) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarEnergy from KilojoulesPerMole of type decimal.
-        /// </summary>
-        public static MolarEnergy FromKilojoulesPerMole(decimal kilojoulespermole)
-        {
-            return new MolarEnergy((Convert.ToDouble(kilojoulespermole)) * 1e3d);
+            double value = (double) kilojoulespermole;
+            return new MolarEnergy(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarEnergy from MegajoulesPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarEnergy FromMegajoulesPerMole(double megajoulespermole)
         {
-            return new MolarEnergy((megajoulespermole) * 1e6d);
+            double value = (double) megajoulespermole;
+            return new MolarEnergy((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MolarEnergy from MegajoulesPerMole.
-        /// </summary>
-        public static MolarEnergy FromMegajoulesPerMole(int megajoulespermole)
+#else
+        public static MolarEnergy FromMegajoulesPerMole(QuantityValue megajoulespermole)
         {
-            return new MolarEnergy((megajoulespermole) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MolarEnergy from MegajoulesPerMole.
-        /// </summary>
-        public static MolarEnergy FromMegajoulesPerMole(long megajoulespermole)
-        {
-            return new MolarEnergy((megajoulespermole) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarEnergy from MegajoulesPerMole of type decimal.
-        /// </summary>
-        public static MolarEnergy FromMegajoulesPerMole(decimal megajoulespermole)
-        {
-            return new MolarEnergy((Convert.ToDouble(megajoulespermole)) * 1e6d);
+            double value = (double) megajoulespermole;
+            return new MolarEnergy(((value) * 1e6d));
         }
 #endif
 
@@ -281,52 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarEnergy from nullable JoulesPerMole.
         /// </summary>
-        public static MolarEnergy? FromJoulesPerMole(double? joulespermole)
-        {
-            if (joulespermole.HasValue)
-            {
-                return FromJoulesPerMole(joulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from nullable JoulesPerMole.
-        /// </summary>
-        public static MolarEnergy? FromJoulesPerMole(int? joulespermole)
-        {
-            if (joulespermole.HasValue)
-            {
-                return FromJoulesPerMole(joulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from nullable JoulesPerMole.
-        /// </summary>
-        public static MolarEnergy? FromJoulesPerMole(long? joulespermole)
-        {
-            if (joulespermole.HasValue)
-            {
-                return FromJoulesPerMole(joulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from JoulesPerMole of type decimal.
-        /// </summary>
-        public static MolarEnergy? FromJoulesPerMole(decimal? joulespermole)
+        public static MolarEnergy? FromJoulesPerMole(QuantityValue? joulespermole)
         {
             if (joulespermole.HasValue)
             {
@@ -341,52 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarEnergy from nullable KilojoulesPerMole.
         /// </summary>
-        public static MolarEnergy? FromKilojoulesPerMole(double? kilojoulespermole)
-        {
-            if (kilojoulespermole.HasValue)
-            {
-                return FromKilojoulesPerMole(kilojoulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from nullable KilojoulesPerMole.
-        /// </summary>
-        public static MolarEnergy? FromKilojoulesPerMole(int? kilojoulespermole)
-        {
-            if (kilojoulespermole.HasValue)
-            {
-                return FromKilojoulesPerMole(kilojoulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from nullable KilojoulesPerMole.
-        /// </summary>
-        public static MolarEnergy? FromKilojoulesPerMole(long? kilojoulespermole)
-        {
-            if (kilojoulespermole.HasValue)
-            {
-                return FromKilojoulesPerMole(kilojoulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from KilojoulesPerMole of type decimal.
-        /// </summary>
-        public static MolarEnergy? FromKilojoulesPerMole(decimal? kilojoulespermole)
+        public static MolarEnergy? FromKilojoulesPerMole(QuantityValue? kilojoulespermole)
         {
             if (kilojoulespermole.HasValue)
             {
@@ -401,52 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarEnergy from nullable MegajoulesPerMole.
         /// </summary>
-        public static MolarEnergy? FromMegajoulesPerMole(double? megajoulespermole)
-        {
-            if (megajoulespermole.HasValue)
-            {
-                return FromMegajoulesPerMole(megajoulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from nullable MegajoulesPerMole.
-        /// </summary>
-        public static MolarEnergy? FromMegajoulesPerMole(int? megajoulespermole)
-        {
-            if (megajoulespermole.HasValue)
-            {
-                return FromMegajoulesPerMole(megajoulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from nullable MegajoulesPerMole.
-        /// </summary>
-        public static MolarEnergy? FromMegajoulesPerMole(long? megajoulespermole)
-        {
-            if (megajoulespermole.HasValue)
-            {
-                return FromMegajoulesPerMole(megajoulespermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEnergy from MegajoulesPerMole of type decimal.
-        /// </summary>
-        public static MolarEnergy? FromMegajoulesPerMole(decimal? megajoulespermole)
+        public static MolarEnergy? FromMegajoulesPerMole(QuantityValue? megajoulespermole)
         {
             if (megajoulespermole.HasValue)
             {
@@ -463,19 +268,25 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MolarEnergyUnit" /> to <see cref="MolarEnergy" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MolarEnergy unit value.</returns>
-        public static MolarEnergy From(double val, MolarEnergyUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static MolarEnergy From(double value, MolarEnergyUnit fromUnit)
+#else
+        public static MolarEnergy From(QuantityValue value, MolarEnergyUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MolarEnergyUnit.JoulePerMole:
-                    return FromJoulesPerMole(val);
+                    return FromJoulesPerMole(value);
                 case MolarEnergyUnit.KilojoulePerMole:
-                    return FromKilojoulesPerMole(val);
+                    return FromKilojoulesPerMole(value);
                 case MolarEnergyUnit.MegajoulePerMole:
-                    return FromMegajoulesPerMole(val);
+                    return FromMegajoulesPerMole(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -490,7 +301,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MolarEnergy unit value.</returns>
-        public static MolarEnergy? From(double? value, MolarEnergyUnit fromUnit)
+        public static MolarEnergy? From(QuantityValue? value, MolarEnergyUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -165,114 +165,54 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from JoulesPerMoleKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarEntropy FromJoulesPerMoleKelvin(double joulespermolekelvin)
         {
-            return new MolarEntropy(joulespermolekelvin);
+            double value = (double) joulespermolekelvin;
+            return new MolarEntropy(value);
         }
-
-        /// <summary>
-        ///     Get MolarEntropy from JoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy FromJoulesPerMoleKelvin(int joulespermolekelvin)
+#else
+        public static MolarEntropy FromJoulesPerMoleKelvin(QuantityValue joulespermolekelvin)
         {
-            return new MolarEntropy(joulespermolekelvin);
-        }
-
-        /// <summary>
-        ///     Get MolarEntropy from JoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy FromJoulesPerMoleKelvin(long joulespermolekelvin)
-        {
-            return new MolarEntropy(joulespermolekelvin);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarEntropy from JoulesPerMoleKelvin of type decimal.
-        /// </summary>
-        public static MolarEntropy FromJoulesPerMoleKelvin(decimal joulespermolekelvin)
-        {
-            return new MolarEntropy(Convert.ToDouble(joulespermolekelvin));
+            double value = (double) joulespermolekelvin;
+            return new MolarEntropy((value));
         }
 #endif
 
         /// <summary>
         ///     Get MolarEntropy from KilojoulesPerMoleKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarEntropy FromKilojoulesPerMoleKelvin(double kilojoulespermolekelvin)
         {
-            return new MolarEntropy((kilojoulespermolekelvin) * 1e3d);
+            double value = (double) kilojoulespermolekelvin;
+            return new MolarEntropy((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MolarEntropy from KilojoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy FromKilojoulesPerMoleKelvin(int kilojoulespermolekelvin)
+#else
+        public static MolarEntropy FromKilojoulesPerMoleKelvin(QuantityValue kilojoulespermolekelvin)
         {
-            return new MolarEntropy((kilojoulespermolekelvin) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MolarEntropy from KilojoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy FromKilojoulesPerMoleKelvin(long kilojoulespermolekelvin)
-        {
-            return new MolarEntropy((kilojoulespermolekelvin) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarEntropy from KilojoulesPerMoleKelvin of type decimal.
-        /// </summary>
-        public static MolarEntropy FromKilojoulesPerMoleKelvin(decimal kilojoulespermolekelvin)
-        {
-            return new MolarEntropy((Convert.ToDouble(kilojoulespermolekelvin)) * 1e3d);
+            double value = (double) kilojoulespermolekelvin;
+            return new MolarEntropy(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarEntropy from MegajoulesPerMoleKelvin.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarEntropy FromMegajoulesPerMoleKelvin(double megajoulespermolekelvin)
         {
-            return new MolarEntropy((megajoulespermolekelvin) * 1e6d);
+            double value = (double) megajoulespermolekelvin;
+            return new MolarEntropy((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MolarEntropy from MegajoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy FromMegajoulesPerMoleKelvin(int megajoulespermolekelvin)
+#else
+        public static MolarEntropy FromMegajoulesPerMoleKelvin(QuantityValue megajoulespermolekelvin)
         {
-            return new MolarEntropy((megajoulespermolekelvin) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MolarEntropy from MegajoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy FromMegajoulesPerMoleKelvin(long megajoulespermolekelvin)
-        {
-            return new MolarEntropy((megajoulespermolekelvin) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarEntropy from MegajoulesPerMoleKelvin of type decimal.
-        /// </summary>
-        public static MolarEntropy FromMegajoulesPerMoleKelvin(decimal megajoulespermolekelvin)
-        {
-            return new MolarEntropy((Convert.ToDouble(megajoulespermolekelvin)) * 1e6d);
+            double value = (double) megajoulespermolekelvin;
+            return new MolarEntropy(((value) * 1e6d));
         }
 #endif
 
@@ -281,52 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarEntropy from nullable JoulesPerMoleKelvin.
         /// </summary>
-        public static MolarEntropy? FromJoulesPerMoleKelvin(double? joulespermolekelvin)
-        {
-            if (joulespermolekelvin.HasValue)
-            {
-                return FromJoulesPerMoleKelvin(joulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from nullable JoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy? FromJoulesPerMoleKelvin(int? joulespermolekelvin)
-        {
-            if (joulespermolekelvin.HasValue)
-            {
-                return FromJoulesPerMoleKelvin(joulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from nullable JoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy? FromJoulesPerMoleKelvin(long? joulespermolekelvin)
-        {
-            if (joulespermolekelvin.HasValue)
-            {
-                return FromJoulesPerMoleKelvin(joulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from JoulesPerMoleKelvin of type decimal.
-        /// </summary>
-        public static MolarEntropy? FromJoulesPerMoleKelvin(decimal? joulespermolekelvin)
+        public static MolarEntropy? FromJoulesPerMoleKelvin(QuantityValue? joulespermolekelvin)
         {
             if (joulespermolekelvin.HasValue)
             {
@@ -341,52 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarEntropy from nullable KilojoulesPerMoleKelvin.
         /// </summary>
-        public static MolarEntropy? FromKilojoulesPerMoleKelvin(double? kilojoulespermolekelvin)
-        {
-            if (kilojoulespermolekelvin.HasValue)
-            {
-                return FromKilojoulesPerMoleKelvin(kilojoulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from nullable KilojoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy? FromKilojoulesPerMoleKelvin(int? kilojoulespermolekelvin)
-        {
-            if (kilojoulespermolekelvin.HasValue)
-            {
-                return FromKilojoulesPerMoleKelvin(kilojoulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from nullable KilojoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy? FromKilojoulesPerMoleKelvin(long? kilojoulespermolekelvin)
-        {
-            if (kilojoulespermolekelvin.HasValue)
-            {
-                return FromKilojoulesPerMoleKelvin(kilojoulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from KilojoulesPerMoleKelvin of type decimal.
-        /// </summary>
-        public static MolarEntropy? FromKilojoulesPerMoleKelvin(decimal? kilojoulespermolekelvin)
+        public static MolarEntropy? FromKilojoulesPerMoleKelvin(QuantityValue? kilojoulespermolekelvin)
         {
             if (kilojoulespermolekelvin.HasValue)
             {
@@ -401,52 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarEntropy from nullable MegajoulesPerMoleKelvin.
         /// </summary>
-        public static MolarEntropy? FromMegajoulesPerMoleKelvin(double? megajoulespermolekelvin)
-        {
-            if (megajoulespermolekelvin.HasValue)
-            {
-                return FromMegajoulesPerMoleKelvin(megajoulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from nullable MegajoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy? FromMegajoulesPerMoleKelvin(int? megajoulespermolekelvin)
-        {
-            if (megajoulespermolekelvin.HasValue)
-            {
-                return FromMegajoulesPerMoleKelvin(megajoulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from nullable MegajoulesPerMoleKelvin.
-        /// </summary>
-        public static MolarEntropy? FromMegajoulesPerMoleKelvin(long? megajoulespermolekelvin)
-        {
-            if (megajoulespermolekelvin.HasValue)
-            {
-                return FromMegajoulesPerMoleKelvin(megajoulespermolekelvin.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarEntropy from MegajoulesPerMoleKelvin of type decimal.
-        /// </summary>
-        public static MolarEntropy? FromMegajoulesPerMoleKelvin(decimal? megajoulespermolekelvin)
+        public static MolarEntropy? FromMegajoulesPerMoleKelvin(QuantityValue? megajoulespermolekelvin)
         {
             if (megajoulespermolekelvin.HasValue)
             {
@@ -463,19 +268,25 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MolarEntropyUnit" /> to <see cref="MolarEntropy" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MolarEntropy unit value.</returns>
-        public static MolarEntropy From(double val, MolarEntropyUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static MolarEntropy From(double value, MolarEntropyUnit fromUnit)
+#else
+        public static MolarEntropy From(QuantityValue value, MolarEntropyUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MolarEntropyUnit.JoulePerMoleKelvin:
-                    return FromJoulesPerMoleKelvin(val);
+                    return FromJoulesPerMoleKelvin(value);
                 case MolarEntropyUnit.KilojoulePerMoleKelvin:
-                    return FromKilojoulesPerMoleKelvin(val);
+                    return FromKilojoulesPerMoleKelvin(value);
                 case MolarEntropyUnit.MegajoulePerMoleKelvin:
-                    return FromMegajoulesPerMoleKelvin(val);
+                    return FromMegajoulesPerMoleKelvin(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -490,7 +301,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MolarEntropy unit value.</returns>
-        public static MolarEntropy? From(double? value, MolarEntropyUnit fromUnit)
+        public static MolarEntropy? From(QuantityValue? value, MolarEntropyUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -237,456 +237,216 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from CentigramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromCentigramsPerMole(double centigramspermole)
         {
-            return new MolarMass((centigramspermole/1e3) * 1e-2d);
+            double value = (double) centigramspermole;
+            return new MolarMass((value/1e3) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from CentigramsPerMole.
-        /// </summary>
-        public static MolarMass FromCentigramsPerMole(int centigramspermole)
+#else
+        public static MolarMass FromCentigramsPerMole(QuantityValue centigramspermole)
         {
-            return new MolarMass((centigramspermole/1e3) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from CentigramsPerMole.
-        /// </summary>
-        public static MolarMass FromCentigramsPerMole(long centigramspermole)
-        {
-            return new MolarMass((centigramspermole/1e3) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from CentigramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromCentigramsPerMole(decimal centigramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(centigramspermole)/1e3) * 1e-2d);
+            double value = (double) centigramspermole;
+            return new MolarMass(((value/1e3) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from DecagramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromDecagramsPerMole(double decagramspermole)
         {
-            return new MolarMass((decagramspermole/1e3) * 1e1d);
+            double value = (double) decagramspermole;
+            return new MolarMass((value/1e3) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from DecagramsPerMole.
-        /// </summary>
-        public static MolarMass FromDecagramsPerMole(int decagramspermole)
+#else
+        public static MolarMass FromDecagramsPerMole(QuantityValue decagramspermole)
         {
-            return new MolarMass((decagramspermole/1e3) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from DecagramsPerMole.
-        /// </summary>
-        public static MolarMass FromDecagramsPerMole(long decagramspermole)
-        {
-            return new MolarMass((decagramspermole/1e3) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from DecagramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromDecagramsPerMole(decimal decagramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(decagramspermole)/1e3) * 1e1d);
+            double value = (double) decagramspermole;
+            return new MolarMass(((value/1e3) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from DecigramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromDecigramsPerMole(double decigramspermole)
         {
-            return new MolarMass((decigramspermole/1e3) * 1e-1d);
+            double value = (double) decigramspermole;
+            return new MolarMass((value/1e3) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from DecigramsPerMole.
-        /// </summary>
-        public static MolarMass FromDecigramsPerMole(int decigramspermole)
+#else
+        public static MolarMass FromDecigramsPerMole(QuantityValue decigramspermole)
         {
-            return new MolarMass((decigramspermole/1e3) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from DecigramsPerMole.
-        /// </summary>
-        public static MolarMass FromDecigramsPerMole(long decigramspermole)
-        {
-            return new MolarMass((decigramspermole/1e3) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from DecigramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromDecigramsPerMole(decimal decigramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(decigramspermole)/1e3) * 1e-1d);
+            double value = (double) decigramspermole;
+            return new MolarMass(((value/1e3) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from GramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromGramsPerMole(double gramspermole)
         {
-            return new MolarMass(gramspermole/1e3);
+            double value = (double) gramspermole;
+            return new MolarMass(value/1e3);
         }
-
-        /// <summary>
-        ///     Get MolarMass from GramsPerMole.
-        /// </summary>
-        public static MolarMass FromGramsPerMole(int gramspermole)
+#else
+        public static MolarMass FromGramsPerMole(QuantityValue gramspermole)
         {
-            return new MolarMass(gramspermole/1e3);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from GramsPerMole.
-        /// </summary>
-        public static MolarMass FromGramsPerMole(long gramspermole)
-        {
-            return new MolarMass(gramspermole/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from GramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromGramsPerMole(decimal gramspermole)
-        {
-            return new MolarMass(Convert.ToDouble(gramspermole)/1e3);
+            double value = (double) gramspermole;
+            return new MolarMass((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from HectogramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromHectogramsPerMole(double hectogramspermole)
         {
-            return new MolarMass((hectogramspermole/1e3) * 1e2d);
+            double value = (double) hectogramspermole;
+            return new MolarMass((value/1e3) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from HectogramsPerMole.
-        /// </summary>
-        public static MolarMass FromHectogramsPerMole(int hectogramspermole)
+#else
+        public static MolarMass FromHectogramsPerMole(QuantityValue hectogramspermole)
         {
-            return new MolarMass((hectogramspermole/1e3) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from HectogramsPerMole.
-        /// </summary>
-        public static MolarMass FromHectogramsPerMole(long hectogramspermole)
-        {
-            return new MolarMass((hectogramspermole/1e3) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from HectogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromHectogramsPerMole(decimal hectogramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(hectogramspermole)/1e3) * 1e2d);
+            double value = (double) hectogramspermole;
+            return new MolarMass(((value/1e3) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from KilogramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromKilogramsPerMole(double kilogramspermole)
         {
-            return new MolarMass((kilogramspermole/1e3) * 1e3d);
+            double value = (double) kilogramspermole;
+            return new MolarMass((value/1e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from KilogramsPerMole.
-        /// </summary>
-        public static MolarMass FromKilogramsPerMole(int kilogramspermole)
+#else
+        public static MolarMass FromKilogramsPerMole(QuantityValue kilogramspermole)
         {
-            return new MolarMass((kilogramspermole/1e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from KilogramsPerMole.
-        /// </summary>
-        public static MolarMass FromKilogramsPerMole(long kilogramspermole)
-        {
-            return new MolarMass((kilogramspermole/1e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from KilogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromKilogramsPerMole(decimal kilogramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(kilogramspermole)/1e3) * 1e3d);
+            double value = (double) kilogramspermole;
+            return new MolarMass(((value/1e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from KilopoundsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromKilopoundsPerMole(double kilopoundspermole)
         {
-            return new MolarMass((kilopoundspermole*0.45359237) * 1e3d);
+            double value = (double) kilopoundspermole;
+            return new MolarMass((value*0.45359237) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from KilopoundsPerMole.
-        /// </summary>
-        public static MolarMass FromKilopoundsPerMole(int kilopoundspermole)
+#else
+        public static MolarMass FromKilopoundsPerMole(QuantityValue kilopoundspermole)
         {
-            return new MolarMass((kilopoundspermole*0.45359237) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from KilopoundsPerMole.
-        /// </summary>
-        public static MolarMass FromKilopoundsPerMole(long kilopoundspermole)
-        {
-            return new MolarMass((kilopoundspermole*0.45359237) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from KilopoundsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromKilopoundsPerMole(decimal kilopoundspermole)
-        {
-            return new MolarMass((Convert.ToDouble(kilopoundspermole)*0.45359237) * 1e3d);
+            double value = (double) kilopoundspermole;
+            return new MolarMass(((value*0.45359237) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from MegapoundsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromMegapoundsPerMole(double megapoundspermole)
         {
-            return new MolarMass((megapoundspermole*0.45359237) * 1e6d);
+            double value = (double) megapoundspermole;
+            return new MolarMass((value*0.45359237) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from MegapoundsPerMole.
-        /// </summary>
-        public static MolarMass FromMegapoundsPerMole(int megapoundspermole)
+#else
+        public static MolarMass FromMegapoundsPerMole(QuantityValue megapoundspermole)
         {
-            return new MolarMass((megapoundspermole*0.45359237) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from MegapoundsPerMole.
-        /// </summary>
-        public static MolarMass FromMegapoundsPerMole(long megapoundspermole)
-        {
-            return new MolarMass((megapoundspermole*0.45359237) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from MegapoundsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromMegapoundsPerMole(decimal megapoundspermole)
-        {
-            return new MolarMass((Convert.ToDouble(megapoundspermole)*0.45359237) * 1e6d);
+            double value = (double) megapoundspermole;
+            return new MolarMass(((value*0.45359237) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from MicrogramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromMicrogramsPerMole(double microgramspermole)
         {
-            return new MolarMass((microgramspermole/1e3) * 1e-6d);
+            double value = (double) microgramspermole;
+            return new MolarMass((value/1e3) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from MicrogramsPerMole.
-        /// </summary>
-        public static MolarMass FromMicrogramsPerMole(int microgramspermole)
+#else
+        public static MolarMass FromMicrogramsPerMole(QuantityValue microgramspermole)
         {
-            return new MolarMass((microgramspermole/1e3) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from MicrogramsPerMole.
-        /// </summary>
-        public static MolarMass FromMicrogramsPerMole(long microgramspermole)
-        {
-            return new MolarMass((microgramspermole/1e3) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from MicrogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromMicrogramsPerMole(decimal microgramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(microgramspermole)/1e3) * 1e-6d);
+            double value = (double) microgramspermole;
+            return new MolarMass(((value/1e3) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from MilligramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromMilligramsPerMole(double milligramspermole)
         {
-            return new MolarMass((milligramspermole/1e3) * 1e-3d);
+            double value = (double) milligramspermole;
+            return new MolarMass((value/1e3) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from MilligramsPerMole.
-        /// </summary>
-        public static MolarMass FromMilligramsPerMole(int milligramspermole)
+#else
+        public static MolarMass FromMilligramsPerMole(QuantityValue milligramspermole)
         {
-            return new MolarMass((milligramspermole/1e3) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from MilligramsPerMole.
-        /// </summary>
-        public static MolarMass FromMilligramsPerMole(long milligramspermole)
-        {
-            return new MolarMass((milligramspermole/1e3) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from MilligramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromMilligramsPerMole(decimal milligramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(milligramspermole)/1e3) * 1e-3d);
+            double value = (double) milligramspermole;
+            return new MolarMass(((value/1e3) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from NanogramsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromNanogramsPerMole(double nanogramspermole)
         {
-            return new MolarMass((nanogramspermole/1e3) * 1e-9d);
+            double value = (double) nanogramspermole;
+            return new MolarMass((value/1e3) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get MolarMass from NanogramsPerMole.
-        /// </summary>
-        public static MolarMass FromNanogramsPerMole(int nanogramspermole)
+#else
+        public static MolarMass FromNanogramsPerMole(QuantityValue nanogramspermole)
         {
-            return new MolarMass((nanogramspermole/1e3) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from NanogramsPerMole.
-        /// </summary>
-        public static MolarMass FromNanogramsPerMole(long nanogramspermole)
-        {
-            return new MolarMass((nanogramspermole/1e3) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from NanogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromNanogramsPerMole(decimal nanogramspermole)
-        {
-            return new MolarMass((Convert.ToDouble(nanogramspermole)/1e3) * 1e-9d);
+            double value = (double) nanogramspermole;
+            return new MolarMass(((value/1e3) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get MolarMass from PoundsPerMole.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static MolarMass FromPoundsPerMole(double poundspermole)
         {
-            return new MolarMass(poundspermole*0.45359237);
+            double value = (double) poundspermole;
+            return new MolarMass(value*0.45359237);
         }
-
-        /// <summary>
-        ///     Get MolarMass from PoundsPerMole.
-        /// </summary>
-        public static MolarMass FromPoundsPerMole(int poundspermole)
+#else
+        public static MolarMass FromPoundsPerMole(QuantityValue poundspermole)
         {
-            return new MolarMass(poundspermole*0.45359237);
-        }
-
-        /// <summary>
-        ///     Get MolarMass from PoundsPerMole.
-        /// </summary>
-        public static MolarMass FromPoundsPerMole(long poundspermole)
-        {
-            return new MolarMass(poundspermole*0.45359237);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get MolarMass from PoundsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass FromPoundsPerMole(decimal poundspermole)
-        {
-            return new MolarMass(Convert.ToDouble(poundspermole)*0.45359237);
+            double value = (double) poundspermole;
+            return new MolarMass((value*0.45359237));
         }
 #endif
 
@@ -695,52 +455,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable CentigramsPerMole.
         /// </summary>
-        public static MolarMass? FromCentigramsPerMole(double? centigramspermole)
-        {
-            if (centigramspermole.HasValue)
-            {
-                return FromCentigramsPerMole(centigramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable CentigramsPerMole.
-        /// </summary>
-        public static MolarMass? FromCentigramsPerMole(int? centigramspermole)
-        {
-            if (centigramspermole.HasValue)
-            {
-                return FromCentigramsPerMole(centigramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable CentigramsPerMole.
-        /// </summary>
-        public static MolarMass? FromCentigramsPerMole(long? centigramspermole)
-        {
-            if (centigramspermole.HasValue)
-            {
-                return FromCentigramsPerMole(centigramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from CentigramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromCentigramsPerMole(decimal? centigramspermole)
+        public static MolarMass? FromCentigramsPerMole(QuantityValue? centigramspermole)
         {
             if (centigramspermole.HasValue)
             {
@@ -755,52 +470,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable DecagramsPerMole.
         /// </summary>
-        public static MolarMass? FromDecagramsPerMole(double? decagramspermole)
-        {
-            if (decagramspermole.HasValue)
-            {
-                return FromDecagramsPerMole(decagramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable DecagramsPerMole.
-        /// </summary>
-        public static MolarMass? FromDecagramsPerMole(int? decagramspermole)
-        {
-            if (decagramspermole.HasValue)
-            {
-                return FromDecagramsPerMole(decagramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable DecagramsPerMole.
-        /// </summary>
-        public static MolarMass? FromDecagramsPerMole(long? decagramspermole)
-        {
-            if (decagramspermole.HasValue)
-            {
-                return FromDecagramsPerMole(decagramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from DecagramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromDecagramsPerMole(decimal? decagramspermole)
+        public static MolarMass? FromDecagramsPerMole(QuantityValue? decagramspermole)
         {
             if (decagramspermole.HasValue)
             {
@@ -815,52 +485,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable DecigramsPerMole.
         /// </summary>
-        public static MolarMass? FromDecigramsPerMole(double? decigramspermole)
-        {
-            if (decigramspermole.HasValue)
-            {
-                return FromDecigramsPerMole(decigramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable DecigramsPerMole.
-        /// </summary>
-        public static MolarMass? FromDecigramsPerMole(int? decigramspermole)
-        {
-            if (decigramspermole.HasValue)
-            {
-                return FromDecigramsPerMole(decigramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable DecigramsPerMole.
-        /// </summary>
-        public static MolarMass? FromDecigramsPerMole(long? decigramspermole)
-        {
-            if (decigramspermole.HasValue)
-            {
-                return FromDecigramsPerMole(decigramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from DecigramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromDecigramsPerMole(decimal? decigramspermole)
+        public static MolarMass? FromDecigramsPerMole(QuantityValue? decigramspermole)
         {
             if (decigramspermole.HasValue)
             {
@@ -875,52 +500,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable GramsPerMole.
         /// </summary>
-        public static MolarMass? FromGramsPerMole(double? gramspermole)
-        {
-            if (gramspermole.HasValue)
-            {
-                return FromGramsPerMole(gramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable GramsPerMole.
-        /// </summary>
-        public static MolarMass? FromGramsPerMole(int? gramspermole)
-        {
-            if (gramspermole.HasValue)
-            {
-                return FromGramsPerMole(gramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable GramsPerMole.
-        /// </summary>
-        public static MolarMass? FromGramsPerMole(long? gramspermole)
-        {
-            if (gramspermole.HasValue)
-            {
-                return FromGramsPerMole(gramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from GramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromGramsPerMole(decimal? gramspermole)
+        public static MolarMass? FromGramsPerMole(QuantityValue? gramspermole)
         {
             if (gramspermole.HasValue)
             {
@@ -935,52 +515,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable HectogramsPerMole.
         /// </summary>
-        public static MolarMass? FromHectogramsPerMole(double? hectogramspermole)
-        {
-            if (hectogramspermole.HasValue)
-            {
-                return FromHectogramsPerMole(hectogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable HectogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromHectogramsPerMole(int? hectogramspermole)
-        {
-            if (hectogramspermole.HasValue)
-            {
-                return FromHectogramsPerMole(hectogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable HectogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromHectogramsPerMole(long? hectogramspermole)
-        {
-            if (hectogramspermole.HasValue)
-            {
-                return FromHectogramsPerMole(hectogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from HectogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromHectogramsPerMole(decimal? hectogramspermole)
+        public static MolarMass? FromHectogramsPerMole(QuantityValue? hectogramspermole)
         {
             if (hectogramspermole.HasValue)
             {
@@ -995,52 +530,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable KilogramsPerMole.
         /// </summary>
-        public static MolarMass? FromKilogramsPerMole(double? kilogramspermole)
-        {
-            if (kilogramspermole.HasValue)
-            {
-                return FromKilogramsPerMole(kilogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable KilogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromKilogramsPerMole(int? kilogramspermole)
-        {
-            if (kilogramspermole.HasValue)
-            {
-                return FromKilogramsPerMole(kilogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable KilogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromKilogramsPerMole(long? kilogramspermole)
-        {
-            if (kilogramspermole.HasValue)
-            {
-                return FromKilogramsPerMole(kilogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from KilogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromKilogramsPerMole(decimal? kilogramspermole)
+        public static MolarMass? FromKilogramsPerMole(QuantityValue? kilogramspermole)
         {
             if (kilogramspermole.HasValue)
             {
@@ -1055,52 +545,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable KilopoundsPerMole.
         /// </summary>
-        public static MolarMass? FromKilopoundsPerMole(double? kilopoundspermole)
-        {
-            if (kilopoundspermole.HasValue)
-            {
-                return FromKilopoundsPerMole(kilopoundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable KilopoundsPerMole.
-        /// </summary>
-        public static MolarMass? FromKilopoundsPerMole(int? kilopoundspermole)
-        {
-            if (kilopoundspermole.HasValue)
-            {
-                return FromKilopoundsPerMole(kilopoundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable KilopoundsPerMole.
-        /// </summary>
-        public static MolarMass? FromKilopoundsPerMole(long? kilopoundspermole)
-        {
-            if (kilopoundspermole.HasValue)
-            {
-                return FromKilopoundsPerMole(kilopoundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from KilopoundsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromKilopoundsPerMole(decimal? kilopoundspermole)
+        public static MolarMass? FromKilopoundsPerMole(QuantityValue? kilopoundspermole)
         {
             if (kilopoundspermole.HasValue)
             {
@@ -1115,52 +560,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable MegapoundsPerMole.
         /// </summary>
-        public static MolarMass? FromMegapoundsPerMole(double? megapoundspermole)
-        {
-            if (megapoundspermole.HasValue)
-            {
-                return FromMegapoundsPerMole(megapoundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable MegapoundsPerMole.
-        /// </summary>
-        public static MolarMass? FromMegapoundsPerMole(int? megapoundspermole)
-        {
-            if (megapoundspermole.HasValue)
-            {
-                return FromMegapoundsPerMole(megapoundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable MegapoundsPerMole.
-        /// </summary>
-        public static MolarMass? FromMegapoundsPerMole(long? megapoundspermole)
-        {
-            if (megapoundspermole.HasValue)
-            {
-                return FromMegapoundsPerMole(megapoundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from MegapoundsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromMegapoundsPerMole(decimal? megapoundspermole)
+        public static MolarMass? FromMegapoundsPerMole(QuantityValue? megapoundspermole)
         {
             if (megapoundspermole.HasValue)
             {
@@ -1175,52 +575,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable MicrogramsPerMole.
         /// </summary>
-        public static MolarMass? FromMicrogramsPerMole(double? microgramspermole)
-        {
-            if (microgramspermole.HasValue)
-            {
-                return FromMicrogramsPerMole(microgramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable MicrogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromMicrogramsPerMole(int? microgramspermole)
-        {
-            if (microgramspermole.HasValue)
-            {
-                return FromMicrogramsPerMole(microgramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable MicrogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromMicrogramsPerMole(long? microgramspermole)
-        {
-            if (microgramspermole.HasValue)
-            {
-                return FromMicrogramsPerMole(microgramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from MicrogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromMicrogramsPerMole(decimal? microgramspermole)
+        public static MolarMass? FromMicrogramsPerMole(QuantityValue? microgramspermole)
         {
             if (microgramspermole.HasValue)
             {
@@ -1235,52 +590,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable MilligramsPerMole.
         /// </summary>
-        public static MolarMass? FromMilligramsPerMole(double? milligramspermole)
-        {
-            if (milligramspermole.HasValue)
-            {
-                return FromMilligramsPerMole(milligramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable MilligramsPerMole.
-        /// </summary>
-        public static MolarMass? FromMilligramsPerMole(int? milligramspermole)
-        {
-            if (milligramspermole.HasValue)
-            {
-                return FromMilligramsPerMole(milligramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable MilligramsPerMole.
-        /// </summary>
-        public static MolarMass? FromMilligramsPerMole(long? milligramspermole)
-        {
-            if (milligramspermole.HasValue)
-            {
-                return FromMilligramsPerMole(milligramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from MilligramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromMilligramsPerMole(decimal? milligramspermole)
+        public static MolarMass? FromMilligramsPerMole(QuantityValue? milligramspermole)
         {
             if (milligramspermole.HasValue)
             {
@@ -1295,52 +605,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable NanogramsPerMole.
         /// </summary>
-        public static MolarMass? FromNanogramsPerMole(double? nanogramspermole)
-        {
-            if (nanogramspermole.HasValue)
-            {
-                return FromNanogramsPerMole(nanogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable NanogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromNanogramsPerMole(int? nanogramspermole)
-        {
-            if (nanogramspermole.HasValue)
-            {
-                return FromNanogramsPerMole(nanogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable NanogramsPerMole.
-        /// </summary>
-        public static MolarMass? FromNanogramsPerMole(long? nanogramspermole)
-        {
-            if (nanogramspermole.HasValue)
-            {
-                return FromNanogramsPerMole(nanogramspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from NanogramsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromNanogramsPerMole(decimal? nanogramspermole)
+        public static MolarMass? FromNanogramsPerMole(QuantityValue? nanogramspermole)
         {
             if (nanogramspermole.HasValue)
             {
@@ -1355,52 +620,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable MolarMass from nullable PoundsPerMole.
         /// </summary>
-        public static MolarMass? FromPoundsPerMole(double? poundspermole)
-        {
-            if (poundspermole.HasValue)
-            {
-                return FromPoundsPerMole(poundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable PoundsPerMole.
-        /// </summary>
-        public static MolarMass? FromPoundsPerMole(int? poundspermole)
-        {
-            if (poundspermole.HasValue)
-            {
-                return FromPoundsPerMole(poundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from nullable PoundsPerMole.
-        /// </summary>
-        public static MolarMass? FromPoundsPerMole(long? poundspermole)
-        {
-            if (poundspermole.HasValue)
-            {
-                return FromPoundsPerMole(poundspermole.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable MolarMass from PoundsPerMole of type decimal.
-        /// </summary>
-        public static MolarMass? FromPoundsPerMole(decimal? poundspermole)
+        public static MolarMass? FromPoundsPerMole(QuantityValue? poundspermole)
         {
             if (poundspermole.HasValue)
             {
@@ -1417,37 +637,43 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MolarMassUnit" /> to <see cref="MolarMass" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MolarMass unit value.</returns>
-        public static MolarMass From(double val, MolarMassUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static MolarMass From(double value, MolarMassUnit fromUnit)
+#else
+        public static MolarMass From(QuantityValue value, MolarMassUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MolarMassUnit.CentigramPerMole:
-                    return FromCentigramsPerMole(val);
+                    return FromCentigramsPerMole(value);
                 case MolarMassUnit.DecagramPerMole:
-                    return FromDecagramsPerMole(val);
+                    return FromDecagramsPerMole(value);
                 case MolarMassUnit.DecigramPerMole:
-                    return FromDecigramsPerMole(val);
+                    return FromDecigramsPerMole(value);
                 case MolarMassUnit.GramPerMole:
-                    return FromGramsPerMole(val);
+                    return FromGramsPerMole(value);
                 case MolarMassUnit.HectogramPerMole:
-                    return FromHectogramsPerMole(val);
+                    return FromHectogramsPerMole(value);
                 case MolarMassUnit.KilogramPerMole:
-                    return FromKilogramsPerMole(val);
+                    return FromKilogramsPerMole(value);
                 case MolarMassUnit.KilopoundPerMole:
-                    return FromKilopoundsPerMole(val);
+                    return FromKilopoundsPerMole(value);
                 case MolarMassUnit.MegapoundPerMole:
-                    return FromMegapoundsPerMole(val);
+                    return FromMegapoundsPerMole(value);
                 case MolarMassUnit.MicrogramPerMole:
-                    return FromMicrogramsPerMole(val);
+                    return FromMicrogramsPerMole(value);
                 case MolarMassUnit.MilligramPerMole:
-                    return FromMilligramsPerMole(val);
+                    return FromMilligramsPerMole(value);
                 case MolarMassUnit.NanogramPerMole:
-                    return FromNanogramsPerMole(val);
+                    return FromNanogramsPerMole(value);
                 case MolarMassUnit.PoundPerMole:
-                    return FromPoundsPerMole(val);
+                    return FromPoundsPerMole(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1462,7 +688,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>MolarMass unit value.</returns>
-        public static MolarMass? From(double? value, MolarMassUnit fromUnit)
+        public static MolarMass? From(QuantityValue? value, MolarMassUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from CentimolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromCentimolesPerLiter(double centimolesperliter)
         {
-            return new Molarity((centimolesperliter/1e-3) * 1e-2d);
+            double value = (double) centimolesperliter;
+            return new Molarity((value/1e-3) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Molarity from CentimolesPerLiter.
-        /// </summary>
-        public static Molarity FromCentimolesPerLiter(int centimolesperliter)
+#else
+        public static Molarity FromCentimolesPerLiter(QuantityValue centimolesperliter)
         {
-            return new Molarity((centimolesperliter/1e-3) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Molarity from CentimolesPerLiter.
-        /// </summary>
-        public static Molarity FromCentimolesPerLiter(long centimolesperliter)
-        {
-            return new Molarity((centimolesperliter/1e-3) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from CentimolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromCentimolesPerLiter(decimal centimolesperliter)
-        {
-            return new Molarity((Convert.ToDouble(centimolesperliter)/1e-3) * 1e-2d);
+            double value = (double) centimolesperliter;
+            return new Molarity(((value/1e-3) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromDecimolesPerLiter(double decimolesperliter)
         {
-            return new Molarity((decimolesperliter/1e-3) * 1e-1d);
+            double value = (double) decimolesperliter;
+            return new Molarity((value/1e-3) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Molarity from DecimolesPerLiter.
-        /// </summary>
-        public static Molarity FromDecimolesPerLiter(int decimolesperliter)
+#else
+        public static Molarity FromDecimolesPerLiter(QuantityValue decimolesperliter)
         {
-            return new Molarity((decimolesperliter/1e-3) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Molarity from DecimolesPerLiter.
-        /// </summary>
-        public static Molarity FromDecimolesPerLiter(long decimolesperliter)
-        {
-            return new Molarity((decimolesperliter/1e-3) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from DecimolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromDecimolesPerLiter(decimal decimolesperliter)
-        {
-            return new Molarity((Convert.ToDouble(decimolesperliter)/1e-3) * 1e-1d);
+            double value = (double) decimolesperliter;
+            return new Molarity(((value/1e-3) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromMicromolesPerLiter(double micromolesperliter)
         {
-            return new Molarity((micromolesperliter/1e-3) * 1e-6d);
+            double value = (double) micromolesperliter;
+            return new Molarity((value/1e-3) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Molarity from MicromolesPerLiter.
-        /// </summary>
-        public static Molarity FromMicromolesPerLiter(int micromolesperliter)
+#else
+        public static Molarity FromMicromolesPerLiter(QuantityValue micromolesperliter)
         {
-            return new Molarity((micromolesperliter/1e-3) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Molarity from MicromolesPerLiter.
-        /// </summary>
-        public static Molarity FromMicromolesPerLiter(long micromolesperliter)
-        {
-            return new Molarity((micromolesperliter/1e-3) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from MicromolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromMicromolesPerLiter(decimal micromolesperliter)
-        {
-            return new Molarity((Convert.ToDouble(micromolesperliter)/1e-3) * 1e-6d);
+            double value = (double) micromolesperliter;
+            return new Molarity(((value/1e-3) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromMillimolesPerLiter(double millimolesperliter)
         {
-            return new Molarity((millimolesperliter/1e-3) * 1e-3d);
+            double value = (double) millimolesperliter;
+            return new Molarity((value/1e-3) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Molarity from MillimolesPerLiter.
-        /// </summary>
-        public static Molarity FromMillimolesPerLiter(int millimolesperliter)
+#else
+        public static Molarity FromMillimolesPerLiter(QuantityValue millimolesperliter)
         {
-            return new Molarity((millimolesperliter/1e-3) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Molarity from MillimolesPerLiter.
-        /// </summary>
-        public static Molarity FromMillimolesPerLiter(long millimolesperliter)
-        {
-            return new Molarity((millimolesperliter/1e-3) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from MillimolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromMillimolesPerLiter(decimal millimolesperliter)
-        {
-            return new Molarity((Convert.ToDouble(millimolesperliter)/1e-3) * 1e-3d);
+            double value = (double) millimolesperliter;
+            return new Molarity(((value/1e-3) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromMolesPerCubicMeter(double molespercubicmeter)
         {
-            return new Molarity(molespercubicmeter);
+            double value = (double) molespercubicmeter;
+            return new Molarity(value);
         }
-
-        /// <summary>
-        ///     Get Molarity from MolesPerCubicMeter.
-        /// </summary>
-        public static Molarity FromMolesPerCubicMeter(int molespercubicmeter)
+#else
+        public static Molarity FromMolesPerCubicMeter(QuantityValue molespercubicmeter)
         {
-            return new Molarity(molespercubicmeter);
-        }
-
-        /// <summary>
-        ///     Get Molarity from MolesPerCubicMeter.
-        /// </summary>
-        public static Molarity FromMolesPerCubicMeter(long molespercubicmeter)
-        {
-            return new Molarity(molespercubicmeter);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from MolesPerCubicMeter of type decimal.
-        /// </summary>
-        public static Molarity FromMolesPerCubicMeter(decimal molespercubicmeter)
-        {
-            return new Molarity(Convert.ToDouble(molespercubicmeter));
+            double value = (double) molespercubicmeter;
+            return new Molarity((value));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromMolesPerLiter(double molesperliter)
         {
-            return new Molarity(molesperliter/1e-3);
+            double value = (double) molesperliter;
+            return new Molarity(value/1e-3);
         }
-
-        /// <summary>
-        ///     Get Molarity from MolesPerLiter.
-        /// </summary>
-        public static Molarity FromMolesPerLiter(int molesperliter)
+#else
+        public static Molarity FromMolesPerLiter(QuantityValue molesperliter)
         {
-            return new Molarity(molesperliter/1e-3);
-        }
-
-        /// <summary>
-        ///     Get Molarity from MolesPerLiter.
-        /// </summary>
-        public static Molarity FromMolesPerLiter(long molesperliter)
-        {
-            return new Molarity(molesperliter/1e-3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from MolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromMolesPerLiter(decimal molesperliter)
-        {
-            return new Molarity(Convert.ToDouble(molesperliter)/1e-3);
+            double value = (double) molesperliter;
+            return new Molarity((value/1e-3));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromNanomolesPerLiter(double nanomolesperliter)
         {
-            return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
+            double value = (double) nanomolesperliter;
+            return new Molarity((value/1e-3) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Molarity from NanomolesPerLiter.
-        /// </summary>
-        public static Molarity FromNanomolesPerLiter(int nanomolesperliter)
+#else
+        public static Molarity FromNanomolesPerLiter(QuantityValue nanomolesperliter)
         {
-            return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Molarity from NanomolesPerLiter.
-        /// </summary>
-        public static Molarity FromNanomolesPerLiter(long nanomolesperliter)
-        {
-            return new Molarity((nanomolesperliter/1e-3) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from NanomolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromNanomolesPerLiter(decimal nanomolesperliter)
-        {
-            return new Molarity((Convert.ToDouble(nanomolesperliter)/1e-3) * 1e-9d);
+            double value = (double) nanomolesperliter;
+            return new Molarity(((value/1e-3) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Molarity FromPicomolesPerLiter(double picomolesperliter)
         {
-            return new Molarity((picomolesperliter/1e-3) * 1e-12d);
+            double value = (double) picomolesperliter;
+            return new Molarity((value/1e-3) * 1e-12d);
         }
-
-        /// <summary>
-        ///     Get Molarity from PicomolesPerLiter.
-        /// </summary>
-        public static Molarity FromPicomolesPerLiter(int picomolesperliter)
+#else
+        public static Molarity FromPicomolesPerLiter(QuantityValue picomolesperliter)
         {
-            return new Molarity((picomolesperliter/1e-3) * 1e-12d);
-        }
-
-        /// <summary>
-        ///     Get Molarity from PicomolesPerLiter.
-        /// </summary>
-        public static Molarity FromPicomolesPerLiter(long picomolesperliter)
-        {
-            return new Molarity((picomolesperliter/1e-3) * 1e-12d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Molarity from PicomolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity FromPicomolesPerLiter(decimal picomolesperliter)
-        {
-            return new Molarity((Convert.ToDouble(picomolesperliter)/1e-3) * 1e-12d);
+            double value = (double) picomolesperliter;
+            return new Molarity(((value/1e-3) * 1e-12d));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable CentimolesPerLiter.
         /// </summary>
-        public static Molarity? FromCentimolesPerLiter(double? centimolesperliter)
-        {
-            if (centimolesperliter.HasValue)
-            {
-                return FromCentimolesPerLiter(centimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable CentimolesPerLiter.
-        /// </summary>
-        public static Molarity? FromCentimolesPerLiter(int? centimolesperliter)
-        {
-            if (centimolesperliter.HasValue)
-            {
-                return FromCentimolesPerLiter(centimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable CentimolesPerLiter.
-        /// </summary>
-        public static Molarity? FromCentimolesPerLiter(long? centimolesperliter)
-        {
-            if (centimolesperliter.HasValue)
-            {
-                return FromCentimolesPerLiter(centimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from CentimolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromCentimolesPerLiter(decimal? centimolesperliter)
+        public static Molarity? FromCentimolesPerLiter(QuantityValue? centimolesperliter)
         {
             if (centimolesperliter.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable DecimolesPerLiter.
         /// </summary>
-        public static Molarity? FromDecimolesPerLiter(double? decimolesperliter)
-        {
-            if (decimolesperliter.HasValue)
-            {
-                return FromDecimolesPerLiter(decimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable DecimolesPerLiter.
-        /// </summary>
-        public static Molarity? FromDecimolesPerLiter(int? decimolesperliter)
-        {
-            if (decimolesperliter.HasValue)
-            {
-                return FromDecimolesPerLiter(decimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable DecimolesPerLiter.
-        /// </summary>
-        public static Molarity? FromDecimolesPerLiter(long? decimolesperliter)
-        {
-            if (decimolesperliter.HasValue)
-            {
-                return FromDecimolesPerLiter(decimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from DecimolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromDecimolesPerLiter(decimal? decimolesperliter)
+        public static Molarity? FromDecimolesPerLiter(QuantityValue? decimolesperliter)
         {
             if (decimolesperliter.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable MicromolesPerLiter.
         /// </summary>
-        public static Molarity? FromMicromolesPerLiter(double? micromolesperliter)
-        {
-            if (micromolesperliter.HasValue)
-            {
-                return FromMicromolesPerLiter(micromolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MicromolesPerLiter.
-        /// </summary>
-        public static Molarity? FromMicromolesPerLiter(int? micromolesperliter)
-        {
-            if (micromolesperliter.HasValue)
-            {
-                return FromMicromolesPerLiter(micromolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MicromolesPerLiter.
-        /// </summary>
-        public static Molarity? FromMicromolesPerLiter(long? micromolesperliter)
-        {
-            if (micromolesperliter.HasValue)
-            {
-                return FromMicromolesPerLiter(micromolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from MicromolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromMicromolesPerLiter(decimal? micromolesperliter)
+        public static Molarity? FromMicromolesPerLiter(QuantityValue? micromolesperliter)
         {
             if (micromolesperliter.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable MillimolesPerLiter.
         /// </summary>
-        public static Molarity? FromMillimolesPerLiter(double? millimolesperliter)
-        {
-            if (millimolesperliter.HasValue)
-            {
-                return FromMillimolesPerLiter(millimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MillimolesPerLiter.
-        /// </summary>
-        public static Molarity? FromMillimolesPerLiter(int? millimolesperliter)
-        {
-            if (millimolesperliter.HasValue)
-            {
-                return FromMillimolesPerLiter(millimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MillimolesPerLiter.
-        /// </summary>
-        public static Molarity? FromMillimolesPerLiter(long? millimolesperliter)
-        {
-            if (millimolesperliter.HasValue)
-            {
-                return FromMillimolesPerLiter(millimolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from MillimolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromMillimolesPerLiter(decimal? millimolesperliter)
+        public static Molarity? FromMillimolesPerLiter(QuantityValue? millimolesperliter)
         {
             if (millimolesperliter.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable MolesPerCubicMeter.
         /// </summary>
-        public static Molarity? FromMolesPerCubicMeter(double? molespercubicmeter)
-        {
-            if (molespercubicmeter.HasValue)
-            {
-                return FromMolesPerCubicMeter(molespercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MolesPerCubicMeter.
-        /// </summary>
-        public static Molarity? FromMolesPerCubicMeter(int? molespercubicmeter)
-        {
-            if (molespercubicmeter.HasValue)
-            {
-                return FromMolesPerCubicMeter(molespercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MolesPerCubicMeter.
-        /// </summary>
-        public static Molarity? FromMolesPerCubicMeter(long? molespercubicmeter)
-        {
-            if (molespercubicmeter.HasValue)
-            {
-                return FromMolesPerCubicMeter(molespercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from MolesPerCubicMeter of type decimal.
-        /// </summary>
-        public static Molarity? FromMolesPerCubicMeter(decimal? molespercubicmeter)
+        public static Molarity? FromMolesPerCubicMeter(QuantityValue? molespercubicmeter)
         {
             if (molespercubicmeter.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable MolesPerLiter.
         /// </summary>
-        public static Molarity? FromMolesPerLiter(double? molesperliter)
-        {
-            if (molesperliter.HasValue)
-            {
-                return FromMolesPerLiter(molesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MolesPerLiter.
-        /// </summary>
-        public static Molarity? FromMolesPerLiter(int? molesperliter)
-        {
-            if (molesperliter.HasValue)
-            {
-                return FromMolesPerLiter(molesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable MolesPerLiter.
-        /// </summary>
-        public static Molarity? FromMolesPerLiter(long? molesperliter)
-        {
-            if (molesperliter.HasValue)
-            {
-                return FromMolesPerLiter(molesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from MolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromMolesPerLiter(decimal? molesperliter)
+        public static Molarity? FromMolesPerLiter(QuantityValue? molesperliter)
         {
             if (molesperliter.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable NanomolesPerLiter.
         /// </summary>
-        public static Molarity? FromNanomolesPerLiter(double? nanomolesperliter)
-        {
-            if (nanomolesperliter.HasValue)
-            {
-                return FromNanomolesPerLiter(nanomolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable NanomolesPerLiter.
-        /// </summary>
-        public static Molarity? FromNanomolesPerLiter(int? nanomolesperliter)
-        {
-            if (nanomolesperliter.HasValue)
-            {
-                return FromNanomolesPerLiter(nanomolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable NanomolesPerLiter.
-        /// </summary>
-        public static Molarity? FromNanomolesPerLiter(long? nanomolesperliter)
-        {
-            if (nanomolesperliter.HasValue)
-            {
-                return FromNanomolesPerLiter(nanomolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from NanomolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromNanomolesPerLiter(decimal? nanomolesperliter)
+        public static Molarity? FromNanomolesPerLiter(QuantityValue? nanomolesperliter)
         {
             if (nanomolesperliter.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Molarity from nullable PicomolesPerLiter.
         /// </summary>
-        public static Molarity? FromPicomolesPerLiter(double? picomolesperliter)
-        {
-            if (picomolesperliter.HasValue)
-            {
-                return FromPicomolesPerLiter(picomolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable PicomolesPerLiter.
-        /// </summary>
-        public static Molarity? FromPicomolesPerLiter(int? picomolesperliter)
-        {
-            if (picomolesperliter.HasValue)
-            {
-                return FromPicomolesPerLiter(picomolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from nullable PicomolesPerLiter.
-        /// </summary>
-        public static Molarity? FromPicomolesPerLiter(long? picomolesperliter)
-        {
-            if (picomolesperliter.HasValue)
-            {
-                return FromPicomolesPerLiter(picomolesperliter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Molarity from PicomolesPerLiter of type decimal.
-        /// </summary>
-        public static Molarity? FromPicomolesPerLiter(decimal? picomolesperliter)
+        public static Molarity? FromPicomolesPerLiter(QuantityValue? picomolesperliter)
         {
             if (picomolesperliter.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="MolarityUnit" /> to <see cref="Molarity" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Molarity unit value.</returns>
-        public static Molarity From(double val, MolarityUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Molarity From(double value, MolarityUnit fromUnit)
+#else
+        public static Molarity From(QuantityValue value, MolarityUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case MolarityUnit.CentimolesPerLiter:
-                    return FromCentimolesPerLiter(val);
+                    return FromCentimolesPerLiter(value);
                 case MolarityUnit.DecimolesPerLiter:
-                    return FromDecimolesPerLiter(val);
+                    return FromDecimolesPerLiter(value);
                 case MolarityUnit.MicromolesPerLiter:
-                    return FromMicromolesPerLiter(val);
+                    return FromMicromolesPerLiter(value);
                 case MolarityUnit.MillimolesPerLiter:
-                    return FromMillimolesPerLiter(val);
+                    return FromMillimolesPerLiter(value);
                 case MolarityUnit.MolesPerCubicMeter:
-                    return FromMolesPerCubicMeter(val);
+                    return FromMolesPerCubicMeter(value);
                 case MolarityUnit.MolesPerLiter:
-                    return FromMolesPerLiter(val);
+                    return FromMolesPerLiter(value);
                 case MolarityUnit.NanomolesPerLiter:
-                    return FromNanomolesPerLiter(val);
+                    return FromNanomolesPerLiter(value);
                 case MolarityUnit.PicomolesPerLiter:
-                    return FromPicomolesPerLiter(val);
+                    return FromPicomolesPerLiter(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Molarity unit value.</returns>
-        public static Molarity? From(double? value, MolarityUnit fromUnit)
+        public static Molarity? From(QuantityValue? value, MolarityUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -285,684 +285,324 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BoilerHorsepower.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromBoilerHorsepower(double boilerhorsepower)
         {
-            return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
+            double value = (double) boilerhorsepower;
+            return new Power(Convert.ToDecimal(value*9812.5d));
         }
-
-        /// <summary>
-        ///     Get Power from BoilerHorsepower.
-        /// </summary>
-        public static Power FromBoilerHorsepower(int boilerhorsepower)
+#else
+        public static Power FromBoilerHorsepower(QuantityValue boilerhorsepower)
         {
-            return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
-        }
-
-        /// <summary>
-        ///     Get Power from BoilerHorsepower.
-        /// </summary>
-        public static Power FromBoilerHorsepower(long boilerhorsepower)
-        {
-            return new Power(Convert.ToDecimal(boilerhorsepower*9812.5d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from BoilerHorsepower of type decimal.
-        /// </summary>
-        public static Power FromBoilerHorsepower(decimal boilerhorsepower)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(boilerhorsepower)*9812.5d));
+            double value = (double) boilerhorsepower;
+            return new Power((Convert.ToDecimal(value*9812.5d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromBritishThermalUnitsPerHour(double britishthermalunitsperhour)
         {
-            return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
+            double value = (double) britishthermalunitsperhour;
+            return new Power(Convert.ToDecimal(value*0.293071d));
         }
-
-        /// <summary>
-        ///     Get Power from BritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power FromBritishThermalUnitsPerHour(int britishthermalunitsperhour)
+#else
+        public static Power FromBritishThermalUnitsPerHour(QuantityValue britishthermalunitsperhour)
         {
-            return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
-        }
-
-        /// <summary>
-        ///     Get Power from BritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power FromBritishThermalUnitsPerHour(long britishthermalunitsperhour)
-        {
-            return new Power(Convert.ToDecimal(britishthermalunitsperhour*0.293071d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from BritishThermalUnitsPerHour of type decimal.
-        /// </summary>
-        public static Power FromBritishThermalUnitsPerHour(decimal britishthermalunitsperhour)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(britishthermalunitsperhour)*0.293071d));
+            double value = (double) britishthermalunitsperhour;
+            return new Power((Convert.ToDecimal(value*0.293071d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from ElectricalHorsepower.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromElectricalHorsepower(double electricalhorsepower)
         {
-            return new Power(Convert.ToDecimal(electricalhorsepower*746d));
+            double value = (double) electricalhorsepower;
+            return new Power(Convert.ToDecimal(value*746d));
         }
-
-        /// <summary>
-        ///     Get Power from ElectricalHorsepower.
-        /// </summary>
-        public static Power FromElectricalHorsepower(int electricalhorsepower)
+#else
+        public static Power FromElectricalHorsepower(QuantityValue electricalhorsepower)
         {
-            return new Power(Convert.ToDecimal(electricalhorsepower*746d));
-        }
-
-        /// <summary>
-        ///     Get Power from ElectricalHorsepower.
-        /// </summary>
-        public static Power FromElectricalHorsepower(long electricalhorsepower)
-        {
-            return new Power(Convert.ToDecimal(electricalhorsepower*746d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from ElectricalHorsepower of type decimal.
-        /// </summary>
-        public static Power FromElectricalHorsepower(decimal electricalhorsepower)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(electricalhorsepower)*746d));
+            double value = (double) electricalhorsepower;
+            return new Power((Convert.ToDecimal(value*746d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromFemtowatts(double femtowatts)
         {
-            return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
+            double value = (double) femtowatts;
+            return new Power(Convert.ToDecimal((value) * 1e-15d));
         }
-
-        /// <summary>
-        ///     Get Power from Femtowatts.
-        /// </summary>
-        public static Power FromFemtowatts(int femtowatts)
+#else
+        public static Power FromFemtowatts(QuantityValue femtowatts)
         {
-            return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
-        }
-
-        /// <summary>
-        ///     Get Power from Femtowatts.
-        /// </summary>
-        public static Power FromFemtowatts(long femtowatts)
-        {
-            return new Power(Convert.ToDecimal((femtowatts) * 1e-15d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Femtowatts of type decimal.
-        /// </summary>
-        public static Power FromFemtowatts(decimal femtowatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(femtowatts)) * 1e-15d));
+            double value = (double) femtowatts;
+            return new Power((Convert.ToDecimal((value) * 1e-15d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Gigawatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromGigawatts(double gigawatts)
         {
-            return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
+            double value = (double) gigawatts;
+            return new Power(Convert.ToDecimal((value) * 1e9d));
         }
-
-        /// <summary>
-        ///     Get Power from Gigawatts.
-        /// </summary>
-        public static Power FromGigawatts(int gigawatts)
+#else
+        public static Power FromGigawatts(QuantityValue gigawatts)
         {
-            return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
-        }
-
-        /// <summary>
-        ///     Get Power from Gigawatts.
-        /// </summary>
-        public static Power FromGigawatts(long gigawatts)
-        {
-            return new Power(Convert.ToDecimal((gigawatts) * 1e9d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Gigawatts of type decimal.
-        /// </summary>
-        public static Power FromGigawatts(decimal gigawatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(gigawatts)) * 1e9d));
+            double value = (double) gigawatts;
+            return new Power((Convert.ToDecimal((value) * 1e9d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromHydraulicHorsepower(double hydraulichorsepower)
         {
-            return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
+            double value = (double) hydraulichorsepower;
+            return new Power(Convert.ToDecimal(value*745.69988145d));
         }
-
-        /// <summary>
-        ///     Get Power from HydraulicHorsepower.
-        /// </summary>
-        public static Power FromHydraulicHorsepower(int hydraulichorsepower)
+#else
+        public static Power FromHydraulicHorsepower(QuantityValue hydraulichorsepower)
         {
-            return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
-        }
-
-        /// <summary>
-        ///     Get Power from HydraulicHorsepower.
-        /// </summary>
-        public static Power FromHydraulicHorsepower(long hydraulichorsepower)
-        {
-            return new Power(Convert.ToDecimal(hydraulichorsepower*745.69988145d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from HydraulicHorsepower of type decimal.
-        /// </summary>
-        public static Power FromHydraulicHorsepower(decimal hydraulichorsepower)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(hydraulichorsepower)*745.69988145d));
+            double value = (double) hydraulichorsepower;
+            return new Power((Convert.ToDecimal(value*745.69988145d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromKilobritishThermalUnitsPerHour(double kilobritishthermalunitsperhour)
         {
-            return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
+            double value = (double) kilobritishthermalunitsperhour;
+            return new Power(Convert.ToDecimal((value*0.293071d) * 1e3d));
         }
-
-        /// <summary>
-        ///     Get Power from KilobritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power FromKilobritishThermalUnitsPerHour(int kilobritishthermalunitsperhour)
+#else
+        public static Power FromKilobritishThermalUnitsPerHour(QuantityValue kilobritishthermalunitsperhour)
         {
-            return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
-        }
-
-        /// <summary>
-        ///     Get Power from KilobritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power FromKilobritishThermalUnitsPerHour(long kilobritishthermalunitsperhour)
-        {
-            return new Power(Convert.ToDecimal((kilobritishthermalunitsperhour*0.293071d) * 1e3d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from KilobritishThermalUnitsPerHour of type decimal.
-        /// </summary>
-        public static Power FromKilobritishThermalUnitsPerHour(decimal kilobritishthermalunitsperhour)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(kilobritishthermalunitsperhour)*0.293071d) * 1e3d));
+            double value = (double) kilobritishthermalunitsperhour;
+            return new Power((Convert.ToDecimal((value*0.293071d) * 1e3d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromKilowatts(double kilowatts)
         {
-            return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
+            double value = (double) kilowatts;
+            return new Power(Convert.ToDecimal((value) * 1e3d));
         }
-
-        /// <summary>
-        ///     Get Power from Kilowatts.
-        /// </summary>
-        public static Power FromKilowatts(int kilowatts)
+#else
+        public static Power FromKilowatts(QuantityValue kilowatts)
         {
-            return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
-        }
-
-        /// <summary>
-        ///     Get Power from Kilowatts.
-        /// </summary>
-        public static Power FromKilowatts(long kilowatts)
-        {
-            return new Power(Convert.ToDecimal((kilowatts) * 1e3d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Kilowatts of type decimal.
-        /// </summary>
-        public static Power FromKilowatts(decimal kilowatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(kilowatts)) * 1e3d));
+            double value = (double) kilowatts;
+            return new Power((Convert.ToDecimal((value) * 1e3d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from MechanicalHorsepower.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromMechanicalHorsepower(double mechanicalhorsepower)
         {
-            return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
+            double value = (double) mechanicalhorsepower;
+            return new Power(Convert.ToDecimal(value*745.69d));
         }
-
-        /// <summary>
-        ///     Get Power from MechanicalHorsepower.
-        /// </summary>
-        public static Power FromMechanicalHorsepower(int mechanicalhorsepower)
+#else
+        public static Power FromMechanicalHorsepower(QuantityValue mechanicalhorsepower)
         {
-            return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
-        }
-
-        /// <summary>
-        ///     Get Power from MechanicalHorsepower.
-        /// </summary>
-        public static Power FromMechanicalHorsepower(long mechanicalhorsepower)
-        {
-            return new Power(Convert.ToDecimal(mechanicalhorsepower*745.69d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from MechanicalHorsepower of type decimal.
-        /// </summary>
-        public static Power FromMechanicalHorsepower(decimal mechanicalhorsepower)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(mechanicalhorsepower)*745.69d));
+            double value = (double) mechanicalhorsepower;
+            return new Power((Convert.ToDecimal(value*745.69d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromMegawatts(double megawatts)
         {
-            return new Power(Convert.ToDecimal((megawatts) * 1e6d));
+            double value = (double) megawatts;
+            return new Power(Convert.ToDecimal((value) * 1e6d));
         }
-
-        /// <summary>
-        ///     Get Power from Megawatts.
-        /// </summary>
-        public static Power FromMegawatts(int megawatts)
+#else
+        public static Power FromMegawatts(QuantityValue megawatts)
         {
-            return new Power(Convert.ToDecimal((megawatts) * 1e6d));
-        }
-
-        /// <summary>
-        ///     Get Power from Megawatts.
-        /// </summary>
-        public static Power FromMegawatts(long megawatts)
-        {
-            return new Power(Convert.ToDecimal((megawatts) * 1e6d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Megawatts of type decimal.
-        /// </summary>
-        public static Power FromMegawatts(decimal megawatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(megawatts)) * 1e6d));
+            double value = (double) megawatts;
+            return new Power((Convert.ToDecimal((value) * 1e6d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from MetricHorsepower.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromMetricHorsepower(double metrichorsepower)
         {
-            return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
+            double value = (double) metrichorsepower;
+            return new Power(Convert.ToDecimal(value*735.49875d));
         }
-
-        /// <summary>
-        ///     Get Power from MetricHorsepower.
-        /// </summary>
-        public static Power FromMetricHorsepower(int metrichorsepower)
+#else
+        public static Power FromMetricHorsepower(QuantityValue metrichorsepower)
         {
-            return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
-        }
-
-        /// <summary>
-        ///     Get Power from MetricHorsepower.
-        /// </summary>
-        public static Power FromMetricHorsepower(long metrichorsepower)
-        {
-            return new Power(Convert.ToDecimal(metrichorsepower*735.49875d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from MetricHorsepower of type decimal.
-        /// </summary>
-        public static Power FromMetricHorsepower(decimal metrichorsepower)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(metrichorsepower)*735.49875d));
+            double value = (double) metrichorsepower;
+            return new Power((Convert.ToDecimal(value*735.49875d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromMicrowatts(double microwatts)
         {
-            return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
+            double value = (double) microwatts;
+            return new Power(Convert.ToDecimal((value) * 1e-6d));
         }
-
-        /// <summary>
-        ///     Get Power from Microwatts.
-        /// </summary>
-        public static Power FromMicrowatts(int microwatts)
+#else
+        public static Power FromMicrowatts(QuantityValue microwatts)
         {
-            return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
-        }
-
-        /// <summary>
-        ///     Get Power from Microwatts.
-        /// </summary>
-        public static Power FromMicrowatts(long microwatts)
-        {
-            return new Power(Convert.ToDecimal((microwatts) * 1e-6d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Microwatts of type decimal.
-        /// </summary>
-        public static Power FromMicrowatts(decimal microwatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(microwatts)) * 1e-6d));
+            double value = (double) microwatts;
+            return new Power((Convert.ToDecimal((value) * 1e-6d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Milliwatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromMilliwatts(double milliwatts)
         {
-            return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
+            double value = (double) milliwatts;
+            return new Power(Convert.ToDecimal((value) * 1e-3d));
         }
-
-        /// <summary>
-        ///     Get Power from Milliwatts.
-        /// </summary>
-        public static Power FromMilliwatts(int milliwatts)
+#else
+        public static Power FromMilliwatts(QuantityValue milliwatts)
         {
-            return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
-        }
-
-        /// <summary>
-        ///     Get Power from Milliwatts.
-        /// </summary>
-        public static Power FromMilliwatts(long milliwatts)
-        {
-            return new Power(Convert.ToDecimal((milliwatts) * 1e-3d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Milliwatts of type decimal.
-        /// </summary>
-        public static Power FromMilliwatts(decimal milliwatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(milliwatts)) * 1e-3d));
+            double value = (double) milliwatts;
+            return new Power((Convert.ToDecimal((value) * 1e-3d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromNanowatts(double nanowatts)
         {
-            return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
+            double value = (double) nanowatts;
+            return new Power(Convert.ToDecimal((value) * 1e-9d));
         }
-
-        /// <summary>
-        ///     Get Power from Nanowatts.
-        /// </summary>
-        public static Power FromNanowatts(int nanowatts)
+#else
+        public static Power FromNanowatts(QuantityValue nanowatts)
         {
-            return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
-        }
-
-        /// <summary>
-        ///     Get Power from Nanowatts.
-        /// </summary>
-        public static Power FromNanowatts(long nanowatts)
-        {
-            return new Power(Convert.ToDecimal((nanowatts) * 1e-9d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Nanowatts of type decimal.
-        /// </summary>
-        public static Power FromNanowatts(decimal nanowatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(nanowatts)) * 1e-9d));
+            double value = (double) nanowatts;
+            return new Power((Convert.ToDecimal((value) * 1e-9d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Petawatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromPetawatts(double petawatts)
         {
-            return new Power(Convert.ToDecimal((petawatts) * 1e15d));
+            double value = (double) petawatts;
+            return new Power(Convert.ToDecimal((value) * 1e15d));
         }
-
-        /// <summary>
-        ///     Get Power from Petawatts.
-        /// </summary>
-        public static Power FromPetawatts(int petawatts)
+#else
+        public static Power FromPetawatts(QuantityValue petawatts)
         {
-            return new Power(Convert.ToDecimal((petawatts) * 1e15d));
-        }
-
-        /// <summary>
-        ///     Get Power from Petawatts.
-        /// </summary>
-        public static Power FromPetawatts(long petawatts)
-        {
-            return new Power(Convert.ToDecimal((petawatts) * 1e15d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Petawatts of type decimal.
-        /// </summary>
-        public static Power FromPetawatts(decimal petawatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(petawatts)) * 1e15d));
+            double value = (double) petawatts;
+            return new Power((Convert.ToDecimal((value) * 1e15d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromPicowatts(double picowatts)
         {
-            return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
+            double value = (double) picowatts;
+            return new Power(Convert.ToDecimal((value) * 1e-12d));
         }
-
-        /// <summary>
-        ///     Get Power from Picowatts.
-        /// </summary>
-        public static Power FromPicowatts(int picowatts)
+#else
+        public static Power FromPicowatts(QuantityValue picowatts)
         {
-            return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
-        }
-
-        /// <summary>
-        ///     Get Power from Picowatts.
-        /// </summary>
-        public static Power FromPicowatts(long picowatts)
-        {
-            return new Power(Convert.ToDecimal((picowatts) * 1e-12d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Picowatts of type decimal.
-        /// </summary>
-        public static Power FromPicowatts(decimal picowatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(picowatts)) * 1e-12d));
+            double value = (double) picowatts;
+            return new Power((Convert.ToDecimal((value) * 1e-12d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Terawatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromTerawatts(double terawatts)
         {
-            return new Power(Convert.ToDecimal((terawatts) * 1e12d));
+            double value = (double) terawatts;
+            return new Power(Convert.ToDecimal((value) * 1e12d));
         }
-
-        /// <summary>
-        ///     Get Power from Terawatts.
-        /// </summary>
-        public static Power FromTerawatts(int terawatts)
+#else
+        public static Power FromTerawatts(QuantityValue terawatts)
         {
-            return new Power(Convert.ToDecimal((terawatts) * 1e12d));
-        }
-
-        /// <summary>
-        ///     Get Power from Terawatts.
-        /// </summary>
-        public static Power FromTerawatts(long terawatts)
-        {
-            return new Power(Convert.ToDecimal((terawatts) * 1e12d));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Terawatts of type decimal.
-        /// </summary>
-        public static Power FromTerawatts(decimal terawatts)
-        {
-            return new Power(Convert.ToDecimal((Convert.ToDouble(terawatts)) * 1e12d));
+            double value = (double) terawatts;
+            return new Power((Convert.ToDecimal((value) * 1e12d)));
         }
 #endif
 
         /// <summary>
         ///     Get Power from Watts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Power FromWatts(double watts)
         {
-            return new Power(Convert.ToDecimal(watts));
+            double value = (double) watts;
+            return new Power(Convert.ToDecimal(value));
         }
-
-        /// <summary>
-        ///     Get Power from Watts.
-        /// </summary>
-        public static Power FromWatts(int watts)
+#else
+        public static Power FromWatts(QuantityValue watts)
         {
-            return new Power(Convert.ToDecimal(watts));
-        }
-
-        /// <summary>
-        ///     Get Power from Watts.
-        /// </summary>
-        public static Power FromWatts(long watts)
-        {
-            return new Power(Convert.ToDecimal(watts));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Power from Watts of type decimal.
-        /// </summary>
-        public static Power FromWatts(decimal watts)
-        {
-            return new Power(Convert.ToDecimal(Convert.ToDouble(watts)));
+            double value = (double) watts;
+            return new Power((Convert.ToDecimal(value)));
         }
 #endif
 
@@ -971,52 +611,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable BoilerHorsepower.
         /// </summary>
-        public static Power? FromBoilerHorsepower(double? boilerhorsepower)
-        {
-            if (boilerhorsepower.HasValue)
-            {
-                return FromBoilerHorsepower(boilerhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable BoilerHorsepower.
-        /// </summary>
-        public static Power? FromBoilerHorsepower(int? boilerhorsepower)
-        {
-            if (boilerhorsepower.HasValue)
-            {
-                return FromBoilerHorsepower(boilerhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable BoilerHorsepower.
-        /// </summary>
-        public static Power? FromBoilerHorsepower(long? boilerhorsepower)
-        {
-            if (boilerhorsepower.HasValue)
-            {
-                return FromBoilerHorsepower(boilerhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from BoilerHorsepower of type decimal.
-        /// </summary>
-        public static Power? FromBoilerHorsepower(decimal? boilerhorsepower)
+        public static Power? FromBoilerHorsepower(QuantityValue? boilerhorsepower)
         {
             if (boilerhorsepower.HasValue)
             {
@@ -1031,52 +626,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
         /// </summary>
-        public static Power? FromBritishThermalUnitsPerHour(double? britishthermalunitsperhour)
-        {
-            if (britishthermalunitsperhour.HasValue)
-            {
-                return FromBritishThermalUnitsPerHour(britishthermalunitsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power? FromBritishThermalUnitsPerHour(int? britishthermalunitsperhour)
-        {
-            if (britishthermalunitsperhour.HasValue)
-            {
-                return FromBritishThermalUnitsPerHour(britishthermalunitsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable BritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power? FromBritishThermalUnitsPerHour(long? britishthermalunitsperhour)
-        {
-            if (britishthermalunitsperhour.HasValue)
-            {
-                return FromBritishThermalUnitsPerHour(britishthermalunitsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from BritishThermalUnitsPerHour of type decimal.
-        /// </summary>
-        public static Power? FromBritishThermalUnitsPerHour(decimal? britishthermalunitsperhour)
+        public static Power? FromBritishThermalUnitsPerHour(QuantityValue? britishthermalunitsperhour)
         {
             if (britishthermalunitsperhour.HasValue)
             {
@@ -1091,52 +641,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable ElectricalHorsepower.
         /// </summary>
-        public static Power? FromElectricalHorsepower(double? electricalhorsepower)
-        {
-            if (electricalhorsepower.HasValue)
-            {
-                return FromElectricalHorsepower(electricalhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable ElectricalHorsepower.
-        /// </summary>
-        public static Power? FromElectricalHorsepower(int? electricalhorsepower)
-        {
-            if (electricalhorsepower.HasValue)
-            {
-                return FromElectricalHorsepower(electricalhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable ElectricalHorsepower.
-        /// </summary>
-        public static Power? FromElectricalHorsepower(long? electricalhorsepower)
-        {
-            if (electricalhorsepower.HasValue)
-            {
-                return FromElectricalHorsepower(electricalhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from ElectricalHorsepower of type decimal.
-        /// </summary>
-        public static Power? FromElectricalHorsepower(decimal? electricalhorsepower)
+        public static Power? FromElectricalHorsepower(QuantityValue? electricalhorsepower)
         {
             if (electricalhorsepower.HasValue)
             {
@@ -1151,52 +656,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Femtowatts.
         /// </summary>
-        public static Power? FromFemtowatts(double? femtowatts)
-        {
-            if (femtowatts.HasValue)
-            {
-                return FromFemtowatts(femtowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Femtowatts.
-        /// </summary>
-        public static Power? FromFemtowatts(int? femtowatts)
-        {
-            if (femtowatts.HasValue)
-            {
-                return FromFemtowatts(femtowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Femtowatts.
-        /// </summary>
-        public static Power? FromFemtowatts(long? femtowatts)
-        {
-            if (femtowatts.HasValue)
-            {
-                return FromFemtowatts(femtowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Femtowatts of type decimal.
-        /// </summary>
-        public static Power? FromFemtowatts(decimal? femtowatts)
+        public static Power? FromFemtowatts(QuantityValue? femtowatts)
         {
             if (femtowatts.HasValue)
             {
@@ -1211,52 +671,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Gigawatts.
         /// </summary>
-        public static Power? FromGigawatts(double? gigawatts)
-        {
-            if (gigawatts.HasValue)
-            {
-                return FromGigawatts(gigawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Gigawatts.
-        /// </summary>
-        public static Power? FromGigawatts(int? gigawatts)
-        {
-            if (gigawatts.HasValue)
-            {
-                return FromGigawatts(gigawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Gigawatts.
-        /// </summary>
-        public static Power? FromGigawatts(long? gigawatts)
-        {
-            if (gigawatts.HasValue)
-            {
-                return FromGigawatts(gigawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Gigawatts of type decimal.
-        /// </summary>
-        public static Power? FromGigawatts(decimal? gigawatts)
+        public static Power? FromGigawatts(QuantityValue? gigawatts)
         {
             if (gigawatts.HasValue)
             {
@@ -1271,52 +686,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable HydraulicHorsepower.
         /// </summary>
-        public static Power? FromHydraulicHorsepower(double? hydraulichorsepower)
-        {
-            if (hydraulichorsepower.HasValue)
-            {
-                return FromHydraulicHorsepower(hydraulichorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable HydraulicHorsepower.
-        /// </summary>
-        public static Power? FromHydraulicHorsepower(int? hydraulichorsepower)
-        {
-            if (hydraulichorsepower.HasValue)
-            {
-                return FromHydraulicHorsepower(hydraulichorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable HydraulicHorsepower.
-        /// </summary>
-        public static Power? FromHydraulicHorsepower(long? hydraulichorsepower)
-        {
-            if (hydraulichorsepower.HasValue)
-            {
-                return FromHydraulicHorsepower(hydraulichorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from HydraulicHorsepower of type decimal.
-        /// </summary>
-        public static Power? FromHydraulicHorsepower(decimal? hydraulichorsepower)
+        public static Power? FromHydraulicHorsepower(QuantityValue? hydraulichorsepower)
         {
             if (hydraulichorsepower.HasValue)
             {
@@ -1331,52 +701,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
         /// </summary>
-        public static Power? FromKilobritishThermalUnitsPerHour(double? kilobritishthermalunitsperhour)
-        {
-            if (kilobritishthermalunitsperhour.HasValue)
-            {
-                return FromKilobritishThermalUnitsPerHour(kilobritishthermalunitsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power? FromKilobritishThermalUnitsPerHour(int? kilobritishthermalunitsperhour)
-        {
-            if (kilobritishthermalunitsperhour.HasValue)
-            {
-                return FromKilobritishThermalUnitsPerHour(kilobritishthermalunitsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable KilobritishThermalUnitsPerHour.
-        /// </summary>
-        public static Power? FromKilobritishThermalUnitsPerHour(long? kilobritishthermalunitsperhour)
-        {
-            if (kilobritishthermalunitsperhour.HasValue)
-            {
-                return FromKilobritishThermalUnitsPerHour(kilobritishthermalunitsperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from KilobritishThermalUnitsPerHour of type decimal.
-        /// </summary>
-        public static Power? FromKilobritishThermalUnitsPerHour(decimal? kilobritishthermalunitsperhour)
+        public static Power? FromKilobritishThermalUnitsPerHour(QuantityValue? kilobritishthermalunitsperhour)
         {
             if (kilobritishthermalunitsperhour.HasValue)
             {
@@ -1391,52 +716,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Kilowatts.
         /// </summary>
-        public static Power? FromKilowatts(double? kilowatts)
-        {
-            if (kilowatts.HasValue)
-            {
-                return FromKilowatts(kilowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Kilowatts.
-        /// </summary>
-        public static Power? FromKilowatts(int? kilowatts)
-        {
-            if (kilowatts.HasValue)
-            {
-                return FromKilowatts(kilowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Kilowatts.
-        /// </summary>
-        public static Power? FromKilowatts(long? kilowatts)
-        {
-            if (kilowatts.HasValue)
-            {
-                return FromKilowatts(kilowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Kilowatts of type decimal.
-        /// </summary>
-        public static Power? FromKilowatts(decimal? kilowatts)
+        public static Power? FromKilowatts(QuantityValue? kilowatts)
         {
             if (kilowatts.HasValue)
             {
@@ -1451,52 +731,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable MechanicalHorsepower.
         /// </summary>
-        public static Power? FromMechanicalHorsepower(double? mechanicalhorsepower)
-        {
-            if (mechanicalhorsepower.HasValue)
-            {
-                return FromMechanicalHorsepower(mechanicalhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable MechanicalHorsepower.
-        /// </summary>
-        public static Power? FromMechanicalHorsepower(int? mechanicalhorsepower)
-        {
-            if (mechanicalhorsepower.HasValue)
-            {
-                return FromMechanicalHorsepower(mechanicalhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable MechanicalHorsepower.
-        /// </summary>
-        public static Power? FromMechanicalHorsepower(long? mechanicalhorsepower)
-        {
-            if (mechanicalhorsepower.HasValue)
-            {
-                return FromMechanicalHorsepower(mechanicalhorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from MechanicalHorsepower of type decimal.
-        /// </summary>
-        public static Power? FromMechanicalHorsepower(decimal? mechanicalhorsepower)
+        public static Power? FromMechanicalHorsepower(QuantityValue? mechanicalhorsepower)
         {
             if (mechanicalhorsepower.HasValue)
             {
@@ -1511,52 +746,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Megawatts.
         /// </summary>
-        public static Power? FromMegawatts(double? megawatts)
-        {
-            if (megawatts.HasValue)
-            {
-                return FromMegawatts(megawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Megawatts.
-        /// </summary>
-        public static Power? FromMegawatts(int? megawatts)
-        {
-            if (megawatts.HasValue)
-            {
-                return FromMegawatts(megawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Megawatts.
-        /// </summary>
-        public static Power? FromMegawatts(long? megawatts)
-        {
-            if (megawatts.HasValue)
-            {
-                return FromMegawatts(megawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Megawatts of type decimal.
-        /// </summary>
-        public static Power? FromMegawatts(decimal? megawatts)
+        public static Power? FromMegawatts(QuantityValue? megawatts)
         {
             if (megawatts.HasValue)
             {
@@ -1571,52 +761,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable MetricHorsepower.
         /// </summary>
-        public static Power? FromMetricHorsepower(double? metrichorsepower)
-        {
-            if (metrichorsepower.HasValue)
-            {
-                return FromMetricHorsepower(metrichorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable MetricHorsepower.
-        /// </summary>
-        public static Power? FromMetricHorsepower(int? metrichorsepower)
-        {
-            if (metrichorsepower.HasValue)
-            {
-                return FromMetricHorsepower(metrichorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable MetricHorsepower.
-        /// </summary>
-        public static Power? FromMetricHorsepower(long? metrichorsepower)
-        {
-            if (metrichorsepower.HasValue)
-            {
-                return FromMetricHorsepower(metrichorsepower.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from MetricHorsepower of type decimal.
-        /// </summary>
-        public static Power? FromMetricHorsepower(decimal? metrichorsepower)
+        public static Power? FromMetricHorsepower(QuantityValue? metrichorsepower)
         {
             if (metrichorsepower.HasValue)
             {
@@ -1631,52 +776,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Microwatts.
         /// </summary>
-        public static Power? FromMicrowatts(double? microwatts)
-        {
-            if (microwatts.HasValue)
-            {
-                return FromMicrowatts(microwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Microwatts.
-        /// </summary>
-        public static Power? FromMicrowatts(int? microwatts)
-        {
-            if (microwatts.HasValue)
-            {
-                return FromMicrowatts(microwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Microwatts.
-        /// </summary>
-        public static Power? FromMicrowatts(long? microwatts)
-        {
-            if (microwatts.HasValue)
-            {
-                return FromMicrowatts(microwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Microwatts of type decimal.
-        /// </summary>
-        public static Power? FromMicrowatts(decimal? microwatts)
+        public static Power? FromMicrowatts(QuantityValue? microwatts)
         {
             if (microwatts.HasValue)
             {
@@ -1691,52 +791,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Milliwatts.
         /// </summary>
-        public static Power? FromMilliwatts(double? milliwatts)
-        {
-            if (milliwatts.HasValue)
-            {
-                return FromMilliwatts(milliwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Milliwatts.
-        /// </summary>
-        public static Power? FromMilliwatts(int? milliwatts)
-        {
-            if (milliwatts.HasValue)
-            {
-                return FromMilliwatts(milliwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Milliwatts.
-        /// </summary>
-        public static Power? FromMilliwatts(long? milliwatts)
-        {
-            if (milliwatts.HasValue)
-            {
-                return FromMilliwatts(milliwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Milliwatts of type decimal.
-        /// </summary>
-        public static Power? FromMilliwatts(decimal? milliwatts)
+        public static Power? FromMilliwatts(QuantityValue? milliwatts)
         {
             if (milliwatts.HasValue)
             {
@@ -1751,52 +806,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Nanowatts.
         /// </summary>
-        public static Power? FromNanowatts(double? nanowatts)
-        {
-            if (nanowatts.HasValue)
-            {
-                return FromNanowatts(nanowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Nanowatts.
-        /// </summary>
-        public static Power? FromNanowatts(int? nanowatts)
-        {
-            if (nanowatts.HasValue)
-            {
-                return FromNanowatts(nanowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Nanowatts.
-        /// </summary>
-        public static Power? FromNanowatts(long? nanowatts)
-        {
-            if (nanowatts.HasValue)
-            {
-                return FromNanowatts(nanowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Nanowatts of type decimal.
-        /// </summary>
-        public static Power? FromNanowatts(decimal? nanowatts)
+        public static Power? FromNanowatts(QuantityValue? nanowatts)
         {
             if (nanowatts.HasValue)
             {
@@ -1811,52 +821,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Petawatts.
         /// </summary>
-        public static Power? FromPetawatts(double? petawatts)
-        {
-            if (petawatts.HasValue)
-            {
-                return FromPetawatts(petawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Petawatts.
-        /// </summary>
-        public static Power? FromPetawatts(int? petawatts)
-        {
-            if (petawatts.HasValue)
-            {
-                return FromPetawatts(petawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Petawatts.
-        /// </summary>
-        public static Power? FromPetawatts(long? petawatts)
-        {
-            if (petawatts.HasValue)
-            {
-                return FromPetawatts(petawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Petawatts of type decimal.
-        /// </summary>
-        public static Power? FromPetawatts(decimal? petawatts)
+        public static Power? FromPetawatts(QuantityValue? petawatts)
         {
             if (petawatts.HasValue)
             {
@@ -1871,52 +836,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Picowatts.
         /// </summary>
-        public static Power? FromPicowatts(double? picowatts)
-        {
-            if (picowatts.HasValue)
-            {
-                return FromPicowatts(picowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Picowatts.
-        /// </summary>
-        public static Power? FromPicowatts(int? picowatts)
-        {
-            if (picowatts.HasValue)
-            {
-                return FromPicowatts(picowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Picowatts.
-        /// </summary>
-        public static Power? FromPicowatts(long? picowatts)
-        {
-            if (picowatts.HasValue)
-            {
-                return FromPicowatts(picowatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Picowatts of type decimal.
-        /// </summary>
-        public static Power? FromPicowatts(decimal? picowatts)
+        public static Power? FromPicowatts(QuantityValue? picowatts)
         {
             if (picowatts.HasValue)
             {
@@ -1931,52 +851,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Terawatts.
         /// </summary>
-        public static Power? FromTerawatts(double? terawatts)
-        {
-            if (terawatts.HasValue)
-            {
-                return FromTerawatts(terawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Terawatts.
-        /// </summary>
-        public static Power? FromTerawatts(int? terawatts)
-        {
-            if (terawatts.HasValue)
-            {
-                return FromTerawatts(terawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Terawatts.
-        /// </summary>
-        public static Power? FromTerawatts(long? terawatts)
-        {
-            if (terawatts.HasValue)
-            {
-                return FromTerawatts(terawatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Terawatts of type decimal.
-        /// </summary>
-        public static Power? FromTerawatts(decimal? terawatts)
+        public static Power? FromTerawatts(QuantityValue? terawatts)
         {
             if (terawatts.HasValue)
             {
@@ -1991,52 +866,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Power from nullable Watts.
         /// </summary>
-        public static Power? FromWatts(double? watts)
-        {
-            if (watts.HasValue)
-            {
-                return FromWatts(watts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Watts.
-        /// </summary>
-        public static Power? FromWatts(int? watts)
-        {
-            if (watts.HasValue)
-            {
-                return FromWatts(watts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from nullable Watts.
-        /// </summary>
-        public static Power? FromWatts(long? watts)
-        {
-            if (watts.HasValue)
-            {
-                return FromWatts(watts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Power from Watts of type decimal.
-        /// </summary>
-        public static Power? FromWatts(decimal? watts)
+        public static Power? FromWatts(QuantityValue? watts)
         {
             if (watts.HasValue)
             {
@@ -2053,49 +883,55 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="PowerUnit" /> to <see cref="Power" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Power unit value.</returns>
-        public static Power From(double val, PowerUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Power From(double value, PowerUnit fromUnit)
+#else
+        public static Power From(QuantityValue value, PowerUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case PowerUnit.BoilerHorsepower:
-                    return FromBoilerHorsepower(val);
+                    return FromBoilerHorsepower(value);
                 case PowerUnit.BritishThermalUnitPerHour:
-                    return FromBritishThermalUnitsPerHour(val);
+                    return FromBritishThermalUnitsPerHour(value);
                 case PowerUnit.ElectricalHorsepower:
-                    return FromElectricalHorsepower(val);
+                    return FromElectricalHorsepower(value);
                 case PowerUnit.Femtowatt:
-                    return FromFemtowatts(val);
+                    return FromFemtowatts(value);
                 case PowerUnit.Gigawatt:
-                    return FromGigawatts(val);
+                    return FromGigawatts(value);
                 case PowerUnit.HydraulicHorsepower:
-                    return FromHydraulicHorsepower(val);
+                    return FromHydraulicHorsepower(value);
                 case PowerUnit.KilobritishThermalUnitPerHour:
-                    return FromKilobritishThermalUnitsPerHour(val);
+                    return FromKilobritishThermalUnitsPerHour(value);
                 case PowerUnit.Kilowatt:
-                    return FromKilowatts(val);
+                    return FromKilowatts(value);
                 case PowerUnit.MechanicalHorsepower:
-                    return FromMechanicalHorsepower(val);
+                    return FromMechanicalHorsepower(value);
                 case PowerUnit.Megawatt:
-                    return FromMegawatts(val);
+                    return FromMegawatts(value);
                 case PowerUnit.MetricHorsepower:
-                    return FromMetricHorsepower(val);
+                    return FromMetricHorsepower(value);
                 case PowerUnit.Microwatt:
-                    return FromMicrowatts(val);
+                    return FromMicrowatts(value);
                 case PowerUnit.Milliwatt:
-                    return FromMilliwatts(val);
+                    return FromMilliwatts(value);
                 case PowerUnit.Nanowatt:
-                    return FromNanowatts(val);
+                    return FromNanowatts(value);
                 case PowerUnit.Petawatt:
-                    return FromPetawatts(val);
+                    return FromPetawatts(value);
                 case PowerUnit.Picowatt:
-                    return FromPicowatts(val);
+                    return FromPicowatts(value);
                 case PowerUnit.Terawatt:
-                    return FromTerawatts(val);
+                    return FromTerawatts(value);
                 case PowerUnit.Watt:
-                    return FromWatts(val);
+                    return FromWatts(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2110,7 +946,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Power unit value.</returns>
-        public static Power? From(double? value, PowerUnit fromUnit)
+        public static Power? From(QuantityValue? value, PowerUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -157,76 +157,36 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static PowerRatio FromDecibelMilliwatts(double decibelmilliwatts)
         {
-            return new PowerRatio(decibelmilliwatts - 30);
+            double value = (double) decibelmilliwatts;
+            return new PowerRatio(value - 30);
         }
-
-        /// <summary>
-        ///     Get PowerRatio from DecibelMilliwatts.
-        /// </summary>
-        public static PowerRatio FromDecibelMilliwatts(int decibelmilliwatts)
+#else
+        public static PowerRatio FromDecibelMilliwatts(QuantityValue decibelmilliwatts)
         {
-            return new PowerRatio(decibelmilliwatts - 30);
-        }
-
-        /// <summary>
-        ///     Get PowerRatio from DecibelMilliwatts.
-        /// </summary>
-        public static PowerRatio FromDecibelMilliwatts(long decibelmilliwatts)
-        {
-            return new PowerRatio(decibelmilliwatts - 30);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get PowerRatio from DecibelMilliwatts of type decimal.
-        /// </summary>
-        public static PowerRatio FromDecibelMilliwatts(decimal decibelmilliwatts)
-        {
-            return new PowerRatio(Convert.ToDouble(decibelmilliwatts) - 30);
+            double value = (double) decibelmilliwatts;
+            return new PowerRatio((value - 30));
         }
 #endif
 
         /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static PowerRatio FromDecibelWatts(double decibelwatts)
         {
-            return new PowerRatio(decibelwatts);
+            double value = (double) decibelwatts;
+            return new PowerRatio(value);
         }
-
-        /// <summary>
-        ///     Get PowerRatio from DecibelWatts.
-        /// </summary>
-        public static PowerRatio FromDecibelWatts(int decibelwatts)
+#else
+        public static PowerRatio FromDecibelWatts(QuantityValue decibelwatts)
         {
-            return new PowerRatio(decibelwatts);
-        }
-
-        /// <summary>
-        ///     Get PowerRatio from DecibelWatts.
-        /// </summary>
-        public static PowerRatio FromDecibelWatts(long decibelwatts)
-        {
-            return new PowerRatio(decibelwatts);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get PowerRatio from DecibelWatts of type decimal.
-        /// </summary>
-        public static PowerRatio FromDecibelWatts(decimal decibelwatts)
-        {
-            return new PowerRatio(Convert.ToDouble(decibelwatts));
+            double value = (double) decibelwatts;
+            return new PowerRatio((value));
         }
 #endif
 
@@ -235,52 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
         /// </summary>
-        public static PowerRatio? FromDecibelMilliwatts(double? decibelmilliwatts)
-        {
-            if (decibelmilliwatts.HasValue)
-            {
-                return FromDecibelMilliwatts(decibelmilliwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
-        /// </summary>
-        public static PowerRatio? FromDecibelMilliwatts(int? decibelmilliwatts)
-        {
-            if (decibelmilliwatts.HasValue)
-            {
-                return FromDecibelMilliwatts(decibelmilliwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PowerRatio from nullable DecibelMilliwatts.
-        /// </summary>
-        public static PowerRatio? FromDecibelMilliwatts(long? decibelmilliwatts)
-        {
-            if (decibelmilliwatts.HasValue)
-            {
-                return FromDecibelMilliwatts(decibelmilliwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PowerRatio from DecibelMilliwatts of type decimal.
-        /// </summary>
-        public static PowerRatio? FromDecibelMilliwatts(decimal? decibelmilliwatts)
+        public static PowerRatio? FromDecibelMilliwatts(QuantityValue? decibelmilliwatts)
         {
             if (decibelmilliwatts.HasValue)
             {
@@ -295,52 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable PowerRatio from nullable DecibelWatts.
         /// </summary>
-        public static PowerRatio? FromDecibelWatts(double? decibelwatts)
-        {
-            if (decibelwatts.HasValue)
-            {
-                return FromDecibelWatts(decibelwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PowerRatio from nullable DecibelWatts.
-        /// </summary>
-        public static PowerRatio? FromDecibelWatts(int? decibelwatts)
-        {
-            if (decibelwatts.HasValue)
-            {
-                return FromDecibelWatts(decibelwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PowerRatio from nullable DecibelWatts.
-        /// </summary>
-        public static PowerRatio? FromDecibelWatts(long? decibelwatts)
-        {
-            if (decibelwatts.HasValue)
-            {
-                return FromDecibelWatts(decibelwatts.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PowerRatio from DecibelWatts of type decimal.
-        /// </summary>
-        public static PowerRatio? FromDecibelWatts(decimal? decibelwatts)
+        public static PowerRatio? FromDecibelWatts(QuantityValue? decibelwatts)
         {
             if (decibelwatts.HasValue)
             {
@@ -357,17 +227,23 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="PowerRatioUnit" /> to <see cref="PowerRatio" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>PowerRatio unit value.</returns>
-        public static PowerRatio From(double val, PowerRatioUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static PowerRatio From(double value, PowerRatioUnit fromUnit)
+#else
+        public static PowerRatio From(QuantityValue value, PowerRatioUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case PowerRatioUnit.DecibelMilliwatt:
-                    return FromDecibelMilliwatts(val);
+                    return FromDecibelMilliwatts(value);
                 case PowerRatioUnit.DecibelWatt:
-                    return FromDecibelWatts(val);
+                    return FromDecibelWatts(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -382,7 +258,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>PowerRatio unit value.</returns>
-        public static PowerRatio? From(double? value, PowerRatioUnit fromUnit)
+        public static PowerRatio? From(QuantityValue? value, PowerRatioUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -438,1406 +438,666 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Atmospheres.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromAtmospheres(double atmospheres)
         {
-            return new Pressure(atmospheres*1.01325*1e5);
+            double value = (double) atmospheres;
+            return new Pressure(value*1.01325*1e5);
         }
-
-        /// <summary>
-        ///     Get Pressure from Atmospheres.
-        /// </summary>
-        public static Pressure FromAtmospheres(int atmospheres)
+#else
+        public static Pressure FromAtmospheres(QuantityValue atmospheres)
         {
-            return new Pressure(atmospheres*1.01325*1e5);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Atmospheres.
-        /// </summary>
-        public static Pressure FromAtmospheres(long atmospheres)
-        {
-            return new Pressure(atmospheres*1.01325*1e5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Atmospheres of type decimal.
-        /// </summary>
-        public static Pressure FromAtmospheres(decimal atmospheres)
-        {
-            return new Pressure(Convert.ToDouble(atmospheres)*1.01325*1e5);
+            double value = (double) atmospheres;
+            return new Pressure((value*1.01325*1e5));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromBars(double bars)
         {
-            return new Pressure(bars*1e5);
+            double value = (double) bars;
+            return new Pressure(value*1e5);
         }
-
-        /// <summary>
-        ///     Get Pressure from Bars.
-        /// </summary>
-        public static Pressure FromBars(int bars)
+#else
+        public static Pressure FromBars(QuantityValue bars)
         {
-            return new Pressure(bars*1e5);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Bars.
-        /// </summary>
-        public static Pressure FromBars(long bars)
-        {
-            return new Pressure(bars*1e5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Bars of type decimal.
-        /// </summary>
-        public static Pressure FromBars(decimal bars)
-        {
-            return new Pressure(Convert.ToDouble(bars)*1e5);
+            double value = (double) bars;
+            return new Pressure((value*1e5));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Centibars.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromCentibars(double centibars)
         {
-            return new Pressure((centibars*1e5) * 1e-2d);
+            double value = (double) centibars;
+            return new Pressure((value*1e5) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Centibars.
-        /// </summary>
-        public static Pressure FromCentibars(int centibars)
+#else
+        public static Pressure FromCentibars(QuantityValue centibars)
         {
-            return new Pressure((centibars*1e5) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Centibars.
-        /// </summary>
-        public static Pressure FromCentibars(long centibars)
-        {
-            return new Pressure((centibars*1e5) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Centibars of type decimal.
-        /// </summary>
-        public static Pressure FromCentibars(decimal centibars)
-        {
-            return new Pressure((Convert.ToDouble(centibars)*1e5) * 1e-2d);
+            double value = (double) centibars;
+            return new Pressure(((value*1e5) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromDecapascals(double decapascals)
         {
-            return new Pressure((decapascals) * 1e1d);
+            double value = (double) decapascals;
+            return new Pressure((value) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Decapascals.
-        /// </summary>
-        public static Pressure FromDecapascals(int decapascals)
+#else
+        public static Pressure FromDecapascals(QuantityValue decapascals)
         {
-            return new Pressure((decapascals) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Decapascals.
-        /// </summary>
-        public static Pressure FromDecapascals(long decapascals)
-        {
-            return new Pressure((decapascals) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Decapascals of type decimal.
-        /// </summary>
-        public static Pressure FromDecapascals(decimal decapascals)
-        {
-            return new Pressure((Convert.ToDouble(decapascals)) * 1e1d);
+            double value = (double) decapascals;
+            return new Pressure(((value) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Decibars.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromDecibars(double decibars)
         {
-            return new Pressure((decibars*1e5) * 1e-1d);
+            double value = (double) decibars;
+            return new Pressure((value*1e5) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Decibars.
-        /// </summary>
-        public static Pressure FromDecibars(int decibars)
+#else
+        public static Pressure FromDecibars(QuantityValue decibars)
         {
-            return new Pressure((decibars*1e5) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Decibars.
-        /// </summary>
-        public static Pressure FromDecibars(long decibars)
-        {
-            return new Pressure((decibars*1e5) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Decibars of type decimal.
-        /// </summary>
-        public static Pressure FromDecibars(decimal decibars)
-        {
-            return new Pressure((Convert.ToDouble(decibars)*1e5) * 1e-1d);
+            double value = (double) decibars;
+            return new Pressure(((value*1e5) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromFeetOfHead(double feetofhead)
         {
-            return new Pressure(feetofhead*2989.0669);
+            double value = (double) feetofhead;
+            return new Pressure(value*2989.0669);
         }
-
-        /// <summary>
-        ///     Get Pressure from FeetOfHead.
-        /// </summary>
-        public static Pressure FromFeetOfHead(int feetofhead)
+#else
+        public static Pressure FromFeetOfHead(QuantityValue feetofhead)
         {
-            return new Pressure(feetofhead*2989.0669);
-        }
-
-        /// <summary>
-        ///     Get Pressure from FeetOfHead.
-        /// </summary>
-        public static Pressure FromFeetOfHead(long feetofhead)
-        {
-            return new Pressure(feetofhead*2989.0669);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from FeetOfHead of type decimal.
-        /// </summary>
-        public static Pressure FromFeetOfHead(decimal feetofhead)
-        {
-            return new Pressure(Convert.ToDouble(feetofhead)*2989.0669);
+            double value = (double) feetofhead;
+            return new Pressure((value*2989.0669));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Gigapascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromGigapascals(double gigapascals)
         {
-            return new Pressure((gigapascals) * 1e9d);
+            double value = (double) gigapascals;
+            return new Pressure((value) * 1e9d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Gigapascals.
-        /// </summary>
-        public static Pressure FromGigapascals(int gigapascals)
+#else
+        public static Pressure FromGigapascals(QuantityValue gigapascals)
         {
-            return new Pressure((gigapascals) * 1e9d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Gigapascals.
-        /// </summary>
-        public static Pressure FromGigapascals(long gigapascals)
-        {
-            return new Pressure((gigapascals) * 1e9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Gigapascals of type decimal.
-        /// </summary>
-        public static Pressure FromGigapascals(decimal gigapascals)
-        {
-            return new Pressure((Convert.ToDouble(gigapascals)) * 1e9d);
+            double value = (double) gigapascals;
+            return new Pressure(((value) * 1e9d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromHectopascals(double hectopascals)
         {
-            return new Pressure((hectopascals) * 1e2d);
+            double value = (double) hectopascals;
+            return new Pressure((value) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Hectopascals.
-        /// </summary>
-        public static Pressure FromHectopascals(int hectopascals)
+#else
+        public static Pressure FromHectopascals(QuantityValue hectopascals)
         {
-            return new Pressure((hectopascals) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Hectopascals.
-        /// </summary>
-        public static Pressure FromHectopascals(long hectopascals)
-        {
-            return new Pressure((hectopascals) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Hectopascals of type decimal.
-        /// </summary>
-        public static Pressure FromHectopascals(decimal hectopascals)
-        {
-            return new Pressure((Convert.ToDouble(hectopascals)) * 1e2d);
+            double value = (double) hectopascals;
+            return new Pressure(((value) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from InchesOfMercury.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromInchesOfMercury(double inchesofmercury)
         {
-            return new Pressure(inchesofmercury/2.95299830714159e-4);
+            double value = (double) inchesofmercury;
+            return new Pressure(value/2.95299830714159e-4);
         }
-
-        /// <summary>
-        ///     Get Pressure from InchesOfMercury.
-        /// </summary>
-        public static Pressure FromInchesOfMercury(int inchesofmercury)
+#else
+        public static Pressure FromInchesOfMercury(QuantityValue inchesofmercury)
         {
-            return new Pressure(inchesofmercury/2.95299830714159e-4);
-        }
-
-        /// <summary>
-        ///     Get Pressure from InchesOfMercury.
-        /// </summary>
-        public static Pressure FromInchesOfMercury(long inchesofmercury)
-        {
-            return new Pressure(inchesofmercury/2.95299830714159e-4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from InchesOfMercury of type decimal.
-        /// </summary>
-        public static Pressure FromInchesOfMercury(decimal inchesofmercury)
-        {
-            return new Pressure(Convert.ToDouble(inchesofmercury)/2.95299830714159e-4);
+            double value = (double) inchesofmercury;
+            return new Pressure((value/2.95299830714159e-4));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilobars(double kilobars)
         {
-            return new Pressure((kilobars*1e5) * 1e3d);
+            double value = (double) kilobars;
+            return new Pressure((value*1e5) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Kilobars.
-        /// </summary>
-        public static Pressure FromKilobars(int kilobars)
+#else
+        public static Pressure FromKilobars(QuantityValue kilobars)
         {
-            return new Pressure((kilobars*1e5) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Kilobars.
-        /// </summary>
-        public static Pressure FromKilobars(long kilobars)
-        {
-            return new Pressure((kilobars*1e5) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Kilobars of type decimal.
-        /// </summary>
-        public static Pressure FromKilobars(decimal kilobars)
-        {
-            return new Pressure((Convert.ToDouble(kilobars)*1e5) * 1e3d);
+            double value = (double) kilobars;
+            return new Pressure(((value*1e5) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilogramsForcePerSquareCentimeter(double kilogramsforcepersquarecentimeter)
         {
-            return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
+            double value = (double) kilogramsforcepersquarecentimeter;
+            return new Pressure(value*9.80665*1e4);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareCentimeter(int kilogramsforcepersquarecentimeter)
+#else
+        public static Pressure FromKilogramsForcePerSquareCentimeter(QuantityValue kilogramsforcepersquarecentimeter)
         {
-            return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareCentimeter(long kilogramsforcepersquarecentimeter)
-        {
-            return new Pressure(kilogramsforcepersquarecentimeter*9.80665*1e4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareCentimeter(decimal kilogramsforcepersquarecentimeter)
-        {
-            return new Pressure(Convert.ToDouble(kilogramsforcepersquarecentimeter)*9.80665*1e4);
+            double value = (double) kilogramsforcepersquarecentimeter;
+            return new Pressure((value*9.80665*1e4));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilogramsForcePerSquareMeter(double kilogramsforcepersquaremeter)
         {
-            return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
+            double value = (double) kilogramsforcepersquaremeter;
+            return new Pressure(value*9.80665019960652);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareMeter.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareMeter(int kilogramsforcepersquaremeter)
+#else
+        public static Pressure FromKilogramsForcePerSquareMeter(QuantityValue kilogramsforcepersquaremeter)
         {
-            return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareMeter.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareMeter(long kilogramsforcepersquaremeter)
-        {
-            return new Pressure(kilogramsforcepersquaremeter*9.80665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareMeter(decimal kilogramsforcepersquaremeter)
-        {
-            return new Pressure(Convert.ToDouble(kilogramsforcepersquaremeter)*9.80665019960652);
+            double value = (double) kilogramsforcepersquaremeter;
+            return new Pressure((value*9.80665019960652));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilogramsForcePerSquareMillimeter(double kilogramsforcepersquaremillimeter)
         {
-            return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
+            double value = (double) kilogramsforcepersquaremillimeter;
+            return new Pressure(value*9806650.19960652);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareMillimeter(int kilogramsforcepersquaremillimeter)
+#else
+        public static Pressure FromKilogramsForcePerSquareMillimeter(QuantityValue kilogramsforcepersquaremillimeter)
         {
-            return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareMillimeter(long kilogramsforcepersquaremillimeter)
-        {
-            return new Pressure(kilogramsforcepersquaremillimeter*9806650.19960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilogramsForcePerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure FromKilogramsForcePerSquareMillimeter(decimal kilogramsforcepersquaremillimeter)
-        {
-            return new Pressure(Convert.ToDouble(kilogramsforcepersquaremillimeter)*9806650.19960652);
+            double value = (double) kilogramsforcepersquaremillimeter;
+            return new Pressure((value*9806650.19960652));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilonewtonsPerSquareCentimeter(double kilonewtonspersquarecentimeter)
         {
-            return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
+            double value = (double) kilonewtonspersquarecentimeter;
+            return new Pressure((value*1e4) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareCentimeter(int kilonewtonspersquarecentimeter)
+#else
+        public static Pressure FromKilonewtonsPerSquareCentimeter(QuantityValue kilonewtonspersquarecentimeter)
         {
-            return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareCentimeter(long kilonewtonspersquarecentimeter)
-        {
-            return new Pressure((kilonewtonspersquarecentimeter*1e4) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareCentimeter(decimal kilonewtonspersquarecentimeter)
-        {
-            return new Pressure((Convert.ToDouble(kilonewtonspersquarecentimeter)*1e4) * 1e3d);
+            double value = (double) kilonewtonspersquarecentimeter;
+            return new Pressure(((value*1e4) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilonewtonsPerSquareMeter(double kilonewtonspersquaremeter)
         {
-            return new Pressure((kilonewtonspersquaremeter) * 1e3d);
+            double value = (double) kilonewtonspersquaremeter;
+            return new Pressure((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareMeter(int kilonewtonspersquaremeter)
+#else
+        public static Pressure FromKilonewtonsPerSquareMeter(QuantityValue kilonewtonspersquaremeter)
         {
-            return new Pressure((kilonewtonspersquaremeter) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareMeter(long kilonewtonspersquaremeter)
-        {
-            return new Pressure((kilonewtonspersquaremeter) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareMeter(decimal kilonewtonspersquaremeter)
-        {
-            return new Pressure((Convert.ToDouble(kilonewtonspersquaremeter)) * 1e3d);
+            double value = (double) kilonewtonspersquaremeter;
+            return new Pressure(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilonewtonsPerSquareMillimeter(double kilonewtonspersquaremillimeter)
         {
-            return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
+            double value = (double) kilonewtonspersquaremillimeter;
+            return new Pressure((value*1e6) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareMillimeter(int kilonewtonspersquaremillimeter)
+#else
+        public static Pressure FromKilonewtonsPerSquareMillimeter(QuantityValue kilonewtonspersquaremillimeter)
         {
-            return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareMillimeter(long kilonewtonspersquaremillimeter)
-        {
-            return new Pressure((kilonewtonspersquaremillimeter*1e6) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilonewtonsPerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure FromKilonewtonsPerSquareMillimeter(decimal kilonewtonspersquaremillimeter)
-        {
-            return new Pressure((Convert.ToDouble(kilonewtonspersquaremillimeter)*1e6) * 1e3d);
+            double value = (double) kilonewtonspersquaremillimeter;
+            return new Pressure(((value*1e6) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Kilopascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilopascals(double kilopascals)
         {
-            return new Pressure((kilopascals) * 1e3d);
+            double value = (double) kilopascals;
+            return new Pressure((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Kilopascals.
-        /// </summary>
-        public static Pressure FromKilopascals(int kilopascals)
+#else
+        public static Pressure FromKilopascals(QuantityValue kilopascals)
         {
-            return new Pressure((kilopascals) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Kilopascals.
-        /// </summary>
-        public static Pressure FromKilopascals(long kilopascals)
-        {
-            return new Pressure((kilopascals) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Kilopascals of type decimal.
-        /// </summary>
-        public static Pressure FromKilopascals(decimal kilopascals)
-        {
-            return new Pressure((Convert.ToDouble(kilopascals)) * 1e3d);
+            double value = (double) kilopascals;
+            return new Pressure(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilopoundsForcePerSquareFoot(double kilopoundsforcepersquarefoot)
         {
-            return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
+            double value = (double) kilopoundsforcepersquarefoot;
+            return new Pressure((value*47.8802631216372) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilopoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure FromKilopoundsForcePerSquareFoot(int kilopoundsforcepersquarefoot)
+#else
+        public static Pressure FromKilopoundsForcePerSquareFoot(QuantityValue kilopoundsforcepersquarefoot)
         {
-            return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilopoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure FromKilopoundsForcePerSquareFoot(long kilopoundsforcepersquarefoot)
-        {
-            return new Pressure((kilopoundsforcepersquarefoot*47.8802631216372) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilopoundsForcePerSquareFoot of type decimal.
-        /// </summary>
-        public static Pressure FromKilopoundsForcePerSquareFoot(decimal kilopoundsforcepersquarefoot)
-        {
-            return new Pressure((Convert.ToDouble(kilopoundsforcepersquarefoot)*47.8802631216372) * 1e3d);
+            double value = (double) kilopoundsforcepersquarefoot;
+            return new Pressure(((value*47.8802631216372) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromKilopoundsForcePerSquareInch(double kilopoundsforcepersquareinch)
         {
-            return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
+            double value = (double) kilopoundsforcepersquareinch;
+            return new Pressure((value*6894.75729316836) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from KilopoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure FromKilopoundsForcePerSquareInch(int kilopoundsforcepersquareinch)
+#else
+        public static Pressure FromKilopoundsForcePerSquareInch(QuantityValue kilopoundsforcepersquareinch)
         {
-            return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from KilopoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure FromKilopoundsForcePerSquareInch(long kilopoundsforcepersquareinch)
-        {
-            return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from KilopoundsForcePerSquareInch of type decimal.
-        /// </summary>
-        public static Pressure FromKilopoundsForcePerSquareInch(decimal kilopoundsforcepersquareinch)
-        {
-            return new Pressure((Convert.ToDouble(kilopoundsforcepersquareinch)*6894.75729316836) * 1e3d);
+            double value = (double) kilopoundsforcepersquareinch;
+            return new Pressure(((value*6894.75729316836) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromMegabars(double megabars)
         {
-            return new Pressure((megabars*1e5) * 1e6d);
+            double value = (double) megabars;
+            return new Pressure((value*1e5) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Megabars.
-        /// </summary>
-        public static Pressure FromMegabars(int megabars)
+#else
+        public static Pressure FromMegabars(QuantityValue megabars)
         {
-            return new Pressure((megabars*1e5) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Megabars.
-        /// </summary>
-        public static Pressure FromMegabars(long megabars)
-        {
-            return new Pressure((megabars*1e5) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Megabars of type decimal.
-        /// </summary>
-        public static Pressure FromMegabars(decimal megabars)
-        {
-            return new Pressure((Convert.ToDouble(megabars)*1e5) * 1e6d);
+            double value = (double) megabars;
+            return new Pressure(((value*1e5) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Megapascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromMegapascals(double megapascals)
         {
-            return new Pressure((megapascals) * 1e6d);
+            double value = (double) megapascals;
+            return new Pressure((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Megapascals.
-        /// </summary>
-        public static Pressure FromMegapascals(int megapascals)
+#else
+        public static Pressure FromMegapascals(QuantityValue megapascals)
         {
-            return new Pressure((megapascals) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Megapascals.
-        /// </summary>
-        public static Pressure FromMegapascals(long megapascals)
-        {
-            return new Pressure((megapascals) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Megapascals of type decimal.
-        /// </summary>
-        public static Pressure FromMegapascals(decimal megapascals)
-        {
-            return new Pressure((Convert.ToDouble(megapascals)) * 1e6d);
+            double value = (double) megapascals;
+            return new Pressure(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromMetersOfHead(double metersofhead)
         {
-            return new Pressure(metersofhead*9804.139432);
+            double value = (double) metersofhead;
+            return new Pressure(value*9804.139432);
         }
-
-        /// <summary>
-        ///     Get Pressure from MetersOfHead.
-        /// </summary>
-        public static Pressure FromMetersOfHead(int metersofhead)
+#else
+        public static Pressure FromMetersOfHead(QuantityValue metersofhead)
         {
-            return new Pressure(metersofhead*9804.139432);
-        }
-
-        /// <summary>
-        ///     Get Pressure from MetersOfHead.
-        /// </summary>
-        public static Pressure FromMetersOfHead(long metersofhead)
-        {
-            return new Pressure(metersofhead*9804.139432);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from MetersOfHead of type decimal.
-        /// </summary>
-        public static Pressure FromMetersOfHead(decimal metersofhead)
-        {
-            return new Pressure(Convert.ToDouble(metersofhead)*9804.139432);
+            double value = (double) metersofhead;
+            return new Pressure((value*9804.139432));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Micropascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromMicropascals(double micropascals)
         {
-            return new Pressure((micropascals) * 1e-6d);
+            double value = (double) micropascals;
+            return new Pressure((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Micropascals.
-        /// </summary>
-        public static Pressure FromMicropascals(int micropascals)
+#else
+        public static Pressure FromMicropascals(QuantityValue micropascals)
         {
-            return new Pressure((micropascals) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Micropascals.
-        /// </summary>
-        public static Pressure FromMicropascals(long micropascals)
-        {
-            return new Pressure((micropascals) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Micropascals of type decimal.
-        /// </summary>
-        public static Pressure FromMicropascals(decimal micropascals)
-        {
-            return new Pressure((Convert.ToDouble(micropascals)) * 1e-6d);
+            double value = (double) micropascals;
+            return new Pressure(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromMillibars(double millibars)
         {
-            return new Pressure((millibars*1e5) * 1e-3d);
+            double value = (double) millibars;
+            return new Pressure((value*1e5) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Pressure from Millibars.
-        /// </summary>
-        public static Pressure FromMillibars(int millibars)
+#else
+        public static Pressure FromMillibars(QuantityValue millibars)
         {
-            return new Pressure((millibars*1e5) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Millibars.
-        /// </summary>
-        public static Pressure FromMillibars(long millibars)
-        {
-            return new Pressure((millibars*1e5) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Millibars of type decimal.
-        /// </summary>
-        public static Pressure FromMillibars(decimal millibars)
-        {
-            return new Pressure((Convert.ToDouble(millibars)*1e5) * 1e-3d);
+            double value = (double) millibars;
+            return new Pressure(((value*1e5) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromMillimetersOfMercury(double millimetersofmercury)
         {
-            return new Pressure(millimetersofmercury/7.50061561302643e-3);
+            double value = (double) millimetersofmercury;
+            return new Pressure(value/7.50061561302643e-3);
         }
-
-        /// <summary>
-        ///     Get Pressure from MillimetersOfMercury.
-        /// </summary>
-        public static Pressure FromMillimetersOfMercury(int millimetersofmercury)
+#else
+        public static Pressure FromMillimetersOfMercury(QuantityValue millimetersofmercury)
         {
-            return new Pressure(millimetersofmercury/7.50061561302643e-3);
-        }
-
-        /// <summary>
-        ///     Get Pressure from MillimetersOfMercury.
-        /// </summary>
-        public static Pressure FromMillimetersOfMercury(long millimetersofmercury)
-        {
-            return new Pressure(millimetersofmercury/7.50061561302643e-3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from MillimetersOfMercury of type decimal.
-        /// </summary>
-        public static Pressure FromMillimetersOfMercury(decimal millimetersofmercury)
-        {
-            return new Pressure(Convert.ToDouble(millimetersofmercury)/7.50061561302643e-3);
+            double value = (double) millimetersofmercury;
+            return new Pressure((value/7.50061561302643e-3));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromNewtonsPerSquareCentimeter(double newtonspersquarecentimeter)
         {
-            return new Pressure(newtonspersquarecentimeter*1e4);
+            double value = (double) newtonspersquarecentimeter;
+            return new Pressure(value*1e4);
         }
-
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareCentimeter(int newtonspersquarecentimeter)
+#else
+        public static Pressure FromNewtonsPerSquareCentimeter(QuantityValue newtonspersquarecentimeter)
         {
-            return new Pressure(newtonspersquarecentimeter*1e4);
-        }
-
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareCentimeter(long newtonspersquarecentimeter)
-        {
-            return new Pressure(newtonspersquarecentimeter*1e4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareCentimeter(decimal newtonspersquarecentimeter)
-        {
-            return new Pressure(Convert.ToDouble(newtonspersquarecentimeter)*1e4);
+            double value = (double) newtonspersquarecentimeter;
+            return new Pressure((value*1e4));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromNewtonsPerSquareMeter(double newtonspersquaremeter)
         {
-            return new Pressure(newtonspersquaremeter);
+            double value = (double) newtonspersquaremeter;
+            return new Pressure(value);
         }
-
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareMeter(int newtonspersquaremeter)
+#else
+        public static Pressure FromNewtonsPerSquareMeter(QuantityValue newtonspersquaremeter)
         {
-            return new Pressure(newtonspersquaremeter);
-        }
-
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareMeter(long newtonspersquaremeter)
-        {
-            return new Pressure(newtonspersquaremeter);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareMeter(decimal newtonspersquaremeter)
-        {
-            return new Pressure(Convert.ToDouble(newtonspersquaremeter));
+            double value = (double) newtonspersquaremeter;
+            return new Pressure((value));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromNewtonsPerSquareMillimeter(double newtonspersquaremillimeter)
         {
-            return new Pressure(newtonspersquaremillimeter*1e6);
+            double value = (double) newtonspersquaremillimeter;
+            return new Pressure(value*1e6);
         }
-
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareMillimeter(int newtonspersquaremillimeter)
+#else
+        public static Pressure FromNewtonsPerSquareMillimeter(QuantityValue newtonspersquaremillimeter)
         {
-            return new Pressure(newtonspersquaremillimeter*1e6);
-        }
-
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareMillimeter(long newtonspersquaremillimeter)
-        {
-            return new Pressure(newtonspersquaremillimeter*1e6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from NewtonsPerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure FromNewtonsPerSquareMillimeter(decimal newtonspersquaremillimeter)
-        {
-            return new Pressure(Convert.ToDouble(newtonspersquaremillimeter)*1e6);
+            double value = (double) newtonspersquaremillimeter;
+            return new Pressure((value*1e6));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Pascals.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromPascals(double pascals)
         {
-            return new Pressure(pascals);
+            double value = (double) pascals;
+            return new Pressure(value);
         }
-
-        /// <summary>
-        ///     Get Pressure from Pascals.
-        /// </summary>
-        public static Pressure FromPascals(int pascals)
+#else
+        public static Pressure FromPascals(QuantityValue pascals)
         {
-            return new Pressure(pascals);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Pascals.
-        /// </summary>
-        public static Pressure FromPascals(long pascals)
-        {
-            return new Pressure(pascals);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Pascals of type decimal.
-        /// </summary>
-        public static Pressure FromPascals(decimal pascals)
-        {
-            return new Pressure(Convert.ToDouble(pascals));
+            double value = (double) pascals;
+            return new Pressure((value));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromPoundsForcePerSquareFoot(double poundsforcepersquarefoot)
         {
-            return new Pressure(poundsforcepersquarefoot*47.8802631216372);
+            double value = (double) poundsforcepersquarefoot;
+            return new Pressure(value*47.8802631216372);
         }
-
-        /// <summary>
-        ///     Get Pressure from PoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure FromPoundsForcePerSquareFoot(int poundsforcepersquarefoot)
+#else
+        public static Pressure FromPoundsForcePerSquareFoot(QuantityValue poundsforcepersquarefoot)
         {
-            return new Pressure(poundsforcepersquarefoot*47.8802631216372);
-        }
-
-        /// <summary>
-        ///     Get Pressure from PoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure FromPoundsForcePerSquareFoot(long poundsforcepersquarefoot)
-        {
-            return new Pressure(poundsforcepersquarefoot*47.8802631216372);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from PoundsForcePerSquareFoot of type decimal.
-        /// </summary>
-        public static Pressure FromPoundsForcePerSquareFoot(decimal poundsforcepersquarefoot)
-        {
-            return new Pressure(Convert.ToDouble(poundsforcepersquarefoot)*47.8802631216372);
+            double value = (double) poundsforcepersquarefoot;
+            return new Pressure((value*47.8802631216372));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromPoundsForcePerSquareInch(double poundsforcepersquareinch)
         {
-            return new Pressure(poundsforcepersquareinch*6894.75729316836);
+            double value = (double) poundsforcepersquareinch;
+            return new Pressure(value*6894.75729316836);
         }
-
-        /// <summary>
-        ///     Get Pressure from PoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure FromPoundsForcePerSquareInch(int poundsforcepersquareinch)
+#else
+        public static Pressure FromPoundsForcePerSquareInch(QuantityValue poundsforcepersquareinch)
         {
-            return new Pressure(poundsforcepersquareinch*6894.75729316836);
-        }
-
-        /// <summary>
-        ///     Get Pressure from PoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure FromPoundsForcePerSquareInch(long poundsforcepersquareinch)
-        {
-            return new Pressure(poundsforcepersquareinch*6894.75729316836);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from PoundsForcePerSquareInch of type decimal.
-        /// </summary>
-        public static Pressure FromPoundsForcePerSquareInch(decimal poundsforcepersquareinch)
-        {
-            return new Pressure(Convert.ToDouble(poundsforcepersquareinch)*6894.75729316836);
+            double value = (double) poundsforcepersquareinch;
+            return new Pressure((value*6894.75729316836));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Psi.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromPsi(double psi)
         {
-            return new Pressure(psi*6.89464975179*1e3);
+            double value = (double) psi;
+            return new Pressure(value*6.89464975179*1e3);
         }
-
-        /// <summary>
-        ///     Get Pressure from Psi.
-        /// </summary>
-        public static Pressure FromPsi(int psi)
+#else
+        public static Pressure FromPsi(QuantityValue psi)
         {
-            return new Pressure(psi*6.89464975179*1e3);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Psi.
-        /// </summary>
-        public static Pressure FromPsi(long psi)
-        {
-            return new Pressure(psi*6.89464975179*1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Psi of type decimal.
-        /// </summary>
-        public static Pressure FromPsi(decimal psi)
-        {
-            return new Pressure(Convert.ToDouble(psi)*6.89464975179*1e3);
+            double value = (double) psi;
+            return new Pressure((value*6.89464975179*1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromTechnicalAtmospheres(double technicalatmospheres)
         {
-            return new Pressure(technicalatmospheres*9.80680592331*1e4);
+            double value = (double) technicalatmospheres;
+            return new Pressure(value*9.80680592331*1e4);
         }
-
-        /// <summary>
-        ///     Get Pressure from TechnicalAtmospheres.
-        /// </summary>
-        public static Pressure FromTechnicalAtmospheres(int technicalatmospheres)
+#else
+        public static Pressure FromTechnicalAtmospheres(QuantityValue technicalatmospheres)
         {
-            return new Pressure(technicalatmospheres*9.80680592331*1e4);
-        }
-
-        /// <summary>
-        ///     Get Pressure from TechnicalAtmospheres.
-        /// </summary>
-        public static Pressure FromTechnicalAtmospheres(long technicalatmospheres)
-        {
-            return new Pressure(technicalatmospheres*9.80680592331*1e4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from TechnicalAtmospheres of type decimal.
-        /// </summary>
-        public static Pressure FromTechnicalAtmospheres(decimal technicalatmospheres)
-        {
-            return new Pressure(Convert.ToDouble(technicalatmospheres)*9.80680592331*1e4);
+            double value = (double) technicalatmospheres;
+            return new Pressure((value*9.80680592331*1e4));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromTonnesForcePerSquareCentimeter(double tonnesforcepersquarecentimeter)
         {
-            return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
+            double value = (double) tonnesforcepersquarecentimeter;
+            return new Pressure(value*98066501.9960652);
         }
-
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareCentimeter(int tonnesforcepersquarecentimeter)
+#else
+        public static Pressure FromTonnesForcePerSquareCentimeter(QuantityValue tonnesforcepersquarecentimeter)
         {
-            return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
-        }
-
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareCentimeter(long tonnesforcepersquarecentimeter)
-        {
-            return new Pressure(tonnesforcepersquarecentimeter*98066501.9960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareCentimeter(decimal tonnesforcepersquarecentimeter)
-        {
-            return new Pressure(Convert.ToDouble(tonnesforcepersquarecentimeter)*98066501.9960652);
+            double value = (double) tonnesforcepersquarecentimeter;
+            return new Pressure((value*98066501.9960652));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromTonnesForcePerSquareMeter(double tonnesforcepersquaremeter)
         {
-            return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
+            double value = (double) tonnesforcepersquaremeter;
+            return new Pressure(value*9806.65019960653);
         }
-
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareMeter.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareMeter(int tonnesforcepersquaremeter)
+#else
+        public static Pressure FromTonnesForcePerSquareMeter(QuantityValue tonnesforcepersquaremeter)
         {
-            return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
-        }
-
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareMeter.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareMeter(long tonnesforcepersquaremeter)
-        {
-            return new Pressure(tonnesforcepersquaremeter*9806.65019960653);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareMeter(decimal tonnesforcepersquaremeter)
-        {
-            return new Pressure(Convert.ToDouble(tonnesforcepersquaremeter)*9806.65019960653);
+            double value = (double) tonnesforcepersquaremeter;
+            return new Pressure((value*9806.65019960653));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromTonnesForcePerSquareMillimeter(double tonnesforcepersquaremillimeter)
         {
-            return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
+            double value = (double) tonnesforcepersquaremillimeter;
+            return new Pressure(value*9806650199.60653);
         }
-
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareMillimeter(int tonnesforcepersquaremillimeter)
+#else
+        public static Pressure FromTonnesForcePerSquareMillimeter(QuantityValue tonnesforcepersquaremillimeter)
         {
-            return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
-        }
-
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareMillimeter(long tonnesforcepersquaremillimeter)
-        {
-            return new Pressure(tonnesforcepersquaremillimeter*9806650199.60653);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from TonnesForcePerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure FromTonnesForcePerSquareMillimeter(decimal tonnesforcepersquaremillimeter)
-        {
-            return new Pressure(Convert.ToDouble(tonnesforcepersquaremillimeter)*9806650199.60653);
+            double value = (double) tonnesforcepersquaremillimeter;
+            return new Pressure((value*9806650199.60653));
         }
 #endif
 
         /// <summary>
         ///     Get Pressure from Torrs.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Pressure FromTorrs(double torrs)
         {
-            return new Pressure(torrs*1.3332266752*1e2);
+            double value = (double) torrs;
+            return new Pressure(value*1.3332266752*1e2);
         }
-
-        /// <summary>
-        ///     Get Pressure from Torrs.
-        /// </summary>
-        public static Pressure FromTorrs(int torrs)
+#else
+        public static Pressure FromTorrs(QuantityValue torrs)
         {
-            return new Pressure(torrs*1.3332266752*1e2);
-        }
-
-        /// <summary>
-        ///     Get Pressure from Torrs.
-        /// </summary>
-        public static Pressure FromTorrs(long torrs)
-        {
-            return new Pressure(torrs*1.3332266752*1e2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Pressure from Torrs of type decimal.
-        /// </summary>
-        public static Pressure FromTorrs(decimal torrs)
-        {
-            return new Pressure(Convert.ToDouble(torrs)*1.3332266752*1e2);
+            double value = (double) torrs;
+            return new Pressure((value*1.3332266752*1e2));
         }
 #endif
 
@@ -1846,52 +1106,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Atmospheres.
         /// </summary>
-        public static Pressure? FromAtmospheres(double? atmospheres)
-        {
-            if (atmospheres.HasValue)
-            {
-                return FromAtmospheres(atmospheres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Atmospheres.
-        /// </summary>
-        public static Pressure? FromAtmospheres(int? atmospheres)
-        {
-            if (atmospheres.HasValue)
-            {
-                return FromAtmospheres(atmospheres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Atmospheres.
-        /// </summary>
-        public static Pressure? FromAtmospheres(long? atmospheres)
-        {
-            if (atmospheres.HasValue)
-            {
-                return FromAtmospheres(atmospheres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Atmospheres of type decimal.
-        /// </summary>
-        public static Pressure? FromAtmospheres(decimal? atmospheres)
+        public static Pressure? FromAtmospheres(QuantityValue? atmospheres)
         {
             if (atmospheres.HasValue)
             {
@@ -1906,52 +1121,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Bars.
         /// </summary>
-        public static Pressure? FromBars(double? bars)
-        {
-            if (bars.HasValue)
-            {
-                return FromBars(bars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Bars.
-        /// </summary>
-        public static Pressure? FromBars(int? bars)
-        {
-            if (bars.HasValue)
-            {
-                return FromBars(bars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Bars.
-        /// </summary>
-        public static Pressure? FromBars(long? bars)
-        {
-            if (bars.HasValue)
-            {
-                return FromBars(bars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Bars of type decimal.
-        /// </summary>
-        public static Pressure? FromBars(decimal? bars)
+        public static Pressure? FromBars(QuantityValue? bars)
         {
             if (bars.HasValue)
             {
@@ -1966,52 +1136,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Centibars.
         /// </summary>
-        public static Pressure? FromCentibars(double? centibars)
-        {
-            if (centibars.HasValue)
-            {
-                return FromCentibars(centibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Centibars.
-        /// </summary>
-        public static Pressure? FromCentibars(int? centibars)
-        {
-            if (centibars.HasValue)
-            {
-                return FromCentibars(centibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Centibars.
-        /// </summary>
-        public static Pressure? FromCentibars(long? centibars)
-        {
-            if (centibars.HasValue)
-            {
-                return FromCentibars(centibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Centibars of type decimal.
-        /// </summary>
-        public static Pressure? FromCentibars(decimal? centibars)
+        public static Pressure? FromCentibars(QuantityValue? centibars)
         {
             if (centibars.HasValue)
             {
@@ -2026,52 +1151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Decapascals.
         /// </summary>
-        public static Pressure? FromDecapascals(double? decapascals)
-        {
-            if (decapascals.HasValue)
-            {
-                return FromDecapascals(decapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Decapascals.
-        /// </summary>
-        public static Pressure? FromDecapascals(int? decapascals)
-        {
-            if (decapascals.HasValue)
-            {
-                return FromDecapascals(decapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Decapascals.
-        /// </summary>
-        public static Pressure? FromDecapascals(long? decapascals)
-        {
-            if (decapascals.HasValue)
-            {
-                return FromDecapascals(decapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Decapascals of type decimal.
-        /// </summary>
-        public static Pressure? FromDecapascals(decimal? decapascals)
+        public static Pressure? FromDecapascals(QuantityValue? decapascals)
         {
             if (decapascals.HasValue)
             {
@@ -2086,52 +1166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Decibars.
         /// </summary>
-        public static Pressure? FromDecibars(double? decibars)
-        {
-            if (decibars.HasValue)
-            {
-                return FromDecibars(decibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Decibars.
-        /// </summary>
-        public static Pressure? FromDecibars(int? decibars)
-        {
-            if (decibars.HasValue)
-            {
-                return FromDecibars(decibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Decibars.
-        /// </summary>
-        public static Pressure? FromDecibars(long? decibars)
-        {
-            if (decibars.HasValue)
-            {
-                return FromDecibars(decibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Decibars of type decimal.
-        /// </summary>
-        public static Pressure? FromDecibars(decimal? decibars)
+        public static Pressure? FromDecibars(QuantityValue? decibars)
         {
             if (decibars.HasValue)
             {
@@ -2146,52 +1181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable FeetOfHead.
         /// </summary>
-        public static Pressure? FromFeetOfHead(double? feetofhead)
-        {
-            if (feetofhead.HasValue)
-            {
-                return FromFeetOfHead(feetofhead.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable FeetOfHead.
-        /// </summary>
-        public static Pressure? FromFeetOfHead(int? feetofhead)
-        {
-            if (feetofhead.HasValue)
-            {
-                return FromFeetOfHead(feetofhead.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable FeetOfHead.
-        /// </summary>
-        public static Pressure? FromFeetOfHead(long? feetofhead)
-        {
-            if (feetofhead.HasValue)
-            {
-                return FromFeetOfHead(feetofhead.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from FeetOfHead of type decimal.
-        /// </summary>
-        public static Pressure? FromFeetOfHead(decimal? feetofhead)
+        public static Pressure? FromFeetOfHead(QuantityValue? feetofhead)
         {
             if (feetofhead.HasValue)
             {
@@ -2206,52 +1196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Gigapascals.
         /// </summary>
-        public static Pressure? FromGigapascals(double? gigapascals)
-        {
-            if (gigapascals.HasValue)
-            {
-                return FromGigapascals(gigapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Gigapascals.
-        /// </summary>
-        public static Pressure? FromGigapascals(int? gigapascals)
-        {
-            if (gigapascals.HasValue)
-            {
-                return FromGigapascals(gigapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Gigapascals.
-        /// </summary>
-        public static Pressure? FromGigapascals(long? gigapascals)
-        {
-            if (gigapascals.HasValue)
-            {
-                return FromGigapascals(gigapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Gigapascals of type decimal.
-        /// </summary>
-        public static Pressure? FromGigapascals(decimal? gigapascals)
+        public static Pressure? FromGigapascals(QuantityValue? gigapascals)
         {
             if (gigapascals.HasValue)
             {
@@ -2266,52 +1211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Hectopascals.
         /// </summary>
-        public static Pressure? FromHectopascals(double? hectopascals)
-        {
-            if (hectopascals.HasValue)
-            {
-                return FromHectopascals(hectopascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Hectopascals.
-        /// </summary>
-        public static Pressure? FromHectopascals(int? hectopascals)
-        {
-            if (hectopascals.HasValue)
-            {
-                return FromHectopascals(hectopascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Hectopascals.
-        /// </summary>
-        public static Pressure? FromHectopascals(long? hectopascals)
-        {
-            if (hectopascals.HasValue)
-            {
-                return FromHectopascals(hectopascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Hectopascals of type decimal.
-        /// </summary>
-        public static Pressure? FromHectopascals(decimal? hectopascals)
+        public static Pressure? FromHectopascals(QuantityValue? hectopascals)
         {
             if (hectopascals.HasValue)
             {
@@ -2326,52 +1226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable InchesOfMercury.
         /// </summary>
-        public static Pressure? FromInchesOfMercury(double? inchesofmercury)
-        {
-            if (inchesofmercury.HasValue)
-            {
-                return FromInchesOfMercury(inchesofmercury.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable InchesOfMercury.
-        /// </summary>
-        public static Pressure? FromInchesOfMercury(int? inchesofmercury)
-        {
-            if (inchesofmercury.HasValue)
-            {
-                return FromInchesOfMercury(inchesofmercury.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable InchesOfMercury.
-        /// </summary>
-        public static Pressure? FromInchesOfMercury(long? inchesofmercury)
-        {
-            if (inchesofmercury.HasValue)
-            {
-                return FromInchesOfMercury(inchesofmercury.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from InchesOfMercury of type decimal.
-        /// </summary>
-        public static Pressure? FromInchesOfMercury(decimal? inchesofmercury)
+        public static Pressure? FromInchesOfMercury(QuantityValue? inchesofmercury)
         {
             if (inchesofmercury.HasValue)
             {
@@ -2386,52 +1241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Kilobars.
         /// </summary>
-        public static Pressure? FromKilobars(double? kilobars)
-        {
-            if (kilobars.HasValue)
-            {
-                return FromKilobars(kilobars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Kilobars.
-        /// </summary>
-        public static Pressure? FromKilobars(int? kilobars)
-        {
-            if (kilobars.HasValue)
-            {
-                return FromKilobars(kilobars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Kilobars.
-        /// </summary>
-        public static Pressure? FromKilobars(long? kilobars)
-        {
-            if (kilobars.HasValue)
-            {
-                return FromKilobars(kilobars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Kilobars of type decimal.
-        /// </summary>
-        public static Pressure? FromKilobars(decimal? kilobars)
+        public static Pressure? FromKilobars(QuantityValue? kilobars)
         {
             if (kilobars.HasValue)
             {
@@ -2446,52 +1256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
         /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareCentimeter(double? kilogramsforcepersquarecentimeter)
-        {
-            if (kilogramsforcepersquarecentimeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareCentimeter(kilogramsforcepersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareCentimeter(int? kilogramsforcepersquarecentimeter)
-        {
-            if (kilogramsforcepersquarecentimeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareCentimeter(kilogramsforcepersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilogramsForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareCentimeter(long? kilogramsforcepersquarecentimeter)
-        {
-            if (kilogramsforcepersquarecentimeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareCentimeter(kilogramsforcepersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilogramsForcePerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareCentimeter(decimal? kilogramsforcepersquarecentimeter)
+        public static Pressure? FromKilogramsForcePerSquareCentimeter(QuantityValue? kilogramsforcepersquarecentimeter)
         {
             if (kilogramsforcepersquarecentimeter.HasValue)
             {
@@ -2506,52 +1271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
         /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMeter(double? kilogramsforcepersquaremeter)
-        {
-            if (kilogramsforcepersquaremeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareMeter(kilogramsforcepersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMeter(int? kilogramsforcepersquaremeter)
-        {
-            if (kilogramsforcepersquaremeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareMeter(kilogramsforcepersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMeter.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMeter(long? kilogramsforcepersquaremeter)
-        {
-            if (kilogramsforcepersquaremeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareMeter(kilogramsforcepersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilogramsForcePerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMeter(decimal? kilogramsforcepersquaremeter)
+        public static Pressure? FromKilogramsForcePerSquareMeter(QuantityValue? kilogramsforcepersquaremeter)
         {
             if (kilogramsforcepersquaremeter.HasValue)
             {
@@ -2566,52 +1286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
         /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMillimeter(double? kilogramsforcepersquaremillimeter)
-        {
-            if (kilogramsforcepersquaremillimeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareMillimeter(kilogramsforcepersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMillimeter(int? kilogramsforcepersquaremillimeter)
-        {
-            if (kilogramsforcepersquaremillimeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareMillimeter(kilogramsforcepersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilogramsForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMillimeter(long? kilogramsforcepersquaremillimeter)
-        {
-            if (kilogramsforcepersquaremillimeter.HasValue)
-            {
-                return FromKilogramsForcePerSquareMillimeter(kilogramsforcepersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilogramsForcePerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromKilogramsForcePerSquareMillimeter(decimal? kilogramsforcepersquaremillimeter)
+        public static Pressure? FromKilogramsForcePerSquareMillimeter(QuantityValue? kilogramsforcepersquaremillimeter)
         {
             if (kilogramsforcepersquaremillimeter.HasValue)
             {
@@ -2626,52 +1301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
         /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareCentimeter(double? kilonewtonspersquarecentimeter)
-        {
-            if (kilonewtonspersquarecentimeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareCentimeter(kilonewtonspersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareCentimeter(int? kilonewtonspersquarecentimeter)
-        {
-            if (kilonewtonspersquarecentimeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareCentimeter(kilonewtonspersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilonewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareCentimeter(long? kilonewtonspersquarecentimeter)
-        {
-            if (kilonewtonspersquarecentimeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareCentimeter(kilonewtonspersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilonewtonsPerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareCentimeter(decimal? kilonewtonspersquarecentimeter)
+        public static Pressure? FromKilonewtonsPerSquareCentimeter(QuantityValue? kilonewtonspersquarecentimeter)
         {
             if (kilonewtonspersquarecentimeter.HasValue)
             {
@@ -2686,52 +1316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
         /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMeter(double? kilonewtonspersquaremeter)
-        {
-            if (kilonewtonspersquaremeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareMeter(kilonewtonspersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMeter(int? kilonewtonspersquaremeter)
-        {
-            if (kilonewtonspersquaremeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareMeter(kilonewtonspersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMeter(long? kilonewtonspersquaremeter)
-        {
-            if (kilonewtonspersquaremeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareMeter(kilonewtonspersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilonewtonsPerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMeter(decimal? kilonewtonspersquaremeter)
+        public static Pressure? FromKilonewtonsPerSquareMeter(QuantityValue? kilonewtonspersquaremeter)
         {
             if (kilonewtonspersquaremeter.HasValue)
             {
@@ -2746,52 +1331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
         /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMillimeter(double? kilonewtonspersquaremillimeter)
-        {
-            if (kilonewtonspersquaremillimeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareMillimeter(kilonewtonspersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMillimeter(int? kilonewtonspersquaremillimeter)
-        {
-            if (kilonewtonspersquaremillimeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareMillimeter(kilonewtonspersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilonewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMillimeter(long? kilonewtonspersquaremillimeter)
-        {
-            if (kilonewtonspersquaremillimeter.HasValue)
-            {
-                return FromKilonewtonsPerSquareMillimeter(kilonewtonspersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilonewtonsPerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromKilonewtonsPerSquareMillimeter(decimal? kilonewtonspersquaremillimeter)
+        public static Pressure? FromKilonewtonsPerSquareMillimeter(QuantityValue? kilonewtonspersquaremillimeter)
         {
             if (kilonewtonspersquaremillimeter.HasValue)
             {
@@ -2806,52 +1346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Kilopascals.
         /// </summary>
-        public static Pressure? FromKilopascals(double? kilopascals)
-        {
-            if (kilopascals.HasValue)
-            {
-                return FromKilopascals(kilopascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Kilopascals.
-        /// </summary>
-        public static Pressure? FromKilopascals(int? kilopascals)
-        {
-            if (kilopascals.HasValue)
-            {
-                return FromKilopascals(kilopascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Kilopascals.
-        /// </summary>
-        public static Pressure? FromKilopascals(long? kilopascals)
-        {
-            if (kilopascals.HasValue)
-            {
-                return FromKilopascals(kilopascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Kilopascals of type decimal.
-        /// </summary>
-        public static Pressure? FromKilopascals(decimal? kilopascals)
+        public static Pressure? FromKilopascals(QuantityValue? kilopascals)
         {
             if (kilopascals.HasValue)
             {
@@ -2866,52 +1361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
         /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareFoot(double? kilopoundsforcepersquarefoot)
-        {
-            if (kilopoundsforcepersquarefoot.HasValue)
-            {
-                return FromKilopoundsForcePerSquareFoot(kilopoundsforcepersquarefoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareFoot(int? kilopoundsforcepersquarefoot)
-        {
-            if (kilopoundsforcepersquarefoot.HasValue)
-            {
-                return FromKilopoundsForcePerSquareFoot(kilopoundsforcepersquarefoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareFoot(long? kilopoundsforcepersquarefoot)
-        {
-            if (kilopoundsforcepersquarefoot.HasValue)
-            {
-                return FromKilopoundsForcePerSquareFoot(kilopoundsforcepersquarefoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilopoundsForcePerSquareFoot of type decimal.
-        /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareFoot(decimal? kilopoundsforcepersquarefoot)
+        public static Pressure? FromKilopoundsForcePerSquareFoot(QuantityValue? kilopoundsforcepersquarefoot)
         {
             if (kilopoundsforcepersquarefoot.HasValue)
             {
@@ -2926,52 +1376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
         /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareInch(double? kilopoundsforcepersquareinch)
-        {
-            if (kilopoundsforcepersquareinch.HasValue)
-            {
-                return FromKilopoundsForcePerSquareInch(kilopoundsforcepersquareinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareInch(int? kilopoundsforcepersquareinch)
-        {
-            if (kilopoundsforcepersquareinch.HasValue)
-            {
-                return FromKilopoundsForcePerSquareInch(kilopoundsforcepersquareinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable KilopoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareInch(long? kilopoundsforcepersquareinch)
-        {
-            if (kilopoundsforcepersquareinch.HasValue)
-            {
-                return FromKilopoundsForcePerSquareInch(kilopoundsforcepersquareinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from KilopoundsForcePerSquareInch of type decimal.
-        /// </summary>
-        public static Pressure? FromKilopoundsForcePerSquareInch(decimal? kilopoundsforcepersquareinch)
+        public static Pressure? FromKilopoundsForcePerSquareInch(QuantityValue? kilopoundsforcepersquareinch)
         {
             if (kilopoundsforcepersquareinch.HasValue)
             {
@@ -2986,52 +1391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Megabars.
         /// </summary>
-        public static Pressure? FromMegabars(double? megabars)
-        {
-            if (megabars.HasValue)
-            {
-                return FromMegabars(megabars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Megabars.
-        /// </summary>
-        public static Pressure? FromMegabars(int? megabars)
-        {
-            if (megabars.HasValue)
-            {
-                return FromMegabars(megabars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Megabars.
-        /// </summary>
-        public static Pressure? FromMegabars(long? megabars)
-        {
-            if (megabars.HasValue)
-            {
-                return FromMegabars(megabars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Megabars of type decimal.
-        /// </summary>
-        public static Pressure? FromMegabars(decimal? megabars)
+        public static Pressure? FromMegabars(QuantityValue? megabars)
         {
             if (megabars.HasValue)
             {
@@ -3046,52 +1406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Megapascals.
         /// </summary>
-        public static Pressure? FromMegapascals(double? megapascals)
-        {
-            if (megapascals.HasValue)
-            {
-                return FromMegapascals(megapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Megapascals.
-        /// </summary>
-        public static Pressure? FromMegapascals(int? megapascals)
-        {
-            if (megapascals.HasValue)
-            {
-                return FromMegapascals(megapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Megapascals.
-        /// </summary>
-        public static Pressure? FromMegapascals(long? megapascals)
-        {
-            if (megapascals.HasValue)
-            {
-                return FromMegapascals(megapascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Megapascals of type decimal.
-        /// </summary>
-        public static Pressure? FromMegapascals(decimal? megapascals)
+        public static Pressure? FromMegapascals(QuantityValue? megapascals)
         {
             if (megapascals.HasValue)
             {
@@ -3106,52 +1421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable MetersOfHead.
         /// </summary>
-        public static Pressure? FromMetersOfHead(double? metersofhead)
-        {
-            if (metersofhead.HasValue)
-            {
-                return FromMetersOfHead(metersofhead.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable MetersOfHead.
-        /// </summary>
-        public static Pressure? FromMetersOfHead(int? metersofhead)
-        {
-            if (metersofhead.HasValue)
-            {
-                return FromMetersOfHead(metersofhead.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable MetersOfHead.
-        /// </summary>
-        public static Pressure? FromMetersOfHead(long? metersofhead)
-        {
-            if (metersofhead.HasValue)
-            {
-                return FromMetersOfHead(metersofhead.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from MetersOfHead of type decimal.
-        /// </summary>
-        public static Pressure? FromMetersOfHead(decimal? metersofhead)
+        public static Pressure? FromMetersOfHead(QuantityValue? metersofhead)
         {
             if (metersofhead.HasValue)
             {
@@ -3166,52 +1436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Micropascals.
         /// </summary>
-        public static Pressure? FromMicropascals(double? micropascals)
-        {
-            if (micropascals.HasValue)
-            {
-                return FromMicropascals(micropascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Micropascals.
-        /// </summary>
-        public static Pressure? FromMicropascals(int? micropascals)
-        {
-            if (micropascals.HasValue)
-            {
-                return FromMicropascals(micropascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Micropascals.
-        /// </summary>
-        public static Pressure? FromMicropascals(long? micropascals)
-        {
-            if (micropascals.HasValue)
-            {
-                return FromMicropascals(micropascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Micropascals of type decimal.
-        /// </summary>
-        public static Pressure? FromMicropascals(decimal? micropascals)
+        public static Pressure? FromMicropascals(QuantityValue? micropascals)
         {
             if (micropascals.HasValue)
             {
@@ -3226,52 +1451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Millibars.
         /// </summary>
-        public static Pressure? FromMillibars(double? millibars)
-        {
-            if (millibars.HasValue)
-            {
-                return FromMillibars(millibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Millibars.
-        /// </summary>
-        public static Pressure? FromMillibars(int? millibars)
-        {
-            if (millibars.HasValue)
-            {
-                return FromMillibars(millibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Millibars.
-        /// </summary>
-        public static Pressure? FromMillibars(long? millibars)
-        {
-            if (millibars.HasValue)
-            {
-                return FromMillibars(millibars.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Millibars of type decimal.
-        /// </summary>
-        public static Pressure? FromMillibars(decimal? millibars)
+        public static Pressure? FromMillibars(QuantityValue? millibars)
         {
             if (millibars.HasValue)
             {
@@ -3286,52 +1466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable MillimetersOfMercury.
         /// </summary>
-        public static Pressure? FromMillimetersOfMercury(double? millimetersofmercury)
-        {
-            if (millimetersofmercury.HasValue)
-            {
-                return FromMillimetersOfMercury(millimetersofmercury.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable MillimetersOfMercury.
-        /// </summary>
-        public static Pressure? FromMillimetersOfMercury(int? millimetersofmercury)
-        {
-            if (millimetersofmercury.HasValue)
-            {
-                return FromMillimetersOfMercury(millimetersofmercury.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable MillimetersOfMercury.
-        /// </summary>
-        public static Pressure? FromMillimetersOfMercury(long? millimetersofmercury)
-        {
-            if (millimetersofmercury.HasValue)
-            {
-                return FromMillimetersOfMercury(millimetersofmercury.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from MillimetersOfMercury of type decimal.
-        /// </summary>
-        public static Pressure? FromMillimetersOfMercury(decimal? millimetersofmercury)
+        public static Pressure? FromMillimetersOfMercury(QuantityValue? millimetersofmercury)
         {
             if (millimetersofmercury.HasValue)
             {
@@ -3346,52 +1481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
         /// </summary>
-        public static Pressure? FromNewtonsPerSquareCentimeter(double? newtonspersquarecentimeter)
-        {
-            if (newtonspersquarecentimeter.HasValue)
-            {
-                return FromNewtonsPerSquareCentimeter(newtonspersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareCentimeter(int? newtonspersquarecentimeter)
-        {
-            if (newtonspersquarecentimeter.HasValue)
-            {
-                return FromNewtonsPerSquareCentimeter(newtonspersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable NewtonsPerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareCentimeter(long? newtonspersquarecentimeter)
-        {
-            if (newtonspersquarecentimeter.HasValue)
-            {
-                return FromNewtonsPerSquareCentimeter(newtonspersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from NewtonsPerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareCentimeter(decimal? newtonspersquarecentimeter)
+        public static Pressure? FromNewtonsPerSquareCentimeter(QuantityValue? newtonspersquarecentimeter)
         {
             if (newtonspersquarecentimeter.HasValue)
             {
@@ -3406,52 +1496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
         /// </summary>
-        public static Pressure? FromNewtonsPerSquareMeter(double? newtonspersquaremeter)
-        {
-            if (newtonspersquaremeter.HasValue)
-            {
-                return FromNewtonsPerSquareMeter(newtonspersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareMeter(int? newtonspersquaremeter)
-        {
-            if (newtonspersquaremeter.HasValue)
-            {
-                return FromNewtonsPerSquareMeter(newtonspersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable NewtonsPerSquareMeter.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareMeter(long? newtonspersquaremeter)
-        {
-            if (newtonspersquaremeter.HasValue)
-            {
-                return FromNewtonsPerSquareMeter(newtonspersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from NewtonsPerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareMeter(decimal? newtonspersquaremeter)
+        public static Pressure? FromNewtonsPerSquareMeter(QuantityValue? newtonspersquaremeter)
         {
             if (newtonspersquaremeter.HasValue)
             {
@@ -3466,52 +1511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
         /// </summary>
-        public static Pressure? FromNewtonsPerSquareMillimeter(double? newtonspersquaremillimeter)
-        {
-            if (newtonspersquaremillimeter.HasValue)
-            {
-                return FromNewtonsPerSquareMillimeter(newtonspersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareMillimeter(int? newtonspersquaremillimeter)
-        {
-            if (newtonspersquaremillimeter.HasValue)
-            {
-                return FromNewtonsPerSquareMillimeter(newtonspersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable NewtonsPerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareMillimeter(long? newtonspersquaremillimeter)
-        {
-            if (newtonspersquaremillimeter.HasValue)
-            {
-                return FromNewtonsPerSquareMillimeter(newtonspersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from NewtonsPerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromNewtonsPerSquareMillimeter(decimal? newtonspersquaremillimeter)
+        public static Pressure? FromNewtonsPerSquareMillimeter(QuantityValue? newtonspersquaremillimeter)
         {
             if (newtonspersquaremillimeter.HasValue)
             {
@@ -3526,52 +1526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Pascals.
         /// </summary>
-        public static Pressure? FromPascals(double? pascals)
-        {
-            if (pascals.HasValue)
-            {
-                return FromPascals(pascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Pascals.
-        /// </summary>
-        public static Pressure? FromPascals(int? pascals)
-        {
-            if (pascals.HasValue)
-            {
-                return FromPascals(pascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Pascals.
-        /// </summary>
-        public static Pressure? FromPascals(long? pascals)
-        {
-            if (pascals.HasValue)
-            {
-                return FromPascals(pascals.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Pascals of type decimal.
-        /// </summary>
-        public static Pressure? FromPascals(decimal? pascals)
+        public static Pressure? FromPascals(QuantityValue? pascals)
         {
             if (pascals.HasValue)
             {
@@ -3586,52 +1541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
         /// </summary>
-        public static Pressure? FromPoundsForcePerSquareFoot(double? poundsforcepersquarefoot)
-        {
-            if (poundsforcepersquarefoot.HasValue)
-            {
-                return FromPoundsForcePerSquareFoot(poundsforcepersquarefoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure? FromPoundsForcePerSquareFoot(int? poundsforcepersquarefoot)
-        {
-            if (poundsforcepersquarefoot.HasValue)
-            {
-                return FromPoundsForcePerSquareFoot(poundsforcepersquarefoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable PoundsForcePerSquareFoot.
-        /// </summary>
-        public static Pressure? FromPoundsForcePerSquareFoot(long? poundsforcepersquarefoot)
-        {
-            if (poundsforcepersquarefoot.HasValue)
-            {
-                return FromPoundsForcePerSquareFoot(poundsforcepersquarefoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from PoundsForcePerSquareFoot of type decimal.
-        /// </summary>
-        public static Pressure? FromPoundsForcePerSquareFoot(decimal? poundsforcepersquarefoot)
+        public static Pressure? FromPoundsForcePerSquareFoot(QuantityValue? poundsforcepersquarefoot)
         {
             if (poundsforcepersquarefoot.HasValue)
             {
@@ -3646,52 +1556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
         /// </summary>
-        public static Pressure? FromPoundsForcePerSquareInch(double? poundsforcepersquareinch)
-        {
-            if (poundsforcepersquareinch.HasValue)
-            {
-                return FromPoundsForcePerSquareInch(poundsforcepersquareinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure? FromPoundsForcePerSquareInch(int? poundsforcepersquareinch)
-        {
-            if (poundsforcepersquareinch.HasValue)
-            {
-                return FromPoundsForcePerSquareInch(poundsforcepersquareinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable PoundsForcePerSquareInch.
-        /// </summary>
-        public static Pressure? FromPoundsForcePerSquareInch(long? poundsforcepersquareinch)
-        {
-            if (poundsforcepersquareinch.HasValue)
-            {
-                return FromPoundsForcePerSquareInch(poundsforcepersquareinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from PoundsForcePerSquareInch of type decimal.
-        /// </summary>
-        public static Pressure? FromPoundsForcePerSquareInch(decimal? poundsforcepersquareinch)
+        public static Pressure? FromPoundsForcePerSquareInch(QuantityValue? poundsforcepersquareinch)
         {
             if (poundsforcepersquareinch.HasValue)
             {
@@ -3706,52 +1571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Psi.
         /// </summary>
-        public static Pressure? FromPsi(double? psi)
-        {
-            if (psi.HasValue)
-            {
-                return FromPsi(psi.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Psi.
-        /// </summary>
-        public static Pressure? FromPsi(int? psi)
-        {
-            if (psi.HasValue)
-            {
-                return FromPsi(psi.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Psi.
-        /// </summary>
-        public static Pressure? FromPsi(long? psi)
-        {
-            if (psi.HasValue)
-            {
-                return FromPsi(psi.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Psi of type decimal.
-        /// </summary>
-        public static Pressure? FromPsi(decimal? psi)
+        public static Pressure? FromPsi(QuantityValue? psi)
         {
             if (psi.HasValue)
             {
@@ -3766,52 +1586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable TechnicalAtmospheres.
         /// </summary>
-        public static Pressure? FromTechnicalAtmospheres(double? technicalatmospheres)
-        {
-            if (technicalatmospheres.HasValue)
-            {
-                return FromTechnicalAtmospheres(technicalatmospheres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TechnicalAtmospheres.
-        /// </summary>
-        public static Pressure? FromTechnicalAtmospheres(int? technicalatmospheres)
-        {
-            if (technicalatmospheres.HasValue)
-            {
-                return FromTechnicalAtmospheres(technicalatmospheres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TechnicalAtmospheres.
-        /// </summary>
-        public static Pressure? FromTechnicalAtmospheres(long? technicalatmospheres)
-        {
-            if (technicalatmospheres.HasValue)
-            {
-                return FromTechnicalAtmospheres(technicalatmospheres.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from TechnicalAtmospheres of type decimal.
-        /// </summary>
-        public static Pressure? FromTechnicalAtmospheres(decimal? technicalatmospheres)
+        public static Pressure? FromTechnicalAtmospheres(QuantityValue? technicalatmospheres)
         {
             if (technicalatmospheres.HasValue)
             {
@@ -3826,52 +1601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
         /// </summary>
-        public static Pressure? FromTonnesForcePerSquareCentimeter(double? tonnesforcepersquarecentimeter)
-        {
-            if (tonnesforcepersquarecentimeter.HasValue)
-            {
-                return FromTonnesForcePerSquareCentimeter(tonnesforcepersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareCentimeter(int? tonnesforcepersquarecentimeter)
-        {
-            if (tonnesforcepersquarecentimeter.HasValue)
-            {
-                return FromTonnesForcePerSquareCentimeter(tonnesforcepersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TonnesForcePerSquareCentimeter.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareCentimeter(long? tonnesforcepersquarecentimeter)
-        {
-            if (tonnesforcepersquarecentimeter.HasValue)
-            {
-                return FromTonnesForcePerSquareCentimeter(tonnesforcepersquarecentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from TonnesForcePerSquareCentimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareCentimeter(decimal? tonnesforcepersquarecentimeter)
+        public static Pressure? FromTonnesForcePerSquareCentimeter(QuantityValue? tonnesforcepersquarecentimeter)
         {
             if (tonnesforcepersquarecentimeter.HasValue)
             {
@@ -3886,52 +1616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
         /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMeter(double? tonnesforcepersquaremeter)
-        {
-            if (tonnesforcepersquaremeter.HasValue)
-            {
-                return FromTonnesForcePerSquareMeter(tonnesforcepersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMeter(int? tonnesforcepersquaremeter)
-        {
-            if (tonnesforcepersquaremeter.HasValue)
-            {
-                return FromTonnesForcePerSquareMeter(tonnesforcepersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TonnesForcePerSquareMeter.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMeter(long? tonnesforcepersquaremeter)
-        {
-            if (tonnesforcepersquaremeter.HasValue)
-            {
-                return FromTonnesForcePerSquareMeter(tonnesforcepersquaremeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from TonnesForcePerSquareMeter of type decimal.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMeter(decimal? tonnesforcepersquaremeter)
+        public static Pressure? FromTonnesForcePerSquareMeter(QuantityValue? tonnesforcepersquaremeter)
         {
             if (tonnesforcepersquaremeter.HasValue)
             {
@@ -3946,52 +1631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
         /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMillimeter(double? tonnesforcepersquaremillimeter)
-        {
-            if (tonnesforcepersquaremillimeter.HasValue)
-            {
-                return FromTonnesForcePerSquareMillimeter(tonnesforcepersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMillimeter(int? tonnesforcepersquaremillimeter)
-        {
-            if (tonnesforcepersquaremillimeter.HasValue)
-            {
-                return FromTonnesForcePerSquareMillimeter(tonnesforcepersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable TonnesForcePerSquareMillimeter.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMillimeter(long? tonnesforcepersquaremillimeter)
-        {
-            if (tonnesforcepersquaremillimeter.HasValue)
-            {
-                return FromTonnesForcePerSquareMillimeter(tonnesforcepersquaremillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from TonnesForcePerSquareMillimeter of type decimal.
-        /// </summary>
-        public static Pressure? FromTonnesForcePerSquareMillimeter(decimal? tonnesforcepersquaremillimeter)
+        public static Pressure? FromTonnesForcePerSquareMillimeter(QuantityValue? tonnesforcepersquaremillimeter)
         {
             if (tonnesforcepersquaremillimeter.HasValue)
             {
@@ -4006,52 +1646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Pressure from nullable Torrs.
         /// </summary>
-        public static Pressure? FromTorrs(double? torrs)
-        {
-            if (torrs.HasValue)
-            {
-                return FromTorrs(torrs.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Torrs.
-        /// </summary>
-        public static Pressure? FromTorrs(int? torrs)
-        {
-            if (torrs.HasValue)
-            {
-                return FromTorrs(torrs.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from nullable Torrs.
-        /// </summary>
-        public static Pressure? FromTorrs(long? torrs)
-        {
-            if (torrs.HasValue)
-            {
-                return FromTorrs(torrs.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Pressure from Torrs of type decimal.
-        /// </summary>
-        public static Pressure? FromTorrs(decimal? torrs)
+        public static Pressure? FromTorrs(QuantityValue? torrs)
         {
             if (torrs.HasValue)
             {
@@ -4068,87 +1663,93 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="PressureUnit" /> to <see cref="Pressure" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Pressure unit value.</returns>
-        public static Pressure From(double val, PressureUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Pressure From(double value, PressureUnit fromUnit)
+#else
+        public static Pressure From(QuantityValue value, PressureUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case PressureUnit.Atmosphere:
-                    return FromAtmospheres(val);
+                    return FromAtmospheres(value);
                 case PressureUnit.Bar:
-                    return FromBars(val);
+                    return FromBars(value);
                 case PressureUnit.Centibar:
-                    return FromCentibars(val);
+                    return FromCentibars(value);
                 case PressureUnit.Decapascal:
-                    return FromDecapascals(val);
+                    return FromDecapascals(value);
                 case PressureUnit.Decibar:
-                    return FromDecibars(val);
+                    return FromDecibars(value);
                 case PressureUnit.FootOfHead:
-                    return FromFeetOfHead(val);
+                    return FromFeetOfHead(value);
                 case PressureUnit.Gigapascal:
-                    return FromGigapascals(val);
+                    return FromGigapascals(value);
                 case PressureUnit.Hectopascal:
-                    return FromHectopascals(val);
+                    return FromHectopascals(value);
                 case PressureUnit.InchOfMercury:
-                    return FromInchesOfMercury(val);
+                    return FromInchesOfMercury(value);
                 case PressureUnit.Kilobar:
-                    return FromKilobars(val);
+                    return FromKilobars(value);
                 case PressureUnit.KilogramForcePerSquareCentimeter:
-                    return FromKilogramsForcePerSquareCentimeter(val);
+                    return FromKilogramsForcePerSquareCentimeter(value);
                 case PressureUnit.KilogramForcePerSquareMeter:
-                    return FromKilogramsForcePerSquareMeter(val);
+                    return FromKilogramsForcePerSquareMeter(value);
                 case PressureUnit.KilogramForcePerSquareMillimeter:
-                    return FromKilogramsForcePerSquareMillimeter(val);
+                    return FromKilogramsForcePerSquareMillimeter(value);
                 case PressureUnit.KilonewtonPerSquareCentimeter:
-                    return FromKilonewtonsPerSquareCentimeter(val);
+                    return FromKilonewtonsPerSquareCentimeter(value);
                 case PressureUnit.KilonewtonPerSquareMeter:
-                    return FromKilonewtonsPerSquareMeter(val);
+                    return FromKilonewtonsPerSquareMeter(value);
                 case PressureUnit.KilonewtonPerSquareMillimeter:
-                    return FromKilonewtonsPerSquareMillimeter(val);
+                    return FromKilonewtonsPerSquareMillimeter(value);
                 case PressureUnit.Kilopascal:
-                    return FromKilopascals(val);
+                    return FromKilopascals(value);
                 case PressureUnit.KilopoundForcePerSquareFoot:
-                    return FromKilopoundsForcePerSquareFoot(val);
+                    return FromKilopoundsForcePerSquareFoot(value);
                 case PressureUnit.KilopoundForcePerSquareInch:
-                    return FromKilopoundsForcePerSquareInch(val);
+                    return FromKilopoundsForcePerSquareInch(value);
                 case PressureUnit.Megabar:
-                    return FromMegabars(val);
+                    return FromMegabars(value);
                 case PressureUnit.Megapascal:
-                    return FromMegapascals(val);
+                    return FromMegapascals(value);
                 case PressureUnit.MeterOfHead:
-                    return FromMetersOfHead(val);
+                    return FromMetersOfHead(value);
                 case PressureUnit.Micropascal:
-                    return FromMicropascals(val);
+                    return FromMicropascals(value);
                 case PressureUnit.Millibar:
-                    return FromMillibars(val);
+                    return FromMillibars(value);
                 case PressureUnit.MillimeterOfMercury:
-                    return FromMillimetersOfMercury(val);
+                    return FromMillimetersOfMercury(value);
                 case PressureUnit.NewtonPerSquareCentimeter:
-                    return FromNewtonsPerSquareCentimeter(val);
+                    return FromNewtonsPerSquareCentimeter(value);
                 case PressureUnit.NewtonPerSquareMeter:
-                    return FromNewtonsPerSquareMeter(val);
+                    return FromNewtonsPerSquareMeter(value);
                 case PressureUnit.NewtonPerSquareMillimeter:
-                    return FromNewtonsPerSquareMillimeter(val);
+                    return FromNewtonsPerSquareMillimeter(value);
                 case PressureUnit.Pascal:
-                    return FromPascals(val);
+                    return FromPascals(value);
                 case PressureUnit.PoundForcePerSquareFoot:
-                    return FromPoundsForcePerSquareFoot(val);
+                    return FromPoundsForcePerSquareFoot(value);
                 case PressureUnit.PoundForcePerSquareInch:
-                    return FromPoundsForcePerSquareInch(val);
+                    return FromPoundsForcePerSquareInch(value);
                 case PressureUnit.Psi:
-                    return FromPsi(val);
+                    return FromPsi(value);
                 case PressureUnit.TechnicalAtmosphere:
-                    return FromTechnicalAtmospheres(val);
+                    return FromTechnicalAtmospheres(value);
                 case PressureUnit.TonneForcePerSquareCentimeter:
-                    return FromTonnesForcePerSquareCentimeter(val);
+                    return FromTonnesForcePerSquareCentimeter(value);
                 case PressureUnit.TonneForcePerSquareMeter:
-                    return FromTonnesForcePerSquareMeter(val);
+                    return FromTonnesForcePerSquareMeter(value);
                 case PressureUnit.TonneForcePerSquareMillimeter:
-                    return FromTonnesForcePerSquareMillimeter(val);
+                    return FromTonnesForcePerSquareMillimeter(value);
                 case PressureUnit.Torr:
-                    return FromTorrs(val);
+                    return FromTorrs(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -4163,7 +1764,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Pressure unit value.</returns>
-        public static Pressure? From(double? value, PressureUnit fromUnit)
+        public static Pressure? From(QuantityValue? value, PressureUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -173,152 +173,72 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static PressureChangeRate FromAtmospheresPerSecond(double atmospherespersecond)
         {
-            return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
+            double value = (double) atmospherespersecond;
+            return new PressureChangeRate(value * 1.01325*1e5);
         }
-
-        /// <summary>
-        ///     Get PressureChangeRate from AtmospheresPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromAtmospheresPerSecond(int atmospherespersecond)
+#else
+        public static PressureChangeRate FromAtmospheresPerSecond(QuantityValue atmospherespersecond)
         {
-            return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
-        }
-
-        /// <summary>
-        ///     Get PressureChangeRate from AtmospheresPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromAtmospheresPerSecond(long atmospherespersecond)
-        {
-            return new PressureChangeRate(atmospherespersecond * 1.01325*1e5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get PressureChangeRate from AtmospheresPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate FromAtmospheresPerSecond(decimal atmospherespersecond)
-        {
-            return new PressureChangeRate(Convert.ToDouble(atmospherespersecond) * 1.01325*1e5);
+            double value = (double) atmospherespersecond;
+            return new PressureChangeRate((value * 1.01325*1e5));
         }
 #endif
 
         /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static PressureChangeRate FromKilopascalsPerSecond(double kilopascalspersecond)
         {
-            return new PressureChangeRate((kilopascalspersecond) * 1e3d);
+            double value = (double) kilopascalspersecond;
+            return new PressureChangeRate((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get PressureChangeRate from KilopascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromKilopascalsPerSecond(int kilopascalspersecond)
+#else
+        public static PressureChangeRate FromKilopascalsPerSecond(QuantityValue kilopascalspersecond)
         {
-            return new PressureChangeRate((kilopascalspersecond) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get PressureChangeRate from KilopascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromKilopascalsPerSecond(long kilopascalspersecond)
-        {
-            return new PressureChangeRate((kilopascalspersecond) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get PressureChangeRate from KilopascalsPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate FromKilopascalsPerSecond(decimal kilopascalspersecond)
-        {
-            return new PressureChangeRate((Convert.ToDouble(kilopascalspersecond)) * 1e3d);
+            double value = (double) kilopascalspersecond;
+            return new PressureChangeRate(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static PressureChangeRate FromMegapascalsPerSecond(double megapascalspersecond)
         {
-            return new PressureChangeRate((megapascalspersecond) * 1e6d);
+            double value = (double) megapascalspersecond;
+            return new PressureChangeRate((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get PressureChangeRate from MegapascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromMegapascalsPerSecond(int megapascalspersecond)
+#else
+        public static PressureChangeRate FromMegapascalsPerSecond(QuantityValue megapascalspersecond)
         {
-            return new PressureChangeRate((megapascalspersecond) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get PressureChangeRate from MegapascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromMegapascalsPerSecond(long megapascalspersecond)
-        {
-            return new PressureChangeRate((megapascalspersecond) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get PressureChangeRate from MegapascalsPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate FromMegapascalsPerSecond(decimal megapascalspersecond)
-        {
-            return new PressureChangeRate((Convert.ToDouble(megapascalspersecond)) * 1e6d);
+            double value = (double) megapascalspersecond;
+            return new PressureChangeRate(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static PressureChangeRate FromPascalsPerSecond(double pascalspersecond)
         {
-            return new PressureChangeRate(pascalspersecond);
+            double value = (double) pascalspersecond;
+            return new PressureChangeRate(value);
         }
-
-        /// <summary>
-        ///     Get PressureChangeRate from PascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromPascalsPerSecond(int pascalspersecond)
+#else
+        public static PressureChangeRate FromPascalsPerSecond(QuantityValue pascalspersecond)
         {
-            return new PressureChangeRate(pascalspersecond);
-        }
-
-        /// <summary>
-        ///     Get PressureChangeRate from PascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate FromPascalsPerSecond(long pascalspersecond)
-        {
-            return new PressureChangeRate(pascalspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get PressureChangeRate from PascalsPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate FromPascalsPerSecond(decimal pascalspersecond)
-        {
-            return new PressureChangeRate(Convert.ToDouble(pascalspersecond));
+            double value = (double) pascalspersecond;
+            return new PressureChangeRate((value));
         }
 #endif
 
@@ -327,52 +247,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
         /// </summary>
-        public static PressureChangeRate? FromAtmospheresPerSecond(double? atmospherespersecond)
-        {
-            if (atmospherespersecond.HasValue)
-            {
-                return FromAtmospheresPerSecond(atmospherespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromAtmospheresPerSecond(int? atmospherespersecond)
-        {
-            if (atmospherespersecond.HasValue)
-            {
-                return FromAtmospheresPerSecond(atmospherespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable AtmospheresPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromAtmospheresPerSecond(long? atmospherespersecond)
-        {
-            if (atmospherespersecond.HasValue)
-            {
-                return FromAtmospheresPerSecond(atmospherespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from AtmospheresPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate? FromAtmospheresPerSecond(decimal? atmospherespersecond)
+        public static PressureChangeRate? FromAtmospheresPerSecond(QuantityValue? atmospherespersecond)
         {
             if (atmospherespersecond.HasValue)
             {
@@ -387,52 +262,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
         /// </summary>
-        public static PressureChangeRate? FromKilopascalsPerSecond(double? kilopascalspersecond)
-        {
-            if (kilopascalspersecond.HasValue)
-            {
-                return FromKilopascalsPerSecond(kilopascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromKilopascalsPerSecond(int? kilopascalspersecond)
-        {
-            if (kilopascalspersecond.HasValue)
-            {
-                return FromKilopascalsPerSecond(kilopascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable KilopascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromKilopascalsPerSecond(long? kilopascalspersecond)
-        {
-            if (kilopascalspersecond.HasValue)
-            {
-                return FromKilopascalsPerSecond(kilopascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from KilopascalsPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate? FromKilopascalsPerSecond(decimal? kilopascalspersecond)
+        public static PressureChangeRate? FromKilopascalsPerSecond(QuantityValue? kilopascalspersecond)
         {
             if (kilopascalspersecond.HasValue)
             {
@@ -447,52 +277,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
         /// </summary>
-        public static PressureChangeRate? FromMegapascalsPerSecond(double? megapascalspersecond)
-        {
-            if (megapascalspersecond.HasValue)
-            {
-                return FromMegapascalsPerSecond(megapascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromMegapascalsPerSecond(int? megapascalspersecond)
-        {
-            if (megapascalspersecond.HasValue)
-            {
-                return FromMegapascalsPerSecond(megapascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable MegapascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromMegapascalsPerSecond(long? megapascalspersecond)
-        {
-            if (megapascalspersecond.HasValue)
-            {
-                return FromMegapascalsPerSecond(megapascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from MegapascalsPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate? FromMegapascalsPerSecond(decimal? megapascalspersecond)
+        public static PressureChangeRate? FromMegapascalsPerSecond(QuantityValue? megapascalspersecond)
         {
             if (megapascalspersecond.HasValue)
             {
@@ -507,52 +292,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
         /// </summary>
-        public static PressureChangeRate? FromPascalsPerSecond(double? pascalspersecond)
-        {
-            if (pascalspersecond.HasValue)
-            {
-                return FromPascalsPerSecond(pascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromPascalsPerSecond(int? pascalspersecond)
-        {
-            if (pascalspersecond.HasValue)
-            {
-                return FromPascalsPerSecond(pascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from nullable PascalsPerSecond.
-        /// </summary>
-        public static PressureChangeRate? FromPascalsPerSecond(long? pascalspersecond)
-        {
-            if (pascalspersecond.HasValue)
-            {
-                return FromPascalsPerSecond(pascalspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable PressureChangeRate from PascalsPerSecond of type decimal.
-        /// </summary>
-        public static PressureChangeRate? FromPascalsPerSecond(decimal? pascalspersecond)
+        public static PressureChangeRate? FromPascalsPerSecond(QuantityValue? pascalspersecond)
         {
             if (pascalspersecond.HasValue)
             {
@@ -569,21 +309,27 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="PressureChangeRateUnit" /> to <see cref="PressureChangeRate" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>PressureChangeRate unit value.</returns>
-        public static PressureChangeRate From(double val, PressureChangeRateUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static PressureChangeRate From(double value, PressureChangeRateUnit fromUnit)
+#else
+        public static PressureChangeRate From(QuantityValue value, PressureChangeRateUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case PressureChangeRateUnit.AtmospherePerSecond:
-                    return FromAtmospheresPerSecond(val);
+                    return FromAtmospheresPerSecond(value);
                 case PressureChangeRateUnit.KilopascalPerSecond:
-                    return FromKilopascalsPerSecond(val);
+                    return FromKilopascalsPerSecond(value);
                 case PressureChangeRateUnit.MegapascalPerSecond:
-                    return FromMegapascalsPerSecond(val);
+                    return FromMegapascalsPerSecond(value);
                 case PressureChangeRateUnit.PascalPerSecond:
-                    return FromPascalsPerSecond(val);
+                    return FromPascalsPerSecond(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -598,7 +344,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>PressureChangeRate unit value.</returns>
-        public static PressureChangeRate? From(double? value, PressureChangeRateUnit fromUnit)
+        public static PressureChangeRate? From(QuantityValue? value, PressureChangeRateUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -189,228 +189,108 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from DecimalFractions.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Ratio FromDecimalFractions(double decimalfractions)
         {
-            return new Ratio(decimalfractions);
+            double value = (double) decimalfractions;
+            return new Ratio(value);
         }
-
-        /// <summary>
-        ///     Get Ratio from DecimalFractions.
-        /// </summary>
-        public static Ratio FromDecimalFractions(int decimalfractions)
+#else
+        public static Ratio FromDecimalFractions(QuantityValue decimalfractions)
         {
-            return new Ratio(decimalfractions);
-        }
-
-        /// <summary>
-        ///     Get Ratio from DecimalFractions.
-        /// </summary>
-        public static Ratio FromDecimalFractions(long decimalfractions)
-        {
-            return new Ratio(decimalfractions);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Ratio from DecimalFractions of type decimal.
-        /// </summary>
-        public static Ratio FromDecimalFractions(decimal decimalfractions)
-        {
-            return new Ratio(Convert.ToDouble(decimalfractions));
+            double value = (double) decimalfractions;
+            return new Ratio((value));
         }
 #endif
 
         /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Ratio FromPartsPerBillion(double partsperbillion)
         {
-            return new Ratio(partsperbillion/1e9);
+            double value = (double) partsperbillion;
+            return new Ratio(value/1e9);
         }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerBillion.
-        /// </summary>
-        public static Ratio FromPartsPerBillion(int partsperbillion)
+#else
+        public static Ratio FromPartsPerBillion(QuantityValue partsperbillion)
         {
-            return new Ratio(partsperbillion/1e9);
-        }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerBillion.
-        /// </summary>
-        public static Ratio FromPartsPerBillion(long partsperbillion)
-        {
-            return new Ratio(partsperbillion/1e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Ratio from PartsPerBillion of type decimal.
-        /// </summary>
-        public static Ratio FromPartsPerBillion(decimal partsperbillion)
-        {
-            return new Ratio(Convert.ToDouble(partsperbillion)/1e9);
+            double value = (double) partsperbillion;
+            return new Ratio((value/1e9));
         }
 #endif
 
         /// <summary>
         ///     Get Ratio from PartsPerMillion.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Ratio FromPartsPerMillion(double partspermillion)
         {
-            return new Ratio(partspermillion/1e6);
+            double value = (double) partspermillion;
+            return new Ratio(value/1e6);
         }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerMillion.
-        /// </summary>
-        public static Ratio FromPartsPerMillion(int partspermillion)
+#else
+        public static Ratio FromPartsPerMillion(QuantityValue partspermillion)
         {
-            return new Ratio(partspermillion/1e6);
-        }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerMillion.
-        /// </summary>
-        public static Ratio FromPartsPerMillion(long partspermillion)
-        {
-            return new Ratio(partspermillion/1e6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Ratio from PartsPerMillion of type decimal.
-        /// </summary>
-        public static Ratio FromPartsPerMillion(decimal partspermillion)
-        {
-            return new Ratio(Convert.ToDouble(partspermillion)/1e6);
+            double value = (double) partspermillion;
+            return new Ratio((value/1e6));
         }
 #endif
 
         /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Ratio FromPartsPerThousand(double partsperthousand)
         {
-            return new Ratio(partsperthousand/1e3);
+            double value = (double) partsperthousand;
+            return new Ratio(value/1e3);
         }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerThousand.
-        /// </summary>
-        public static Ratio FromPartsPerThousand(int partsperthousand)
+#else
+        public static Ratio FromPartsPerThousand(QuantityValue partsperthousand)
         {
-            return new Ratio(partsperthousand/1e3);
-        }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerThousand.
-        /// </summary>
-        public static Ratio FromPartsPerThousand(long partsperthousand)
-        {
-            return new Ratio(partsperthousand/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Ratio from PartsPerThousand of type decimal.
-        /// </summary>
-        public static Ratio FromPartsPerThousand(decimal partsperthousand)
-        {
-            return new Ratio(Convert.ToDouble(partsperthousand)/1e3);
+            double value = (double) partsperthousand;
+            return new Ratio((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Ratio from PartsPerTrillion.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Ratio FromPartsPerTrillion(double partspertrillion)
         {
-            return new Ratio(partspertrillion/1e12);
+            double value = (double) partspertrillion;
+            return new Ratio(value/1e12);
         }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerTrillion.
-        /// </summary>
-        public static Ratio FromPartsPerTrillion(int partspertrillion)
+#else
+        public static Ratio FromPartsPerTrillion(QuantityValue partspertrillion)
         {
-            return new Ratio(partspertrillion/1e12);
-        }
-
-        /// <summary>
-        ///     Get Ratio from PartsPerTrillion.
-        /// </summary>
-        public static Ratio FromPartsPerTrillion(long partspertrillion)
-        {
-            return new Ratio(partspertrillion/1e12);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Ratio from PartsPerTrillion of type decimal.
-        /// </summary>
-        public static Ratio FromPartsPerTrillion(decimal partspertrillion)
-        {
-            return new Ratio(Convert.ToDouble(partspertrillion)/1e12);
+            double value = (double) partspertrillion;
+            return new Ratio((value/1e12));
         }
 #endif
 
         /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Ratio FromPercent(double percent)
         {
-            return new Ratio(percent/1e2);
+            double value = (double) percent;
+            return new Ratio(value/1e2);
         }
-
-        /// <summary>
-        ///     Get Ratio from Percent.
-        /// </summary>
-        public static Ratio FromPercent(int percent)
+#else
+        public static Ratio FromPercent(QuantityValue percent)
         {
-            return new Ratio(percent/1e2);
-        }
-
-        /// <summary>
-        ///     Get Ratio from Percent.
-        /// </summary>
-        public static Ratio FromPercent(long percent)
-        {
-            return new Ratio(percent/1e2);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Ratio from Percent of type decimal.
-        /// </summary>
-        public static Ratio FromPercent(decimal percent)
-        {
-            return new Ratio(Convert.ToDouble(percent)/1e2);
+            double value = (double) percent;
+            return new Ratio((value/1e2));
         }
 #endif
 
@@ -419,52 +299,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Ratio from nullable DecimalFractions.
         /// </summary>
-        public static Ratio? FromDecimalFractions(double? decimalfractions)
-        {
-            if (decimalfractions.HasValue)
-            {
-                return FromDecimalFractions(decimalfractions.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable DecimalFractions.
-        /// </summary>
-        public static Ratio? FromDecimalFractions(int? decimalfractions)
-        {
-            if (decimalfractions.HasValue)
-            {
-                return FromDecimalFractions(decimalfractions.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable DecimalFractions.
-        /// </summary>
-        public static Ratio? FromDecimalFractions(long? decimalfractions)
-        {
-            if (decimalfractions.HasValue)
-            {
-                return FromDecimalFractions(decimalfractions.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from DecimalFractions of type decimal.
-        /// </summary>
-        public static Ratio? FromDecimalFractions(decimal? decimalfractions)
+        public static Ratio? FromDecimalFractions(QuantityValue? decimalfractions)
         {
             if (decimalfractions.HasValue)
             {
@@ -479,52 +314,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Ratio from nullable PartsPerBillion.
         /// </summary>
-        public static Ratio? FromPartsPerBillion(double? partsperbillion)
-        {
-            if (partsperbillion.HasValue)
-            {
-                return FromPartsPerBillion(partsperbillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerBillion.
-        /// </summary>
-        public static Ratio? FromPartsPerBillion(int? partsperbillion)
-        {
-            if (partsperbillion.HasValue)
-            {
-                return FromPartsPerBillion(partsperbillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerBillion.
-        /// </summary>
-        public static Ratio? FromPartsPerBillion(long? partsperbillion)
-        {
-            if (partsperbillion.HasValue)
-            {
-                return FromPartsPerBillion(partsperbillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from PartsPerBillion of type decimal.
-        /// </summary>
-        public static Ratio? FromPartsPerBillion(decimal? partsperbillion)
+        public static Ratio? FromPartsPerBillion(QuantityValue? partsperbillion)
         {
             if (partsperbillion.HasValue)
             {
@@ -539,52 +329,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Ratio from nullable PartsPerMillion.
         /// </summary>
-        public static Ratio? FromPartsPerMillion(double? partspermillion)
-        {
-            if (partspermillion.HasValue)
-            {
-                return FromPartsPerMillion(partspermillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerMillion.
-        /// </summary>
-        public static Ratio? FromPartsPerMillion(int? partspermillion)
-        {
-            if (partspermillion.HasValue)
-            {
-                return FromPartsPerMillion(partspermillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerMillion.
-        /// </summary>
-        public static Ratio? FromPartsPerMillion(long? partspermillion)
-        {
-            if (partspermillion.HasValue)
-            {
-                return FromPartsPerMillion(partspermillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from PartsPerMillion of type decimal.
-        /// </summary>
-        public static Ratio? FromPartsPerMillion(decimal? partspermillion)
+        public static Ratio? FromPartsPerMillion(QuantityValue? partspermillion)
         {
             if (partspermillion.HasValue)
             {
@@ -599,52 +344,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Ratio from nullable PartsPerThousand.
         /// </summary>
-        public static Ratio? FromPartsPerThousand(double? partsperthousand)
-        {
-            if (partsperthousand.HasValue)
-            {
-                return FromPartsPerThousand(partsperthousand.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerThousand.
-        /// </summary>
-        public static Ratio? FromPartsPerThousand(int? partsperthousand)
-        {
-            if (partsperthousand.HasValue)
-            {
-                return FromPartsPerThousand(partsperthousand.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerThousand.
-        /// </summary>
-        public static Ratio? FromPartsPerThousand(long? partsperthousand)
-        {
-            if (partsperthousand.HasValue)
-            {
-                return FromPartsPerThousand(partsperthousand.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from PartsPerThousand of type decimal.
-        /// </summary>
-        public static Ratio? FromPartsPerThousand(decimal? partsperthousand)
+        public static Ratio? FromPartsPerThousand(QuantityValue? partsperthousand)
         {
             if (partsperthousand.HasValue)
             {
@@ -659,52 +359,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Ratio from nullable PartsPerTrillion.
         /// </summary>
-        public static Ratio? FromPartsPerTrillion(double? partspertrillion)
-        {
-            if (partspertrillion.HasValue)
-            {
-                return FromPartsPerTrillion(partspertrillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerTrillion.
-        /// </summary>
-        public static Ratio? FromPartsPerTrillion(int? partspertrillion)
-        {
-            if (partspertrillion.HasValue)
-            {
-                return FromPartsPerTrillion(partspertrillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable PartsPerTrillion.
-        /// </summary>
-        public static Ratio? FromPartsPerTrillion(long? partspertrillion)
-        {
-            if (partspertrillion.HasValue)
-            {
-                return FromPartsPerTrillion(partspertrillion.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from PartsPerTrillion of type decimal.
-        /// </summary>
-        public static Ratio? FromPartsPerTrillion(decimal? partspertrillion)
+        public static Ratio? FromPartsPerTrillion(QuantityValue? partspertrillion)
         {
             if (partspertrillion.HasValue)
             {
@@ -719,52 +374,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Ratio from nullable Percent.
         /// </summary>
-        public static Ratio? FromPercent(double? percent)
-        {
-            if (percent.HasValue)
-            {
-                return FromPercent(percent.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable Percent.
-        /// </summary>
-        public static Ratio? FromPercent(int? percent)
-        {
-            if (percent.HasValue)
-            {
-                return FromPercent(percent.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from nullable Percent.
-        /// </summary>
-        public static Ratio? FromPercent(long? percent)
-        {
-            if (percent.HasValue)
-            {
-                return FromPercent(percent.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Ratio from Percent of type decimal.
-        /// </summary>
-        public static Ratio? FromPercent(decimal? percent)
+        public static Ratio? FromPercent(QuantityValue? percent)
         {
             if (percent.HasValue)
             {
@@ -781,25 +391,31 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="RatioUnit" /> to <see cref="Ratio" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Ratio unit value.</returns>
-        public static Ratio From(double val, RatioUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Ratio From(double value, RatioUnit fromUnit)
+#else
+        public static Ratio From(QuantityValue value, RatioUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case RatioUnit.DecimalFraction:
-                    return FromDecimalFractions(val);
+                    return FromDecimalFractions(value);
                 case RatioUnit.PartPerBillion:
-                    return FromPartsPerBillion(val);
+                    return FromPartsPerBillion(value);
                 case RatioUnit.PartPerMillion:
-                    return FromPartsPerMillion(val);
+                    return FromPartsPerMillion(value);
                 case RatioUnit.PartPerThousand:
-                    return FromPartsPerThousand(val);
+                    return FromPartsPerThousand(value);
                 case RatioUnit.PartPerTrillion:
-                    return FromPartsPerTrillion(val);
+                    return FromPartsPerTrillion(value);
                 case RatioUnit.Percent:
-                    return FromPercent(val);
+                    return FromPercent(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -814,7 +430,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Ratio unit value.</returns>
-        public static Ratio? From(double? value, RatioUnit fromUnit)
+        public static Ratio? From(QuantityValue? value, RatioUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -165,114 +165,54 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ReactivePower FromKilovoltamperesReactive(double kilovoltamperesreactive)
         {
-            return new ReactivePower((kilovoltamperesreactive) * 1e3d);
+            double value = (double) kilovoltamperesreactive;
+            return new ReactivePower((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get ReactivePower from KilovoltamperesReactive.
-        /// </summary>
-        public static ReactivePower FromKilovoltamperesReactive(int kilovoltamperesreactive)
+#else
+        public static ReactivePower FromKilovoltamperesReactive(QuantityValue kilovoltamperesreactive)
         {
-            return new ReactivePower((kilovoltamperesreactive) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get ReactivePower from KilovoltamperesReactive.
-        /// </summary>
-        public static ReactivePower FromKilovoltamperesReactive(long kilovoltamperesreactive)
-        {
-            return new ReactivePower((kilovoltamperesreactive) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ReactivePower from KilovoltamperesReactive of type decimal.
-        /// </summary>
-        public static ReactivePower FromKilovoltamperesReactive(decimal kilovoltamperesreactive)
-        {
-            return new ReactivePower((Convert.ToDouble(kilovoltamperesreactive)) * 1e3d);
+            double value = (double) kilovoltamperesreactive;
+            return new ReactivePower(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ReactivePower FromMegavoltamperesReactive(double megavoltamperesreactive)
         {
-            return new ReactivePower((megavoltamperesreactive) * 1e6d);
+            double value = (double) megavoltamperesreactive;
+            return new ReactivePower((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get ReactivePower from MegavoltamperesReactive.
-        /// </summary>
-        public static ReactivePower FromMegavoltamperesReactive(int megavoltamperesreactive)
+#else
+        public static ReactivePower FromMegavoltamperesReactive(QuantityValue megavoltamperesreactive)
         {
-            return new ReactivePower((megavoltamperesreactive) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get ReactivePower from MegavoltamperesReactive.
-        /// </summary>
-        public static ReactivePower FromMegavoltamperesReactive(long megavoltamperesreactive)
-        {
-            return new ReactivePower((megavoltamperesreactive) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ReactivePower from MegavoltamperesReactive of type decimal.
-        /// </summary>
-        public static ReactivePower FromMegavoltamperesReactive(decimal megavoltamperesreactive)
-        {
-            return new ReactivePower((Convert.ToDouble(megavoltamperesreactive)) * 1e6d);
+            double value = (double) megavoltamperesreactive;
+            return new ReactivePower(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ReactivePower FromVoltamperesReactive(double voltamperesreactive)
         {
-            return new ReactivePower(voltamperesreactive);
+            double value = (double) voltamperesreactive;
+            return new ReactivePower(value);
         }
-
-        /// <summary>
-        ///     Get ReactivePower from VoltamperesReactive.
-        /// </summary>
-        public static ReactivePower FromVoltamperesReactive(int voltamperesreactive)
+#else
+        public static ReactivePower FromVoltamperesReactive(QuantityValue voltamperesreactive)
         {
-            return new ReactivePower(voltamperesreactive);
-        }
-
-        /// <summary>
-        ///     Get ReactivePower from VoltamperesReactive.
-        /// </summary>
-        public static ReactivePower FromVoltamperesReactive(long voltamperesreactive)
-        {
-            return new ReactivePower(voltamperesreactive);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ReactivePower from VoltamperesReactive of type decimal.
-        /// </summary>
-        public static ReactivePower FromVoltamperesReactive(decimal voltamperesreactive)
-        {
-            return new ReactivePower(Convert.ToDouble(voltamperesreactive));
+            double value = (double) voltamperesreactive;
+            return new ReactivePower((value));
         }
 #endif
 
@@ -281,52 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
         /// </summary>
-        public static ReactivePower? FromKilovoltamperesReactive(double? kilovoltamperesreactive)
-        {
-            if (kilovoltamperesreactive.HasValue)
-            {
-                return FromKilovoltamperesReactive(kilovoltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
-        /// </summary>
-        public static ReactivePower? FromKilovoltamperesReactive(int? kilovoltamperesreactive)
-        {
-            if (kilovoltamperesreactive.HasValue)
-            {
-                return FromKilovoltamperesReactive(kilovoltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from nullable KilovoltamperesReactive.
-        /// </summary>
-        public static ReactivePower? FromKilovoltamperesReactive(long? kilovoltamperesreactive)
-        {
-            if (kilovoltamperesreactive.HasValue)
-            {
-                return FromKilovoltamperesReactive(kilovoltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from KilovoltamperesReactive of type decimal.
-        /// </summary>
-        public static ReactivePower? FromKilovoltamperesReactive(decimal? kilovoltamperesreactive)
+        public static ReactivePower? FromKilovoltamperesReactive(QuantityValue? kilovoltamperesreactive)
         {
             if (kilovoltamperesreactive.HasValue)
             {
@@ -341,52 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
         /// </summary>
-        public static ReactivePower? FromMegavoltamperesReactive(double? megavoltamperesreactive)
-        {
-            if (megavoltamperesreactive.HasValue)
-            {
-                return FromMegavoltamperesReactive(megavoltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
-        /// </summary>
-        public static ReactivePower? FromMegavoltamperesReactive(int? megavoltamperesreactive)
-        {
-            if (megavoltamperesreactive.HasValue)
-            {
-                return FromMegavoltamperesReactive(megavoltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from nullable MegavoltamperesReactive.
-        /// </summary>
-        public static ReactivePower? FromMegavoltamperesReactive(long? megavoltamperesreactive)
-        {
-            if (megavoltamperesreactive.HasValue)
-            {
-                return FromMegavoltamperesReactive(megavoltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from MegavoltamperesReactive of type decimal.
-        /// </summary>
-        public static ReactivePower? FromMegavoltamperesReactive(decimal? megavoltamperesreactive)
+        public static ReactivePower? FromMegavoltamperesReactive(QuantityValue? megavoltamperesreactive)
         {
             if (megavoltamperesreactive.HasValue)
             {
@@ -401,52 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ReactivePower from nullable VoltamperesReactive.
         /// </summary>
-        public static ReactivePower? FromVoltamperesReactive(double? voltamperesreactive)
-        {
-            if (voltamperesreactive.HasValue)
-            {
-                return FromVoltamperesReactive(voltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from nullable VoltamperesReactive.
-        /// </summary>
-        public static ReactivePower? FromVoltamperesReactive(int? voltamperesreactive)
-        {
-            if (voltamperesreactive.HasValue)
-            {
-                return FromVoltamperesReactive(voltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from nullable VoltamperesReactive.
-        /// </summary>
-        public static ReactivePower? FromVoltamperesReactive(long? voltamperesreactive)
-        {
-            if (voltamperesreactive.HasValue)
-            {
-                return FromVoltamperesReactive(voltamperesreactive.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ReactivePower from VoltamperesReactive of type decimal.
-        /// </summary>
-        public static ReactivePower? FromVoltamperesReactive(decimal? voltamperesreactive)
+        public static ReactivePower? FromVoltamperesReactive(QuantityValue? voltamperesreactive)
         {
             if (voltamperesreactive.HasValue)
             {
@@ -463,19 +268,25 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ReactivePowerUnit" /> to <see cref="ReactivePower" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ReactivePower unit value.</returns>
-        public static ReactivePower From(double val, ReactivePowerUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ReactivePower From(double value, ReactivePowerUnit fromUnit)
+#else
+        public static ReactivePower From(QuantityValue value, ReactivePowerUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ReactivePowerUnit.KilovoltampereReactive:
-                    return FromKilovoltamperesReactive(val);
+                    return FromKilovoltamperesReactive(value);
                 case ReactivePowerUnit.MegavoltampereReactive:
-                    return FromMegavoltamperesReactive(val);
+                    return FromMegavoltamperesReactive(value);
                 case ReactivePowerUnit.VoltampereReactive:
-                    return FromVoltamperesReactive(val);
+                    return FromVoltamperesReactive(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -490,7 +301,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ReactivePower unit value.</returns>
-        public static ReactivePower? From(double? value, ReactivePowerUnit fromUnit)
+        public static ReactivePower? From(QuantityValue? value, ReactivePowerUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -157,76 +157,36 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalAcceleration FromDegreesPerSecondSquared(double degreespersecondsquared)
         {
-            return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
+            double value = (double) degreespersecondsquared;
+            return new RotationalAcceleration((Math.PI/180)*value);
         }
-
-        /// <summary>
-        ///     Get RotationalAcceleration from DegreesPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration FromDegreesPerSecondSquared(int degreespersecondsquared)
+#else
+        public static RotationalAcceleration FromDegreesPerSecondSquared(QuantityValue degreespersecondsquared)
         {
-            return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
-        }
-
-        /// <summary>
-        ///     Get RotationalAcceleration from DegreesPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration FromDegreesPerSecondSquared(long degreespersecondsquared)
-        {
-            return new RotationalAcceleration((Math.PI/180)*degreespersecondsquared);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalAcceleration from DegreesPerSecondSquared of type decimal.
-        /// </summary>
-        public static RotationalAcceleration FromDegreesPerSecondSquared(decimal degreespersecondsquared)
-        {
-            return new RotationalAcceleration((Math.PI/180)*Convert.ToDouble(degreespersecondsquared));
+            double value = (double) degreespersecondsquared;
+            return new RotationalAcceleration(((Math.PI/180)*value));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalAcceleration FromRadiansPerSecondSquared(double radianspersecondsquared)
         {
-            return new RotationalAcceleration(radianspersecondsquared);
+            double value = (double) radianspersecondsquared;
+            return new RotationalAcceleration(value);
         }
-
-        /// <summary>
-        ///     Get RotationalAcceleration from RadiansPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration FromRadiansPerSecondSquared(int radianspersecondsquared)
+#else
+        public static RotationalAcceleration FromRadiansPerSecondSquared(QuantityValue radianspersecondsquared)
         {
-            return new RotationalAcceleration(radianspersecondsquared);
-        }
-
-        /// <summary>
-        ///     Get RotationalAcceleration from RadiansPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration FromRadiansPerSecondSquared(long radianspersecondsquared)
-        {
-            return new RotationalAcceleration(radianspersecondsquared);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalAcceleration from RadiansPerSecondSquared of type decimal.
-        /// </summary>
-        public static RotationalAcceleration FromRadiansPerSecondSquared(decimal radianspersecondsquared)
-        {
-            return new RotationalAcceleration(Convert.ToDouble(radianspersecondsquared));
+            double value = (double) radianspersecondsquared;
+            return new RotationalAcceleration((value));
         }
 #endif
 
@@ -235,52 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
         /// </summary>
-        public static RotationalAcceleration? FromDegreesPerSecondSquared(double? degreespersecondsquared)
-        {
-            if (degreespersecondsquared.HasValue)
-            {
-                return FromDegreesPerSecondSquared(degreespersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration? FromDegreesPerSecondSquared(int? degreespersecondsquared)
-        {
-            if (degreespersecondsquared.HasValue)
-            {
-                return FromDegreesPerSecondSquared(degreespersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalAcceleration from nullable DegreesPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration? FromDegreesPerSecondSquared(long? degreespersecondsquared)
-        {
-            if (degreespersecondsquared.HasValue)
-            {
-                return FromDegreesPerSecondSquared(degreespersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalAcceleration from DegreesPerSecondSquared of type decimal.
-        /// </summary>
-        public static RotationalAcceleration? FromDegreesPerSecondSquared(decimal? degreespersecondsquared)
+        public static RotationalAcceleration? FromDegreesPerSecondSquared(QuantityValue? degreespersecondsquared)
         {
             if (degreespersecondsquared.HasValue)
             {
@@ -295,52 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
         /// </summary>
-        public static RotationalAcceleration? FromRadiansPerSecondSquared(double? radianspersecondsquared)
-        {
-            if (radianspersecondsquared.HasValue)
-            {
-                return FromRadiansPerSecondSquared(radianspersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration? FromRadiansPerSecondSquared(int? radianspersecondsquared)
-        {
-            if (radianspersecondsquared.HasValue)
-            {
-                return FromRadiansPerSecondSquared(radianspersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalAcceleration from nullable RadiansPerSecondSquared.
-        /// </summary>
-        public static RotationalAcceleration? FromRadiansPerSecondSquared(long? radianspersecondsquared)
-        {
-            if (radianspersecondsquared.HasValue)
-            {
-                return FromRadiansPerSecondSquared(radianspersecondsquared.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalAcceleration from RadiansPerSecondSquared of type decimal.
-        /// </summary>
-        public static RotationalAcceleration? FromRadiansPerSecondSquared(decimal? radianspersecondsquared)
+        public static RotationalAcceleration? FromRadiansPerSecondSquared(QuantityValue? radianspersecondsquared)
         {
             if (radianspersecondsquared.HasValue)
             {
@@ -357,17 +227,23 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="RotationalAccelerationUnit" /> to <see cref="RotationalAcceleration" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>RotationalAcceleration unit value.</returns>
-        public static RotationalAcceleration From(double val, RotationalAccelerationUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static RotationalAcceleration From(double value, RotationalAccelerationUnit fromUnit)
+#else
+        public static RotationalAcceleration From(QuantityValue value, RotationalAccelerationUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case RotationalAccelerationUnit.DegreePerSecondSquared:
-                    return FromDegreesPerSecondSquared(val);
+                    return FromDegreesPerSecondSquared(value);
                 case RotationalAccelerationUnit.RadianPerSecondSquared:
-                    return FromRadiansPerSecondSquared(val);
+                    return FromRadiansPerSecondSquared(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -382,7 +258,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>RotationalAcceleration unit value.</returns>
-        public static RotationalAcceleration? From(double? value, RotationalAccelerationUnit fromUnit)
+        public static RotationalAcceleration? From(QuantityValue? value, RotationalAccelerationUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -245,494 +245,234 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromCentiradiansPerSecond(double centiradianspersecond)
         {
-            return new RotationalSpeed((centiradianspersecond) * 1e-2d);
+            double value = (double) centiradianspersecond;
+            return new RotationalSpeed((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from CentiradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromCentiradiansPerSecond(int centiradianspersecond)
+#else
+        public static RotationalSpeed FromCentiradiansPerSecond(QuantityValue centiradianspersecond)
         {
-            return new RotationalSpeed((centiradianspersecond) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from CentiradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromCentiradiansPerSecond(long centiradianspersecond)
-        {
-            return new RotationalSpeed((centiradianspersecond) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from CentiradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromCentiradiansPerSecond(decimal centiradianspersecond)
-        {
-            return new RotationalSpeed((Convert.ToDouble(centiradianspersecond)) * 1e-2d);
+            double value = (double) centiradianspersecond;
+            return new RotationalSpeed(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromDeciradiansPerSecond(double deciradianspersecond)
         {
-            return new RotationalSpeed((deciradianspersecond) * 1e-1d);
+            double value = (double) deciradianspersecond;
+            return new RotationalSpeed((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from DeciradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromDeciradiansPerSecond(int deciradianspersecond)
+#else
+        public static RotationalSpeed FromDeciradiansPerSecond(QuantityValue deciradianspersecond)
         {
-            return new RotationalSpeed((deciradianspersecond) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from DeciradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromDeciradiansPerSecond(long deciradianspersecond)
-        {
-            return new RotationalSpeed((deciradianspersecond) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from DeciradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromDeciradiansPerSecond(decimal deciradianspersecond)
-        {
-            return new RotationalSpeed((Convert.ToDouble(deciradianspersecond)) * 1e-1d);
+            double value = (double) deciradianspersecond;
+            return new RotationalSpeed(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromDegreesPerMinute(double degreesperminute)
         {
-            return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
+            double value = (double) degreesperminute;
+            return new RotationalSpeed((Math.PI/(180*60))*value);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from DegreesPerMinute.
-        /// </summary>
-        public static RotationalSpeed FromDegreesPerMinute(int degreesperminute)
+#else
+        public static RotationalSpeed FromDegreesPerMinute(QuantityValue degreesperminute)
         {
-            return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from DegreesPerMinute.
-        /// </summary>
-        public static RotationalSpeed FromDegreesPerMinute(long degreesperminute)
-        {
-            return new RotationalSpeed((Math.PI/(180*60))*degreesperminute);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from DegreesPerMinute of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromDegreesPerMinute(decimal degreesperminute)
-        {
-            return new RotationalSpeed((Math.PI/(180*60))*Convert.ToDouble(degreesperminute));
+            double value = (double) degreesperminute;
+            return new RotationalSpeed(((Math.PI/(180*60))*value));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromDegreesPerSecond(double degreespersecond)
         {
-            return new RotationalSpeed((Math.PI/180)*degreespersecond);
+            double value = (double) degreespersecond;
+            return new RotationalSpeed((Math.PI/180)*value);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from DegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromDegreesPerSecond(int degreespersecond)
+#else
+        public static RotationalSpeed FromDegreesPerSecond(QuantityValue degreespersecond)
         {
-            return new RotationalSpeed((Math.PI/180)*degreespersecond);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from DegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromDegreesPerSecond(long degreespersecond)
-        {
-            return new RotationalSpeed((Math.PI/180)*degreespersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from DegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromDegreesPerSecond(decimal degreespersecond)
-        {
-            return new RotationalSpeed((Math.PI/180)*Convert.ToDouble(degreespersecond));
+            double value = (double) degreespersecond;
+            return new RotationalSpeed(((Math.PI/180)*value));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromMicrodegreesPerSecond(double microdegreespersecond)
         {
-            return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
+            double value = (double) microdegreespersecond;
+            return new RotationalSpeed(((Math.PI/180)*value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MicrodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMicrodegreesPerSecond(int microdegreespersecond)
+#else
+        public static RotationalSpeed FromMicrodegreesPerSecond(QuantityValue microdegreespersecond)
         {
-            return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MicrodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMicrodegreesPerSecond(long microdegreespersecond)
-        {
-            return new RotationalSpeed(((Math.PI/180)*microdegreespersecond) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from MicrodegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromMicrodegreesPerSecond(decimal microdegreespersecond)
-        {
-            return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(microdegreespersecond)) * 1e-6d);
+            double value = (double) microdegreespersecond;
+            return new RotationalSpeed((((Math.PI/180)*value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromMicroradiansPerSecond(double microradianspersecond)
         {
-            return new RotationalSpeed((microradianspersecond) * 1e-6d);
+            double value = (double) microradianspersecond;
+            return new RotationalSpeed((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MicroradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMicroradiansPerSecond(int microradianspersecond)
+#else
+        public static RotationalSpeed FromMicroradiansPerSecond(QuantityValue microradianspersecond)
         {
-            return new RotationalSpeed((microradianspersecond) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MicroradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMicroradiansPerSecond(long microradianspersecond)
-        {
-            return new RotationalSpeed((microradianspersecond) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from MicroradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromMicroradiansPerSecond(decimal microradianspersecond)
-        {
-            return new RotationalSpeed((Convert.ToDouble(microradianspersecond)) * 1e-6d);
+            double value = (double) microradianspersecond;
+            return new RotationalSpeed(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromMillidegreesPerSecond(double millidegreespersecond)
         {
-            return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
+            double value = (double) millidegreespersecond;
+            return new RotationalSpeed(((Math.PI/180)*value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MillidegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMillidegreesPerSecond(int millidegreespersecond)
+#else
+        public static RotationalSpeed FromMillidegreesPerSecond(QuantityValue millidegreespersecond)
         {
-            return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MillidegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMillidegreesPerSecond(long millidegreespersecond)
-        {
-            return new RotationalSpeed(((Math.PI/180)*millidegreespersecond) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from MillidegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromMillidegreesPerSecond(decimal millidegreespersecond)
-        {
-            return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(millidegreespersecond)) * 1e-3d);
+            double value = (double) millidegreespersecond;
+            return new RotationalSpeed((((Math.PI/180)*value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromMilliradiansPerSecond(double milliradianspersecond)
         {
-            return new RotationalSpeed((milliradianspersecond) * 1e-3d);
+            double value = (double) milliradianspersecond;
+            return new RotationalSpeed((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MilliradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMilliradiansPerSecond(int milliradianspersecond)
+#else
+        public static RotationalSpeed FromMilliradiansPerSecond(QuantityValue milliradianspersecond)
         {
-            return new RotationalSpeed((milliradianspersecond) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from MilliradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromMilliradiansPerSecond(long milliradianspersecond)
-        {
-            return new RotationalSpeed((milliradianspersecond) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from MilliradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromMilliradiansPerSecond(decimal milliradianspersecond)
-        {
-            return new RotationalSpeed((Convert.ToDouble(milliradianspersecond)) * 1e-3d);
+            double value = (double) milliradianspersecond;
+            return new RotationalSpeed(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromNanodegreesPerSecond(double nanodegreespersecond)
         {
-            return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
+            double value = (double) nanodegreespersecond;
+            return new RotationalSpeed(((Math.PI/180)*value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from NanodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromNanodegreesPerSecond(int nanodegreespersecond)
+#else
+        public static RotationalSpeed FromNanodegreesPerSecond(QuantityValue nanodegreespersecond)
         {
-            return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from NanodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromNanodegreesPerSecond(long nanodegreespersecond)
-        {
-            return new RotationalSpeed(((Math.PI/180)*nanodegreespersecond) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from NanodegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromNanodegreesPerSecond(decimal nanodegreespersecond)
-        {
-            return new RotationalSpeed(((Math.PI/180)*Convert.ToDouble(nanodegreespersecond)) * 1e-9d);
+            double value = (double) nanodegreespersecond;
+            return new RotationalSpeed((((Math.PI/180)*value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromNanoradiansPerSecond(double nanoradianspersecond)
         {
-            return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
+            double value = (double) nanoradianspersecond;
+            return new RotationalSpeed((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from NanoradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromNanoradiansPerSecond(int nanoradianspersecond)
+#else
+        public static RotationalSpeed FromNanoradiansPerSecond(QuantityValue nanoradianspersecond)
         {
-            return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from NanoradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromNanoradiansPerSecond(long nanoradianspersecond)
-        {
-            return new RotationalSpeed((nanoradianspersecond) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from NanoradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromNanoradiansPerSecond(decimal nanoradianspersecond)
-        {
-            return new RotationalSpeed((Convert.ToDouble(nanoradianspersecond)) * 1e-9d);
+            double value = (double) nanoradianspersecond;
+            return new RotationalSpeed(((value) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromRadiansPerSecond(double radianspersecond)
         {
-            return new RotationalSpeed(radianspersecond);
+            double value = (double) radianspersecond;
+            return new RotationalSpeed(value);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from RadiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromRadiansPerSecond(int radianspersecond)
+#else
+        public static RotationalSpeed FromRadiansPerSecond(QuantityValue radianspersecond)
         {
-            return new RotationalSpeed(radianspersecond);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from RadiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromRadiansPerSecond(long radianspersecond)
-        {
-            return new RotationalSpeed(radianspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from RadiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromRadiansPerSecond(decimal radianspersecond)
-        {
-            return new RotationalSpeed(Convert.ToDouble(radianspersecond));
+            double value = (double) radianspersecond;
+            return new RotationalSpeed((value));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromRevolutionsPerMinute(double revolutionsperminute)
         {
-            return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
+            double value = (double) revolutionsperminute;
+            return new RotationalSpeed((value*6.2831853072)/60);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from RevolutionsPerMinute.
-        /// </summary>
-        public static RotationalSpeed FromRevolutionsPerMinute(int revolutionsperminute)
+#else
+        public static RotationalSpeed FromRevolutionsPerMinute(QuantityValue revolutionsperminute)
         {
-            return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from RevolutionsPerMinute.
-        /// </summary>
-        public static RotationalSpeed FromRevolutionsPerMinute(long revolutionsperminute)
-        {
-            return new RotationalSpeed((revolutionsperminute*6.2831853072)/60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from RevolutionsPerMinute of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromRevolutionsPerMinute(decimal revolutionsperminute)
-        {
-            return new RotationalSpeed((Convert.ToDouble(revolutionsperminute)*6.2831853072)/60);
+            double value = (double) revolutionsperminute;
+            return new RotationalSpeed(((value*6.2831853072)/60));
         }
 #endif
 
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static RotationalSpeed FromRevolutionsPerSecond(double revolutionspersecond)
         {
-            return new RotationalSpeed(revolutionspersecond*6.2831853072);
+            double value = (double) revolutionspersecond;
+            return new RotationalSpeed(value*6.2831853072);
         }
-
-        /// <summary>
-        ///     Get RotationalSpeed from RevolutionsPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromRevolutionsPerSecond(int revolutionspersecond)
+#else
+        public static RotationalSpeed FromRevolutionsPerSecond(QuantityValue revolutionspersecond)
         {
-            return new RotationalSpeed(revolutionspersecond*6.2831853072);
-        }
-
-        /// <summary>
-        ///     Get RotationalSpeed from RevolutionsPerSecond.
-        /// </summary>
-        public static RotationalSpeed FromRevolutionsPerSecond(long revolutionspersecond)
-        {
-            return new RotationalSpeed(revolutionspersecond*6.2831853072);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get RotationalSpeed from RevolutionsPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed FromRevolutionsPerSecond(decimal revolutionspersecond)
-        {
-            return new RotationalSpeed(Convert.ToDouble(revolutionspersecond)*6.2831853072);
+            double value = (double) revolutionspersecond;
+            return new RotationalSpeed((value*6.2831853072));
         }
 #endif
 
@@ -741,52 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromCentiradiansPerSecond(double? centiradianspersecond)
-        {
-            if (centiradianspersecond.HasValue)
-            {
-                return FromCentiradiansPerSecond(centiradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromCentiradiansPerSecond(int? centiradianspersecond)
-        {
-            if (centiradianspersecond.HasValue)
-            {
-                return FromCentiradiansPerSecond(centiradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable CentiradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromCentiradiansPerSecond(long? centiradianspersecond)
-        {
-            if (centiradianspersecond.HasValue)
-            {
-                return FromCentiradiansPerSecond(centiradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from CentiradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromCentiradiansPerSecond(decimal? centiradianspersecond)
+        public static RotationalSpeed? FromCentiradiansPerSecond(QuantityValue? centiradianspersecond)
         {
             if (centiradianspersecond.HasValue)
             {
@@ -801,52 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromDeciradiansPerSecond(double? deciradianspersecond)
-        {
-            if (deciradianspersecond.HasValue)
-            {
-                return FromDeciradiansPerSecond(deciradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromDeciradiansPerSecond(int? deciradianspersecond)
-        {
-            if (deciradianspersecond.HasValue)
-            {
-                return FromDeciradiansPerSecond(deciradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable DeciradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromDeciradiansPerSecond(long? deciradianspersecond)
-        {
-            if (deciradianspersecond.HasValue)
-            {
-                return FromDeciradiansPerSecond(deciradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from DeciradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromDeciradiansPerSecond(decimal? deciradianspersecond)
+        public static RotationalSpeed? FromDeciradiansPerSecond(QuantityValue? deciradianspersecond)
         {
             if (deciradianspersecond.HasValue)
             {
@@ -861,52 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
         /// </summary>
-        public static RotationalSpeed? FromDegreesPerMinute(double? degreesperminute)
-        {
-            if (degreesperminute.HasValue)
-            {
-                return FromDegreesPerMinute(degreesperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
-        /// </summary>
-        public static RotationalSpeed? FromDegreesPerMinute(int? degreesperminute)
-        {
-            if (degreesperminute.HasValue)
-            {
-                return FromDegreesPerMinute(degreesperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable DegreesPerMinute.
-        /// </summary>
-        public static RotationalSpeed? FromDegreesPerMinute(long? degreesperminute)
-        {
-            if (degreesperminute.HasValue)
-            {
-                return FromDegreesPerMinute(degreesperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from DegreesPerMinute of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromDegreesPerMinute(decimal? degreesperminute)
+        public static RotationalSpeed? FromDegreesPerMinute(QuantityValue? degreesperminute)
         {
             if (degreesperminute.HasValue)
             {
@@ -921,52 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromDegreesPerSecond(double? degreespersecond)
-        {
-            if (degreespersecond.HasValue)
-            {
-                return FromDegreesPerSecond(degreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromDegreesPerSecond(int? degreespersecond)
-        {
-            if (degreespersecond.HasValue)
-            {
-                return FromDegreesPerSecond(degreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable DegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromDegreesPerSecond(long? degreespersecond)
-        {
-            if (degreespersecond.HasValue)
-            {
-                return FromDegreesPerSecond(degreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from DegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromDegreesPerSecond(decimal? degreespersecond)
+        public static RotationalSpeed? FromDegreesPerSecond(QuantityValue? degreespersecond)
         {
             if (degreespersecond.HasValue)
             {
@@ -981,52 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromMicrodegreesPerSecond(double? microdegreespersecond)
-        {
-            if (microdegreespersecond.HasValue)
-            {
-                return FromMicrodegreesPerSecond(microdegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMicrodegreesPerSecond(int? microdegreespersecond)
-        {
-            if (microdegreespersecond.HasValue)
-            {
-                return FromMicrodegreesPerSecond(microdegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MicrodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMicrodegreesPerSecond(long? microdegreespersecond)
-        {
-            if (microdegreespersecond.HasValue)
-            {
-                return FromMicrodegreesPerSecond(microdegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from MicrodegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromMicrodegreesPerSecond(decimal? microdegreespersecond)
+        public static RotationalSpeed? FromMicrodegreesPerSecond(QuantityValue? microdegreespersecond)
         {
             if (microdegreespersecond.HasValue)
             {
@@ -1041,52 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromMicroradiansPerSecond(double? microradianspersecond)
-        {
-            if (microradianspersecond.HasValue)
-            {
-                return FromMicroradiansPerSecond(microradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMicroradiansPerSecond(int? microradianspersecond)
-        {
-            if (microradianspersecond.HasValue)
-            {
-                return FromMicroradiansPerSecond(microradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MicroradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMicroradiansPerSecond(long? microradianspersecond)
-        {
-            if (microradianspersecond.HasValue)
-            {
-                return FromMicroradiansPerSecond(microradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from MicroradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromMicroradiansPerSecond(decimal? microradianspersecond)
+        public static RotationalSpeed? FromMicroradiansPerSecond(QuantityValue? microradianspersecond)
         {
             if (microradianspersecond.HasValue)
             {
@@ -1101,52 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromMillidegreesPerSecond(double? millidegreespersecond)
-        {
-            if (millidegreespersecond.HasValue)
-            {
-                return FromMillidegreesPerSecond(millidegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMillidegreesPerSecond(int? millidegreespersecond)
-        {
-            if (millidegreespersecond.HasValue)
-            {
-                return FromMillidegreesPerSecond(millidegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MillidegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMillidegreesPerSecond(long? millidegreespersecond)
-        {
-            if (millidegreespersecond.HasValue)
-            {
-                return FromMillidegreesPerSecond(millidegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from MillidegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromMillidegreesPerSecond(decimal? millidegreespersecond)
+        public static RotationalSpeed? FromMillidegreesPerSecond(QuantityValue? millidegreespersecond)
         {
             if (millidegreespersecond.HasValue)
             {
@@ -1161,52 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromMilliradiansPerSecond(double? milliradianspersecond)
-        {
-            if (milliradianspersecond.HasValue)
-            {
-                return FromMilliradiansPerSecond(milliradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMilliradiansPerSecond(int? milliradianspersecond)
-        {
-            if (milliradianspersecond.HasValue)
-            {
-                return FromMilliradiansPerSecond(milliradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable MilliradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromMilliradiansPerSecond(long? milliradianspersecond)
-        {
-            if (milliradianspersecond.HasValue)
-            {
-                return FromMilliradiansPerSecond(milliradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from MilliradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromMilliradiansPerSecond(decimal? milliradianspersecond)
+        public static RotationalSpeed? FromMilliradiansPerSecond(QuantityValue? milliradianspersecond)
         {
             if (milliradianspersecond.HasValue)
             {
@@ -1221,52 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromNanodegreesPerSecond(double? nanodegreespersecond)
-        {
-            if (nanodegreespersecond.HasValue)
-            {
-                return FromNanodegreesPerSecond(nanodegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromNanodegreesPerSecond(int? nanodegreespersecond)
-        {
-            if (nanodegreespersecond.HasValue)
-            {
-                return FromNanodegreesPerSecond(nanodegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable NanodegreesPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromNanodegreesPerSecond(long? nanodegreespersecond)
-        {
-            if (nanodegreespersecond.HasValue)
-            {
-                return FromNanodegreesPerSecond(nanodegreespersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from NanodegreesPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromNanodegreesPerSecond(decimal? nanodegreespersecond)
+        public static RotationalSpeed? FromNanodegreesPerSecond(QuantityValue? nanodegreespersecond)
         {
             if (nanodegreespersecond.HasValue)
             {
@@ -1281,52 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromNanoradiansPerSecond(double? nanoradianspersecond)
-        {
-            if (nanoradianspersecond.HasValue)
-            {
-                return FromNanoradiansPerSecond(nanoradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromNanoradiansPerSecond(int? nanoradianspersecond)
-        {
-            if (nanoradianspersecond.HasValue)
-            {
-                return FromNanoradiansPerSecond(nanoradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable NanoradiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromNanoradiansPerSecond(long? nanoradianspersecond)
-        {
-            if (nanoradianspersecond.HasValue)
-            {
-                return FromNanoradiansPerSecond(nanoradianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from NanoradiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromNanoradiansPerSecond(decimal? nanoradianspersecond)
+        public static RotationalSpeed? FromNanoradiansPerSecond(QuantityValue? nanoradianspersecond)
         {
             if (nanoradianspersecond.HasValue)
             {
@@ -1341,52 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromRadiansPerSecond(double? radianspersecond)
-        {
-            if (radianspersecond.HasValue)
-            {
-                return FromRadiansPerSecond(radianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromRadiansPerSecond(int? radianspersecond)
-        {
-            if (radianspersecond.HasValue)
-            {
-                return FromRadiansPerSecond(radianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable RadiansPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromRadiansPerSecond(long? radianspersecond)
-        {
-            if (radianspersecond.HasValue)
-            {
-                return FromRadiansPerSecond(radianspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from RadiansPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromRadiansPerSecond(decimal? radianspersecond)
+        public static RotationalSpeed? FromRadiansPerSecond(QuantityValue? radianspersecond)
         {
             if (radianspersecond.HasValue)
             {
@@ -1401,52 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
         /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerMinute(double? revolutionsperminute)
-        {
-            if (revolutionsperminute.HasValue)
-            {
-                return FromRevolutionsPerMinute(revolutionsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
-        /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerMinute(int? revolutionsperminute)
-        {
-            if (revolutionsperminute.HasValue)
-            {
-                return FromRevolutionsPerMinute(revolutionsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable RevolutionsPerMinute.
-        /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerMinute(long? revolutionsperminute)
-        {
-            if (revolutionsperminute.HasValue)
-            {
-                return FromRevolutionsPerMinute(revolutionsperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from RevolutionsPerMinute of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerMinute(decimal? revolutionsperminute)
+        public static RotationalSpeed? FromRevolutionsPerMinute(QuantityValue? revolutionsperminute)
         {
             if (revolutionsperminute.HasValue)
             {
@@ -1461,52 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
         /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerSecond(double? revolutionspersecond)
-        {
-            if (revolutionspersecond.HasValue)
-            {
-                return FromRevolutionsPerSecond(revolutionspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerSecond(int? revolutionspersecond)
-        {
-            if (revolutionspersecond.HasValue)
-            {
-                return FromRevolutionsPerSecond(revolutionspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from nullable RevolutionsPerSecond.
-        /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerSecond(long? revolutionspersecond)
-        {
-            if (revolutionspersecond.HasValue)
-            {
-                return FromRevolutionsPerSecond(revolutionspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable RotationalSpeed from RevolutionsPerSecond of type decimal.
-        /// </summary>
-        public static RotationalSpeed? FromRevolutionsPerSecond(decimal? revolutionspersecond)
+        public static RotationalSpeed? FromRevolutionsPerSecond(QuantityValue? revolutionspersecond)
         {
             if (revolutionspersecond.HasValue)
             {
@@ -1523,39 +678,45 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="RotationalSpeedUnit" /> to <see cref="RotationalSpeed" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>RotationalSpeed unit value.</returns>
-        public static RotationalSpeed From(double val, RotationalSpeedUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static RotationalSpeed From(double value, RotationalSpeedUnit fromUnit)
+#else
+        public static RotationalSpeed From(QuantityValue value, RotationalSpeedUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case RotationalSpeedUnit.CentiradianPerSecond:
-                    return FromCentiradiansPerSecond(val);
+                    return FromCentiradiansPerSecond(value);
                 case RotationalSpeedUnit.DeciradianPerSecond:
-                    return FromDeciradiansPerSecond(val);
+                    return FromDeciradiansPerSecond(value);
                 case RotationalSpeedUnit.DegreePerMinute:
-                    return FromDegreesPerMinute(val);
+                    return FromDegreesPerMinute(value);
                 case RotationalSpeedUnit.DegreePerSecond:
-                    return FromDegreesPerSecond(val);
+                    return FromDegreesPerSecond(value);
                 case RotationalSpeedUnit.MicrodegreePerSecond:
-                    return FromMicrodegreesPerSecond(val);
+                    return FromMicrodegreesPerSecond(value);
                 case RotationalSpeedUnit.MicroradianPerSecond:
-                    return FromMicroradiansPerSecond(val);
+                    return FromMicroradiansPerSecond(value);
                 case RotationalSpeedUnit.MillidegreePerSecond:
-                    return FromMillidegreesPerSecond(val);
+                    return FromMillidegreesPerSecond(value);
                 case RotationalSpeedUnit.MilliradianPerSecond:
-                    return FromMilliradiansPerSecond(val);
+                    return FromMilliradiansPerSecond(value);
                 case RotationalSpeedUnit.NanodegreePerSecond:
-                    return FromNanodegreesPerSecond(val);
+                    return FromNanodegreesPerSecond(value);
                 case RotationalSpeedUnit.NanoradianPerSecond:
-                    return FromNanoradiansPerSecond(val);
+                    return FromNanoradiansPerSecond(value);
                 case RotationalSpeedUnit.RadianPerSecond:
-                    return FromRadiansPerSecond(val);
+                    return FromRadiansPerSecond(value);
                 case RotationalSpeedUnit.RevolutionPerMinute:
-                    return FromRevolutionsPerMinute(val);
+                    return FromRevolutionsPerMinute(value);
                 case RotationalSpeedUnit.RevolutionPerSecond:
-                    return FromRevolutionsPerSecond(val);
+                    return FromRevolutionsPerSecond(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1570,7 +731,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>RotationalSpeed unit value.</returns>
-        public static RotationalSpeed? From(double? value, RotationalSpeedUnit fromUnit)
+        public static RotationalSpeed? From(QuantityValue? value, RotationalSpeedUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromCaloriesPerGram(double caloriespergram)
         {
-            return new SpecificEnergy(caloriespergram*4.184e3);
+            double value = (double) caloriespergram;
+            return new SpecificEnergy(value*4.184e3);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from CaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy FromCaloriesPerGram(int caloriespergram)
+#else
+        public static SpecificEnergy FromCaloriesPerGram(QuantityValue caloriespergram)
         {
-            return new SpecificEnergy(caloriespergram*4.184e3);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from CaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy FromCaloriesPerGram(long caloriespergram)
-        {
-            return new SpecificEnergy(caloriespergram*4.184e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from CaloriesPerGram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromCaloriesPerGram(decimal caloriespergram)
-        {
-            return new SpecificEnergy(Convert.ToDouble(caloriespergram)*4.184e3);
+            double value = (double) caloriespergram;
+            return new SpecificEnergy((value*4.184e3));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromJoulesPerKilogram(double joulesperkilogram)
         {
-            return new SpecificEnergy(joulesperkilogram);
+            double value = (double) joulesperkilogram;
+            return new SpecificEnergy(value);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from JoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromJoulesPerKilogram(int joulesperkilogram)
+#else
+        public static SpecificEnergy FromJoulesPerKilogram(QuantityValue joulesperkilogram)
         {
-            return new SpecificEnergy(joulesperkilogram);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from JoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromJoulesPerKilogram(long joulesperkilogram)
-        {
-            return new SpecificEnergy(joulesperkilogram);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from JoulesPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromJoulesPerKilogram(decimal joulesperkilogram)
-        {
-            return new SpecificEnergy(Convert.ToDouble(joulesperkilogram));
+            double value = (double) joulesperkilogram;
+            return new SpecificEnergy((value));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromKilocaloriesPerGram(double kilocaloriespergram)
         {
-            return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
+            double value = (double) kilocaloriespergram;
+            return new SpecificEnergy((value*4.184e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from KilocaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy FromKilocaloriesPerGram(int kilocaloriespergram)
+#else
+        public static SpecificEnergy FromKilocaloriesPerGram(QuantityValue kilocaloriespergram)
         {
-            return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from KilocaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy FromKilocaloriesPerGram(long kilocaloriespergram)
-        {
-            return new SpecificEnergy((kilocaloriespergram*4.184e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from KilocaloriesPerGram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromKilocaloriesPerGram(decimal kilocaloriespergram)
-        {
-            return new SpecificEnergy((Convert.ToDouble(kilocaloriespergram)*4.184e3) * 1e3d);
+            double value = (double) kilocaloriespergram;
+            return new SpecificEnergy(((value*4.184e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromKilojoulesPerKilogram(double kilojoulesperkilogram)
         {
-            return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
+            double value = (double) kilojoulesperkilogram;
+            return new SpecificEnergy((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from KilojoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromKilojoulesPerKilogram(int kilojoulesperkilogram)
+#else
+        public static SpecificEnergy FromKilojoulesPerKilogram(QuantityValue kilojoulesperkilogram)
         {
-            return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from KilojoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromKilojoulesPerKilogram(long kilojoulesperkilogram)
-        {
-            return new SpecificEnergy((kilojoulesperkilogram) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from KilojoulesPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromKilojoulesPerKilogram(decimal kilojoulesperkilogram)
-        {
-            return new SpecificEnergy((Convert.ToDouble(kilojoulesperkilogram)) * 1e3d);
+            double value = (double) kilojoulesperkilogram;
+            return new SpecificEnergy(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromKilowattHoursPerKilogram(double kilowatthoursperkilogram)
         {
-            return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
+            double value = (double) kilowatthoursperkilogram;
+            return new SpecificEnergy((value*3.6e3) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from KilowattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromKilowattHoursPerKilogram(int kilowatthoursperkilogram)
+#else
+        public static SpecificEnergy FromKilowattHoursPerKilogram(QuantityValue kilowatthoursperkilogram)
         {
-            return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from KilowattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromKilowattHoursPerKilogram(long kilowatthoursperkilogram)
-        {
-            return new SpecificEnergy((kilowatthoursperkilogram*3.6e3) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from KilowattHoursPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromKilowattHoursPerKilogram(decimal kilowatthoursperkilogram)
-        {
-            return new SpecificEnergy((Convert.ToDouble(kilowatthoursperkilogram)*3.6e3) * 1e3d);
+            double value = (double) kilowatthoursperkilogram;
+            return new SpecificEnergy(((value*3.6e3) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromMegajoulesPerKilogram(double megajoulesperkilogram)
         {
-            return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
+            double value = (double) megajoulesperkilogram;
+            return new SpecificEnergy((value) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from MegajoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromMegajoulesPerKilogram(int megajoulesperkilogram)
+#else
+        public static SpecificEnergy FromMegajoulesPerKilogram(QuantityValue megajoulesperkilogram)
         {
-            return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from MegajoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromMegajoulesPerKilogram(long megajoulesperkilogram)
-        {
-            return new SpecificEnergy((megajoulesperkilogram) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from MegajoulesPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromMegajoulesPerKilogram(decimal megajoulesperkilogram)
-        {
-            return new SpecificEnergy((Convert.ToDouble(megajoulesperkilogram)) * 1e6d);
+            double value = (double) megajoulesperkilogram;
+            return new SpecificEnergy(((value) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromMegawattHoursPerKilogram(double megawatthoursperkilogram)
         {
-            return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
+            double value = (double) megawatthoursperkilogram;
+            return new SpecificEnergy((value*3.6e3) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from MegawattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromMegawattHoursPerKilogram(int megawatthoursperkilogram)
+#else
+        public static SpecificEnergy FromMegawattHoursPerKilogram(QuantityValue megawatthoursperkilogram)
         {
-            return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from MegawattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromMegawattHoursPerKilogram(long megawatthoursperkilogram)
-        {
-            return new SpecificEnergy((megawatthoursperkilogram*3.6e3) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from MegawattHoursPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromMegawattHoursPerKilogram(decimal megawatthoursperkilogram)
-        {
-            return new SpecificEnergy((Convert.ToDouble(megawatthoursperkilogram)*3.6e3) * 1e6d);
+            double value = (double) megawatthoursperkilogram;
+            return new SpecificEnergy(((value*3.6e3) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificEnergy FromWattHoursPerKilogram(double watthoursperkilogram)
         {
-            return new SpecificEnergy(watthoursperkilogram*3.6e3);
+            double value = (double) watthoursperkilogram;
+            return new SpecificEnergy(value*3.6e3);
         }
-
-        /// <summary>
-        ///     Get SpecificEnergy from WattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromWattHoursPerKilogram(int watthoursperkilogram)
+#else
+        public static SpecificEnergy FromWattHoursPerKilogram(QuantityValue watthoursperkilogram)
         {
-            return new SpecificEnergy(watthoursperkilogram*3.6e3);
-        }
-
-        /// <summary>
-        ///     Get SpecificEnergy from WattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy FromWattHoursPerKilogram(long watthoursperkilogram)
-        {
-            return new SpecificEnergy(watthoursperkilogram*3.6e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificEnergy from WattHoursPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy FromWattHoursPerKilogram(decimal watthoursperkilogram)
-        {
-            return new SpecificEnergy(Convert.ToDouble(watthoursperkilogram)*3.6e3);
+            double value = (double) watthoursperkilogram;
+            return new SpecificEnergy((value*3.6e3));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
         /// </summary>
-        public static SpecificEnergy? FromCaloriesPerGram(double? caloriespergram)
-        {
-            if (caloriespergram.HasValue)
-            {
-                return FromCaloriesPerGram(caloriespergram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy? FromCaloriesPerGram(int? caloriespergram)
-        {
-            if (caloriespergram.HasValue)
-            {
-                return FromCaloriesPerGram(caloriespergram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable CaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy? FromCaloriesPerGram(long? caloriespergram)
-        {
-            if (caloriespergram.HasValue)
-            {
-                return FromCaloriesPerGram(caloriespergram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from CaloriesPerGram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromCaloriesPerGram(decimal? caloriespergram)
+        public static SpecificEnergy? FromCaloriesPerGram(QuantityValue? caloriespergram)
         {
             if (caloriespergram.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
         /// </summary>
-        public static SpecificEnergy? FromJoulesPerKilogram(double? joulesperkilogram)
-        {
-            if (joulesperkilogram.HasValue)
-            {
-                return FromJoulesPerKilogram(joulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromJoulesPerKilogram(int? joulesperkilogram)
-        {
-            if (joulesperkilogram.HasValue)
-            {
-                return FromJoulesPerKilogram(joulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable JoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromJoulesPerKilogram(long? joulesperkilogram)
-        {
-            if (joulesperkilogram.HasValue)
-            {
-                return FromJoulesPerKilogram(joulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from JoulesPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromJoulesPerKilogram(decimal? joulesperkilogram)
+        public static SpecificEnergy? FromJoulesPerKilogram(QuantityValue? joulesperkilogram)
         {
             if (joulesperkilogram.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
         /// </summary>
-        public static SpecificEnergy? FromKilocaloriesPerGram(double? kilocaloriespergram)
-        {
-            if (kilocaloriespergram.HasValue)
-            {
-                return FromKilocaloriesPerGram(kilocaloriespergram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy? FromKilocaloriesPerGram(int? kilocaloriespergram)
-        {
-            if (kilocaloriespergram.HasValue)
-            {
-                return FromKilocaloriesPerGram(kilocaloriespergram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable KilocaloriesPerGram.
-        /// </summary>
-        public static SpecificEnergy? FromKilocaloriesPerGram(long? kilocaloriespergram)
-        {
-            if (kilocaloriespergram.HasValue)
-            {
-                return FromKilocaloriesPerGram(kilocaloriespergram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from KilocaloriesPerGram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromKilocaloriesPerGram(decimal? kilocaloriespergram)
+        public static SpecificEnergy? FromKilocaloriesPerGram(QuantityValue? kilocaloriespergram)
         {
             if (kilocaloriespergram.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
         /// </summary>
-        public static SpecificEnergy? FromKilojoulesPerKilogram(double? kilojoulesperkilogram)
-        {
-            if (kilojoulesperkilogram.HasValue)
-            {
-                return FromKilojoulesPerKilogram(kilojoulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromKilojoulesPerKilogram(int? kilojoulesperkilogram)
-        {
-            if (kilojoulesperkilogram.HasValue)
-            {
-                return FromKilojoulesPerKilogram(kilojoulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable KilojoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromKilojoulesPerKilogram(long? kilojoulesperkilogram)
-        {
-            if (kilojoulesperkilogram.HasValue)
-            {
-                return FromKilojoulesPerKilogram(kilojoulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from KilojoulesPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromKilojoulesPerKilogram(decimal? kilojoulesperkilogram)
+        public static SpecificEnergy? FromKilojoulesPerKilogram(QuantityValue? kilojoulesperkilogram)
         {
             if (kilojoulesperkilogram.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
         /// </summary>
-        public static SpecificEnergy? FromKilowattHoursPerKilogram(double? kilowatthoursperkilogram)
-        {
-            if (kilowatthoursperkilogram.HasValue)
-            {
-                return FromKilowattHoursPerKilogram(kilowatthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromKilowattHoursPerKilogram(int? kilowatthoursperkilogram)
-        {
-            if (kilowatthoursperkilogram.HasValue)
-            {
-                return FromKilowattHoursPerKilogram(kilowatthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable KilowattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromKilowattHoursPerKilogram(long? kilowatthoursperkilogram)
-        {
-            if (kilowatthoursperkilogram.HasValue)
-            {
-                return FromKilowattHoursPerKilogram(kilowatthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from KilowattHoursPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromKilowattHoursPerKilogram(decimal? kilowatthoursperkilogram)
+        public static SpecificEnergy? FromKilowattHoursPerKilogram(QuantityValue? kilowatthoursperkilogram)
         {
             if (kilowatthoursperkilogram.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
         /// </summary>
-        public static SpecificEnergy? FromMegajoulesPerKilogram(double? megajoulesperkilogram)
-        {
-            if (megajoulesperkilogram.HasValue)
-            {
-                return FromMegajoulesPerKilogram(megajoulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromMegajoulesPerKilogram(int? megajoulesperkilogram)
-        {
-            if (megajoulesperkilogram.HasValue)
-            {
-                return FromMegajoulesPerKilogram(megajoulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable MegajoulesPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromMegajoulesPerKilogram(long? megajoulesperkilogram)
-        {
-            if (megajoulesperkilogram.HasValue)
-            {
-                return FromMegajoulesPerKilogram(megajoulesperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from MegajoulesPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromMegajoulesPerKilogram(decimal? megajoulesperkilogram)
+        public static SpecificEnergy? FromMegajoulesPerKilogram(QuantityValue? megajoulesperkilogram)
         {
             if (megajoulesperkilogram.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
         /// </summary>
-        public static SpecificEnergy? FromMegawattHoursPerKilogram(double? megawatthoursperkilogram)
-        {
-            if (megawatthoursperkilogram.HasValue)
-            {
-                return FromMegawattHoursPerKilogram(megawatthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromMegawattHoursPerKilogram(int? megawatthoursperkilogram)
-        {
-            if (megawatthoursperkilogram.HasValue)
-            {
-                return FromMegawattHoursPerKilogram(megawatthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable MegawattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromMegawattHoursPerKilogram(long? megawatthoursperkilogram)
-        {
-            if (megawatthoursperkilogram.HasValue)
-            {
-                return FromMegawattHoursPerKilogram(megawatthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from MegawattHoursPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromMegawattHoursPerKilogram(decimal? megawatthoursperkilogram)
+        public static SpecificEnergy? FromMegawattHoursPerKilogram(QuantityValue? megawatthoursperkilogram)
         {
             if (megawatthoursperkilogram.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
         /// </summary>
-        public static SpecificEnergy? FromWattHoursPerKilogram(double? watthoursperkilogram)
-        {
-            if (watthoursperkilogram.HasValue)
-            {
-                return FromWattHoursPerKilogram(watthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromWattHoursPerKilogram(int? watthoursperkilogram)
-        {
-            if (watthoursperkilogram.HasValue)
-            {
-                return FromWattHoursPerKilogram(watthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from nullable WattHoursPerKilogram.
-        /// </summary>
-        public static SpecificEnergy? FromWattHoursPerKilogram(long? watthoursperkilogram)
-        {
-            if (watthoursperkilogram.HasValue)
-            {
-                return FromWattHoursPerKilogram(watthoursperkilogram.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificEnergy from WattHoursPerKilogram of type decimal.
-        /// </summary>
-        public static SpecificEnergy? FromWattHoursPerKilogram(decimal? watthoursperkilogram)
+        public static SpecificEnergy? FromWattHoursPerKilogram(QuantityValue? watthoursperkilogram)
         {
             if (watthoursperkilogram.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="SpecificEnergyUnit" /> to <see cref="SpecificEnergy" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>SpecificEnergy unit value.</returns>
-        public static SpecificEnergy From(double val, SpecificEnergyUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static SpecificEnergy From(double value, SpecificEnergyUnit fromUnit)
+#else
+        public static SpecificEnergy From(QuantityValue value, SpecificEnergyUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case SpecificEnergyUnit.CaloriePerGram:
-                    return FromCaloriesPerGram(val);
+                    return FromCaloriesPerGram(value);
                 case SpecificEnergyUnit.JoulePerKilogram:
-                    return FromJoulesPerKilogram(val);
+                    return FromJoulesPerKilogram(value);
                 case SpecificEnergyUnit.KilocaloriePerGram:
-                    return FromKilocaloriesPerGram(val);
+                    return FromKilocaloriesPerGram(value);
                 case SpecificEnergyUnit.KilojoulePerKilogram:
-                    return FromKilojoulesPerKilogram(val);
+                    return FromKilojoulesPerKilogram(value);
                 case SpecificEnergyUnit.KilowattHourPerKilogram:
-                    return FromKilowattHoursPerKilogram(val);
+                    return FromKilowattHoursPerKilogram(value);
                 case SpecificEnergyUnit.MegajoulePerKilogram:
-                    return FromMegajoulesPerKilogram(val);
+                    return FromMegajoulesPerKilogram(value);
                 case SpecificEnergyUnit.MegawattHourPerKilogram:
-                    return FromMegawattHoursPerKilogram(val);
+                    return FromMegawattHoursPerKilogram(value);
                 case SpecificEnergyUnit.WattHourPerKilogram:
-                    return FromWattHoursPerKilogram(val);
+                    return FromWattHoursPerKilogram(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>SpecificEnergy unit value.</returns>
-        public static SpecificEnergy? From(double? value, SpecificEnergyUnit fromUnit)
+        public static SpecificEnergy? From(QuantityValue? value, SpecificEnergyUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -269,608 +269,288 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(double kilogramsforcepercubiccentimeter)
         {
-            return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
+            double value = (double) kilogramsforcepercubiccentimeter;
+            return new SpecificWeight(value*9806650.19960652);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(int kilogramsforcepercubiccentimeter)
+#else
+        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(QuantityValue kilogramsforcepercubiccentimeter)
         {
-            return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(long kilogramsforcepercubiccentimeter)
-        {
-            return new SpecificWeight(kilogramsforcepercubiccentimeter*9806650.19960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicCentimeter(decimal kilogramsforcepercubiccentimeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubiccentimeter)*9806650.19960652);
+            double value = (double) kilogramsforcepercubiccentimeter;
+            return new SpecificWeight((value*9806650.19960652));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilogramsForcePerCubicMeter(double kilogramsforcepercubicmeter)
         {
-            return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
+            double value = (double) kilogramsforcepercubicmeter;
+            return new SpecificWeight(value*9.80665019960652);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicMeter(int kilogramsforcepercubicmeter)
+#else
+        public static SpecificWeight FromKilogramsForcePerCubicMeter(QuantityValue kilogramsforcepercubicmeter)
         {
-            return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicMeter(long kilogramsforcepercubicmeter)
-        {
-            return new SpecificWeight(kilogramsforcepercubicmeter*9.80665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicMeter(decimal kilogramsforcepercubicmeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmeter)*9.80665019960652);
+            double value = (double) kilogramsforcepercubicmeter;
+            return new SpecificWeight((value*9.80665019960652));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(double kilogramsforcepercubicmillimeter)
         {
-            return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
+            double value = (double) kilogramsforcepercubicmillimeter;
+            return new SpecificWeight(value*9806650199.60653);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(int kilogramsforcepercubicmillimeter)
+#else
+        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(QuantityValue kilogramsforcepercubicmillimeter)
         {
-            return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(long kilogramsforcepercubicmillimeter)
-        {
-            return new SpecificWeight(kilogramsforcepercubicmillimeter*9806650199.60653);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilogramsForcePerCubicMillimeter(decimal kilogramsforcepercubicmillimeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(kilogramsforcepercubicmillimeter)*9806650199.60653);
+            double value = (double) kilogramsforcepercubicmillimeter;
+            return new SpecificWeight((value*9806650199.60653));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(double kilonewtonspercubiccentimeter)
         {
-            return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
+            double value = (double) kilonewtonspercubiccentimeter;
+            return new SpecificWeight((value*1000000) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(int kilonewtonspercubiccentimeter)
+#else
+        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(QuantityValue kilonewtonspercubiccentimeter)
         {
-            return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(long kilonewtonspercubiccentimeter)
-        {
-            return new SpecificWeight((kilonewtonspercubiccentimeter*1000000) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicCentimeter(decimal kilonewtonspercubiccentimeter)
-        {
-            return new SpecificWeight((Convert.ToDouble(kilonewtonspercubiccentimeter)*1000000) * 1e3d);
+            double value = (double) kilonewtonspercubiccentimeter;
+            return new SpecificWeight(((value*1000000) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilonewtonsPerCubicMeter(double kilonewtonspercubicmeter)
         {
-            return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
+            double value = (double) kilonewtonspercubicmeter;
+            return new SpecificWeight((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicMeter(int kilonewtonspercubicmeter)
+#else
+        public static SpecificWeight FromKilonewtonsPerCubicMeter(QuantityValue kilonewtonspercubicmeter)
         {
-            return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicMeter(long kilonewtonspercubicmeter)
-        {
-            return new SpecificWeight((kilonewtonspercubicmeter) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicMeter(decimal kilonewtonspercubicmeter)
-        {
-            return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmeter)) * 1e3d);
+            double value = (double) kilonewtonspercubicmeter;
+            return new SpecificWeight(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(double kilonewtonspercubicmillimeter)
         {
-            return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
+            double value = (double) kilonewtonspercubicmillimeter;
+            return new SpecificWeight((value*1000000000) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(int kilonewtonspercubicmillimeter)
+#else
+        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(QuantityValue kilonewtonspercubicmillimeter)
         {
-            return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(long kilonewtonspercubicmillimeter)
-        {
-            return new SpecificWeight((kilonewtonspercubicmillimeter*1000000000) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilonewtonsPerCubicMillimeter(decimal kilonewtonspercubicmillimeter)
-        {
-            return new SpecificWeight((Convert.ToDouble(kilonewtonspercubicmillimeter)*1000000000) * 1e3d);
+            double value = (double) kilonewtonspercubicmillimeter;
+            return new SpecificWeight(((value*1000000000) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(double kilopoundsforcepercubicfoot)
         {
-            return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
+            double value = (double) kilopoundsforcepercubicfoot;
+            return new SpecificWeight((value*157.087477433193) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight FromKilopoundsForcePerCubicFoot(int kilopoundsforcepercubicfoot)
+#else
+        public static SpecificWeight FromKilopoundsForcePerCubicFoot(QuantityValue kilopoundsforcepercubicfoot)
         {
-            return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight FromKilopoundsForcePerCubicFoot(long kilopoundsforcepercubicfoot)
-        {
-            return new SpecificWeight((kilopoundsforcepercubicfoot*157.087477433193) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilopoundsForcePerCubicFoot of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilopoundsForcePerCubicFoot(decimal kilopoundsforcepercubicfoot)
-        {
-            return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicfoot)*157.087477433193) * 1e3d);
+            double value = (double) kilopoundsforcepercubicfoot;
+            return new SpecificWeight(((value*157.087477433193) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromKilopoundsForcePerCubicInch(double kilopoundsforcepercubicinch)
         {
-            return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
+            double value = (double) kilopoundsforcepercubicinch;
+            return new SpecificWeight((value*271447.161004558) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight FromKilopoundsForcePerCubicInch(int kilopoundsforcepercubicinch)
+#else
+        public static SpecificWeight FromKilopoundsForcePerCubicInch(QuantityValue kilopoundsforcepercubicinch)
         {
-            return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight FromKilopoundsForcePerCubicInch(long kilopoundsforcepercubicinch)
-        {
-            return new SpecificWeight((kilopoundsforcepercubicinch*271447.161004558) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from KilopoundsForcePerCubicInch of type decimal.
-        /// </summary>
-        public static SpecificWeight FromKilopoundsForcePerCubicInch(decimal kilopoundsforcepercubicinch)
-        {
-            return new SpecificWeight((Convert.ToDouble(kilopoundsforcepercubicinch)*271447.161004558) * 1e3d);
+            double value = (double) kilopoundsforcepercubicinch;
+            return new SpecificWeight(((value*271447.161004558) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromNewtonsPerCubicCentimeter(double newtonspercubiccentimeter)
         {
-            return new SpecificWeight(newtonspercubiccentimeter*1000000);
+            double value = (double) newtonspercubiccentimeter;
+            return new SpecificWeight(value*1000000);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicCentimeter(int newtonspercubiccentimeter)
+#else
+        public static SpecificWeight FromNewtonsPerCubicCentimeter(QuantityValue newtonspercubiccentimeter)
         {
-            return new SpecificWeight(newtonspercubiccentimeter*1000000);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicCentimeter(long newtonspercubiccentimeter)
-        {
-            return new SpecificWeight(newtonspercubiccentimeter*1000000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicCentimeter(decimal newtonspercubiccentimeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(newtonspercubiccentimeter)*1000000);
+            double value = (double) newtonspercubiccentimeter;
+            return new SpecificWeight((value*1000000));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromNewtonsPerCubicMeter(double newtonspercubicmeter)
         {
-            return new SpecificWeight(newtonspercubicmeter);
+            double value = (double) newtonspercubicmeter;
+            return new SpecificWeight(value);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicMeter(int newtonspercubicmeter)
+#else
+        public static SpecificWeight FromNewtonsPerCubicMeter(QuantityValue newtonspercubicmeter)
         {
-            return new SpecificWeight(newtonspercubicmeter);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicMeter(long newtonspercubicmeter)
-        {
-            return new SpecificWeight(newtonspercubicmeter);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicMeter(decimal newtonspercubicmeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(newtonspercubicmeter));
+            double value = (double) newtonspercubicmeter;
+            return new SpecificWeight((value));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromNewtonsPerCubicMillimeter(double newtonspercubicmillimeter)
         {
-            return new SpecificWeight(newtonspercubicmillimeter*1000000000);
+            double value = (double) newtonspercubicmillimeter;
+            return new SpecificWeight(value*1000000000);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicMillimeter(int newtonspercubicmillimeter)
+#else
+        public static SpecificWeight FromNewtonsPerCubicMillimeter(QuantityValue newtonspercubicmillimeter)
         {
-            return new SpecificWeight(newtonspercubicmillimeter*1000000000);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicMillimeter(long newtonspercubicmillimeter)
-        {
-            return new SpecificWeight(newtonspercubicmillimeter*1000000000);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from NewtonsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromNewtonsPerCubicMillimeter(decimal newtonspercubicmillimeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(newtonspercubicmillimeter)*1000000000);
+            double value = (double) newtonspercubicmillimeter;
+            return new SpecificWeight((value*1000000000));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromPoundsForcePerCubicFoot(double poundsforcepercubicfoot)
         {
-            return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
+            double value = (double) poundsforcepercubicfoot;
+            return new SpecificWeight(value*157.087477433193);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from PoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight FromPoundsForcePerCubicFoot(int poundsforcepercubicfoot)
+#else
+        public static SpecificWeight FromPoundsForcePerCubicFoot(QuantityValue poundsforcepercubicfoot)
         {
-            return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from PoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight FromPoundsForcePerCubicFoot(long poundsforcepercubicfoot)
-        {
-            return new SpecificWeight(poundsforcepercubicfoot*157.087477433193);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from PoundsForcePerCubicFoot of type decimal.
-        /// </summary>
-        public static SpecificWeight FromPoundsForcePerCubicFoot(decimal poundsforcepercubicfoot)
-        {
-            return new SpecificWeight(Convert.ToDouble(poundsforcepercubicfoot)*157.087477433193);
+            double value = (double) poundsforcepercubicfoot;
+            return new SpecificWeight((value*157.087477433193));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromPoundsForcePerCubicInch(double poundsforcepercubicinch)
         {
-            return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
+            double value = (double) poundsforcepercubicinch;
+            return new SpecificWeight(value*271447.161004558);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from PoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight FromPoundsForcePerCubicInch(int poundsforcepercubicinch)
+#else
+        public static SpecificWeight FromPoundsForcePerCubicInch(QuantityValue poundsforcepercubicinch)
         {
-            return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from PoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight FromPoundsForcePerCubicInch(long poundsforcepercubicinch)
-        {
-            return new SpecificWeight(poundsforcepercubicinch*271447.161004558);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from PoundsForcePerCubicInch of type decimal.
-        /// </summary>
-        public static SpecificWeight FromPoundsForcePerCubicInch(decimal poundsforcepercubicinch)
-        {
-            return new SpecificWeight(Convert.ToDouble(poundsforcepercubicinch)*271447.161004558);
+            double value = (double) poundsforcepercubicinch;
+            return new SpecificWeight((value*271447.161004558));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(double tonnesforcepercubiccentimeter)
         {
-            return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
+            double value = (double) tonnesforcepercubiccentimeter;
+            return new SpecificWeight(value*9806650199.60653);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicCentimeter(int tonnesforcepercubiccentimeter)
+#else
+        public static SpecificWeight FromTonnesForcePerCubicCentimeter(QuantityValue tonnesforcepercubiccentimeter)
         {
-            return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicCentimeter(long tonnesforcepercubiccentimeter)
-        {
-            return new SpecificWeight(tonnesforcepercubiccentimeter*9806650199.60653);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicCentimeter(decimal tonnesforcepercubiccentimeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(tonnesforcepercubiccentimeter)*9806650199.60653);
+            double value = (double) tonnesforcepercubiccentimeter;
+            return new SpecificWeight((value*9806650199.60653));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromTonnesForcePerCubicMeter(double tonnesforcepercubicmeter)
         {
-            return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
+            double value = (double) tonnesforcepercubicmeter;
+            return new SpecificWeight(value*9806.65019960653);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicMeter(int tonnesforcepercubicmeter)
+#else
+        public static SpecificWeight FromTonnesForcePerCubicMeter(QuantityValue tonnesforcepercubicmeter)
         {
-            return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicMeter(long tonnesforcepercubicmeter)
-        {
-            return new SpecificWeight(tonnesforcepercubicmeter*9806.65019960653);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicMeter(decimal tonnesforcepercubicmeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmeter)*9806.65019960653);
+            double value = (double) tonnesforcepercubicmeter;
+            return new SpecificWeight((value*9806.65019960653));
         }
 #endif
 
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(double tonnesforcepercubicmillimeter)
         {
-            return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
+            double value = (double) tonnesforcepercubicmillimeter;
+            return new SpecificWeight(value*9806650199606.53);
         }
-
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicMillimeter(int tonnesforcepercubicmillimeter)
+#else
+        public static SpecificWeight FromTonnesForcePerCubicMillimeter(QuantityValue tonnesforcepercubicmillimeter)
         {
-            return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
-        }
-
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicMillimeter(long tonnesforcepercubicmillimeter)
-        {
-            return new SpecificWeight(tonnesforcepercubicmillimeter*9806650199606.53);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get SpecificWeight from TonnesForcePerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight FromTonnesForcePerCubicMillimeter(decimal tonnesforcepercubicmillimeter)
-        {
-            return new SpecificWeight(Convert.ToDouble(tonnesforcepercubicmillimeter)*9806650199606.53);
+            double value = (double) tonnesforcepercubicmillimeter;
+            return new SpecificWeight((value*9806650199606.53));
         }
 #endif
 
@@ -879,52 +559,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
         /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(double? kilogramsforcepercubiccentimeter)
-        {
-            if (kilogramsforcepercubiccentimeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicCentimeter(kilogramsforcepercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(int? kilogramsforcepercubiccentimeter)
-        {
-            if (kilogramsforcepercubiccentimeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicCentimeter(kilogramsforcepercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(long? kilogramsforcepercubiccentimeter)
-        {
-            if (kilogramsforcepercubiccentimeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicCentimeter(kilogramsforcepercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilogramsForcePerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(decimal? kilogramsforcepercubiccentimeter)
+        public static SpecificWeight? FromKilogramsForcePerCubicCentimeter(QuantityValue? kilogramsforcepercubiccentimeter)
         {
             if (kilogramsforcepercubiccentimeter.HasValue)
             {
@@ -939,52 +574,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
         /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMeter(double? kilogramsforcepercubicmeter)
-        {
-            if (kilogramsforcepercubicmeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicMeter(kilogramsforcepercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMeter(int? kilogramsforcepercubicmeter)
-        {
-            if (kilogramsforcepercubicmeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicMeter(kilogramsforcepercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMeter(long? kilogramsforcepercubicmeter)
-        {
-            if (kilogramsforcepercubicmeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicMeter(kilogramsforcepercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilogramsForcePerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMeter(decimal? kilogramsforcepercubicmeter)
+        public static SpecificWeight? FromKilogramsForcePerCubicMeter(QuantityValue? kilogramsforcepercubicmeter)
         {
             if (kilogramsforcepercubicmeter.HasValue)
             {
@@ -999,52 +589,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
         /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(double? kilogramsforcepercubicmillimeter)
-        {
-            if (kilogramsforcepercubicmillimeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicMillimeter(kilogramsforcepercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(int? kilogramsforcepercubicmillimeter)
-        {
-            if (kilogramsforcepercubicmillimeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicMillimeter(kilogramsforcepercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilogramsForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(long? kilogramsforcepercubicmillimeter)
-        {
-            if (kilogramsforcepercubicmillimeter.HasValue)
-            {
-                return FromKilogramsForcePerCubicMillimeter(kilogramsforcepercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilogramsForcePerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(decimal? kilogramsforcepercubicmillimeter)
+        public static SpecificWeight? FromKilogramsForcePerCubicMillimeter(QuantityValue? kilogramsforcepercubicmillimeter)
         {
             if (kilogramsforcepercubicmillimeter.HasValue)
             {
@@ -1059,52 +604,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
         /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(double? kilonewtonspercubiccentimeter)
-        {
-            if (kilonewtonspercubiccentimeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicCentimeter(kilonewtonspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(int? kilonewtonspercubiccentimeter)
-        {
-            if (kilonewtonspercubiccentimeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicCentimeter(kilonewtonspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(long? kilonewtonspercubiccentimeter)
-        {
-            if (kilonewtonspercubiccentimeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicCentimeter(kilonewtonspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilonewtonsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(decimal? kilonewtonspercubiccentimeter)
+        public static SpecificWeight? FromKilonewtonsPerCubicCentimeter(QuantityValue? kilonewtonspercubiccentimeter)
         {
             if (kilonewtonspercubiccentimeter.HasValue)
             {
@@ -1119,52 +619,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
         /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMeter(double? kilonewtonspercubicmeter)
-        {
-            if (kilonewtonspercubicmeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicMeter(kilonewtonspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMeter(int? kilonewtonspercubicmeter)
-        {
-            if (kilonewtonspercubicmeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicMeter(kilonewtonspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMeter(long? kilonewtonspercubicmeter)
-        {
-            if (kilonewtonspercubicmeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicMeter(kilonewtonspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilonewtonsPerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMeter(decimal? kilonewtonspercubicmeter)
+        public static SpecificWeight? FromKilonewtonsPerCubicMeter(QuantityValue? kilonewtonspercubicmeter)
         {
             if (kilonewtonspercubicmeter.HasValue)
             {
@@ -1179,52 +634,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
         /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(double? kilonewtonspercubicmillimeter)
-        {
-            if (kilonewtonspercubicmillimeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicMillimeter(kilonewtonspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(int? kilonewtonspercubicmillimeter)
-        {
-            if (kilonewtonspercubicmillimeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicMillimeter(kilonewtonspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilonewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(long? kilonewtonspercubicmillimeter)
-        {
-            if (kilonewtonspercubicmillimeter.HasValue)
-            {
-                return FromKilonewtonsPerCubicMillimeter(kilonewtonspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilonewtonsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(decimal? kilonewtonspercubicmillimeter)
+        public static SpecificWeight? FromKilonewtonsPerCubicMillimeter(QuantityValue? kilonewtonspercubicmillimeter)
         {
             if (kilonewtonspercubicmillimeter.HasValue)
             {
@@ -1239,52 +649,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
         /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(double? kilopoundsforcepercubicfoot)
-        {
-            if (kilopoundsforcepercubicfoot.HasValue)
-            {
-                return FromKilopoundsForcePerCubicFoot(kilopoundsforcepercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(int? kilopoundsforcepercubicfoot)
-        {
-            if (kilopoundsforcepercubicfoot.HasValue)
-            {
-                return FromKilopoundsForcePerCubicFoot(kilopoundsforcepercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(long? kilopoundsforcepercubicfoot)
-        {
-            if (kilopoundsforcepercubicfoot.HasValue)
-            {
-                return FromKilopoundsForcePerCubicFoot(kilopoundsforcepercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilopoundsForcePerCubicFoot of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(decimal? kilopoundsforcepercubicfoot)
+        public static SpecificWeight? FromKilopoundsForcePerCubicFoot(QuantityValue? kilopoundsforcepercubicfoot)
         {
             if (kilopoundsforcepercubicfoot.HasValue)
             {
@@ -1299,52 +664,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
         /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicInch(double? kilopoundsforcepercubicinch)
-        {
-            if (kilopoundsforcepercubicinch.HasValue)
-            {
-                return FromKilopoundsForcePerCubicInch(kilopoundsforcepercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicInch(int? kilopoundsforcepercubicinch)
-        {
-            if (kilopoundsforcepercubicinch.HasValue)
-            {
-                return FromKilopoundsForcePerCubicInch(kilopoundsforcepercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable KilopoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicInch(long? kilopoundsforcepercubicinch)
-        {
-            if (kilopoundsforcepercubicinch.HasValue)
-            {
-                return FromKilopoundsForcePerCubicInch(kilopoundsforcepercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from KilopoundsForcePerCubicInch of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromKilopoundsForcePerCubicInch(decimal? kilopoundsforcepercubicinch)
+        public static SpecificWeight? FromKilopoundsForcePerCubicInch(QuantityValue? kilopoundsforcepercubicinch)
         {
             if (kilopoundsforcepercubicinch.HasValue)
             {
@@ -1359,52 +679,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
         /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicCentimeter(double? newtonspercubiccentimeter)
-        {
-            if (newtonspercubiccentimeter.HasValue)
-            {
-                return FromNewtonsPerCubicCentimeter(newtonspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicCentimeter(int? newtonspercubiccentimeter)
-        {
-            if (newtonspercubiccentimeter.HasValue)
-            {
-                return FromNewtonsPerCubicCentimeter(newtonspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicCentimeter(long? newtonspercubiccentimeter)
-        {
-            if (newtonspercubiccentimeter.HasValue)
-            {
-                return FromNewtonsPerCubicCentimeter(newtonspercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from NewtonsPerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicCentimeter(decimal? newtonspercubiccentimeter)
+        public static SpecificWeight? FromNewtonsPerCubicCentimeter(QuantityValue? newtonspercubiccentimeter)
         {
             if (newtonspercubiccentimeter.HasValue)
             {
@@ -1419,52 +694,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
         /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMeter(double? newtonspercubicmeter)
-        {
-            if (newtonspercubicmeter.HasValue)
-            {
-                return FromNewtonsPerCubicMeter(newtonspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMeter(int? newtonspercubicmeter)
-        {
-            if (newtonspercubicmeter.HasValue)
-            {
-                return FromNewtonsPerCubicMeter(newtonspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMeter(long? newtonspercubicmeter)
-        {
-            if (newtonspercubicmeter.HasValue)
-            {
-                return FromNewtonsPerCubicMeter(newtonspercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from NewtonsPerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMeter(decimal? newtonspercubicmeter)
+        public static SpecificWeight? FromNewtonsPerCubicMeter(QuantityValue? newtonspercubicmeter)
         {
             if (newtonspercubicmeter.HasValue)
             {
@@ -1479,52 +709,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
         /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMillimeter(double? newtonspercubicmillimeter)
-        {
-            if (newtonspercubicmillimeter.HasValue)
-            {
-                return FromNewtonsPerCubicMillimeter(newtonspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMillimeter(int? newtonspercubicmillimeter)
-        {
-            if (newtonspercubicmillimeter.HasValue)
-            {
-                return FromNewtonsPerCubicMillimeter(newtonspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable NewtonsPerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMillimeter(long? newtonspercubicmillimeter)
-        {
-            if (newtonspercubicmillimeter.HasValue)
-            {
-                return FromNewtonsPerCubicMillimeter(newtonspercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from NewtonsPerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromNewtonsPerCubicMillimeter(decimal? newtonspercubicmillimeter)
+        public static SpecificWeight? FromNewtonsPerCubicMillimeter(QuantityValue? newtonspercubicmillimeter)
         {
             if (newtonspercubicmillimeter.HasValue)
             {
@@ -1539,52 +724,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
         /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicFoot(double? poundsforcepercubicfoot)
-        {
-            if (poundsforcepercubicfoot.HasValue)
-            {
-                return FromPoundsForcePerCubicFoot(poundsforcepercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicFoot(int? poundsforcepercubicfoot)
-        {
-            if (poundsforcepercubicfoot.HasValue)
-            {
-                return FromPoundsForcePerCubicFoot(poundsforcepercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicFoot.
-        /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicFoot(long? poundsforcepercubicfoot)
-        {
-            if (poundsforcepercubicfoot.HasValue)
-            {
-                return FromPoundsForcePerCubicFoot(poundsforcepercubicfoot.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from PoundsForcePerCubicFoot of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicFoot(decimal? poundsforcepercubicfoot)
+        public static SpecificWeight? FromPoundsForcePerCubicFoot(QuantityValue? poundsforcepercubicfoot)
         {
             if (poundsforcepercubicfoot.HasValue)
             {
@@ -1599,52 +739,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
         /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicInch(double? poundsforcepercubicinch)
-        {
-            if (poundsforcepercubicinch.HasValue)
-            {
-                return FromPoundsForcePerCubicInch(poundsforcepercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicInch(int? poundsforcepercubicinch)
-        {
-            if (poundsforcepercubicinch.HasValue)
-            {
-                return FromPoundsForcePerCubicInch(poundsforcepercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable PoundsForcePerCubicInch.
-        /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicInch(long? poundsforcepercubicinch)
-        {
-            if (poundsforcepercubicinch.HasValue)
-            {
-                return FromPoundsForcePerCubicInch(poundsforcepercubicinch.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from PoundsForcePerCubicInch of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromPoundsForcePerCubicInch(decimal? poundsforcepercubicinch)
+        public static SpecificWeight? FromPoundsForcePerCubicInch(QuantityValue? poundsforcepercubicinch)
         {
             if (poundsforcepercubicinch.HasValue)
             {
@@ -1659,52 +754,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
         /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(double? tonnesforcepercubiccentimeter)
-        {
-            if (tonnesforcepercubiccentimeter.HasValue)
-            {
-                return FromTonnesForcePerCubicCentimeter(tonnesforcepercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(int? tonnesforcepercubiccentimeter)
-        {
-            if (tonnesforcepercubiccentimeter.HasValue)
-            {
-                return FromTonnesForcePerCubicCentimeter(tonnesforcepercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicCentimeter.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(long? tonnesforcepercubiccentimeter)
-        {
-            if (tonnesforcepercubiccentimeter.HasValue)
-            {
-                return FromTonnesForcePerCubicCentimeter(tonnesforcepercubiccentimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from TonnesForcePerCubicCentimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(decimal? tonnesforcepercubiccentimeter)
+        public static SpecificWeight? FromTonnesForcePerCubicCentimeter(QuantityValue? tonnesforcepercubiccentimeter)
         {
             if (tonnesforcepercubiccentimeter.HasValue)
             {
@@ -1719,52 +769,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
         /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMeter(double? tonnesforcepercubicmeter)
-        {
-            if (tonnesforcepercubicmeter.HasValue)
-            {
-                return FromTonnesForcePerCubicMeter(tonnesforcepercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMeter(int? tonnesforcepercubicmeter)
-        {
-            if (tonnesforcepercubicmeter.HasValue)
-            {
-                return FromTonnesForcePerCubicMeter(tonnesforcepercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMeter.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMeter(long? tonnesforcepercubicmeter)
-        {
-            if (tonnesforcepercubicmeter.HasValue)
-            {
-                return FromTonnesForcePerCubicMeter(tonnesforcepercubicmeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from TonnesForcePerCubicMeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMeter(decimal? tonnesforcepercubicmeter)
+        public static SpecificWeight? FromTonnesForcePerCubicMeter(QuantityValue? tonnesforcepercubicmeter)
         {
             if (tonnesforcepercubicmeter.HasValue)
             {
@@ -1779,52 +784,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
         /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(double? tonnesforcepercubicmillimeter)
-        {
-            if (tonnesforcepercubicmillimeter.HasValue)
-            {
-                return FromTonnesForcePerCubicMillimeter(tonnesforcepercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(int? tonnesforcepercubicmillimeter)
-        {
-            if (tonnesforcepercubicmillimeter.HasValue)
-            {
-                return FromTonnesForcePerCubicMillimeter(tonnesforcepercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from nullable TonnesForcePerCubicMillimeter.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(long? tonnesforcepercubicmillimeter)
-        {
-            if (tonnesforcepercubicmillimeter.HasValue)
-            {
-                return FromTonnesForcePerCubicMillimeter(tonnesforcepercubicmillimeter.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable SpecificWeight from TonnesForcePerCubicMillimeter of type decimal.
-        /// </summary>
-        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(decimal? tonnesforcepercubicmillimeter)
+        public static SpecificWeight? FromTonnesForcePerCubicMillimeter(QuantityValue? tonnesforcepercubicmillimeter)
         {
             if (tonnesforcepercubicmillimeter.HasValue)
             {
@@ -1841,45 +801,51 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="SpecificWeightUnit" /> to <see cref="SpecificWeight" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>SpecificWeight unit value.</returns>
-        public static SpecificWeight From(double val, SpecificWeightUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static SpecificWeight From(double value, SpecificWeightUnit fromUnit)
+#else
+        public static SpecificWeight From(QuantityValue value, SpecificWeightUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case SpecificWeightUnit.KilogramForcePerCubicCentimeter:
-                    return FromKilogramsForcePerCubicCentimeter(val);
+                    return FromKilogramsForcePerCubicCentimeter(value);
                 case SpecificWeightUnit.KilogramForcePerCubicMeter:
-                    return FromKilogramsForcePerCubicMeter(val);
+                    return FromKilogramsForcePerCubicMeter(value);
                 case SpecificWeightUnit.KilogramForcePerCubicMillimeter:
-                    return FromKilogramsForcePerCubicMillimeter(val);
+                    return FromKilogramsForcePerCubicMillimeter(value);
                 case SpecificWeightUnit.KilonewtonPerCubicCentimeter:
-                    return FromKilonewtonsPerCubicCentimeter(val);
+                    return FromKilonewtonsPerCubicCentimeter(value);
                 case SpecificWeightUnit.KilonewtonPerCubicMeter:
-                    return FromKilonewtonsPerCubicMeter(val);
+                    return FromKilonewtonsPerCubicMeter(value);
                 case SpecificWeightUnit.KilonewtonPerCubicMillimeter:
-                    return FromKilonewtonsPerCubicMillimeter(val);
+                    return FromKilonewtonsPerCubicMillimeter(value);
                 case SpecificWeightUnit.KilopoundForcePerCubicFoot:
-                    return FromKilopoundsForcePerCubicFoot(val);
+                    return FromKilopoundsForcePerCubicFoot(value);
                 case SpecificWeightUnit.KilopoundForcePerCubicInch:
-                    return FromKilopoundsForcePerCubicInch(val);
+                    return FromKilopoundsForcePerCubicInch(value);
                 case SpecificWeightUnit.NewtonPerCubicCentimeter:
-                    return FromNewtonsPerCubicCentimeter(val);
+                    return FromNewtonsPerCubicCentimeter(value);
                 case SpecificWeightUnit.NewtonPerCubicMeter:
-                    return FromNewtonsPerCubicMeter(val);
+                    return FromNewtonsPerCubicMeter(value);
                 case SpecificWeightUnit.NewtonPerCubicMillimeter:
-                    return FromNewtonsPerCubicMillimeter(val);
+                    return FromNewtonsPerCubicMillimeter(value);
                 case SpecificWeightUnit.PoundForcePerCubicFoot:
-                    return FromPoundsForcePerCubicFoot(val);
+                    return FromPoundsForcePerCubicFoot(value);
                 case SpecificWeightUnit.PoundForcePerCubicInch:
-                    return FromPoundsForcePerCubicInch(val);
+                    return FromPoundsForcePerCubicInch(value);
                 case SpecificWeightUnit.TonneForcePerCubicCentimeter:
-                    return FromTonnesForcePerCubicCentimeter(val);
+                    return FromTonnesForcePerCubicCentimeter(value);
                 case SpecificWeightUnit.TonneForcePerCubicMeter:
-                    return FromTonnesForcePerCubicMeter(val);
+                    return FromTonnesForcePerCubicMeter(value);
                 case SpecificWeightUnit.TonneForcePerCubicMillimeter:
-                    return FromTonnesForcePerCubicMillimeter(val);
+                    return FromTonnesForcePerCubicMillimeter(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1894,7 +860,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>SpecificWeight unit value.</returns>
-        public static SpecificWeight? From(double? value, SpecificWeightUnit fromUnit)
+        public static SpecificWeight? From(QuantityValue? value, SpecificWeightUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -309,798 +309,378 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromCentimetersPerHour(double centimetersperhour)
         {
-            return new Speed((centimetersperhour/3600) * 1e-2d);
+            double value = (double) centimetersperhour;
+            return new Speed((value/3600) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Speed from CentimetersPerHour.
-        /// </summary>
-        public static Speed FromCentimetersPerHour(int centimetersperhour)
+#else
+        public static Speed FromCentimetersPerHour(QuantityValue centimetersperhour)
         {
-            return new Speed((centimetersperhour/3600) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Speed from CentimetersPerHour.
-        /// </summary>
-        public static Speed FromCentimetersPerHour(long centimetersperhour)
-        {
-            return new Speed((centimetersperhour/3600) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from CentimetersPerHour of type decimal.
-        /// </summary>
-        public static Speed FromCentimetersPerHour(decimal centimetersperhour)
-        {
-            return new Speed((Convert.ToDouble(centimetersperhour)/3600) * 1e-2d);
+            double value = (double) centimetersperhour;
+            return new Speed(((value/3600) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromCentimetersPerMinutes(double centimetersperminutes)
         {
-            return new Speed((centimetersperminutes/60) * 1e-2d);
+            double value = (double) centimetersperminutes;
+            return new Speed((value/60) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Speed from CentimetersPerMinutes.
-        /// </summary>
-        public static Speed FromCentimetersPerMinutes(int centimetersperminutes)
+#else
+        public static Speed FromCentimetersPerMinutes(QuantityValue centimetersperminutes)
         {
-            return new Speed((centimetersperminutes/60) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Speed from CentimetersPerMinutes.
-        /// </summary>
-        public static Speed FromCentimetersPerMinutes(long centimetersperminutes)
-        {
-            return new Speed((centimetersperminutes/60) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from CentimetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromCentimetersPerMinutes(decimal centimetersperminutes)
-        {
-            return new Speed((Convert.ToDouble(centimetersperminutes)/60) * 1e-2d);
+            double value = (double) centimetersperminutes;
+            return new Speed(((value/60) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from CentimetersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromCentimetersPerSecond(double centimeterspersecond)
         {
-            return new Speed((centimeterspersecond) * 1e-2d);
+            double value = (double) centimeterspersecond;
+            return new Speed((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Speed from CentimetersPerSecond.
-        /// </summary>
-        public static Speed FromCentimetersPerSecond(int centimeterspersecond)
+#else
+        public static Speed FromCentimetersPerSecond(QuantityValue centimeterspersecond)
         {
-            return new Speed((centimeterspersecond) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Speed from CentimetersPerSecond.
-        /// </summary>
-        public static Speed FromCentimetersPerSecond(long centimeterspersecond)
-        {
-            return new Speed((centimeterspersecond) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from CentimetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromCentimetersPerSecond(decimal centimeterspersecond)
-        {
-            return new Speed((Convert.ToDouble(centimeterspersecond)) * 1e-2d);
+            double value = (double) centimeterspersecond;
+            return new Speed(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromDecimetersPerMinutes(double decimetersperminutes)
         {
-            return new Speed((decimetersperminutes/60) * 1e-1d);
+            double value = (double) decimetersperminutes;
+            return new Speed((value/60) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Speed from DecimetersPerMinutes.
-        /// </summary>
-        public static Speed FromDecimetersPerMinutes(int decimetersperminutes)
+#else
+        public static Speed FromDecimetersPerMinutes(QuantityValue decimetersperminutes)
         {
-            return new Speed((decimetersperminutes/60) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Speed from DecimetersPerMinutes.
-        /// </summary>
-        public static Speed FromDecimetersPerMinutes(long decimetersperminutes)
-        {
-            return new Speed((decimetersperminutes/60) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from DecimetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromDecimetersPerMinutes(decimal decimetersperminutes)
-        {
-            return new Speed((Convert.ToDouble(decimetersperminutes)/60) * 1e-1d);
+            double value = (double) decimetersperminutes;
+            return new Speed(((value/60) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from DecimetersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromDecimetersPerSecond(double decimeterspersecond)
         {
-            return new Speed((decimeterspersecond) * 1e-1d);
+            double value = (double) decimeterspersecond;
+            return new Speed((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Speed from DecimetersPerSecond.
-        /// </summary>
-        public static Speed FromDecimetersPerSecond(int decimeterspersecond)
+#else
+        public static Speed FromDecimetersPerSecond(QuantityValue decimeterspersecond)
         {
-            return new Speed((decimeterspersecond) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Speed from DecimetersPerSecond.
-        /// </summary>
-        public static Speed FromDecimetersPerSecond(long decimeterspersecond)
-        {
-            return new Speed((decimeterspersecond) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from DecimetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromDecimetersPerSecond(decimal decimeterspersecond)
-        {
-            return new Speed((Convert.ToDouble(decimeterspersecond)) * 1e-1d);
+            double value = (double) decimeterspersecond;
+            return new Speed(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromFeetPerSecond(double feetpersecond)
         {
-            return new Speed(feetpersecond*0.3048);
+            double value = (double) feetpersecond;
+            return new Speed(value*0.3048);
         }
-
-        /// <summary>
-        ///     Get Speed from FeetPerSecond.
-        /// </summary>
-        public static Speed FromFeetPerSecond(int feetpersecond)
+#else
+        public static Speed FromFeetPerSecond(QuantityValue feetpersecond)
         {
-            return new Speed(feetpersecond*0.3048);
-        }
-
-        /// <summary>
-        ///     Get Speed from FeetPerSecond.
-        /// </summary>
-        public static Speed FromFeetPerSecond(long feetpersecond)
-        {
-            return new Speed(feetpersecond*0.3048);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from FeetPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromFeetPerSecond(decimal feetpersecond)
-        {
-            return new Speed(Convert.ToDouble(feetpersecond)*0.3048);
+            double value = (double) feetpersecond;
+            return new Speed((value*0.3048));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from KilometersPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromKilometersPerHour(double kilometersperhour)
         {
-            return new Speed((kilometersperhour/3600) * 1e3d);
+            double value = (double) kilometersperhour;
+            return new Speed((value/3600) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Speed from KilometersPerHour.
-        /// </summary>
-        public static Speed FromKilometersPerHour(int kilometersperhour)
+#else
+        public static Speed FromKilometersPerHour(QuantityValue kilometersperhour)
         {
-            return new Speed((kilometersperhour/3600) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Speed from KilometersPerHour.
-        /// </summary>
-        public static Speed FromKilometersPerHour(long kilometersperhour)
-        {
-            return new Speed((kilometersperhour/3600) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from KilometersPerHour of type decimal.
-        /// </summary>
-        public static Speed FromKilometersPerHour(decimal kilometersperhour)
-        {
-            return new Speed((Convert.ToDouble(kilometersperhour)/3600) * 1e3d);
+            double value = (double) kilometersperhour;
+            return new Speed(((value/3600) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromKilometersPerMinutes(double kilometersperminutes)
         {
-            return new Speed((kilometersperminutes/60) * 1e3d);
+            double value = (double) kilometersperminutes;
+            return new Speed((value/60) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Speed from KilometersPerMinutes.
-        /// </summary>
-        public static Speed FromKilometersPerMinutes(int kilometersperminutes)
+#else
+        public static Speed FromKilometersPerMinutes(QuantityValue kilometersperminutes)
         {
-            return new Speed((kilometersperminutes/60) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Speed from KilometersPerMinutes.
-        /// </summary>
-        public static Speed FromKilometersPerMinutes(long kilometersperminutes)
-        {
-            return new Speed((kilometersperminutes/60) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from KilometersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromKilometersPerMinutes(decimal kilometersperminutes)
-        {
-            return new Speed((Convert.ToDouble(kilometersperminutes)/60) * 1e3d);
+            double value = (double) kilometersperminutes;
+            return new Speed(((value/60) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from KilometersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromKilometersPerSecond(double kilometerspersecond)
         {
-            return new Speed((kilometerspersecond) * 1e3d);
+            double value = (double) kilometerspersecond;
+            return new Speed((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Speed from KilometersPerSecond.
-        /// </summary>
-        public static Speed FromKilometersPerSecond(int kilometerspersecond)
+#else
+        public static Speed FromKilometersPerSecond(QuantityValue kilometerspersecond)
         {
-            return new Speed((kilometerspersecond) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Speed from KilometersPerSecond.
-        /// </summary>
-        public static Speed FromKilometersPerSecond(long kilometerspersecond)
-        {
-            return new Speed((kilometerspersecond) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from KilometersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromKilometersPerSecond(decimal kilometerspersecond)
-        {
-            return new Speed((Convert.ToDouble(kilometerspersecond)) * 1e3d);
+            double value = (double) kilometerspersecond;
+            return new Speed(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromKnots(double knots)
         {
-            return new Speed(knots*0.514444);
+            double value = (double) knots;
+            return new Speed(value*0.514444);
         }
-
-        /// <summary>
-        ///     Get Speed from Knots.
-        /// </summary>
-        public static Speed FromKnots(int knots)
+#else
+        public static Speed FromKnots(QuantityValue knots)
         {
-            return new Speed(knots*0.514444);
-        }
-
-        /// <summary>
-        ///     Get Speed from Knots.
-        /// </summary>
-        public static Speed FromKnots(long knots)
-        {
-            return new Speed(knots*0.514444);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from Knots of type decimal.
-        /// </summary>
-        public static Speed FromKnots(decimal knots)
-        {
-            return new Speed(Convert.ToDouble(knots)*0.514444);
+            double value = (double) knots;
+            return new Speed((value*0.514444));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MetersPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMetersPerHour(double metersperhour)
         {
-            return new Speed(metersperhour/3600);
+            double value = (double) metersperhour;
+            return new Speed(value/3600);
         }
-
-        /// <summary>
-        ///     Get Speed from MetersPerHour.
-        /// </summary>
-        public static Speed FromMetersPerHour(int metersperhour)
+#else
+        public static Speed FromMetersPerHour(QuantityValue metersperhour)
         {
-            return new Speed(metersperhour/3600);
-        }
-
-        /// <summary>
-        ///     Get Speed from MetersPerHour.
-        /// </summary>
-        public static Speed FromMetersPerHour(long metersperhour)
-        {
-            return new Speed(metersperhour/3600);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MetersPerHour of type decimal.
-        /// </summary>
-        public static Speed FromMetersPerHour(decimal metersperhour)
-        {
-            return new Speed(Convert.ToDouble(metersperhour)/3600);
+            double value = (double) metersperhour;
+            return new Speed((value/3600));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMetersPerMinutes(double metersperminutes)
         {
-            return new Speed(metersperminutes/60);
+            double value = (double) metersperminutes;
+            return new Speed(value/60);
         }
-
-        /// <summary>
-        ///     Get Speed from MetersPerMinutes.
-        /// </summary>
-        public static Speed FromMetersPerMinutes(int metersperminutes)
+#else
+        public static Speed FromMetersPerMinutes(QuantityValue metersperminutes)
         {
-            return new Speed(metersperminutes/60);
-        }
-
-        /// <summary>
-        ///     Get Speed from MetersPerMinutes.
-        /// </summary>
-        public static Speed FromMetersPerMinutes(long metersperminutes)
-        {
-            return new Speed(metersperminutes/60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromMetersPerMinutes(decimal metersperminutes)
-        {
-            return new Speed(Convert.ToDouble(metersperminutes)/60);
+            double value = (double) metersperminutes;
+            return new Speed((value/60));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MetersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMetersPerSecond(double meterspersecond)
         {
-            return new Speed(meterspersecond);
+            double value = (double) meterspersecond;
+            return new Speed(value);
         }
-
-        /// <summary>
-        ///     Get Speed from MetersPerSecond.
-        /// </summary>
-        public static Speed FromMetersPerSecond(int meterspersecond)
+#else
+        public static Speed FromMetersPerSecond(QuantityValue meterspersecond)
         {
-            return new Speed(meterspersecond);
-        }
-
-        /// <summary>
-        ///     Get Speed from MetersPerSecond.
-        /// </summary>
-        public static Speed FromMetersPerSecond(long meterspersecond)
-        {
-            return new Speed(meterspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromMetersPerSecond(decimal meterspersecond)
-        {
-            return new Speed(Convert.ToDouble(meterspersecond));
+            double value = (double) meterspersecond;
+            return new Speed((value));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMicrometersPerMinutes(double micrometersperminutes)
         {
-            return new Speed((micrometersperminutes/60) * 1e-6d);
+            double value = (double) micrometersperminutes;
+            return new Speed((value/60) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Speed from MicrometersPerMinutes.
-        /// </summary>
-        public static Speed FromMicrometersPerMinutes(int micrometersperminutes)
+#else
+        public static Speed FromMicrometersPerMinutes(QuantityValue micrometersperminutes)
         {
-            return new Speed((micrometersperminutes/60) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Speed from MicrometersPerMinutes.
-        /// </summary>
-        public static Speed FromMicrometersPerMinutes(long micrometersperminutes)
-        {
-            return new Speed((micrometersperminutes/60) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MicrometersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromMicrometersPerMinutes(decimal micrometersperminutes)
-        {
-            return new Speed((Convert.ToDouble(micrometersperminutes)/60) * 1e-6d);
+            double value = (double) micrometersperminutes;
+            return new Speed(((value/60) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MicrometersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMicrometersPerSecond(double micrometerspersecond)
         {
-            return new Speed((micrometerspersecond) * 1e-6d);
+            double value = (double) micrometerspersecond;
+            return new Speed((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Speed from MicrometersPerSecond.
-        /// </summary>
-        public static Speed FromMicrometersPerSecond(int micrometerspersecond)
+#else
+        public static Speed FromMicrometersPerSecond(QuantityValue micrometerspersecond)
         {
-            return new Speed((micrometerspersecond) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Speed from MicrometersPerSecond.
-        /// </summary>
-        public static Speed FromMicrometersPerSecond(long micrometerspersecond)
-        {
-            return new Speed((micrometerspersecond) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MicrometersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromMicrometersPerSecond(decimal micrometerspersecond)
-        {
-            return new Speed((Convert.ToDouble(micrometerspersecond)) * 1e-6d);
+            double value = (double) micrometerspersecond;
+            return new Speed(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMilesPerHour(double milesperhour)
         {
-            return new Speed(milesperhour*0.44704);
+            double value = (double) milesperhour;
+            return new Speed(value*0.44704);
         }
-
-        /// <summary>
-        ///     Get Speed from MilesPerHour.
-        /// </summary>
-        public static Speed FromMilesPerHour(int milesperhour)
+#else
+        public static Speed FromMilesPerHour(QuantityValue milesperhour)
         {
-            return new Speed(milesperhour*0.44704);
-        }
-
-        /// <summary>
-        ///     Get Speed from MilesPerHour.
-        /// </summary>
-        public static Speed FromMilesPerHour(long milesperhour)
-        {
-            return new Speed(milesperhour*0.44704);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MilesPerHour of type decimal.
-        /// </summary>
-        public static Speed FromMilesPerHour(decimal milesperhour)
-        {
-            return new Speed(Convert.ToDouble(milesperhour)*0.44704);
+            double value = (double) milesperhour;
+            return new Speed((value*0.44704));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MillimetersPerHour.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMillimetersPerHour(double millimetersperhour)
         {
-            return new Speed((millimetersperhour/3600) * 1e-3d);
+            double value = (double) millimetersperhour;
+            return new Speed((value/3600) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Speed from MillimetersPerHour.
-        /// </summary>
-        public static Speed FromMillimetersPerHour(int millimetersperhour)
+#else
+        public static Speed FromMillimetersPerHour(QuantityValue millimetersperhour)
         {
-            return new Speed((millimetersperhour/3600) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Speed from MillimetersPerHour.
-        /// </summary>
-        public static Speed FromMillimetersPerHour(long millimetersperhour)
-        {
-            return new Speed((millimetersperhour/3600) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MillimetersPerHour of type decimal.
-        /// </summary>
-        public static Speed FromMillimetersPerHour(decimal millimetersperhour)
-        {
-            return new Speed((Convert.ToDouble(millimetersperhour)/3600) * 1e-3d);
+            double value = (double) millimetersperhour;
+            return new Speed(((value/3600) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMillimetersPerMinutes(double millimetersperminutes)
         {
-            return new Speed((millimetersperminutes/60) * 1e-3d);
+            double value = (double) millimetersperminutes;
+            return new Speed((value/60) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Speed from MillimetersPerMinutes.
-        /// </summary>
-        public static Speed FromMillimetersPerMinutes(int millimetersperminutes)
+#else
+        public static Speed FromMillimetersPerMinutes(QuantityValue millimetersperminutes)
         {
-            return new Speed((millimetersperminutes/60) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Speed from MillimetersPerMinutes.
-        /// </summary>
-        public static Speed FromMillimetersPerMinutes(long millimetersperminutes)
-        {
-            return new Speed((millimetersperminutes/60) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MillimetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromMillimetersPerMinutes(decimal millimetersperminutes)
-        {
-            return new Speed((Convert.ToDouble(millimetersperminutes)/60) * 1e-3d);
+            double value = (double) millimetersperminutes;
+            return new Speed(((value/60) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from MillimetersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromMillimetersPerSecond(double millimeterspersecond)
         {
-            return new Speed((millimeterspersecond) * 1e-3d);
+            double value = (double) millimeterspersecond;
+            return new Speed((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Speed from MillimetersPerSecond.
-        /// </summary>
-        public static Speed FromMillimetersPerSecond(int millimeterspersecond)
+#else
+        public static Speed FromMillimetersPerSecond(QuantityValue millimeterspersecond)
         {
-            return new Speed((millimeterspersecond) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Speed from MillimetersPerSecond.
-        /// </summary>
-        public static Speed FromMillimetersPerSecond(long millimeterspersecond)
-        {
-            return new Speed((millimeterspersecond) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from MillimetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromMillimetersPerSecond(decimal millimeterspersecond)
-        {
-            return new Speed((Convert.ToDouble(millimeterspersecond)) * 1e-3d);
+            double value = (double) millimeterspersecond;
+            return new Speed(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromNanometersPerMinutes(double nanometersperminutes)
         {
-            return new Speed((nanometersperminutes/60) * 1e-9d);
+            double value = (double) nanometersperminutes;
+            return new Speed((value/60) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Speed from NanometersPerMinutes.
-        /// </summary>
-        public static Speed FromNanometersPerMinutes(int nanometersperminutes)
+#else
+        public static Speed FromNanometersPerMinutes(QuantityValue nanometersperminutes)
         {
-            return new Speed((nanometersperminutes/60) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Speed from NanometersPerMinutes.
-        /// </summary>
-        public static Speed FromNanometersPerMinutes(long nanometersperminutes)
-        {
-            return new Speed((nanometersperminutes/60) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from NanometersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed FromNanometersPerMinutes(decimal nanometersperminutes)
-        {
-            return new Speed((Convert.ToDouble(nanometersperminutes)/60) * 1e-9d);
+            double value = (double) nanometersperminutes;
+            return new Speed(((value/60) * 1e-9d));
         }
 #endif
 
         /// <summary>
         ///     Get Speed from NanometersPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Speed FromNanometersPerSecond(double nanometerspersecond)
         {
-            return new Speed((nanometerspersecond) * 1e-9d);
+            double value = (double) nanometerspersecond;
+            return new Speed((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get Speed from NanometersPerSecond.
-        /// </summary>
-        public static Speed FromNanometersPerSecond(int nanometerspersecond)
+#else
+        public static Speed FromNanometersPerSecond(QuantityValue nanometerspersecond)
         {
-            return new Speed((nanometerspersecond) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get Speed from NanometersPerSecond.
-        /// </summary>
-        public static Speed FromNanometersPerSecond(long nanometerspersecond)
-        {
-            return new Speed((nanometerspersecond) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Speed from NanometersPerSecond of type decimal.
-        /// </summary>
-        public static Speed FromNanometersPerSecond(decimal nanometerspersecond)
-        {
-            return new Speed((Convert.ToDouble(nanometerspersecond)) * 1e-9d);
+            double value = (double) nanometerspersecond;
+            return new Speed(((value) * 1e-9d));
         }
 #endif
 
@@ -1109,52 +689,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerHour.
         /// </summary>
-        public static Speed? FromCentimetersPerHour(double? centimetersperhour)
-        {
-            if (centimetersperhour.HasValue)
-            {
-                return FromCentimetersPerHour(centimetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable CentimetersPerHour.
-        /// </summary>
-        public static Speed? FromCentimetersPerHour(int? centimetersperhour)
-        {
-            if (centimetersperhour.HasValue)
-            {
-                return FromCentimetersPerHour(centimetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable CentimetersPerHour.
-        /// </summary>
-        public static Speed? FromCentimetersPerHour(long? centimetersperhour)
-        {
-            if (centimetersperhour.HasValue)
-            {
-                return FromCentimetersPerHour(centimetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from CentimetersPerHour of type decimal.
-        /// </summary>
-        public static Speed? FromCentimetersPerHour(decimal? centimetersperhour)
+        public static Speed? FromCentimetersPerHour(QuantityValue? centimetersperhour)
         {
             if (centimetersperhour.HasValue)
             {
@@ -1169,52 +704,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerMinutes.
         /// </summary>
-        public static Speed? FromCentimetersPerMinutes(double? centimetersperminutes)
-        {
-            if (centimetersperminutes.HasValue)
-            {
-                return FromCentimetersPerMinutes(centimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable CentimetersPerMinutes.
-        /// </summary>
-        public static Speed? FromCentimetersPerMinutes(int? centimetersperminutes)
-        {
-            if (centimetersperminutes.HasValue)
-            {
-                return FromCentimetersPerMinutes(centimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable CentimetersPerMinutes.
-        /// </summary>
-        public static Speed? FromCentimetersPerMinutes(long? centimetersperminutes)
-        {
-            if (centimetersperminutes.HasValue)
-            {
-                return FromCentimetersPerMinutes(centimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from CentimetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromCentimetersPerMinutes(decimal? centimetersperminutes)
+        public static Speed? FromCentimetersPerMinutes(QuantityValue? centimetersperminutes)
         {
             if (centimetersperminutes.HasValue)
             {
@@ -1229,52 +719,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerSecond.
         /// </summary>
-        public static Speed? FromCentimetersPerSecond(double? centimeterspersecond)
-        {
-            if (centimeterspersecond.HasValue)
-            {
-                return FromCentimetersPerSecond(centimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable CentimetersPerSecond.
-        /// </summary>
-        public static Speed? FromCentimetersPerSecond(int? centimeterspersecond)
-        {
-            if (centimeterspersecond.HasValue)
-            {
-                return FromCentimetersPerSecond(centimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable CentimetersPerSecond.
-        /// </summary>
-        public static Speed? FromCentimetersPerSecond(long? centimeterspersecond)
-        {
-            if (centimeterspersecond.HasValue)
-            {
-                return FromCentimetersPerSecond(centimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from CentimetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromCentimetersPerSecond(decimal? centimeterspersecond)
+        public static Speed? FromCentimetersPerSecond(QuantityValue? centimeterspersecond)
         {
             if (centimeterspersecond.HasValue)
             {
@@ -1289,52 +734,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerMinutes.
         /// </summary>
-        public static Speed? FromDecimetersPerMinutes(double? decimetersperminutes)
-        {
-            if (decimetersperminutes.HasValue)
-            {
-                return FromDecimetersPerMinutes(decimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable DecimetersPerMinutes.
-        /// </summary>
-        public static Speed? FromDecimetersPerMinutes(int? decimetersperminutes)
-        {
-            if (decimetersperminutes.HasValue)
-            {
-                return FromDecimetersPerMinutes(decimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable DecimetersPerMinutes.
-        /// </summary>
-        public static Speed? FromDecimetersPerMinutes(long? decimetersperminutes)
-        {
-            if (decimetersperminutes.HasValue)
-            {
-                return FromDecimetersPerMinutes(decimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from DecimetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromDecimetersPerMinutes(decimal? decimetersperminutes)
+        public static Speed? FromDecimetersPerMinutes(QuantityValue? decimetersperminutes)
         {
             if (decimetersperminutes.HasValue)
             {
@@ -1349,52 +749,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable DecimetersPerSecond.
         /// </summary>
-        public static Speed? FromDecimetersPerSecond(double? decimeterspersecond)
-        {
-            if (decimeterspersecond.HasValue)
-            {
-                return FromDecimetersPerSecond(decimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable DecimetersPerSecond.
-        /// </summary>
-        public static Speed? FromDecimetersPerSecond(int? decimeterspersecond)
-        {
-            if (decimeterspersecond.HasValue)
-            {
-                return FromDecimetersPerSecond(decimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable DecimetersPerSecond.
-        /// </summary>
-        public static Speed? FromDecimetersPerSecond(long? decimeterspersecond)
-        {
-            if (decimeterspersecond.HasValue)
-            {
-                return FromDecimetersPerSecond(decimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from DecimetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromDecimetersPerSecond(decimal? decimeterspersecond)
+        public static Speed? FromDecimetersPerSecond(QuantityValue? decimeterspersecond)
         {
             if (decimeterspersecond.HasValue)
             {
@@ -1409,52 +764,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable FeetPerSecond.
         /// </summary>
-        public static Speed? FromFeetPerSecond(double? feetpersecond)
-        {
-            if (feetpersecond.HasValue)
-            {
-                return FromFeetPerSecond(feetpersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable FeetPerSecond.
-        /// </summary>
-        public static Speed? FromFeetPerSecond(int? feetpersecond)
-        {
-            if (feetpersecond.HasValue)
-            {
-                return FromFeetPerSecond(feetpersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable FeetPerSecond.
-        /// </summary>
-        public static Speed? FromFeetPerSecond(long? feetpersecond)
-        {
-            if (feetpersecond.HasValue)
-            {
-                return FromFeetPerSecond(feetpersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from FeetPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromFeetPerSecond(decimal? feetpersecond)
+        public static Speed? FromFeetPerSecond(QuantityValue? feetpersecond)
         {
             if (feetpersecond.HasValue)
             {
@@ -1469,52 +779,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable KilometersPerHour.
         /// </summary>
-        public static Speed? FromKilometersPerHour(double? kilometersperhour)
-        {
-            if (kilometersperhour.HasValue)
-            {
-                return FromKilometersPerHour(kilometersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable KilometersPerHour.
-        /// </summary>
-        public static Speed? FromKilometersPerHour(int? kilometersperhour)
-        {
-            if (kilometersperhour.HasValue)
-            {
-                return FromKilometersPerHour(kilometersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable KilometersPerHour.
-        /// </summary>
-        public static Speed? FromKilometersPerHour(long? kilometersperhour)
-        {
-            if (kilometersperhour.HasValue)
-            {
-                return FromKilometersPerHour(kilometersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from KilometersPerHour of type decimal.
-        /// </summary>
-        public static Speed? FromKilometersPerHour(decimal? kilometersperhour)
+        public static Speed? FromKilometersPerHour(QuantityValue? kilometersperhour)
         {
             if (kilometersperhour.HasValue)
             {
@@ -1529,52 +794,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable KilometersPerMinutes.
         /// </summary>
-        public static Speed? FromKilometersPerMinutes(double? kilometersperminutes)
-        {
-            if (kilometersperminutes.HasValue)
-            {
-                return FromKilometersPerMinutes(kilometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable KilometersPerMinutes.
-        /// </summary>
-        public static Speed? FromKilometersPerMinutes(int? kilometersperminutes)
-        {
-            if (kilometersperminutes.HasValue)
-            {
-                return FromKilometersPerMinutes(kilometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable KilometersPerMinutes.
-        /// </summary>
-        public static Speed? FromKilometersPerMinutes(long? kilometersperminutes)
-        {
-            if (kilometersperminutes.HasValue)
-            {
-                return FromKilometersPerMinutes(kilometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from KilometersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromKilometersPerMinutes(decimal? kilometersperminutes)
+        public static Speed? FromKilometersPerMinutes(QuantityValue? kilometersperminutes)
         {
             if (kilometersperminutes.HasValue)
             {
@@ -1589,52 +809,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable KilometersPerSecond.
         /// </summary>
-        public static Speed? FromKilometersPerSecond(double? kilometerspersecond)
-        {
-            if (kilometerspersecond.HasValue)
-            {
-                return FromKilometersPerSecond(kilometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable KilometersPerSecond.
-        /// </summary>
-        public static Speed? FromKilometersPerSecond(int? kilometerspersecond)
-        {
-            if (kilometerspersecond.HasValue)
-            {
-                return FromKilometersPerSecond(kilometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable KilometersPerSecond.
-        /// </summary>
-        public static Speed? FromKilometersPerSecond(long? kilometerspersecond)
-        {
-            if (kilometerspersecond.HasValue)
-            {
-                return FromKilometersPerSecond(kilometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from KilometersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromKilometersPerSecond(decimal? kilometerspersecond)
+        public static Speed? FromKilometersPerSecond(QuantityValue? kilometerspersecond)
         {
             if (kilometerspersecond.HasValue)
             {
@@ -1649,52 +824,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable Knots.
         /// </summary>
-        public static Speed? FromKnots(double? knots)
-        {
-            if (knots.HasValue)
-            {
-                return FromKnots(knots.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable Knots.
-        /// </summary>
-        public static Speed? FromKnots(int? knots)
-        {
-            if (knots.HasValue)
-            {
-                return FromKnots(knots.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable Knots.
-        /// </summary>
-        public static Speed? FromKnots(long? knots)
-        {
-            if (knots.HasValue)
-            {
-                return FromKnots(knots.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from Knots of type decimal.
-        /// </summary>
-        public static Speed? FromKnots(decimal? knots)
+        public static Speed? FromKnots(QuantityValue? knots)
         {
             if (knots.HasValue)
             {
@@ -1709,52 +839,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MetersPerHour.
         /// </summary>
-        public static Speed? FromMetersPerHour(double? metersperhour)
-        {
-            if (metersperhour.HasValue)
-            {
-                return FromMetersPerHour(metersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MetersPerHour.
-        /// </summary>
-        public static Speed? FromMetersPerHour(int? metersperhour)
-        {
-            if (metersperhour.HasValue)
-            {
-                return FromMetersPerHour(metersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MetersPerHour.
-        /// </summary>
-        public static Speed? FromMetersPerHour(long? metersperhour)
-        {
-            if (metersperhour.HasValue)
-            {
-                return FromMetersPerHour(metersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MetersPerHour of type decimal.
-        /// </summary>
-        public static Speed? FromMetersPerHour(decimal? metersperhour)
+        public static Speed? FromMetersPerHour(QuantityValue? metersperhour)
         {
             if (metersperhour.HasValue)
             {
@@ -1769,52 +854,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MetersPerMinutes.
         /// </summary>
-        public static Speed? FromMetersPerMinutes(double? metersperminutes)
-        {
-            if (metersperminutes.HasValue)
-            {
-                return FromMetersPerMinutes(metersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MetersPerMinutes.
-        /// </summary>
-        public static Speed? FromMetersPerMinutes(int? metersperminutes)
-        {
-            if (metersperminutes.HasValue)
-            {
-                return FromMetersPerMinutes(metersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MetersPerMinutes.
-        /// </summary>
-        public static Speed? FromMetersPerMinutes(long? metersperminutes)
-        {
-            if (metersperminutes.HasValue)
-            {
-                return FromMetersPerMinutes(metersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromMetersPerMinutes(decimal? metersperminutes)
+        public static Speed? FromMetersPerMinutes(QuantityValue? metersperminutes)
         {
             if (metersperminutes.HasValue)
             {
@@ -1829,52 +869,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MetersPerSecond.
         /// </summary>
-        public static Speed? FromMetersPerSecond(double? meterspersecond)
-        {
-            if (meterspersecond.HasValue)
-            {
-                return FromMetersPerSecond(meterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MetersPerSecond.
-        /// </summary>
-        public static Speed? FromMetersPerSecond(int? meterspersecond)
-        {
-            if (meterspersecond.HasValue)
-            {
-                return FromMetersPerSecond(meterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MetersPerSecond.
-        /// </summary>
-        public static Speed? FromMetersPerSecond(long? meterspersecond)
-        {
-            if (meterspersecond.HasValue)
-            {
-                return FromMetersPerSecond(meterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromMetersPerSecond(decimal? meterspersecond)
+        public static Speed? FromMetersPerSecond(QuantityValue? meterspersecond)
         {
             if (meterspersecond.HasValue)
             {
@@ -1889,52 +884,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerMinutes.
         /// </summary>
-        public static Speed? FromMicrometersPerMinutes(double? micrometersperminutes)
-        {
-            if (micrometersperminutes.HasValue)
-            {
-                return FromMicrometersPerMinutes(micrometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MicrometersPerMinutes.
-        /// </summary>
-        public static Speed? FromMicrometersPerMinutes(int? micrometersperminutes)
-        {
-            if (micrometersperminutes.HasValue)
-            {
-                return FromMicrometersPerMinutes(micrometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MicrometersPerMinutes.
-        /// </summary>
-        public static Speed? FromMicrometersPerMinutes(long? micrometersperminutes)
-        {
-            if (micrometersperminutes.HasValue)
-            {
-                return FromMicrometersPerMinutes(micrometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MicrometersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromMicrometersPerMinutes(decimal? micrometersperminutes)
+        public static Speed? FromMicrometersPerMinutes(QuantityValue? micrometersperminutes)
         {
             if (micrometersperminutes.HasValue)
             {
@@ -1949,52 +899,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MicrometersPerSecond.
         /// </summary>
-        public static Speed? FromMicrometersPerSecond(double? micrometerspersecond)
-        {
-            if (micrometerspersecond.HasValue)
-            {
-                return FromMicrometersPerSecond(micrometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MicrometersPerSecond.
-        /// </summary>
-        public static Speed? FromMicrometersPerSecond(int? micrometerspersecond)
-        {
-            if (micrometerspersecond.HasValue)
-            {
-                return FromMicrometersPerSecond(micrometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MicrometersPerSecond.
-        /// </summary>
-        public static Speed? FromMicrometersPerSecond(long? micrometerspersecond)
-        {
-            if (micrometerspersecond.HasValue)
-            {
-                return FromMicrometersPerSecond(micrometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MicrometersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromMicrometersPerSecond(decimal? micrometerspersecond)
+        public static Speed? FromMicrometersPerSecond(QuantityValue? micrometerspersecond)
         {
             if (micrometerspersecond.HasValue)
             {
@@ -2009,52 +914,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MilesPerHour.
         /// </summary>
-        public static Speed? FromMilesPerHour(double? milesperhour)
-        {
-            if (milesperhour.HasValue)
-            {
-                return FromMilesPerHour(milesperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MilesPerHour.
-        /// </summary>
-        public static Speed? FromMilesPerHour(int? milesperhour)
-        {
-            if (milesperhour.HasValue)
-            {
-                return FromMilesPerHour(milesperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MilesPerHour.
-        /// </summary>
-        public static Speed? FromMilesPerHour(long? milesperhour)
-        {
-            if (milesperhour.HasValue)
-            {
-                return FromMilesPerHour(milesperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MilesPerHour of type decimal.
-        /// </summary>
-        public static Speed? FromMilesPerHour(decimal? milesperhour)
+        public static Speed? FromMilesPerHour(QuantityValue? milesperhour)
         {
             if (milesperhour.HasValue)
             {
@@ -2069,52 +929,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerHour.
         /// </summary>
-        public static Speed? FromMillimetersPerHour(double? millimetersperhour)
-        {
-            if (millimetersperhour.HasValue)
-            {
-                return FromMillimetersPerHour(millimetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MillimetersPerHour.
-        /// </summary>
-        public static Speed? FromMillimetersPerHour(int? millimetersperhour)
-        {
-            if (millimetersperhour.HasValue)
-            {
-                return FromMillimetersPerHour(millimetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MillimetersPerHour.
-        /// </summary>
-        public static Speed? FromMillimetersPerHour(long? millimetersperhour)
-        {
-            if (millimetersperhour.HasValue)
-            {
-                return FromMillimetersPerHour(millimetersperhour.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MillimetersPerHour of type decimal.
-        /// </summary>
-        public static Speed? FromMillimetersPerHour(decimal? millimetersperhour)
+        public static Speed? FromMillimetersPerHour(QuantityValue? millimetersperhour)
         {
             if (millimetersperhour.HasValue)
             {
@@ -2129,52 +944,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerMinutes.
         /// </summary>
-        public static Speed? FromMillimetersPerMinutes(double? millimetersperminutes)
-        {
-            if (millimetersperminutes.HasValue)
-            {
-                return FromMillimetersPerMinutes(millimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MillimetersPerMinutes.
-        /// </summary>
-        public static Speed? FromMillimetersPerMinutes(int? millimetersperminutes)
-        {
-            if (millimetersperminutes.HasValue)
-            {
-                return FromMillimetersPerMinutes(millimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MillimetersPerMinutes.
-        /// </summary>
-        public static Speed? FromMillimetersPerMinutes(long? millimetersperminutes)
-        {
-            if (millimetersperminutes.HasValue)
-            {
-                return FromMillimetersPerMinutes(millimetersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MillimetersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromMillimetersPerMinutes(decimal? millimetersperminutes)
+        public static Speed? FromMillimetersPerMinutes(QuantityValue? millimetersperminutes)
         {
             if (millimetersperminutes.HasValue)
             {
@@ -2189,52 +959,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable MillimetersPerSecond.
         /// </summary>
-        public static Speed? FromMillimetersPerSecond(double? millimeterspersecond)
-        {
-            if (millimeterspersecond.HasValue)
-            {
-                return FromMillimetersPerSecond(millimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MillimetersPerSecond.
-        /// </summary>
-        public static Speed? FromMillimetersPerSecond(int? millimeterspersecond)
-        {
-            if (millimeterspersecond.HasValue)
-            {
-                return FromMillimetersPerSecond(millimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable MillimetersPerSecond.
-        /// </summary>
-        public static Speed? FromMillimetersPerSecond(long? millimeterspersecond)
-        {
-            if (millimeterspersecond.HasValue)
-            {
-                return FromMillimetersPerSecond(millimeterspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from MillimetersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromMillimetersPerSecond(decimal? millimeterspersecond)
+        public static Speed? FromMillimetersPerSecond(QuantityValue? millimeterspersecond)
         {
             if (millimeterspersecond.HasValue)
             {
@@ -2249,52 +974,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable NanometersPerMinutes.
         /// </summary>
-        public static Speed? FromNanometersPerMinutes(double? nanometersperminutes)
-        {
-            if (nanometersperminutes.HasValue)
-            {
-                return FromNanometersPerMinutes(nanometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable NanometersPerMinutes.
-        /// </summary>
-        public static Speed? FromNanometersPerMinutes(int? nanometersperminutes)
-        {
-            if (nanometersperminutes.HasValue)
-            {
-                return FromNanometersPerMinutes(nanometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable NanometersPerMinutes.
-        /// </summary>
-        public static Speed? FromNanometersPerMinutes(long? nanometersperminutes)
-        {
-            if (nanometersperminutes.HasValue)
-            {
-                return FromNanometersPerMinutes(nanometersperminutes.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from NanometersPerMinutes of type decimal.
-        /// </summary>
-        public static Speed? FromNanometersPerMinutes(decimal? nanometersperminutes)
+        public static Speed? FromNanometersPerMinutes(QuantityValue? nanometersperminutes)
         {
             if (nanometersperminutes.HasValue)
             {
@@ -2309,52 +989,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Speed from nullable NanometersPerSecond.
         /// </summary>
-        public static Speed? FromNanometersPerSecond(double? nanometerspersecond)
-        {
-            if (nanometerspersecond.HasValue)
-            {
-                return FromNanometersPerSecond(nanometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable NanometersPerSecond.
-        /// </summary>
-        public static Speed? FromNanometersPerSecond(int? nanometerspersecond)
-        {
-            if (nanometerspersecond.HasValue)
-            {
-                return FromNanometersPerSecond(nanometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from nullable NanometersPerSecond.
-        /// </summary>
-        public static Speed? FromNanometersPerSecond(long? nanometerspersecond)
-        {
-            if (nanometerspersecond.HasValue)
-            {
-                return FromNanometersPerSecond(nanometerspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Speed from NanometersPerSecond of type decimal.
-        /// </summary>
-        public static Speed? FromNanometersPerSecond(decimal? nanometerspersecond)
+        public static Speed? FromNanometersPerSecond(QuantityValue? nanometerspersecond)
         {
             if (nanometerspersecond.HasValue)
             {
@@ -2371,55 +1006,61 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="SpeedUnit" /> to <see cref="Speed" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Speed unit value.</returns>
-        public static Speed From(double val, SpeedUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Speed From(double value, SpeedUnit fromUnit)
+#else
+        public static Speed From(QuantityValue value, SpeedUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case SpeedUnit.CentimeterPerHour:
-                    return FromCentimetersPerHour(val);
+                    return FromCentimetersPerHour(value);
                 case SpeedUnit.CentimeterPerMinute:
-                    return FromCentimetersPerMinutes(val);
+                    return FromCentimetersPerMinutes(value);
                 case SpeedUnit.CentimeterPerSecond:
-                    return FromCentimetersPerSecond(val);
+                    return FromCentimetersPerSecond(value);
                 case SpeedUnit.DecimeterPerMinute:
-                    return FromDecimetersPerMinutes(val);
+                    return FromDecimetersPerMinutes(value);
                 case SpeedUnit.DecimeterPerSecond:
-                    return FromDecimetersPerSecond(val);
+                    return FromDecimetersPerSecond(value);
                 case SpeedUnit.FootPerSecond:
-                    return FromFeetPerSecond(val);
+                    return FromFeetPerSecond(value);
                 case SpeedUnit.KilometerPerHour:
-                    return FromKilometersPerHour(val);
+                    return FromKilometersPerHour(value);
                 case SpeedUnit.KilometerPerMinute:
-                    return FromKilometersPerMinutes(val);
+                    return FromKilometersPerMinutes(value);
                 case SpeedUnit.KilometerPerSecond:
-                    return FromKilometersPerSecond(val);
+                    return FromKilometersPerSecond(value);
                 case SpeedUnit.Knot:
-                    return FromKnots(val);
+                    return FromKnots(value);
                 case SpeedUnit.MeterPerHour:
-                    return FromMetersPerHour(val);
+                    return FromMetersPerHour(value);
                 case SpeedUnit.MeterPerMinute:
-                    return FromMetersPerMinutes(val);
+                    return FromMetersPerMinutes(value);
                 case SpeedUnit.MeterPerSecond:
-                    return FromMetersPerSecond(val);
+                    return FromMetersPerSecond(value);
                 case SpeedUnit.MicrometerPerMinute:
-                    return FromMicrometersPerMinutes(val);
+                    return FromMicrometersPerMinutes(value);
                 case SpeedUnit.MicrometerPerSecond:
-                    return FromMicrometersPerSecond(val);
+                    return FromMicrometersPerSecond(value);
                 case SpeedUnit.MilePerHour:
-                    return FromMilesPerHour(val);
+                    return FromMilesPerHour(value);
                 case SpeedUnit.MillimeterPerHour:
-                    return FromMillimetersPerHour(val);
+                    return FromMillimetersPerHour(value);
                 case SpeedUnit.MillimeterPerMinute:
-                    return FromMillimetersPerMinutes(val);
+                    return FromMillimetersPerMinutes(value);
                 case SpeedUnit.MillimeterPerSecond:
-                    return FromMillimetersPerSecond(val);
+                    return FromMillimetersPerSecond(value);
                 case SpeedUnit.NanometerPerMinute:
-                    return FromNanometersPerMinutes(val);
+                    return FromNanometersPerMinutes(value);
                 case SpeedUnit.NanometerPerSecond:
-                    return FromNanometersPerSecond(val);
+                    return FromNanometersPerSecond(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -2434,7 +1075,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Speed unit value.</returns>
-        public static Speed? From(double? value, SpeedUnit fromUnit)
+        public static Speed? From(QuantityValue? value, SpeedUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesCelsius.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesCelsius(double degreescelsius)
         {
-            return new Temperature(degreescelsius + 273.15);
+            double value = (double) degreescelsius;
+            return new Temperature(value + 273.15);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesCelsius.
-        /// </summary>
-        public static Temperature FromDegreesCelsius(int degreescelsius)
+#else
+        public static Temperature FromDegreesCelsius(QuantityValue degreescelsius)
         {
-            return new Temperature(degreescelsius + 273.15);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesCelsius.
-        /// </summary>
-        public static Temperature FromDegreesCelsius(long degreescelsius)
-        {
-            return new Temperature(degreescelsius + 273.15);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesCelsius of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesCelsius(decimal degreescelsius)
-        {
-            return new Temperature(Convert.ToDouble(degreescelsius) + 273.15);
+            double value = (double) degreescelsius;
+            return new Temperature((value + 273.15));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesDelisle(double degreesdelisle)
         {
-            return new Temperature(degreesdelisle*-2/3 + 373.15);
+            double value = (double) degreesdelisle;
+            return new Temperature(value*-2/3 + 373.15);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesDelisle.
-        /// </summary>
-        public static Temperature FromDegreesDelisle(int degreesdelisle)
+#else
+        public static Temperature FromDegreesDelisle(QuantityValue degreesdelisle)
         {
-            return new Temperature(degreesdelisle*-2/3 + 373.15);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesDelisle.
-        /// </summary>
-        public static Temperature FromDegreesDelisle(long degreesdelisle)
-        {
-            return new Temperature(degreesdelisle*-2/3 + 373.15);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesDelisle of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesDelisle(decimal degreesdelisle)
-        {
-            return new Temperature(Convert.ToDouble(degreesdelisle)*-2/3 + 373.15);
+            double value = (double) degreesdelisle;
+            return new Temperature((value*-2/3 + 373.15));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesFahrenheit(double degreesfahrenheit)
         {
-            return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
+            double value = (double) degreesfahrenheit;
+            return new Temperature(value*5/9 + 459.67*5/9);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesFahrenheit.
-        /// </summary>
-        public static Temperature FromDegreesFahrenheit(int degreesfahrenheit)
+#else
+        public static Temperature FromDegreesFahrenheit(QuantityValue degreesfahrenheit)
         {
-            return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesFahrenheit.
-        /// </summary>
-        public static Temperature FromDegreesFahrenheit(long degreesfahrenheit)
-        {
-            return new Temperature(degreesfahrenheit*5/9 + 459.67*5/9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesFahrenheit of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesFahrenheit(decimal degreesfahrenheit)
-        {
-            return new Temperature(Convert.ToDouble(degreesfahrenheit)*5/9 + 459.67*5/9);
+            double value = (double) degreesfahrenheit;
+            return new Temperature((value*5/9 + 459.67*5/9));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesNewton(double degreesnewton)
         {
-            return new Temperature(degreesnewton*100/33 + 273.15);
+            double value = (double) degreesnewton;
+            return new Temperature(value*100/33 + 273.15);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesNewton.
-        /// </summary>
-        public static Temperature FromDegreesNewton(int degreesnewton)
+#else
+        public static Temperature FromDegreesNewton(QuantityValue degreesnewton)
         {
-            return new Temperature(degreesnewton*100/33 + 273.15);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesNewton.
-        /// </summary>
-        public static Temperature FromDegreesNewton(long degreesnewton)
-        {
-            return new Temperature(degreesnewton*100/33 + 273.15);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesNewton of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesNewton(decimal degreesnewton)
-        {
-            return new Temperature(Convert.ToDouble(degreesnewton)*100/33 + 273.15);
+            double value = (double) degreesnewton;
+            return new Temperature((value*100/33 + 273.15));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from DegreesRankine.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesRankine(double degreesrankine)
         {
-            return new Temperature(degreesrankine*5/9);
+            double value = (double) degreesrankine;
+            return new Temperature(value*5/9);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesRankine.
-        /// </summary>
-        public static Temperature FromDegreesRankine(int degreesrankine)
+#else
+        public static Temperature FromDegreesRankine(QuantityValue degreesrankine)
         {
-            return new Temperature(degreesrankine*5/9);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesRankine.
-        /// </summary>
-        public static Temperature FromDegreesRankine(long degreesrankine)
-        {
-            return new Temperature(degreesrankine*5/9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesRankine of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesRankine(decimal degreesrankine)
-        {
-            return new Temperature(Convert.ToDouble(degreesrankine)*5/9);
+            double value = (double) degreesrankine;
+            return new Temperature((value*5/9));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesReaumur(double degreesreaumur)
         {
-            return new Temperature(degreesreaumur*5/4 + 273.15);
+            double value = (double) degreesreaumur;
+            return new Temperature(value*5/4 + 273.15);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesReaumur.
-        /// </summary>
-        public static Temperature FromDegreesReaumur(int degreesreaumur)
+#else
+        public static Temperature FromDegreesReaumur(QuantityValue degreesreaumur)
         {
-            return new Temperature(degreesreaumur*5/4 + 273.15);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesReaumur.
-        /// </summary>
-        public static Temperature FromDegreesReaumur(long degreesreaumur)
-        {
-            return new Temperature(degreesreaumur*5/4 + 273.15);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesReaumur of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesReaumur(decimal degreesreaumur)
-        {
-            return new Temperature(Convert.ToDouble(degreesreaumur)*5/4 + 273.15);
+            double value = (double) degreesreaumur;
+            return new Temperature((value*5/4 + 273.15));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from DegreesRoemer.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromDegreesRoemer(double degreesroemer)
         {
-            return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
+            double value = (double) degreesroemer;
+            return new Temperature(value*40/21 + 273.15 - 7.5*40d/21);
         }
-
-        /// <summary>
-        ///     Get Temperature from DegreesRoemer.
-        /// </summary>
-        public static Temperature FromDegreesRoemer(int degreesroemer)
+#else
+        public static Temperature FromDegreesRoemer(QuantityValue degreesroemer)
         {
-            return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
-        }
-
-        /// <summary>
-        ///     Get Temperature from DegreesRoemer.
-        /// </summary>
-        public static Temperature FromDegreesRoemer(long degreesroemer)
-        {
-            return new Temperature(degreesroemer*40/21 + 273.15 - 7.5*40d/21);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from DegreesRoemer of type decimal.
-        /// </summary>
-        public static Temperature FromDegreesRoemer(decimal degreesroemer)
-        {
-            return new Temperature(Convert.ToDouble(degreesroemer)*40/21 + 273.15 - 7.5*40d/21);
+            double value = (double) degreesroemer;
+            return new Temperature((value*40/21 + 273.15 - 7.5*40d/21));
         }
 #endif
 
         /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Temperature FromKelvins(double kelvins)
         {
-            return new Temperature(kelvins);
+            double value = (double) kelvins;
+            return new Temperature(value);
         }
-
-        /// <summary>
-        ///     Get Temperature from Kelvins.
-        /// </summary>
-        public static Temperature FromKelvins(int kelvins)
+#else
+        public static Temperature FromKelvins(QuantityValue kelvins)
         {
-            return new Temperature(kelvins);
-        }
-
-        /// <summary>
-        ///     Get Temperature from Kelvins.
-        /// </summary>
-        public static Temperature FromKelvins(long kelvins)
-        {
-            return new Temperature(kelvins);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Temperature from Kelvins of type decimal.
-        /// </summary>
-        public static Temperature FromKelvins(decimal kelvins)
-        {
-            return new Temperature(Convert.ToDouble(kelvins));
+            double value = (double) kelvins;
+            return new Temperature((value));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesCelsius.
         /// </summary>
-        public static Temperature? FromDegreesCelsius(double? degreescelsius)
-        {
-            if (degreescelsius.HasValue)
-            {
-                return FromDegreesCelsius(degreescelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesCelsius.
-        /// </summary>
-        public static Temperature? FromDegreesCelsius(int? degreescelsius)
-        {
-            if (degreescelsius.HasValue)
-            {
-                return FromDegreesCelsius(degreescelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesCelsius.
-        /// </summary>
-        public static Temperature? FromDegreesCelsius(long? degreescelsius)
-        {
-            if (degreescelsius.HasValue)
-            {
-                return FromDegreesCelsius(degreescelsius.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesCelsius of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesCelsius(decimal? degreescelsius)
+        public static Temperature? FromDegreesCelsius(QuantityValue? degreescelsius)
         {
             if (degreescelsius.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesDelisle.
         /// </summary>
-        public static Temperature? FromDegreesDelisle(double? degreesdelisle)
-        {
-            if (degreesdelisle.HasValue)
-            {
-                return FromDegreesDelisle(degreesdelisle.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesDelisle.
-        /// </summary>
-        public static Temperature? FromDegreesDelisle(int? degreesdelisle)
-        {
-            if (degreesdelisle.HasValue)
-            {
-                return FromDegreesDelisle(degreesdelisle.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesDelisle.
-        /// </summary>
-        public static Temperature? FromDegreesDelisle(long? degreesdelisle)
-        {
-            if (degreesdelisle.HasValue)
-            {
-                return FromDegreesDelisle(degreesdelisle.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesDelisle of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesDelisle(decimal? degreesdelisle)
+        public static Temperature? FromDegreesDelisle(QuantityValue? degreesdelisle)
         {
             if (degreesdelisle.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesFahrenheit.
         /// </summary>
-        public static Temperature? FromDegreesFahrenheit(double? degreesfahrenheit)
-        {
-            if (degreesfahrenheit.HasValue)
-            {
-                return FromDegreesFahrenheit(degreesfahrenheit.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesFahrenheit.
-        /// </summary>
-        public static Temperature? FromDegreesFahrenheit(int? degreesfahrenheit)
-        {
-            if (degreesfahrenheit.HasValue)
-            {
-                return FromDegreesFahrenheit(degreesfahrenheit.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesFahrenheit.
-        /// </summary>
-        public static Temperature? FromDegreesFahrenheit(long? degreesfahrenheit)
-        {
-            if (degreesfahrenheit.HasValue)
-            {
-                return FromDegreesFahrenheit(degreesfahrenheit.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesFahrenheit of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesFahrenheit(decimal? degreesfahrenheit)
+        public static Temperature? FromDegreesFahrenheit(QuantityValue? degreesfahrenheit)
         {
             if (degreesfahrenheit.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesNewton.
         /// </summary>
-        public static Temperature? FromDegreesNewton(double? degreesnewton)
-        {
-            if (degreesnewton.HasValue)
-            {
-                return FromDegreesNewton(degreesnewton.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesNewton.
-        /// </summary>
-        public static Temperature? FromDegreesNewton(int? degreesnewton)
-        {
-            if (degreesnewton.HasValue)
-            {
-                return FromDegreesNewton(degreesnewton.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesNewton.
-        /// </summary>
-        public static Temperature? FromDegreesNewton(long? degreesnewton)
-        {
-            if (degreesnewton.HasValue)
-            {
-                return FromDegreesNewton(degreesnewton.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesNewton of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesNewton(decimal? degreesnewton)
+        public static Temperature? FromDegreesNewton(QuantityValue? degreesnewton)
         {
             if (degreesnewton.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesRankine.
         /// </summary>
-        public static Temperature? FromDegreesRankine(double? degreesrankine)
-        {
-            if (degreesrankine.HasValue)
-            {
-                return FromDegreesRankine(degreesrankine.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesRankine.
-        /// </summary>
-        public static Temperature? FromDegreesRankine(int? degreesrankine)
-        {
-            if (degreesrankine.HasValue)
-            {
-                return FromDegreesRankine(degreesrankine.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesRankine.
-        /// </summary>
-        public static Temperature? FromDegreesRankine(long? degreesrankine)
-        {
-            if (degreesrankine.HasValue)
-            {
-                return FromDegreesRankine(degreesrankine.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesRankine of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesRankine(decimal? degreesrankine)
+        public static Temperature? FromDegreesRankine(QuantityValue? degreesrankine)
         {
             if (degreesrankine.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesReaumur.
         /// </summary>
-        public static Temperature? FromDegreesReaumur(double? degreesreaumur)
-        {
-            if (degreesreaumur.HasValue)
-            {
-                return FromDegreesReaumur(degreesreaumur.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesReaumur.
-        /// </summary>
-        public static Temperature? FromDegreesReaumur(int? degreesreaumur)
-        {
-            if (degreesreaumur.HasValue)
-            {
-                return FromDegreesReaumur(degreesreaumur.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesReaumur.
-        /// </summary>
-        public static Temperature? FromDegreesReaumur(long? degreesreaumur)
-        {
-            if (degreesreaumur.HasValue)
-            {
-                return FromDegreesReaumur(degreesreaumur.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesReaumur of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesReaumur(decimal? degreesreaumur)
+        public static Temperature? FromDegreesReaumur(QuantityValue? degreesreaumur)
         {
             if (degreesreaumur.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable DegreesRoemer.
         /// </summary>
-        public static Temperature? FromDegreesRoemer(double? degreesroemer)
-        {
-            if (degreesroemer.HasValue)
-            {
-                return FromDegreesRoemer(degreesroemer.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesRoemer.
-        /// </summary>
-        public static Temperature? FromDegreesRoemer(int? degreesroemer)
-        {
-            if (degreesroemer.HasValue)
-            {
-                return FromDegreesRoemer(degreesroemer.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable DegreesRoemer.
-        /// </summary>
-        public static Temperature? FromDegreesRoemer(long? degreesroemer)
-        {
-            if (degreesroemer.HasValue)
-            {
-                return FromDegreesRoemer(degreesroemer.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from DegreesRoemer of type decimal.
-        /// </summary>
-        public static Temperature? FromDegreesRoemer(decimal? degreesroemer)
+        public static Temperature? FromDegreesRoemer(QuantityValue? degreesroemer)
         {
             if (degreesroemer.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Temperature from nullable Kelvins.
         /// </summary>
-        public static Temperature? FromKelvins(double? kelvins)
-        {
-            if (kelvins.HasValue)
-            {
-                return FromKelvins(kelvins.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable Kelvins.
-        /// </summary>
-        public static Temperature? FromKelvins(int? kelvins)
-        {
-            if (kelvins.HasValue)
-            {
-                return FromKelvins(kelvins.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from nullable Kelvins.
-        /// </summary>
-        public static Temperature? FromKelvins(long? kelvins)
-        {
-            if (kelvins.HasValue)
-            {
-                return FromKelvins(kelvins.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Temperature from Kelvins of type decimal.
-        /// </summary>
-        public static Temperature? FromKelvins(decimal? kelvins)
+        public static Temperature? FromKelvins(QuantityValue? kelvins)
         {
             if (kelvins.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="TemperatureUnit" /> to <see cref="Temperature" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Temperature unit value.</returns>
-        public static Temperature From(double val, TemperatureUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Temperature From(double value, TemperatureUnit fromUnit)
+#else
+        public static Temperature From(QuantityValue value, TemperatureUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case TemperatureUnit.DegreeCelsius:
-                    return FromDegreesCelsius(val);
+                    return FromDegreesCelsius(value);
                 case TemperatureUnit.DegreeDelisle:
-                    return FromDegreesDelisle(val);
+                    return FromDegreesDelisle(value);
                 case TemperatureUnit.DegreeFahrenheit:
-                    return FromDegreesFahrenheit(val);
+                    return FromDegreesFahrenheit(value);
                 case TemperatureUnit.DegreeNewton:
-                    return FromDegreesNewton(val);
+                    return FromDegreesNewton(value);
                 case TemperatureUnit.DegreeRankine:
-                    return FromDegreesRankine(val);
+                    return FromDegreesRankine(value);
                 case TemperatureUnit.DegreeReaumur:
-                    return FromDegreesReaumur(val);
+                    return FromDegreesReaumur(value);
                 case TemperatureUnit.DegreeRoemer:
-                    return FromDegreesRoemer(val);
+                    return FromDegreesRoemer(value);
                 case TemperatureUnit.Kelvin:
-                    return FromKelvins(val);
+                    return FromKelvins(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Temperature unit value.</returns>
-        public static Temperature? From(double? value, TemperatureUnit fromUnit)
+        public static Temperature? From(QuantityValue? value, TemperatureUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -221,380 +221,180 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(double centidegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
+            double value = (double) centidegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(int centidegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(QuantityValue centidegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(long centidegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((centidegreescelsiuspersecond) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(decimal centidegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(centidegreescelsiuspersecond)) * 1e-2d);
+            double value = (double) centidegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(double decadegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
+            double value = (double) decadegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e1d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(int decadegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(QuantityValue decadegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(long decadegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((decadegreescelsiuspersecond) * 1e1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(decimal decadegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(decadegreescelsiuspersecond)) * 1e1d);
+            double value = (double) decadegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e1d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(double decidegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
+            double value = (double) decidegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(int decidegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(QuantityValue decidegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(long decidegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((decidegreescelsiuspersecond) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(decimal decidegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(decidegreescelsiuspersecond)) * 1e-1d);
+            double value = (double) decidegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(double degreescelsiusperminute)
         {
-            return new TemperatureChangeRate(degreescelsiusperminute/60);
+            double value = (double) degreescelsiusperminute;
+            return new TemperatureChangeRate(value/60);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
-        /// </summary>
-        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(int degreescelsiusperminute)
+#else
+        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(QuantityValue degreescelsiusperminute)
         {
-            return new TemperatureChangeRate(degreescelsiusperminute/60);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
-        /// </summary>
-        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(long degreescelsiusperminute)
-        {
-            return new TemperatureChangeRate(degreescelsiusperminute/60);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromDegreesCelsiusPerMinute(decimal degreescelsiusperminute)
-        {
-            return new TemperatureChangeRate(Convert.ToDouble(degreescelsiusperminute)/60);
+            double value = (double) degreescelsiusperminute;
+            return new TemperatureChangeRate((value/60));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(double degreescelsiuspersecond)
         {
-            return new TemperatureChangeRate(degreescelsiuspersecond);
+            double value = (double) degreescelsiuspersecond;
+            return new TemperatureChangeRate(value);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(int degreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(QuantityValue degreescelsiuspersecond)
         {
-            return new TemperatureChangeRate(degreescelsiuspersecond);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(long degreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate(degreescelsiuspersecond);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromDegreesCelsiusPerSecond(decimal degreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate(Convert.ToDouble(degreescelsiuspersecond));
+            double value = (double) degreescelsiuspersecond;
+            return new TemperatureChangeRate((value));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(double hectodegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
+            double value = (double) hectodegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(int hectodegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(QuantityValue hectodegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(long hectodegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((hectodegreescelsiuspersecond) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(decimal hectodegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(hectodegreescelsiuspersecond)) * 1e2d);
+            double value = (double) hectodegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(double kilodegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
+            double value = (double) kilodegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(int kilodegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(QuantityValue kilodegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(long kilodegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((kilodegreescelsiuspersecond) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(decimal kilodegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(kilodegreescelsiuspersecond)) * 1e3d);
+            double value = (double) kilodegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(double microdegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
+            double value = (double) microdegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(int microdegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(QuantityValue microdegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(long microdegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((microdegreescelsiuspersecond) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(decimal microdegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(microdegreescelsiuspersecond)) * 1e-6d);
+            double value = (double) microdegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(double millidegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
+            double value = (double) millidegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(int millidegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(QuantityValue millidegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(long millidegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((millidegreescelsiuspersecond) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(decimal millidegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(millidegreescelsiuspersecond)) * 1e-3d);
+            double value = (double) millidegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(double nanodegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
+            double value = (double) nanodegreescelsiuspersecond;
+            return new TemperatureChangeRate((value) * 1e-9d);
         }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(int nanodegreescelsiuspersecond)
+#else
+        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(QuantityValue nanodegreescelsiuspersecond)
         {
-            return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
-        }
-
-        /// <summary>
-        ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(long nanodegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((nanodegreescelsiuspersecond) * 1e-9d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(decimal nanodegreescelsiuspersecond)
-        {
-            return new TemperatureChangeRate((Convert.ToDouble(nanodegreescelsiuspersecond)) * 1e-9d);
+            double value = (double) nanodegreescelsiuspersecond;
+            return new TemperatureChangeRate(((value) * 1e-9d));
         }
 #endif
 
@@ -603,52 +403,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(double? centidegreescelsiuspersecond)
-        {
-            if (centidegreescelsiuspersecond.HasValue)
-            {
-                return FromCentidegreesCelsiusPerSecond(centidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(int? centidegreescelsiuspersecond)
-        {
-            if (centidegreescelsiuspersecond.HasValue)
-            {
-                return FromCentidegreesCelsiusPerSecond(centidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable CentidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(long? centidegreescelsiuspersecond)
-        {
-            if (centidegreescelsiuspersecond.HasValue)
-            {
-                return FromCentidegreesCelsiusPerSecond(centidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from CentidegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(decimal? centidegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromCentidegreesCelsiusPerSecond(QuantityValue? centidegreescelsiuspersecond)
         {
             if (centidegreescelsiuspersecond.HasValue)
             {
@@ -663,52 +418,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(double? decadegreescelsiuspersecond)
-        {
-            if (decadegreescelsiuspersecond.HasValue)
-            {
-                return FromDecadegreesCelsiusPerSecond(decadegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(int? decadegreescelsiuspersecond)
-        {
-            if (decadegreescelsiuspersecond.HasValue)
-            {
-                return FromDecadegreesCelsiusPerSecond(decadegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DecadegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(long? decadegreescelsiuspersecond)
-        {
-            if (decadegreescelsiuspersecond.HasValue)
-            {
-                return FromDecadegreesCelsiusPerSecond(decadegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from DecadegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(decimal? decadegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromDecadegreesCelsiusPerSecond(QuantityValue? decadegreescelsiuspersecond)
         {
             if (decadegreescelsiuspersecond.HasValue)
             {
@@ -723,52 +433,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(double? decidegreescelsiuspersecond)
-        {
-            if (decidegreescelsiuspersecond.HasValue)
-            {
-                return FromDecidegreesCelsiusPerSecond(decidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(int? decidegreescelsiuspersecond)
-        {
-            if (decidegreescelsiuspersecond.HasValue)
-            {
-                return FromDecidegreesCelsiusPerSecond(decidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DecidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(long? decidegreescelsiuspersecond)
-        {
-            if (decidegreescelsiuspersecond.HasValue)
-            {
-                return FromDecidegreesCelsiusPerSecond(decidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from DecidegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(decimal? decidegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromDecidegreesCelsiusPerSecond(QuantityValue? decidegreescelsiuspersecond)
         {
             if (decidegreescelsiuspersecond.HasValue)
             {
@@ -783,52 +448,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
         /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(double? degreescelsiusperminute)
-        {
-            if (degreescelsiusperminute.HasValue)
-            {
-                return FromDegreesCelsiusPerMinute(degreescelsiusperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
-        /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(int? degreescelsiusperminute)
-        {
-            if (degreescelsiusperminute.HasValue)
-            {
-                return FromDegreesCelsiusPerMinute(degreescelsiusperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerMinute.
-        /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(long? degreescelsiusperminute)
-        {
-            if (degreescelsiusperminute.HasValue)
-            {
-                return FromDegreesCelsiusPerMinute(degreescelsiusperminute.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from DegreesCelsiusPerMinute of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(decimal? degreescelsiusperminute)
+        public static TemperatureChangeRate? FromDegreesCelsiusPerMinute(QuantityValue? degreescelsiusperminute)
         {
             if (degreescelsiusperminute.HasValue)
             {
@@ -843,52 +463,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(double? degreescelsiuspersecond)
-        {
-            if (degreescelsiuspersecond.HasValue)
-            {
-                return FromDegreesCelsiusPerSecond(degreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(int? degreescelsiuspersecond)
-        {
-            if (degreescelsiuspersecond.HasValue)
-            {
-                return FromDegreesCelsiusPerSecond(degreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable DegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(long? degreescelsiuspersecond)
-        {
-            if (degreescelsiuspersecond.HasValue)
-            {
-                return FromDegreesCelsiusPerSecond(degreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from DegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(decimal? degreescelsiuspersecond)
+        public static TemperatureChangeRate? FromDegreesCelsiusPerSecond(QuantityValue? degreescelsiuspersecond)
         {
             if (degreescelsiuspersecond.HasValue)
             {
@@ -903,52 +478,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(double? hectodegreescelsiuspersecond)
-        {
-            if (hectodegreescelsiuspersecond.HasValue)
-            {
-                return FromHectodegreesCelsiusPerSecond(hectodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(int? hectodegreescelsiuspersecond)
-        {
-            if (hectodegreescelsiuspersecond.HasValue)
-            {
-                return FromHectodegreesCelsiusPerSecond(hectodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable HectodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(long? hectodegreescelsiuspersecond)
-        {
-            if (hectodegreescelsiuspersecond.HasValue)
-            {
-                return FromHectodegreesCelsiusPerSecond(hectodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from HectodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(decimal? hectodegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromHectodegreesCelsiusPerSecond(QuantityValue? hectodegreescelsiuspersecond)
         {
             if (hectodegreescelsiuspersecond.HasValue)
             {
@@ -963,52 +493,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(double? kilodegreescelsiuspersecond)
-        {
-            if (kilodegreescelsiuspersecond.HasValue)
-            {
-                return FromKilodegreesCelsiusPerSecond(kilodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(int? kilodegreescelsiuspersecond)
-        {
-            if (kilodegreescelsiuspersecond.HasValue)
-            {
-                return FromKilodegreesCelsiusPerSecond(kilodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable KilodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(long? kilodegreescelsiuspersecond)
-        {
-            if (kilodegreescelsiuspersecond.HasValue)
-            {
-                return FromKilodegreesCelsiusPerSecond(kilodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from KilodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(decimal? kilodegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromKilodegreesCelsiusPerSecond(QuantityValue? kilodegreescelsiuspersecond)
         {
             if (kilodegreescelsiuspersecond.HasValue)
             {
@@ -1023,52 +508,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(double? microdegreescelsiuspersecond)
-        {
-            if (microdegreescelsiuspersecond.HasValue)
-            {
-                return FromMicrodegreesCelsiusPerSecond(microdegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(int? microdegreescelsiuspersecond)
-        {
-            if (microdegreescelsiuspersecond.HasValue)
-            {
-                return FromMicrodegreesCelsiusPerSecond(microdegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable MicrodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(long? microdegreescelsiuspersecond)
-        {
-            if (microdegreescelsiuspersecond.HasValue)
-            {
-                return FromMicrodegreesCelsiusPerSecond(microdegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from MicrodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(decimal? microdegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromMicrodegreesCelsiusPerSecond(QuantityValue? microdegreescelsiuspersecond)
         {
             if (microdegreescelsiuspersecond.HasValue)
             {
@@ -1083,52 +523,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(double? millidegreescelsiuspersecond)
-        {
-            if (millidegreescelsiuspersecond.HasValue)
-            {
-                return FromMillidegreesCelsiusPerSecond(millidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(int? millidegreescelsiuspersecond)
-        {
-            if (millidegreescelsiuspersecond.HasValue)
-            {
-                return FromMillidegreesCelsiusPerSecond(millidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable MillidegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(long? millidegreescelsiuspersecond)
-        {
-            if (millidegreescelsiuspersecond.HasValue)
-            {
-                return FromMillidegreesCelsiusPerSecond(millidegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from MillidegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(decimal? millidegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromMillidegreesCelsiusPerSecond(QuantityValue? millidegreescelsiuspersecond)
         {
             if (millidegreescelsiuspersecond.HasValue)
             {
@@ -1143,52 +538,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(double? nanodegreescelsiuspersecond)
-        {
-            if (nanodegreescelsiuspersecond.HasValue)
-            {
-                return FromNanodegreesCelsiusPerSecond(nanodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(int? nanodegreescelsiuspersecond)
-        {
-            if (nanodegreescelsiuspersecond.HasValue)
-            {
-                return FromNanodegreesCelsiusPerSecond(nanodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from nullable NanodegreesCelsiusPerSecond.
-        /// </summary>
-        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(long? nanodegreescelsiuspersecond)
-        {
-            if (nanodegreescelsiuspersecond.HasValue)
-            {
-                return FromNanodegreesCelsiusPerSecond(nanodegreescelsiuspersecond.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureChangeRate from NanodegreesCelsiusPerSecond of type decimal.
-        /// </summary>
-        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(decimal? nanodegreescelsiuspersecond)
+        public static TemperatureChangeRate? FromNanodegreesCelsiusPerSecond(QuantityValue? nanodegreescelsiuspersecond)
         {
             if (nanodegreescelsiuspersecond.HasValue)
             {
@@ -1205,33 +555,39 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="TemperatureChangeRateUnit" /> to <see cref="TemperatureChangeRate" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>TemperatureChangeRate unit value.</returns>
-        public static TemperatureChangeRate From(double val, TemperatureChangeRateUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static TemperatureChangeRate From(double value, TemperatureChangeRateUnit fromUnit)
+#else
+        public static TemperatureChangeRate From(QuantityValue value, TemperatureChangeRateUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case TemperatureChangeRateUnit.CentidegreeCelsiusPerSecond:
-                    return FromCentidegreesCelsiusPerSecond(val);
+                    return FromCentidegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.DecadegreeCelsiusPerSecond:
-                    return FromDecadegreesCelsiusPerSecond(val);
+                    return FromDecadegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.DecidegreeCelsiusPerSecond:
-                    return FromDecidegreesCelsiusPerSecond(val);
+                    return FromDecidegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.DegreeCelsiusPerMinute:
-                    return FromDegreesCelsiusPerMinute(val);
+                    return FromDegreesCelsiusPerMinute(value);
                 case TemperatureChangeRateUnit.DegreeCelsiusPerSecond:
-                    return FromDegreesCelsiusPerSecond(val);
+                    return FromDegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.HectodegreeCelsiusPerSecond:
-                    return FromHectodegreesCelsiusPerSecond(val);
+                    return FromHectodegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.KilodegreeCelsiusPerSecond:
-                    return FromKilodegreesCelsiusPerSecond(val);
+                    return FromKilodegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.MicrodegreeCelsiusPerSecond:
-                    return FromMicrodegreesCelsiusPerSecond(val);
+                    return FromMicrodegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.MillidegreeCelsiusPerSecond:
-                    return FromMillidegreesCelsiusPerSecond(val);
+                    return FromMillidegreesCelsiusPerSecond(value);
                 case TemperatureChangeRateUnit.NanodegreeCelsiusPerSecond:
-                    return FromNanodegreesCelsiusPerSecond(val);
+                    return FromNanodegreesCelsiusPerSecond(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1246,7 +602,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>TemperatureChangeRate unit value.</returns>
-        public static TemperatureChangeRate? From(double? value, TemperatureChangeRateUnit fromUnit)
+        public static TemperatureChangeRate? From(QuantityValue? value, TemperatureChangeRateUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -205,304 +205,144 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesCelsiusDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesCelsiusDelta(double degreescelsiusdelta)
         {
-            return new TemperatureDelta(degreescelsiusdelta);
+            double value = (double) degreescelsiusdelta;
+            return new TemperatureDelta(value);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesCelsiusDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesCelsiusDelta(int degreescelsiusdelta)
+#else
+        public static TemperatureDelta FromDegreesCelsiusDelta(QuantityValue degreescelsiusdelta)
         {
-            return new TemperatureDelta(degreescelsiusdelta);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesCelsiusDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesCelsiusDelta(long degreescelsiusdelta)
-        {
-            return new TemperatureDelta(degreescelsiusdelta);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesCelsiusDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesCelsiusDelta(decimal degreescelsiusdelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreescelsiusdelta));
+            double value = (double) degreescelsiusdelta;
+            return new TemperatureDelta((value));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesDelisleDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesDelisleDelta(double degreesdelisledelta)
         {
-            return new TemperatureDelta(degreesdelisledelta*-2/3);
+            double value = (double) degreesdelisledelta;
+            return new TemperatureDelta(value*-2/3);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesDelisleDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesDelisleDelta(int degreesdelisledelta)
+#else
+        public static TemperatureDelta FromDegreesDelisleDelta(QuantityValue degreesdelisledelta)
         {
-            return new TemperatureDelta(degreesdelisledelta*-2/3);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesDelisleDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesDelisleDelta(long degreesdelisledelta)
-        {
-            return new TemperatureDelta(degreesdelisledelta*-2/3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesDelisleDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesDelisleDelta(decimal degreesdelisledelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreesdelisledelta)*-2/3);
+            double value = (double) degreesdelisledelta;
+            return new TemperatureDelta((value*-2/3));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheitDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesFahrenheitDelta(double degreesfahrenheitdelta)
         {
-            return new TemperatureDelta(degreesfahrenheitdelta*5/9);
+            double value = (double) degreesfahrenheitdelta;
+            return new TemperatureDelta(value*5/9);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesFahrenheitDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesFahrenheitDelta(int degreesfahrenheitdelta)
+#else
+        public static TemperatureDelta FromDegreesFahrenheitDelta(QuantityValue degreesfahrenheitdelta)
         {
-            return new TemperatureDelta(degreesfahrenheitdelta*5/9);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesFahrenheitDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesFahrenheitDelta(long degreesfahrenheitdelta)
-        {
-            return new TemperatureDelta(degreesfahrenheitdelta*5/9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesFahrenheitDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesFahrenheitDelta(decimal degreesfahrenheitdelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreesfahrenheitdelta)*5/9);
+            double value = (double) degreesfahrenheitdelta;
+            return new TemperatureDelta((value*5/9));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesNewtonDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesNewtonDelta(double degreesnewtondelta)
         {
-            return new TemperatureDelta(degreesnewtondelta*100/33);
+            double value = (double) degreesnewtondelta;
+            return new TemperatureDelta(value*100/33);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesNewtonDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesNewtonDelta(int degreesnewtondelta)
+#else
+        public static TemperatureDelta FromDegreesNewtonDelta(QuantityValue degreesnewtondelta)
         {
-            return new TemperatureDelta(degreesnewtondelta*100/33);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesNewtonDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesNewtonDelta(long degreesnewtondelta)
-        {
-            return new TemperatureDelta(degreesnewtondelta*100/33);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesNewtonDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesNewtonDelta(decimal degreesnewtondelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreesnewtondelta)*100/33);
+            double value = (double) degreesnewtondelta;
+            return new TemperatureDelta((value*100/33));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesRankineDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesRankineDelta(double degreesrankinedelta)
         {
-            return new TemperatureDelta(degreesrankinedelta*5/9);
+            double value = (double) degreesrankinedelta;
+            return new TemperatureDelta(value*5/9);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesRankineDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesRankineDelta(int degreesrankinedelta)
+#else
+        public static TemperatureDelta FromDegreesRankineDelta(QuantityValue degreesrankinedelta)
         {
-            return new TemperatureDelta(degreesrankinedelta*5/9);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesRankineDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesRankineDelta(long degreesrankinedelta)
-        {
-            return new TemperatureDelta(degreesrankinedelta*5/9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesRankineDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesRankineDelta(decimal degreesrankinedelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreesrankinedelta)*5/9);
+            double value = (double) degreesrankinedelta;
+            return new TemperatureDelta((value*5/9));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesReaumurDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesReaumurDelta(double degreesreaumurdelta)
         {
-            return new TemperatureDelta(degreesreaumurdelta*5/4);
+            double value = (double) degreesreaumurdelta;
+            return new TemperatureDelta(value*5/4);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesReaumurDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesReaumurDelta(int degreesreaumurdelta)
+#else
+        public static TemperatureDelta FromDegreesReaumurDelta(QuantityValue degreesreaumurdelta)
         {
-            return new TemperatureDelta(degreesreaumurdelta*5/4);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesReaumurDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesReaumurDelta(long degreesreaumurdelta)
-        {
-            return new TemperatureDelta(degreesreaumurdelta*5/4);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesReaumurDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesReaumurDelta(decimal degreesreaumurdelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreesreaumurdelta)*5/4);
+            double value = (double) degreesreaumurdelta;
+            return new TemperatureDelta((value*5/4));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from DegreesRoemerDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromDegreesRoemerDelta(double degreesroemerdelta)
         {
-            return new TemperatureDelta(degreesroemerdelta*40/21);
+            double value = (double) degreesroemerdelta;
+            return new TemperatureDelta(value*40/21);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesRoemerDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesRoemerDelta(int degreesroemerdelta)
+#else
+        public static TemperatureDelta FromDegreesRoemerDelta(QuantityValue degreesroemerdelta)
         {
-            return new TemperatureDelta(degreesroemerdelta*40/21);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesRoemerDelta.
-        /// </summary>
-        public static TemperatureDelta FromDegreesRoemerDelta(long degreesroemerdelta)
-        {
-            return new TemperatureDelta(degreesroemerdelta*40/21);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from DegreesRoemerDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromDegreesRoemerDelta(decimal degreesroemerdelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(degreesroemerdelta)*40/21);
+            double value = (double) degreesroemerdelta;
+            return new TemperatureDelta((value*40/21));
         }
 #endif
 
         /// <summary>
         ///     Get TemperatureDelta from KelvinsDelta.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static TemperatureDelta FromKelvinsDelta(double kelvinsdelta)
         {
-            return new TemperatureDelta(kelvinsdelta);
+            double value = (double) kelvinsdelta;
+            return new TemperatureDelta(value);
         }
-
-        /// <summary>
-        ///     Get TemperatureDelta from KelvinsDelta.
-        /// </summary>
-        public static TemperatureDelta FromKelvinsDelta(int kelvinsdelta)
+#else
+        public static TemperatureDelta FromKelvinsDelta(QuantityValue kelvinsdelta)
         {
-            return new TemperatureDelta(kelvinsdelta);
-        }
-
-        /// <summary>
-        ///     Get TemperatureDelta from KelvinsDelta.
-        /// </summary>
-        public static TemperatureDelta FromKelvinsDelta(long kelvinsdelta)
-        {
-            return new TemperatureDelta(kelvinsdelta);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get TemperatureDelta from KelvinsDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta FromKelvinsDelta(decimal kelvinsdelta)
-        {
-            return new TemperatureDelta(Convert.ToDouble(kelvinsdelta));
+            double value = (double) kelvinsdelta;
+            return new TemperatureDelta((value));
         }
 #endif
 
@@ -511,52 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesCelsiusDelta(double? degreescelsiusdelta)
-        {
-            if (degreescelsiusdelta.HasValue)
-            {
-                return FromDegreesCelsiusDelta(degreescelsiusdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesCelsiusDelta(int? degreescelsiusdelta)
-        {
-            if (degreescelsiusdelta.HasValue)
-            {
-                return FromDegreesCelsiusDelta(degreescelsiusdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesCelsiusDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesCelsiusDelta(long? degreescelsiusdelta)
-        {
-            if (degreescelsiusdelta.HasValue)
-            {
-                return FromDegreesCelsiusDelta(degreescelsiusdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesCelsiusDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesCelsiusDelta(decimal? degreescelsiusdelta)
+        public static TemperatureDelta? FromDegreesCelsiusDelta(QuantityValue? degreescelsiusdelta)
         {
             if (degreescelsiusdelta.HasValue)
             {
@@ -571,52 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesDelisleDelta(double? degreesdelisledelta)
-        {
-            if (degreesdelisledelta.HasValue)
-            {
-                return FromDegreesDelisleDelta(degreesdelisledelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesDelisleDelta(int? degreesdelisledelta)
-        {
-            if (degreesdelisledelta.HasValue)
-            {
-                return FromDegreesDelisleDelta(degreesdelisledelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesDelisleDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesDelisleDelta(long? degreesdelisledelta)
-        {
-            if (degreesdelisledelta.HasValue)
-            {
-                return FromDegreesDelisleDelta(degreesdelisledelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesDelisleDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesDelisleDelta(decimal? degreesdelisledelta)
+        public static TemperatureDelta? FromDegreesDelisleDelta(QuantityValue? degreesdelisledelta)
         {
             if (degreesdelisledelta.HasValue)
             {
@@ -631,52 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesFahrenheitDelta(double? degreesfahrenheitdelta)
-        {
-            if (degreesfahrenheitdelta.HasValue)
-            {
-                return FromDegreesFahrenheitDelta(degreesfahrenheitdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesFahrenheitDelta(int? degreesfahrenheitdelta)
-        {
-            if (degreesfahrenheitdelta.HasValue)
-            {
-                return FromDegreesFahrenheitDelta(degreesfahrenheitdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesFahrenheitDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesFahrenheitDelta(long? degreesfahrenheitdelta)
-        {
-            if (degreesfahrenheitdelta.HasValue)
-            {
-                return FromDegreesFahrenheitDelta(degreesfahrenheitdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesFahrenheitDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesFahrenheitDelta(decimal? degreesfahrenheitdelta)
+        public static TemperatureDelta? FromDegreesFahrenheitDelta(QuantityValue? degreesfahrenheitdelta)
         {
             if (degreesfahrenheitdelta.HasValue)
             {
@@ -691,52 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesNewtonDelta(double? degreesnewtondelta)
-        {
-            if (degreesnewtondelta.HasValue)
-            {
-                return FromDegreesNewtonDelta(degreesnewtondelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesNewtonDelta(int? degreesnewtondelta)
-        {
-            if (degreesnewtondelta.HasValue)
-            {
-                return FromDegreesNewtonDelta(degreesnewtondelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesNewtonDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesNewtonDelta(long? degreesnewtondelta)
-        {
-            if (degreesnewtondelta.HasValue)
-            {
-                return FromDegreesNewtonDelta(degreesnewtondelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesNewtonDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesNewtonDelta(decimal? degreesnewtondelta)
+        public static TemperatureDelta? FromDegreesNewtonDelta(QuantityValue? degreesnewtondelta)
         {
             if (degreesnewtondelta.HasValue)
             {
@@ -751,52 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesRankineDelta(double? degreesrankinedelta)
-        {
-            if (degreesrankinedelta.HasValue)
-            {
-                return FromDegreesRankineDelta(degreesrankinedelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesRankineDelta(int? degreesrankinedelta)
-        {
-            if (degreesrankinedelta.HasValue)
-            {
-                return FromDegreesRankineDelta(degreesrankinedelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesRankineDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesRankineDelta(long? degreesrankinedelta)
-        {
-            if (degreesrankinedelta.HasValue)
-            {
-                return FromDegreesRankineDelta(degreesrankinedelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesRankineDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesRankineDelta(decimal? degreesrankinedelta)
+        public static TemperatureDelta? FromDegreesRankineDelta(QuantityValue? degreesrankinedelta)
         {
             if (degreesrankinedelta.HasValue)
             {
@@ -811,52 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesReaumurDelta(double? degreesreaumurdelta)
-        {
-            if (degreesreaumurdelta.HasValue)
-            {
-                return FromDegreesReaumurDelta(degreesreaumurdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesReaumurDelta(int? degreesreaumurdelta)
-        {
-            if (degreesreaumurdelta.HasValue)
-            {
-                return FromDegreesReaumurDelta(degreesreaumurdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesReaumurDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesReaumurDelta(long? degreesreaumurdelta)
-        {
-            if (degreesreaumurdelta.HasValue)
-            {
-                return FromDegreesReaumurDelta(degreesreaumurdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesReaumurDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesReaumurDelta(decimal? degreesreaumurdelta)
+        public static TemperatureDelta? FromDegreesReaumurDelta(QuantityValue? degreesreaumurdelta)
         {
             if (degreesreaumurdelta.HasValue)
             {
@@ -871,52 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
         /// </summary>
-        public static TemperatureDelta? FromDegreesRoemerDelta(double? degreesroemerdelta)
-        {
-            if (degreesroemerdelta.HasValue)
-            {
-                return FromDegreesRoemerDelta(degreesroemerdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesRoemerDelta(int? degreesroemerdelta)
-        {
-            if (degreesroemerdelta.HasValue)
-            {
-                return FromDegreesRoemerDelta(degreesroemerdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable DegreesRoemerDelta.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesRoemerDelta(long? degreesroemerdelta)
-        {
-            if (degreesroemerdelta.HasValue)
-            {
-                return FromDegreesRoemerDelta(degreesroemerdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from DegreesRoemerDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromDegreesRoemerDelta(decimal? degreesroemerdelta)
+        public static TemperatureDelta? FromDegreesRoemerDelta(QuantityValue? degreesroemerdelta)
         {
             if (degreesroemerdelta.HasValue)
             {
@@ -931,52 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
         /// </summary>
-        public static TemperatureDelta? FromKelvinsDelta(double? kelvinsdelta)
-        {
-            if (kelvinsdelta.HasValue)
-            {
-                return FromKelvinsDelta(kelvinsdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
-        /// </summary>
-        public static TemperatureDelta? FromKelvinsDelta(int? kelvinsdelta)
-        {
-            if (kelvinsdelta.HasValue)
-            {
-                return FromKelvinsDelta(kelvinsdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from nullable KelvinsDelta.
-        /// </summary>
-        public static TemperatureDelta? FromKelvinsDelta(long? kelvinsdelta)
-        {
-            if (kelvinsdelta.HasValue)
-            {
-                return FromKelvinsDelta(kelvinsdelta.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable TemperatureDelta from KelvinsDelta of type decimal.
-        /// </summary>
-        public static TemperatureDelta? FromKelvinsDelta(decimal? kelvinsdelta)
+        public static TemperatureDelta? FromKelvinsDelta(QuantityValue? kelvinsdelta)
         {
             if (kelvinsdelta.HasValue)
             {
@@ -993,29 +473,35 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="TemperatureDeltaUnit" /> to <see cref="TemperatureDelta" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>TemperatureDelta unit value.</returns>
-        public static TemperatureDelta From(double val, TemperatureDeltaUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static TemperatureDelta From(double value, TemperatureDeltaUnit fromUnit)
+#else
+        public static TemperatureDelta From(QuantityValue value, TemperatureDeltaUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case TemperatureDeltaUnit.DegreeCelsiusDelta:
-                    return FromDegreesCelsiusDelta(val);
+                    return FromDegreesCelsiusDelta(value);
                 case TemperatureDeltaUnit.DegreeDelisleDelta:
-                    return FromDegreesDelisleDelta(val);
+                    return FromDegreesDelisleDelta(value);
                 case TemperatureDeltaUnit.DegreeFahrenheitDelta:
-                    return FromDegreesFahrenheitDelta(val);
+                    return FromDegreesFahrenheitDelta(value);
                 case TemperatureDeltaUnit.DegreeNewtonDelta:
-                    return FromDegreesNewtonDelta(val);
+                    return FromDegreesNewtonDelta(value);
                 case TemperatureDeltaUnit.DegreeRankineDelta:
-                    return FromDegreesRankineDelta(val);
+                    return FromDegreesRankineDelta(value);
                 case TemperatureDeltaUnit.DegreeReaumurDelta:
-                    return FromDegreesReaumurDelta(val);
+                    return FromDegreesReaumurDelta(value);
                 case TemperatureDeltaUnit.DegreeRoemerDelta:
-                    return FromDegreesRoemerDelta(val);
+                    return FromDegreesRoemerDelta(value);
                 case TemperatureDeltaUnit.KelvinDelta:
-                    return FromKelvinsDelta(val);
+                    return FromKelvinsDelta(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1030,7 +516,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>TemperatureDelta unit value.</returns>
-        public static TemperatureDelta? From(double? value, TemperatureDeltaUnit fromUnit)
+        public static TemperatureDelta? From(QuantityValue? value, TemperatureDeltaUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -181,190 +181,90 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(double hoursquarefeetdegreesfahrenheitperbtu)
         {
-            return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
+            double value = (double) hoursquarefeetdegreesfahrenheitperbtu;
+            return new ThermalResistance(value*176.1121482159839);
         }
-
-        /// <summary>
-        ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
-        /// </summary>
-        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(int hoursquarefeetdegreesfahrenheitperbtu)
+#else
+        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(QuantityValue hoursquarefeetdegreesfahrenheitperbtu)
         {
-            return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
-        }
-
-        /// <summary>
-        ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
-        /// </summary>
-        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(long hoursquarefeetdegreesfahrenheitperbtu)
-        {
-            return new ThermalResistance(hoursquarefeetdegreesfahrenheitperbtu*176.1121482159839);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu of type decimal.
-        /// </summary>
-        public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(decimal hoursquarefeetdegreesfahrenheitperbtu)
-        {
-            return new ThermalResistance(Convert.ToDouble(hoursquarefeetdegreesfahrenheitperbtu)*176.1121482159839);
+            double value = (double) hoursquarefeetdegreesfahrenheitperbtu;
+            return new ThermalResistance((value*176.1121482159839));
         }
 #endif
 
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(double squarecentimeterhourdegreescelsiusperkilocalorie)
         {
-            return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
+            double value = (double) squarecentimeterhourdegreescelsiusperkilocalorie;
+            return new ThermalResistance(value*0.0859779507590433);
         }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
-        /// </summary>
-        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(int squarecentimeterhourdegreescelsiusperkilocalorie)
+#else
+        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(QuantityValue squarecentimeterhourdegreescelsiusperkilocalorie)
         {
-            return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
-        }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
-        /// </summary>
-        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(long squarecentimeterhourdegreescelsiusperkilocalorie)
-        {
-            return new ThermalResistance(squarecentimeterhourdegreescelsiusperkilocalorie*0.0859779507590433);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie of type decimal.
-        /// </summary>
-        public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(decimal squarecentimeterhourdegreescelsiusperkilocalorie)
-        {
-            return new ThermalResistance(Convert.ToDouble(squarecentimeterhourdegreescelsiusperkilocalorie)*0.0859779507590433);
+            double value = (double) squarecentimeterhourdegreescelsiusperkilocalorie;
+            return new ThermalResistance((value*0.0859779507590433));
         }
 #endif
 
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(double squarecentimeterkelvinsperwatt)
         {
-            return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
+            double value = (double) squarecentimeterkelvinsperwatt;
+            return new ThermalResistance(value*0.0999964777570357);
         }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
-        /// </summary>
-        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(int squarecentimeterkelvinsperwatt)
+#else
+        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(QuantityValue squarecentimeterkelvinsperwatt)
         {
-            return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
-        }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
-        /// </summary>
-        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(long squarecentimeterkelvinsperwatt)
-        {
-            return new ThermalResistance(squarecentimeterkelvinsperwatt*0.0999964777570357);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt of type decimal.
-        /// </summary>
-        public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(decimal squarecentimeterkelvinsperwatt)
-        {
-            return new ThermalResistance(Convert.ToDouble(squarecentimeterkelvinsperwatt)*0.0999964777570357);
+            double value = (double) squarecentimeterkelvinsperwatt;
+            return new ThermalResistance((value*0.0999964777570357));
         }
 #endif
 
         /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(double squaremeterdegreescelsiusperwatt)
         {
-            return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
+            double value = (double) squaremeterdegreescelsiusperwatt;
+            return new ThermalResistance(value*1000.088056074108);
         }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
-        /// </summary>
-        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(int squaremeterdegreescelsiusperwatt)
+#else
+        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(QuantityValue squaremeterdegreescelsiusperwatt)
         {
-            return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
-        }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
-        /// </summary>
-        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(long squaremeterdegreescelsiusperwatt)
-        {
-            return new ThermalResistance(squaremeterdegreescelsiusperwatt*1000.088056074108);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt of type decimal.
-        /// </summary>
-        public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(decimal squaremeterdegreescelsiusperwatt)
-        {
-            return new ThermalResistance(Convert.ToDouble(squaremeterdegreescelsiusperwatt)*1000.088056074108);
+            double value = (double) squaremeterdegreescelsiusperwatt;
+            return new ThermalResistance((value*1000.088056074108));
         }
 #endif
 
         /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(double squaremeterkelvinsperkilowatt)
         {
-            return new ThermalResistance(squaremeterkelvinsperkilowatt);
+            double value = (double) squaremeterkelvinsperkilowatt;
+            return new ThermalResistance(value);
         }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
-        /// </summary>
-        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(int squaremeterkelvinsperkilowatt)
+#else
+        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(QuantityValue squaremeterkelvinsperkilowatt)
         {
-            return new ThermalResistance(squaremeterkelvinsperkilowatt);
-        }
-
-        /// <summary>
-        ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
-        /// </summary>
-        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(long squaremeterkelvinsperkilowatt)
-        {
-            return new ThermalResistance(squaremeterkelvinsperkilowatt);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt of type decimal.
-        /// </summary>
-        public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(decimal squaremeterkelvinsperkilowatt)
-        {
-            return new ThermalResistance(Convert.ToDouble(squaremeterkelvinsperkilowatt));
+            double value = (double) squaremeterkelvinsperkilowatt;
+            return new ThermalResistance((value));
         }
 #endif
 
@@ -373,52 +273,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
-        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(double? hoursquarefeetdegreesfahrenheitperbtu)
-        {
-            if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
-            {
-                return FromHourSquareFeetDegreesFahrenheitPerBtu(hoursquarefeetdegreesfahrenheitperbtu.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
-        /// </summary>
-        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(int? hoursquarefeetdegreesfahrenheitperbtu)
-        {
-            if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
-            {
-                return FromHourSquareFeetDegreesFahrenheitPerBtu(hoursquarefeetdegreesfahrenheitperbtu.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable HourSquareFeetDegreesFahrenheitPerBtu.
-        /// </summary>
-        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(long? hoursquarefeetdegreesfahrenheitperbtu)
-        {
-            if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
-            {
-                return FromHourSquareFeetDegreesFahrenheitPerBtu(hoursquarefeetdegreesfahrenheitperbtu.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu of type decimal.
-        /// </summary>
-        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(decimal? hoursquarefeetdegreesfahrenheitperbtu)
+        public static ThermalResistance? FromHourSquareFeetDegreesFahrenheitPerBtu(QuantityValue? hoursquarefeetdegreesfahrenheitperbtu)
         {
             if (hoursquarefeetdegreesfahrenheitperbtu.HasValue)
             {
@@ -433,52 +288,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
-        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(double? squarecentimeterhourdegreescelsiusperkilocalorie)
-        {
-            if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
-            {
-                return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(squarecentimeterhourdegreescelsiusperkilocalorie.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
-        /// </summary>
-        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(int? squarecentimeterhourdegreescelsiusperkilocalorie)
-        {
-            if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
-            {
-                return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(squarecentimeterhourdegreescelsiusperkilocalorie.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareCentimeterHourDegreesCelsiusPerKilocalorie.
-        /// </summary>
-        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(long? squarecentimeterhourdegreescelsiusperkilocalorie)
-        {
-            if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
-            {
-                return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(squarecentimeterhourdegreescelsiusperkilocalorie.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie of type decimal.
-        /// </summary>
-        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(decimal? squarecentimeterhourdegreescelsiusperkilocalorie)
+        public static ThermalResistance? FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(QuantityValue? squarecentimeterhourdegreescelsiusperkilocalorie)
         {
             if (squarecentimeterhourdegreescelsiusperkilocalorie.HasValue)
             {
@@ -493,52 +303,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
         /// </summary>
-        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(double? squarecentimeterkelvinsperwatt)
-        {
-            if (squarecentimeterkelvinsperwatt.HasValue)
-            {
-                return FromSquareCentimeterKelvinsPerWatt(squarecentimeterkelvinsperwatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
-        /// </summary>
-        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(int? squarecentimeterkelvinsperwatt)
-        {
-            if (squarecentimeterkelvinsperwatt.HasValue)
-            {
-                return FromSquareCentimeterKelvinsPerWatt(squarecentimeterkelvinsperwatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareCentimeterKelvinsPerWatt.
-        /// </summary>
-        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(long? squarecentimeterkelvinsperwatt)
-        {
-            if (squarecentimeterkelvinsperwatt.HasValue)
-            {
-                return FromSquareCentimeterKelvinsPerWatt(squarecentimeterkelvinsperwatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from SquareCentimeterKelvinsPerWatt of type decimal.
-        /// </summary>
-        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(decimal? squarecentimeterkelvinsperwatt)
+        public static ThermalResistance? FromSquareCentimeterKelvinsPerWatt(QuantityValue? squarecentimeterkelvinsperwatt)
         {
             if (squarecentimeterkelvinsperwatt.HasValue)
             {
@@ -553,52 +318,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
-        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(double? squaremeterdegreescelsiusperwatt)
-        {
-            if (squaremeterdegreescelsiusperwatt.HasValue)
-            {
-                return FromSquareMeterDegreesCelsiusPerWatt(squaremeterdegreescelsiusperwatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
-        /// </summary>
-        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(int? squaremeterdegreescelsiusperwatt)
-        {
-            if (squaremeterdegreescelsiusperwatt.HasValue)
-            {
-                return FromSquareMeterDegreesCelsiusPerWatt(squaremeterdegreescelsiusperwatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareMeterDegreesCelsiusPerWatt.
-        /// </summary>
-        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(long? squaremeterdegreescelsiusperwatt)
-        {
-            if (squaremeterdegreescelsiusperwatt.HasValue)
-            {
-                return FromSquareMeterDegreesCelsiusPerWatt(squaremeterdegreescelsiusperwatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from SquareMeterDegreesCelsiusPerWatt of type decimal.
-        /// </summary>
-        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(decimal? squaremeterdegreescelsiusperwatt)
+        public static ThermalResistance? FromSquareMeterDegreesCelsiusPerWatt(QuantityValue? squaremeterdegreescelsiusperwatt)
         {
             if (squaremeterdegreescelsiusperwatt.HasValue)
             {
@@ -613,52 +333,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
         /// </summary>
-        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(double? squaremeterkelvinsperkilowatt)
-        {
-            if (squaremeterkelvinsperkilowatt.HasValue)
-            {
-                return FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinsperkilowatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
-        /// </summary>
-        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(int? squaremeterkelvinsperkilowatt)
-        {
-            if (squaremeterkelvinsperkilowatt.HasValue)
-            {
-                return FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinsperkilowatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from nullable SquareMeterKelvinsPerKilowatt.
-        /// </summary>
-        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(long? squaremeterkelvinsperkilowatt)
-        {
-            if (squaremeterkelvinsperkilowatt.HasValue)
-            {
-                return FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinsperkilowatt.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable ThermalResistance from SquareMeterKelvinsPerKilowatt of type decimal.
-        /// </summary>
-        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(decimal? squaremeterkelvinsperkilowatt)
+        public static ThermalResistance? FromSquareMeterKelvinsPerKilowatt(QuantityValue? squaremeterkelvinsperkilowatt)
         {
             if (squaremeterkelvinsperkilowatt.HasValue)
             {
@@ -675,23 +350,29 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ThermalResistanceUnit" /> to <see cref="ThermalResistance" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ThermalResistance unit value.</returns>
-        public static ThermalResistance From(double val, ThermalResistanceUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static ThermalResistance From(double value, ThermalResistanceUnit fromUnit)
+#else
+        public static ThermalResistance From(QuantityValue value, ThermalResistanceUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case ThermalResistanceUnit.HourSquareFeetDegreeFahrenheitPerBtu:
-                    return FromHourSquareFeetDegreesFahrenheitPerBtu(val);
+                    return FromHourSquareFeetDegreesFahrenheitPerBtu(value);
                 case ThermalResistanceUnit.SquareCentimeterHourDegreeCelsiusPerKilocalorie:
-                    return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(val);
+                    return FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt:
-                    return FromSquareCentimeterKelvinsPerWatt(val);
+                    return FromSquareCentimeterKelvinsPerWatt(value);
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt:
-                    return FromSquareMeterDegreesCelsiusPerWatt(val);
+                    return FromSquareMeterDegreesCelsiusPerWatt(value);
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt:
-                    return FromSquareMeterKelvinsPerKilowatt(val);
+                    return FromSquareMeterKelvinsPerKilowatt(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -706,7 +387,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>ThermalResistance unit value.</returns>
-        public static ThermalResistance? From(double? value, ThermalResistanceUnit fromUnit)
+        public static ThermalResistance? From(QuantityValue? value, ThermalResistanceUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -269,608 +269,288 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilogramForceCentimeters(double kilogramforcecentimeters)
         {
-            return new Torque(kilogramforcecentimeters*0.0980665019960652);
+            double value = (double) kilogramforcecentimeters;
+            return new Torque(value*0.0980665019960652);
         }
-
-        /// <summary>
-        ///     Get Torque from KilogramForceCentimeters.
-        /// </summary>
-        public static Torque FromKilogramForceCentimeters(int kilogramforcecentimeters)
+#else
+        public static Torque FromKilogramForceCentimeters(QuantityValue kilogramforcecentimeters)
         {
-            return new Torque(kilogramforcecentimeters*0.0980665019960652);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilogramForceCentimeters.
-        /// </summary>
-        public static Torque FromKilogramForceCentimeters(long kilogramforcecentimeters)
-        {
-            return new Torque(kilogramforcecentimeters*0.0980665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilogramForceCentimeters of type decimal.
-        /// </summary>
-        public static Torque FromKilogramForceCentimeters(decimal kilogramforcecentimeters)
-        {
-            return new Torque(Convert.ToDouble(kilogramforcecentimeters)*0.0980665019960652);
+            double value = (double) kilogramforcecentimeters;
+            return new Torque((value*0.0980665019960652));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilogramForceMeters(double kilogramforcemeters)
         {
-            return new Torque(kilogramforcemeters*9.80665019960652);
+            double value = (double) kilogramforcemeters;
+            return new Torque(value*9.80665019960652);
         }
-
-        /// <summary>
-        ///     Get Torque from KilogramForceMeters.
-        /// </summary>
-        public static Torque FromKilogramForceMeters(int kilogramforcemeters)
+#else
+        public static Torque FromKilogramForceMeters(QuantityValue kilogramforcemeters)
         {
-            return new Torque(kilogramforcemeters*9.80665019960652);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilogramForceMeters.
-        /// </summary>
-        public static Torque FromKilogramForceMeters(long kilogramforcemeters)
-        {
-            return new Torque(kilogramforcemeters*9.80665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilogramForceMeters of type decimal.
-        /// </summary>
-        public static Torque FromKilogramForceMeters(decimal kilogramforcemeters)
-        {
-            return new Torque(Convert.ToDouble(kilogramforcemeters)*9.80665019960652);
+            double value = (double) kilogramforcemeters;
+            return new Torque((value*9.80665019960652));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilogramForceMillimeters(double kilogramforcemillimeters)
         {
-            return new Torque(kilogramforcemillimeters*0.00980665019960652);
+            double value = (double) kilogramforcemillimeters;
+            return new Torque(value*0.00980665019960652);
         }
-
-        /// <summary>
-        ///     Get Torque from KilogramForceMillimeters.
-        /// </summary>
-        public static Torque FromKilogramForceMillimeters(int kilogramforcemillimeters)
+#else
+        public static Torque FromKilogramForceMillimeters(QuantityValue kilogramforcemillimeters)
         {
-            return new Torque(kilogramforcemillimeters*0.00980665019960652);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilogramForceMillimeters.
-        /// </summary>
-        public static Torque FromKilogramForceMillimeters(long kilogramforcemillimeters)
-        {
-            return new Torque(kilogramforcemillimeters*0.00980665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilogramForceMillimeters of type decimal.
-        /// </summary>
-        public static Torque FromKilogramForceMillimeters(decimal kilogramforcemillimeters)
-        {
-            return new Torque(Convert.ToDouble(kilogramforcemillimeters)*0.00980665019960652);
+            double value = (double) kilogramforcemillimeters;
+            return new Torque((value*0.00980665019960652));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilonewtonCentimeters(double kilonewtoncentimeters)
         {
-            return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
+            double value = (double) kilonewtoncentimeters;
+            return new Torque((value*0.01) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Torque from KilonewtonCentimeters.
-        /// </summary>
-        public static Torque FromKilonewtonCentimeters(int kilonewtoncentimeters)
+#else
+        public static Torque FromKilonewtonCentimeters(QuantityValue kilonewtoncentimeters)
         {
-            return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilonewtonCentimeters.
-        /// </summary>
-        public static Torque FromKilonewtonCentimeters(long kilonewtoncentimeters)
-        {
-            return new Torque((kilonewtoncentimeters*0.01) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilonewtonCentimeters of type decimal.
-        /// </summary>
-        public static Torque FromKilonewtonCentimeters(decimal kilonewtoncentimeters)
-        {
-            return new Torque((Convert.ToDouble(kilonewtoncentimeters)*0.01) * 1e3d);
+            double value = (double) kilonewtoncentimeters;
+            return new Torque(((value*0.01) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilonewtonMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilonewtonMeters(double kilonewtonmeters)
         {
-            return new Torque((kilonewtonmeters) * 1e3d);
+            double value = (double) kilonewtonmeters;
+            return new Torque((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Torque from KilonewtonMeters.
-        /// </summary>
-        public static Torque FromKilonewtonMeters(int kilonewtonmeters)
+#else
+        public static Torque FromKilonewtonMeters(QuantityValue kilonewtonmeters)
         {
-            return new Torque((kilonewtonmeters) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilonewtonMeters.
-        /// </summary>
-        public static Torque FromKilonewtonMeters(long kilonewtonmeters)
-        {
-            return new Torque((kilonewtonmeters) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilonewtonMeters of type decimal.
-        /// </summary>
-        public static Torque FromKilonewtonMeters(decimal kilonewtonmeters)
-        {
-            return new Torque((Convert.ToDouble(kilonewtonmeters)) * 1e3d);
+            double value = (double) kilonewtonmeters;
+            return new Torque(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilonewtonMillimeters(double kilonewtonmillimeters)
         {
-            return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
+            double value = (double) kilonewtonmillimeters;
+            return new Torque((value*0.001) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Torque from KilonewtonMillimeters.
-        /// </summary>
-        public static Torque FromKilonewtonMillimeters(int kilonewtonmillimeters)
+#else
+        public static Torque FromKilonewtonMillimeters(QuantityValue kilonewtonmillimeters)
         {
-            return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilonewtonMillimeters.
-        /// </summary>
-        public static Torque FromKilonewtonMillimeters(long kilonewtonmillimeters)
-        {
-            return new Torque((kilonewtonmillimeters*0.001) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilonewtonMillimeters of type decimal.
-        /// </summary>
-        public static Torque FromKilonewtonMillimeters(decimal kilonewtonmillimeters)
-        {
-            return new Torque((Convert.ToDouble(kilonewtonmillimeters)*0.001) * 1e3d);
+            double value = (double) kilonewtonmillimeters;
+            return new Torque(((value*0.001) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilopoundForceFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilopoundForceFeet(double kilopoundforcefeet)
         {
-            return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
+            double value = (double) kilopoundforcefeet;
+            return new Torque((value*1.3558180656) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Torque from KilopoundForceFeet.
-        /// </summary>
-        public static Torque FromKilopoundForceFeet(int kilopoundforcefeet)
+#else
+        public static Torque FromKilopoundForceFeet(QuantityValue kilopoundforcefeet)
         {
-            return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilopoundForceFeet.
-        /// </summary>
-        public static Torque FromKilopoundForceFeet(long kilopoundforcefeet)
-        {
-            return new Torque((kilopoundforcefeet*1.3558180656) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilopoundForceFeet of type decimal.
-        /// </summary>
-        public static Torque FromKilopoundForceFeet(decimal kilopoundforcefeet)
-        {
-            return new Torque((Convert.ToDouble(kilopoundforcefeet)*1.3558180656) * 1e3d);
+            double value = (double) kilopoundforcefeet;
+            return new Torque(((value*1.3558180656) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromKilopoundForceInches(double kilopoundforceinches)
         {
-            return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
+            double value = (double) kilopoundforceinches;
+            return new Torque((value*0.1129848388) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Torque from KilopoundForceInches.
-        /// </summary>
-        public static Torque FromKilopoundForceInches(int kilopoundforceinches)
+#else
+        public static Torque FromKilopoundForceInches(QuantityValue kilopoundforceinches)
         {
-            return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Torque from KilopoundForceInches.
-        /// </summary>
-        public static Torque FromKilopoundForceInches(long kilopoundforceinches)
-        {
-            return new Torque((kilopoundforceinches*0.1129848388) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from KilopoundForceInches of type decimal.
-        /// </summary>
-        public static Torque FromKilopoundForceInches(decimal kilopoundforceinches)
-        {
-            return new Torque((Convert.ToDouble(kilopoundforceinches)*0.1129848388) * 1e3d);
+            double value = (double) kilopoundforceinches;
+            return new Torque(((value*0.1129848388) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from NewtonCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromNewtonCentimeters(double newtoncentimeters)
         {
-            return new Torque(newtoncentimeters*0.01);
+            double value = (double) newtoncentimeters;
+            return new Torque(value*0.01);
         }
-
-        /// <summary>
-        ///     Get Torque from NewtonCentimeters.
-        /// </summary>
-        public static Torque FromNewtonCentimeters(int newtoncentimeters)
+#else
+        public static Torque FromNewtonCentimeters(QuantityValue newtoncentimeters)
         {
-            return new Torque(newtoncentimeters*0.01);
-        }
-
-        /// <summary>
-        ///     Get Torque from NewtonCentimeters.
-        /// </summary>
-        public static Torque FromNewtonCentimeters(long newtoncentimeters)
-        {
-            return new Torque(newtoncentimeters*0.01);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from NewtonCentimeters of type decimal.
-        /// </summary>
-        public static Torque FromNewtonCentimeters(decimal newtoncentimeters)
-        {
-            return new Torque(Convert.ToDouble(newtoncentimeters)*0.01);
+            double value = (double) newtoncentimeters;
+            return new Torque((value*0.01));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromNewtonMeters(double newtonmeters)
         {
-            return new Torque(newtonmeters);
+            double value = (double) newtonmeters;
+            return new Torque(value);
         }
-
-        /// <summary>
-        ///     Get Torque from NewtonMeters.
-        /// </summary>
-        public static Torque FromNewtonMeters(int newtonmeters)
+#else
+        public static Torque FromNewtonMeters(QuantityValue newtonmeters)
         {
-            return new Torque(newtonmeters);
-        }
-
-        /// <summary>
-        ///     Get Torque from NewtonMeters.
-        /// </summary>
-        public static Torque FromNewtonMeters(long newtonmeters)
-        {
-            return new Torque(newtonmeters);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from NewtonMeters of type decimal.
-        /// </summary>
-        public static Torque FromNewtonMeters(decimal newtonmeters)
-        {
-            return new Torque(Convert.ToDouble(newtonmeters));
+            double value = (double) newtonmeters;
+            return new Torque((value));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from NewtonMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromNewtonMillimeters(double newtonmillimeters)
         {
-            return new Torque(newtonmillimeters*0.001);
+            double value = (double) newtonmillimeters;
+            return new Torque(value*0.001);
         }
-
-        /// <summary>
-        ///     Get Torque from NewtonMillimeters.
-        /// </summary>
-        public static Torque FromNewtonMillimeters(int newtonmillimeters)
+#else
+        public static Torque FromNewtonMillimeters(QuantityValue newtonmillimeters)
         {
-            return new Torque(newtonmillimeters*0.001);
-        }
-
-        /// <summary>
-        ///     Get Torque from NewtonMillimeters.
-        /// </summary>
-        public static Torque FromNewtonMillimeters(long newtonmillimeters)
-        {
-            return new Torque(newtonmillimeters*0.001);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from NewtonMillimeters of type decimal.
-        /// </summary>
-        public static Torque FromNewtonMillimeters(decimal newtonmillimeters)
-        {
-            return new Torque(Convert.ToDouble(newtonmillimeters)*0.001);
+            double value = (double) newtonmillimeters;
+            return new Torque((value*0.001));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromPoundForceFeet(double poundforcefeet)
         {
-            return new Torque(poundforcefeet*1.3558180656);
+            double value = (double) poundforcefeet;
+            return new Torque(value*1.3558180656);
         }
-
-        /// <summary>
-        ///     Get Torque from PoundForceFeet.
-        /// </summary>
-        public static Torque FromPoundForceFeet(int poundforcefeet)
+#else
+        public static Torque FromPoundForceFeet(QuantityValue poundforcefeet)
         {
-            return new Torque(poundforcefeet*1.3558180656);
-        }
-
-        /// <summary>
-        ///     Get Torque from PoundForceFeet.
-        /// </summary>
-        public static Torque FromPoundForceFeet(long poundforcefeet)
-        {
-            return new Torque(poundforcefeet*1.3558180656);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from PoundForceFeet of type decimal.
-        /// </summary>
-        public static Torque FromPoundForceFeet(decimal poundforcefeet)
-        {
-            return new Torque(Convert.ToDouble(poundforcefeet)*1.3558180656);
+            double value = (double) poundforcefeet;
+            return new Torque((value*1.3558180656));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from PoundForceInches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromPoundForceInches(double poundforceinches)
         {
-            return new Torque(poundforceinches*0.1129848388);
+            double value = (double) poundforceinches;
+            return new Torque(value*0.1129848388);
         }
-
-        /// <summary>
-        ///     Get Torque from PoundForceInches.
-        /// </summary>
-        public static Torque FromPoundForceInches(int poundforceinches)
+#else
+        public static Torque FromPoundForceInches(QuantityValue poundforceinches)
         {
-            return new Torque(poundforceinches*0.1129848388);
-        }
-
-        /// <summary>
-        ///     Get Torque from PoundForceInches.
-        /// </summary>
-        public static Torque FromPoundForceInches(long poundforceinches)
-        {
-            return new Torque(poundforceinches*0.1129848388);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from PoundForceInches of type decimal.
-        /// </summary>
-        public static Torque FromPoundForceInches(decimal poundforceinches)
-        {
-            return new Torque(Convert.ToDouble(poundforceinches)*0.1129848388);
+            double value = (double) poundforceinches;
+            return new Torque((value*0.1129848388));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromTonneForceCentimeters(double tonneforcecentimeters)
         {
-            return new Torque(tonneforcecentimeters*98.0665019960652);
+            double value = (double) tonneforcecentimeters;
+            return new Torque(value*98.0665019960652);
         }
-
-        /// <summary>
-        ///     Get Torque from TonneForceCentimeters.
-        /// </summary>
-        public static Torque FromTonneForceCentimeters(int tonneforcecentimeters)
+#else
+        public static Torque FromTonneForceCentimeters(QuantityValue tonneforcecentimeters)
         {
-            return new Torque(tonneforcecentimeters*98.0665019960652);
-        }
-
-        /// <summary>
-        ///     Get Torque from TonneForceCentimeters.
-        /// </summary>
-        public static Torque FromTonneForceCentimeters(long tonneforcecentimeters)
-        {
-            return new Torque(tonneforcecentimeters*98.0665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from TonneForceCentimeters of type decimal.
-        /// </summary>
-        public static Torque FromTonneForceCentimeters(decimal tonneforcecentimeters)
-        {
-            return new Torque(Convert.ToDouble(tonneforcecentimeters)*98.0665019960652);
+            double value = (double) tonneforcecentimeters;
+            return new Torque((value*98.0665019960652));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from TonneForceMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromTonneForceMeters(double tonneforcemeters)
         {
-            return new Torque(tonneforcemeters*9806.65019960653);
+            double value = (double) tonneforcemeters;
+            return new Torque(value*9806.65019960653);
         }
-
-        /// <summary>
-        ///     Get Torque from TonneForceMeters.
-        /// </summary>
-        public static Torque FromTonneForceMeters(int tonneforcemeters)
+#else
+        public static Torque FromTonneForceMeters(QuantityValue tonneforcemeters)
         {
-            return new Torque(tonneforcemeters*9806.65019960653);
-        }
-
-        /// <summary>
-        ///     Get Torque from TonneForceMeters.
-        /// </summary>
-        public static Torque FromTonneForceMeters(long tonneforcemeters)
-        {
-            return new Torque(tonneforcemeters*9806.65019960653);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from TonneForceMeters of type decimal.
-        /// </summary>
-        public static Torque FromTonneForceMeters(decimal tonneforcemeters)
-        {
-            return new Torque(Convert.ToDouble(tonneforcemeters)*9806.65019960653);
+            double value = (double) tonneforcemeters;
+            return new Torque((value*9806.65019960653));
         }
 #endif
 
         /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Torque FromTonneForceMillimeters(double tonneforcemillimeters)
         {
-            return new Torque(tonneforcemillimeters*9.80665019960652);
+            double value = (double) tonneforcemillimeters;
+            return new Torque(value*9.80665019960652);
         }
-
-        /// <summary>
-        ///     Get Torque from TonneForceMillimeters.
-        /// </summary>
-        public static Torque FromTonneForceMillimeters(int tonneforcemillimeters)
+#else
+        public static Torque FromTonneForceMillimeters(QuantityValue tonneforcemillimeters)
         {
-            return new Torque(tonneforcemillimeters*9.80665019960652);
-        }
-
-        /// <summary>
-        ///     Get Torque from TonneForceMillimeters.
-        /// </summary>
-        public static Torque FromTonneForceMillimeters(long tonneforcemillimeters)
-        {
-            return new Torque(tonneforcemillimeters*9.80665019960652);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Torque from TonneForceMillimeters of type decimal.
-        /// </summary>
-        public static Torque FromTonneForceMillimeters(decimal tonneforcemillimeters)
-        {
-            return new Torque(Convert.ToDouble(tonneforcemillimeters)*9.80665019960652);
+            double value = (double) tonneforcemillimeters;
+            return new Torque((value*9.80665019960652));
         }
 #endif
 
@@ -879,52 +559,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilogramForceCentimeters.
         /// </summary>
-        public static Torque? FromKilogramForceCentimeters(double? kilogramforcecentimeters)
-        {
-            if (kilogramforcecentimeters.HasValue)
-            {
-                return FromKilogramForceCentimeters(kilogramforcecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilogramForceCentimeters.
-        /// </summary>
-        public static Torque? FromKilogramForceCentimeters(int? kilogramforcecentimeters)
-        {
-            if (kilogramforcecentimeters.HasValue)
-            {
-                return FromKilogramForceCentimeters(kilogramforcecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilogramForceCentimeters.
-        /// </summary>
-        public static Torque? FromKilogramForceCentimeters(long? kilogramforcecentimeters)
-        {
-            if (kilogramforcecentimeters.HasValue)
-            {
-                return FromKilogramForceCentimeters(kilogramforcecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilogramForceCentimeters of type decimal.
-        /// </summary>
-        public static Torque? FromKilogramForceCentimeters(decimal? kilogramforcecentimeters)
+        public static Torque? FromKilogramForceCentimeters(QuantityValue? kilogramforcecentimeters)
         {
             if (kilogramforcecentimeters.HasValue)
             {
@@ -939,52 +574,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMeters.
         /// </summary>
-        public static Torque? FromKilogramForceMeters(double? kilogramforcemeters)
-        {
-            if (kilogramforcemeters.HasValue)
-            {
-                return FromKilogramForceMeters(kilogramforcemeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilogramForceMeters.
-        /// </summary>
-        public static Torque? FromKilogramForceMeters(int? kilogramforcemeters)
-        {
-            if (kilogramforcemeters.HasValue)
-            {
-                return FromKilogramForceMeters(kilogramforcemeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilogramForceMeters.
-        /// </summary>
-        public static Torque? FromKilogramForceMeters(long? kilogramforcemeters)
-        {
-            if (kilogramforcemeters.HasValue)
-            {
-                return FromKilogramForceMeters(kilogramforcemeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilogramForceMeters of type decimal.
-        /// </summary>
-        public static Torque? FromKilogramForceMeters(decimal? kilogramforcemeters)
+        public static Torque? FromKilogramForceMeters(QuantityValue? kilogramforcemeters)
         {
             if (kilogramforcemeters.HasValue)
             {
@@ -999,52 +589,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilogramForceMillimeters.
         /// </summary>
-        public static Torque? FromKilogramForceMillimeters(double? kilogramforcemillimeters)
-        {
-            if (kilogramforcemillimeters.HasValue)
-            {
-                return FromKilogramForceMillimeters(kilogramforcemillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilogramForceMillimeters.
-        /// </summary>
-        public static Torque? FromKilogramForceMillimeters(int? kilogramforcemillimeters)
-        {
-            if (kilogramforcemillimeters.HasValue)
-            {
-                return FromKilogramForceMillimeters(kilogramforcemillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilogramForceMillimeters.
-        /// </summary>
-        public static Torque? FromKilogramForceMillimeters(long? kilogramforcemillimeters)
-        {
-            if (kilogramforcemillimeters.HasValue)
-            {
-                return FromKilogramForceMillimeters(kilogramforcemillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilogramForceMillimeters of type decimal.
-        /// </summary>
-        public static Torque? FromKilogramForceMillimeters(decimal? kilogramforcemillimeters)
+        public static Torque? FromKilogramForceMillimeters(QuantityValue? kilogramforcemillimeters)
         {
             if (kilogramforcemillimeters.HasValue)
             {
@@ -1059,52 +604,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilonewtonCentimeters.
         /// </summary>
-        public static Torque? FromKilonewtonCentimeters(double? kilonewtoncentimeters)
-        {
-            if (kilonewtoncentimeters.HasValue)
-            {
-                return FromKilonewtonCentimeters(kilonewtoncentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilonewtonCentimeters.
-        /// </summary>
-        public static Torque? FromKilonewtonCentimeters(int? kilonewtoncentimeters)
-        {
-            if (kilonewtoncentimeters.HasValue)
-            {
-                return FromKilonewtonCentimeters(kilonewtoncentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilonewtonCentimeters.
-        /// </summary>
-        public static Torque? FromKilonewtonCentimeters(long? kilonewtoncentimeters)
-        {
-            if (kilonewtoncentimeters.HasValue)
-            {
-                return FromKilonewtonCentimeters(kilonewtoncentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilonewtonCentimeters of type decimal.
-        /// </summary>
-        public static Torque? FromKilonewtonCentimeters(decimal? kilonewtoncentimeters)
+        public static Torque? FromKilonewtonCentimeters(QuantityValue? kilonewtoncentimeters)
         {
             if (kilonewtoncentimeters.HasValue)
             {
@@ -1119,52 +619,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMeters.
         /// </summary>
-        public static Torque? FromKilonewtonMeters(double? kilonewtonmeters)
-        {
-            if (kilonewtonmeters.HasValue)
-            {
-                return FromKilonewtonMeters(kilonewtonmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilonewtonMeters.
-        /// </summary>
-        public static Torque? FromKilonewtonMeters(int? kilonewtonmeters)
-        {
-            if (kilonewtonmeters.HasValue)
-            {
-                return FromKilonewtonMeters(kilonewtonmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilonewtonMeters.
-        /// </summary>
-        public static Torque? FromKilonewtonMeters(long? kilonewtonmeters)
-        {
-            if (kilonewtonmeters.HasValue)
-            {
-                return FromKilonewtonMeters(kilonewtonmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilonewtonMeters of type decimal.
-        /// </summary>
-        public static Torque? FromKilonewtonMeters(decimal? kilonewtonmeters)
+        public static Torque? FromKilonewtonMeters(QuantityValue? kilonewtonmeters)
         {
             if (kilonewtonmeters.HasValue)
             {
@@ -1179,52 +634,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilonewtonMillimeters.
         /// </summary>
-        public static Torque? FromKilonewtonMillimeters(double? kilonewtonmillimeters)
-        {
-            if (kilonewtonmillimeters.HasValue)
-            {
-                return FromKilonewtonMillimeters(kilonewtonmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilonewtonMillimeters.
-        /// </summary>
-        public static Torque? FromKilonewtonMillimeters(int? kilonewtonmillimeters)
-        {
-            if (kilonewtonmillimeters.HasValue)
-            {
-                return FromKilonewtonMillimeters(kilonewtonmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilonewtonMillimeters.
-        /// </summary>
-        public static Torque? FromKilonewtonMillimeters(long? kilonewtonmillimeters)
-        {
-            if (kilonewtonmillimeters.HasValue)
-            {
-                return FromKilonewtonMillimeters(kilonewtonmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilonewtonMillimeters of type decimal.
-        /// </summary>
-        public static Torque? FromKilonewtonMillimeters(decimal? kilonewtonmillimeters)
+        public static Torque? FromKilonewtonMillimeters(QuantityValue? kilonewtonmillimeters)
         {
             if (kilonewtonmillimeters.HasValue)
             {
@@ -1239,52 +649,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceFeet.
         /// </summary>
-        public static Torque? FromKilopoundForceFeet(double? kilopoundforcefeet)
-        {
-            if (kilopoundforcefeet.HasValue)
-            {
-                return FromKilopoundForceFeet(kilopoundforcefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilopoundForceFeet.
-        /// </summary>
-        public static Torque? FromKilopoundForceFeet(int? kilopoundforcefeet)
-        {
-            if (kilopoundforcefeet.HasValue)
-            {
-                return FromKilopoundForceFeet(kilopoundforcefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilopoundForceFeet.
-        /// </summary>
-        public static Torque? FromKilopoundForceFeet(long? kilopoundforcefeet)
-        {
-            if (kilopoundforcefeet.HasValue)
-            {
-                return FromKilopoundForceFeet(kilopoundforcefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilopoundForceFeet of type decimal.
-        /// </summary>
-        public static Torque? FromKilopoundForceFeet(decimal? kilopoundforcefeet)
+        public static Torque? FromKilopoundForceFeet(QuantityValue? kilopoundforcefeet)
         {
             if (kilopoundforcefeet.HasValue)
             {
@@ -1299,52 +664,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable KilopoundForceInches.
         /// </summary>
-        public static Torque? FromKilopoundForceInches(double? kilopoundforceinches)
-        {
-            if (kilopoundforceinches.HasValue)
-            {
-                return FromKilopoundForceInches(kilopoundforceinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilopoundForceInches.
-        /// </summary>
-        public static Torque? FromKilopoundForceInches(int? kilopoundforceinches)
-        {
-            if (kilopoundforceinches.HasValue)
-            {
-                return FromKilopoundForceInches(kilopoundforceinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable KilopoundForceInches.
-        /// </summary>
-        public static Torque? FromKilopoundForceInches(long? kilopoundforceinches)
-        {
-            if (kilopoundforceinches.HasValue)
-            {
-                return FromKilopoundForceInches(kilopoundforceinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from KilopoundForceInches of type decimal.
-        /// </summary>
-        public static Torque? FromKilopoundForceInches(decimal? kilopoundforceinches)
+        public static Torque? FromKilopoundForceInches(QuantityValue? kilopoundforceinches)
         {
             if (kilopoundforceinches.HasValue)
             {
@@ -1359,52 +679,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable NewtonCentimeters.
         /// </summary>
-        public static Torque? FromNewtonCentimeters(double? newtoncentimeters)
-        {
-            if (newtoncentimeters.HasValue)
-            {
-                return FromNewtonCentimeters(newtoncentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable NewtonCentimeters.
-        /// </summary>
-        public static Torque? FromNewtonCentimeters(int? newtoncentimeters)
-        {
-            if (newtoncentimeters.HasValue)
-            {
-                return FromNewtonCentimeters(newtoncentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable NewtonCentimeters.
-        /// </summary>
-        public static Torque? FromNewtonCentimeters(long? newtoncentimeters)
-        {
-            if (newtoncentimeters.HasValue)
-            {
-                return FromNewtonCentimeters(newtoncentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from NewtonCentimeters of type decimal.
-        /// </summary>
-        public static Torque? FromNewtonCentimeters(decimal? newtoncentimeters)
+        public static Torque? FromNewtonCentimeters(QuantityValue? newtoncentimeters)
         {
             if (newtoncentimeters.HasValue)
             {
@@ -1419,52 +694,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable NewtonMeters.
         /// </summary>
-        public static Torque? FromNewtonMeters(double? newtonmeters)
-        {
-            if (newtonmeters.HasValue)
-            {
-                return FromNewtonMeters(newtonmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable NewtonMeters.
-        /// </summary>
-        public static Torque? FromNewtonMeters(int? newtonmeters)
-        {
-            if (newtonmeters.HasValue)
-            {
-                return FromNewtonMeters(newtonmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable NewtonMeters.
-        /// </summary>
-        public static Torque? FromNewtonMeters(long? newtonmeters)
-        {
-            if (newtonmeters.HasValue)
-            {
-                return FromNewtonMeters(newtonmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from NewtonMeters of type decimal.
-        /// </summary>
-        public static Torque? FromNewtonMeters(decimal? newtonmeters)
+        public static Torque? FromNewtonMeters(QuantityValue? newtonmeters)
         {
             if (newtonmeters.HasValue)
             {
@@ -1479,52 +709,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable NewtonMillimeters.
         /// </summary>
-        public static Torque? FromNewtonMillimeters(double? newtonmillimeters)
-        {
-            if (newtonmillimeters.HasValue)
-            {
-                return FromNewtonMillimeters(newtonmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable NewtonMillimeters.
-        /// </summary>
-        public static Torque? FromNewtonMillimeters(int? newtonmillimeters)
-        {
-            if (newtonmillimeters.HasValue)
-            {
-                return FromNewtonMillimeters(newtonmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable NewtonMillimeters.
-        /// </summary>
-        public static Torque? FromNewtonMillimeters(long? newtonmillimeters)
-        {
-            if (newtonmillimeters.HasValue)
-            {
-                return FromNewtonMillimeters(newtonmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from NewtonMillimeters of type decimal.
-        /// </summary>
-        public static Torque? FromNewtonMillimeters(decimal? newtonmillimeters)
+        public static Torque? FromNewtonMillimeters(QuantityValue? newtonmillimeters)
         {
             if (newtonmillimeters.HasValue)
             {
@@ -1539,52 +724,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable PoundForceFeet.
         /// </summary>
-        public static Torque? FromPoundForceFeet(double? poundforcefeet)
-        {
-            if (poundforcefeet.HasValue)
-            {
-                return FromPoundForceFeet(poundforcefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable PoundForceFeet.
-        /// </summary>
-        public static Torque? FromPoundForceFeet(int? poundforcefeet)
-        {
-            if (poundforcefeet.HasValue)
-            {
-                return FromPoundForceFeet(poundforcefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable PoundForceFeet.
-        /// </summary>
-        public static Torque? FromPoundForceFeet(long? poundforcefeet)
-        {
-            if (poundforcefeet.HasValue)
-            {
-                return FromPoundForceFeet(poundforcefeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from PoundForceFeet of type decimal.
-        /// </summary>
-        public static Torque? FromPoundForceFeet(decimal? poundforcefeet)
+        public static Torque? FromPoundForceFeet(QuantityValue? poundforcefeet)
         {
             if (poundforcefeet.HasValue)
             {
@@ -1599,52 +739,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable PoundForceInches.
         /// </summary>
-        public static Torque? FromPoundForceInches(double? poundforceinches)
-        {
-            if (poundforceinches.HasValue)
-            {
-                return FromPoundForceInches(poundforceinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable PoundForceInches.
-        /// </summary>
-        public static Torque? FromPoundForceInches(int? poundforceinches)
-        {
-            if (poundforceinches.HasValue)
-            {
-                return FromPoundForceInches(poundforceinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable PoundForceInches.
-        /// </summary>
-        public static Torque? FromPoundForceInches(long? poundforceinches)
-        {
-            if (poundforceinches.HasValue)
-            {
-                return FromPoundForceInches(poundforceinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from PoundForceInches of type decimal.
-        /// </summary>
-        public static Torque? FromPoundForceInches(decimal? poundforceinches)
+        public static Torque? FromPoundForceInches(QuantityValue? poundforceinches)
         {
             if (poundforceinches.HasValue)
             {
@@ -1659,52 +754,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable TonneForceCentimeters.
         /// </summary>
-        public static Torque? FromTonneForceCentimeters(double? tonneforcecentimeters)
-        {
-            if (tonneforcecentimeters.HasValue)
-            {
-                return FromTonneForceCentimeters(tonneforcecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable TonneForceCentimeters.
-        /// </summary>
-        public static Torque? FromTonneForceCentimeters(int? tonneforcecentimeters)
-        {
-            if (tonneforcecentimeters.HasValue)
-            {
-                return FromTonneForceCentimeters(tonneforcecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable TonneForceCentimeters.
-        /// </summary>
-        public static Torque? FromTonneForceCentimeters(long? tonneforcecentimeters)
-        {
-            if (tonneforcecentimeters.HasValue)
-            {
-                return FromTonneForceCentimeters(tonneforcecentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from TonneForceCentimeters of type decimal.
-        /// </summary>
-        public static Torque? FromTonneForceCentimeters(decimal? tonneforcecentimeters)
+        public static Torque? FromTonneForceCentimeters(QuantityValue? tonneforcecentimeters)
         {
             if (tonneforcecentimeters.HasValue)
             {
@@ -1719,52 +769,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable TonneForceMeters.
         /// </summary>
-        public static Torque? FromTonneForceMeters(double? tonneforcemeters)
-        {
-            if (tonneforcemeters.HasValue)
-            {
-                return FromTonneForceMeters(tonneforcemeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable TonneForceMeters.
-        /// </summary>
-        public static Torque? FromTonneForceMeters(int? tonneforcemeters)
-        {
-            if (tonneforcemeters.HasValue)
-            {
-                return FromTonneForceMeters(tonneforcemeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable TonneForceMeters.
-        /// </summary>
-        public static Torque? FromTonneForceMeters(long? tonneforcemeters)
-        {
-            if (tonneforcemeters.HasValue)
-            {
-                return FromTonneForceMeters(tonneforcemeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from TonneForceMeters of type decimal.
-        /// </summary>
-        public static Torque? FromTonneForceMeters(decimal? tonneforcemeters)
+        public static Torque? FromTonneForceMeters(QuantityValue? tonneforcemeters)
         {
             if (tonneforcemeters.HasValue)
             {
@@ -1779,52 +784,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Torque from nullable TonneForceMillimeters.
         /// </summary>
-        public static Torque? FromTonneForceMillimeters(double? tonneforcemillimeters)
-        {
-            if (tonneforcemillimeters.HasValue)
-            {
-                return FromTonneForceMillimeters(tonneforcemillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable TonneForceMillimeters.
-        /// </summary>
-        public static Torque? FromTonneForceMillimeters(int? tonneforcemillimeters)
-        {
-            if (tonneforcemillimeters.HasValue)
-            {
-                return FromTonneForceMillimeters(tonneforcemillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from nullable TonneForceMillimeters.
-        /// </summary>
-        public static Torque? FromTonneForceMillimeters(long? tonneforcemillimeters)
-        {
-            if (tonneforcemillimeters.HasValue)
-            {
-                return FromTonneForceMillimeters(tonneforcemillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Torque from TonneForceMillimeters of type decimal.
-        /// </summary>
-        public static Torque? FromTonneForceMillimeters(decimal? tonneforcemillimeters)
+        public static Torque? FromTonneForceMillimeters(QuantityValue? tonneforcemillimeters)
         {
             if (tonneforcemillimeters.HasValue)
             {
@@ -1841,45 +801,51 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="TorqueUnit" /> to <see cref="Torque" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Torque unit value.</returns>
-        public static Torque From(double val, TorqueUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Torque From(double value, TorqueUnit fromUnit)
+#else
+        public static Torque From(QuantityValue value, TorqueUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case TorqueUnit.KilogramForceCentimeter:
-                    return FromKilogramForceCentimeters(val);
+                    return FromKilogramForceCentimeters(value);
                 case TorqueUnit.KilogramForceMeter:
-                    return FromKilogramForceMeters(val);
+                    return FromKilogramForceMeters(value);
                 case TorqueUnit.KilogramForceMillimeter:
-                    return FromKilogramForceMillimeters(val);
+                    return FromKilogramForceMillimeters(value);
                 case TorqueUnit.KilonewtonCentimeter:
-                    return FromKilonewtonCentimeters(val);
+                    return FromKilonewtonCentimeters(value);
                 case TorqueUnit.KilonewtonMeter:
-                    return FromKilonewtonMeters(val);
+                    return FromKilonewtonMeters(value);
                 case TorqueUnit.KilonewtonMillimeter:
-                    return FromKilonewtonMillimeters(val);
+                    return FromKilonewtonMillimeters(value);
                 case TorqueUnit.KilopoundForceFoot:
-                    return FromKilopoundForceFeet(val);
+                    return FromKilopoundForceFeet(value);
                 case TorqueUnit.KilopoundForceInch:
-                    return FromKilopoundForceInches(val);
+                    return FromKilopoundForceInches(value);
                 case TorqueUnit.NewtonCentimeter:
-                    return FromNewtonCentimeters(val);
+                    return FromNewtonCentimeters(value);
                 case TorqueUnit.NewtonMeter:
-                    return FromNewtonMeters(val);
+                    return FromNewtonMeters(value);
                 case TorqueUnit.NewtonMillimeter:
-                    return FromNewtonMillimeters(val);
+                    return FromNewtonMillimeters(value);
                 case TorqueUnit.PoundForceFoot:
-                    return FromPoundForceFeet(val);
+                    return FromPoundForceFeet(value);
                 case TorqueUnit.PoundForceInch:
-                    return FromPoundForceInches(val);
+                    return FromPoundForceInches(value);
                 case TorqueUnit.TonneForceCentimeter:
-                    return FromTonneForceCentimeters(val);
+                    return FromTonneForceCentimeters(value);
                 case TorqueUnit.TonneForceMeter:
-                    return FromTonneForceMeters(val);
+                    return FromTonneForceMeters(value);
                 case TorqueUnit.TonneForceMillimeter:
-                    return FromTonneForceMillimeters(val);
+                    return FromTonneForceMillimeters(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1894,7 +860,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Torque unit value.</returns>
-        public static Torque? From(double? value, TorqueUnit fromUnit)
+        public static Torque? From(QuantityValue? value, TorqueUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -149,38 +149,18 @@ namespace UnitsNet
         /// <summary>
         ///     Get VitaminA from InternationalUnits.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static VitaminA FromInternationalUnits(double internationalunits)
         {
-            return new VitaminA(internationalunits);
+            double value = (double) internationalunits;
+            return new VitaminA(value);
         }
-
-        /// <summary>
-        ///     Get VitaminA from InternationalUnits.
-        /// </summary>
-        public static VitaminA FromInternationalUnits(int internationalunits)
+#else
+        public static VitaminA FromInternationalUnits(QuantityValue internationalunits)
         {
-            return new VitaminA(internationalunits);
-        }
-
-        /// <summary>
-        ///     Get VitaminA from InternationalUnits.
-        /// </summary>
-        public static VitaminA FromInternationalUnits(long internationalunits)
-        {
-            return new VitaminA(internationalunits);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get VitaminA from InternationalUnits of type decimal.
-        /// </summary>
-        public static VitaminA FromInternationalUnits(decimal internationalunits)
-        {
-            return new VitaminA(Convert.ToDouble(internationalunits));
+            double value = (double) internationalunits;
+            return new VitaminA((value));
         }
 #endif
 
@@ -189,52 +169,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable VitaminA from nullable InternationalUnits.
         /// </summary>
-        public static VitaminA? FromInternationalUnits(double? internationalunits)
-        {
-            if (internationalunits.HasValue)
-            {
-                return FromInternationalUnits(internationalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable VitaminA from nullable InternationalUnits.
-        /// </summary>
-        public static VitaminA? FromInternationalUnits(int? internationalunits)
-        {
-            if (internationalunits.HasValue)
-            {
-                return FromInternationalUnits(internationalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable VitaminA from nullable InternationalUnits.
-        /// </summary>
-        public static VitaminA? FromInternationalUnits(long? internationalunits)
-        {
-            if (internationalunits.HasValue)
-            {
-                return FromInternationalUnits(internationalunits.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable VitaminA from InternationalUnits of type decimal.
-        /// </summary>
-        public static VitaminA? FromInternationalUnits(decimal? internationalunits)
+        public static VitaminA? FromInternationalUnits(QuantityValue? internationalunits)
         {
             if (internationalunits.HasValue)
             {
@@ -251,15 +186,21 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="VitaminAUnit" /> to <see cref="VitaminA" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>VitaminA unit value.</returns>
-        public static VitaminA From(double val, VitaminAUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static VitaminA From(double value, VitaminAUnit fromUnit)
+#else
+        public static VitaminA From(QuantityValue value, VitaminAUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case VitaminAUnit.InternationalUnit:
-                    return FromInternationalUnits(val);
+                    return FromInternationalUnits(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -274,7 +215,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>VitaminA unit value.</returns>
-        public static VitaminA? From(double? value, VitaminAUnit fromUnit)
+        public static VitaminA? From(QuantityValue? value, VitaminAUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -479,1596 +479,756 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from AuTablespoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromAuTablespoons(double autablespoons)
         {
-            return new Volume(autablespoons*2e-5);
+            double value = (double) autablespoons;
+            return new Volume(value*2e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from AuTablespoons.
-        /// </summary>
-        public static Volume FromAuTablespoons(int autablespoons)
+#else
+        public static Volume FromAuTablespoons(QuantityValue autablespoons)
         {
-            return new Volume(autablespoons*2e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from AuTablespoons.
-        /// </summary>
-        public static Volume FromAuTablespoons(long autablespoons)
-        {
-            return new Volume(autablespoons*2e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from AuTablespoons of type decimal.
-        /// </summary>
-        public static Volume FromAuTablespoons(decimal autablespoons)
-        {
-            return new Volume(Convert.ToDouble(autablespoons)*2e-5);
+            double value = (double) autablespoons;
+            return new Volume((value*2e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCentiliters(double centiliters)
         {
-            return new Volume((centiliters/1e3) * 1e-2d);
+            double value = (double) centiliters;
+            return new Volume((value/1e3) * 1e-2d);
         }
-
-        /// <summary>
-        ///     Get Volume from Centiliters.
-        /// </summary>
-        public static Volume FromCentiliters(int centiliters)
+#else
+        public static Volume FromCentiliters(QuantityValue centiliters)
         {
-            return new Volume((centiliters/1e3) * 1e-2d);
-        }
-
-        /// <summary>
-        ///     Get Volume from Centiliters.
-        /// </summary>
-        public static Volume FromCentiliters(long centiliters)
-        {
-            return new Volume((centiliters/1e3) * 1e-2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Centiliters of type decimal.
-        /// </summary>
-        public static Volume FromCentiliters(decimal centiliters)
-        {
-            return new Volume((Convert.ToDouble(centiliters)/1e3) * 1e-2d);
+            double value = (double) centiliters;
+            return new Volume(((value/1e3) * 1e-2d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicCentimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicCentimeters(double cubiccentimeters)
         {
-            return new Volume(cubiccentimeters/1e6);
+            double value = (double) cubiccentimeters;
+            return new Volume(value/1e6);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicCentimeters.
-        /// </summary>
-        public static Volume FromCubicCentimeters(int cubiccentimeters)
+#else
+        public static Volume FromCubicCentimeters(QuantityValue cubiccentimeters)
         {
-            return new Volume(cubiccentimeters/1e6);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicCentimeters.
-        /// </summary>
-        public static Volume FromCubicCentimeters(long cubiccentimeters)
-        {
-            return new Volume(cubiccentimeters/1e6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicCentimeters of type decimal.
-        /// </summary>
-        public static Volume FromCubicCentimeters(decimal cubiccentimeters)
-        {
-            return new Volume(Convert.ToDouble(cubiccentimeters)/1e6);
+            double value = (double) cubiccentimeters;
+            return new Volume((value/1e6));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicDecimeters(double cubicdecimeters)
         {
-            return new Volume(cubicdecimeters/1e3);
+            double value = (double) cubicdecimeters;
+            return new Volume(value/1e3);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicDecimeters.
-        /// </summary>
-        public static Volume FromCubicDecimeters(int cubicdecimeters)
+#else
+        public static Volume FromCubicDecimeters(QuantityValue cubicdecimeters)
         {
-            return new Volume(cubicdecimeters/1e3);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicDecimeters.
-        /// </summary>
-        public static Volume FromCubicDecimeters(long cubicdecimeters)
-        {
-            return new Volume(cubicdecimeters/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicDecimeters of type decimal.
-        /// </summary>
-        public static Volume FromCubicDecimeters(decimal cubicdecimeters)
-        {
-            return new Volume(Convert.ToDouble(cubicdecimeters)/1e3);
+            double value = (double) cubicdecimeters;
+            return new Volume((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicFeet(double cubicfeet)
         {
-            return new Volume(cubicfeet*0.0283168);
+            double value = (double) cubicfeet;
+            return new Volume(value*0.0283168);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicFeet.
-        /// </summary>
-        public static Volume FromCubicFeet(int cubicfeet)
+#else
+        public static Volume FromCubicFeet(QuantityValue cubicfeet)
         {
-            return new Volume(cubicfeet*0.0283168);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicFeet.
-        /// </summary>
-        public static Volume FromCubicFeet(long cubicfeet)
-        {
-            return new Volume(cubicfeet*0.0283168);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicFeet of type decimal.
-        /// </summary>
-        public static Volume FromCubicFeet(decimal cubicfeet)
-        {
-            return new Volume(Convert.ToDouble(cubicfeet)*0.0283168);
+            double value = (double) cubicfeet;
+            return new Volume((value*0.0283168));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicInches(double cubicinches)
         {
-            return new Volume(cubicinches*1.6387*1e-5);
+            double value = (double) cubicinches;
+            return new Volume(value*1.6387*1e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicInches.
-        /// </summary>
-        public static Volume FromCubicInches(int cubicinches)
+#else
+        public static Volume FromCubicInches(QuantityValue cubicinches)
         {
-            return new Volume(cubicinches*1.6387*1e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicInches.
-        /// </summary>
-        public static Volume FromCubicInches(long cubicinches)
-        {
-            return new Volume(cubicinches*1.6387*1e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicInches of type decimal.
-        /// </summary>
-        public static Volume FromCubicInches(decimal cubicinches)
-        {
-            return new Volume(Convert.ToDouble(cubicinches)*1.6387*1e-5);
+            double value = (double) cubicinches;
+            return new Volume((value*1.6387*1e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicKilometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicKilometers(double cubickilometers)
         {
-            return new Volume(cubickilometers*1e9);
+            double value = (double) cubickilometers;
+            return new Volume(value*1e9);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicKilometers.
-        /// </summary>
-        public static Volume FromCubicKilometers(int cubickilometers)
+#else
+        public static Volume FromCubicKilometers(QuantityValue cubickilometers)
         {
-            return new Volume(cubickilometers*1e9);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicKilometers.
-        /// </summary>
-        public static Volume FromCubicKilometers(long cubickilometers)
-        {
-            return new Volume(cubickilometers*1e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicKilometers of type decimal.
-        /// </summary>
-        public static Volume FromCubicKilometers(decimal cubickilometers)
-        {
-            return new Volume(Convert.ToDouble(cubickilometers)*1e9);
+            double value = (double) cubickilometers;
+            return new Volume((value*1e9));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicMeters(double cubicmeters)
         {
-            return new Volume(cubicmeters);
+            double value = (double) cubicmeters;
+            return new Volume(value);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicMeters.
-        /// </summary>
-        public static Volume FromCubicMeters(int cubicmeters)
+#else
+        public static Volume FromCubicMeters(QuantityValue cubicmeters)
         {
-            return new Volume(cubicmeters);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicMeters.
-        /// </summary>
-        public static Volume FromCubicMeters(long cubicmeters)
-        {
-            return new Volume(cubicmeters);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicMeters of type decimal.
-        /// </summary>
-        public static Volume FromCubicMeters(decimal cubicmeters)
-        {
-            return new Volume(Convert.ToDouble(cubicmeters));
+            double value = (double) cubicmeters;
+            return new Volume((value));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicMicrometers.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicMicrometers(double cubicmicrometers)
         {
-            return new Volume(cubicmicrometers/1e18);
+            double value = (double) cubicmicrometers;
+            return new Volume(value/1e18);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicMicrometers.
-        /// </summary>
-        public static Volume FromCubicMicrometers(int cubicmicrometers)
+#else
+        public static Volume FromCubicMicrometers(QuantityValue cubicmicrometers)
         {
-            return new Volume(cubicmicrometers/1e18);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicMicrometers.
-        /// </summary>
-        public static Volume FromCubicMicrometers(long cubicmicrometers)
-        {
-            return new Volume(cubicmicrometers/1e18);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicMicrometers of type decimal.
-        /// </summary>
-        public static Volume FromCubicMicrometers(decimal cubicmicrometers)
-        {
-            return new Volume(Convert.ToDouble(cubicmicrometers)/1e18);
+            double value = (double) cubicmicrometers;
+            return new Volume((value/1e18));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicMiles(double cubicmiles)
         {
-            return new Volume(cubicmiles*4.16818183*1e9);
+            double value = (double) cubicmiles;
+            return new Volume(value*4.16818183*1e9);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicMiles.
-        /// </summary>
-        public static Volume FromCubicMiles(int cubicmiles)
+#else
+        public static Volume FromCubicMiles(QuantityValue cubicmiles)
         {
-            return new Volume(cubicmiles*4.16818183*1e9);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicMiles.
-        /// </summary>
-        public static Volume FromCubicMiles(long cubicmiles)
-        {
-            return new Volume(cubicmiles*4.16818183*1e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicMiles of type decimal.
-        /// </summary>
-        public static Volume FromCubicMiles(decimal cubicmiles)
-        {
-            return new Volume(Convert.ToDouble(cubicmiles)*4.16818183*1e9);
+            double value = (double) cubicmiles;
+            return new Volume((value*4.16818183*1e9));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicMillimeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicMillimeters(double cubicmillimeters)
         {
-            return new Volume(cubicmillimeters/1e9);
+            double value = (double) cubicmillimeters;
+            return new Volume(value/1e9);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicMillimeters.
-        /// </summary>
-        public static Volume FromCubicMillimeters(int cubicmillimeters)
+#else
+        public static Volume FromCubicMillimeters(QuantityValue cubicmillimeters)
         {
-            return new Volume(cubicmillimeters/1e9);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicMillimeters.
-        /// </summary>
-        public static Volume FromCubicMillimeters(long cubicmillimeters)
-        {
-            return new Volume(cubicmillimeters/1e9);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicMillimeters of type decimal.
-        /// </summary>
-        public static Volume FromCubicMillimeters(decimal cubicmillimeters)
-        {
-            return new Volume(Convert.ToDouble(cubicmillimeters)/1e9);
+            double value = (double) cubicmillimeters;
+            return new Volume((value/1e9));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromCubicYards(double cubicyards)
         {
-            return new Volume(cubicyards*0.764554858);
+            double value = (double) cubicyards;
+            return new Volume(value*0.764554858);
         }
-
-        /// <summary>
-        ///     Get Volume from CubicYards.
-        /// </summary>
-        public static Volume FromCubicYards(int cubicyards)
+#else
+        public static Volume FromCubicYards(QuantityValue cubicyards)
         {
-            return new Volume(cubicyards*0.764554858);
-        }
-
-        /// <summary>
-        ///     Get Volume from CubicYards.
-        /// </summary>
-        public static Volume FromCubicYards(long cubicyards)
-        {
-            return new Volume(cubicyards*0.764554858);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from CubicYards of type decimal.
-        /// </summary>
-        public static Volume FromCubicYards(decimal cubicyards)
-        {
-            return new Volume(Convert.ToDouble(cubicyards)*0.764554858);
+            double value = (double) cubicyards;
+            return new Volume((value*0.764554858));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Deciliters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromDeciliters(double deciliters)
         {
-            return new Volume((deciliters/1e3) * 1e-1d);
+            double value = (double) deciliters;
+            return new Volume((value/1e3) * 1e-1d);
         }
-
-        /// <summary>
-        ///     Get Volume from Deciliters.
-        /// </summary>
-        public static Volume FromDeciliters(int deciliters)
+#else
+        public static Volume FromDeciliters(QuantityValue deciliters)
         {
-            return new Volume((deciliters/1e3) * 1e-1d);
-        }
-
-        /// <summary>
-        ///     Get Volume from Deciliters.
-        /// </summary>
-        public static Volume FromDeciliters(long deciliters)
-        {
-            return new Volume((deciliters/1e3) * 1e-1d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Deciliters of type decimal.
-        /// </summary>
-        public static Volume FromDeciliters(decimal deciliters)
-        {
-            return new Volume((Convert.ToDouble(deciliters)/1e3) * 1e-1d);
+            double value = (double) deciliters;
+            return new Volume(((value/1e3) * 1e-1d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromHectocubicFeet(double hectocubicfeet)
         {
-            return new Volume((hectocubicfeet*0.0283168) * 1e2d);
+            double value = (double) hectocubicfeet;
+            return new Volume((value*0.0283168) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get Volume from HectocubicFeet.
-        /// </summary>
-        public static Volume FromHectocubicFeet(int hectocubicfeet)
+#else
+        public static Volume FromHectocubicFeet(QuantityValue hectocubicfeet)
         {
-            return new Volume((hectocubicfeet*0.0283168) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get Volume from HectocubicFeet.
-        /// </summary>
-        public static Volume FromHectocubicFeet(long hectocubicfeet)
-        {
-            return new Volume((hectocubicfeet*0.0283168) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from HectocubicFeet of type decimal.
-        /// </summary>
-        public static Volume FromHectocubicFeet(decimal hectocubicfeet)
-        {
-            return new Volume((Convert.ToDouble(hectocubicfeet)*0.0283168) * 1e2d);
+            double value = (double) hectocubicfeet;
+            return new Volume(((value*0.0283168) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from HectocubicMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromHectocubicMeters(double hectocubicmeters)
         {
-            return new Volume((hectocubicmeters) * 1e2d);
+            double value = (double) hectocubicmeters;
+            return new Volume((value) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get Volume from HectocubicMeters.
-        /// </summary>
-        public static Volume FromHectocubicMeters(int hectocubicmeters)
+#else
+        public static Volume FromHectocubicMeters(QuantityValue hectocubicmeters)
         {
-            return new Volume((hectocubicmeters) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get Volume from HectocubicMeters.
-        /// </summary>
-        public static Volume FromHectocubicMeters(long hectocubicmeters)
-        {
-            return new Volume((hectocubicmeters) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from HectocubicMeters of type decimal.
-        /// </summary>
-        public static Volume FromHectocubicMeters(decimal hectocubicmeters)
-        {
-            return new Volume((Convert.ToDouble(hectocubicmeters)) * 1e2d);
+            double value = (double) hectocubicmeters;
+            return new Volume(((value) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromHectoliters(double hectoliters)
         {
-            return new Volume((hectoliters/1e3) * 1e2d);
+            double value = (double) hectoliters;
+            return new Volume((value/1e3) * 1e2d);
         }
-
-        /// <summary>
-        ///     Get Volume from Hectoliters.
-        /// </summary>
-        public static Volume FromHectoliters(int hectoliters)
+#else
+        public static Volume FromHectoliters(QuantityValue hectoliters)
         {
-            return new Volume((hectoliters/1e3) * 1e2d);
-        }
-
-        /// <summary>
-        ///     Get Volume from Hectoliters.
-        /// </summary>
-        public static Volume FromHectoliters(long hectoliters)
-        {
-            return new Volume((hectoliters/1e3) * 1e2d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Hectoliters of type decimal.
-        /// </summary>
-        public static Volume FromHectoliters(decimal hectoliters)
-        {
-            return new Volume((Convert.ToDouble(hectoliters)/1e3) * 1e2d);
+            double value = (double) hectoliters;
+            return new Volume(((value/1e3) * 1e2d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromImperialBeerBarrels(double imperialbeerbarrels)
         {
-            return new Volume(imperialbeerbarrels*0.16365924);
+            double value = (double) imperialbeerbarrels;
+            return new Volume(value*0.16365924);
         }
-
-        /// <summary>
-        ///     Get Volume from ImperialBeerBarrels.
-        /// </summary>
-        public static Volume FromImperialBeerBarrels(int imperialbeerbarrels)
+#else
+        public static Volume FromImperialBeerBarrels(QuantityValue imperialbeerbarrels)
         {
-            return new Volume(imperialbeerbarrels*0.16365924);
-        }
-
-        /// <summary>
-        ///     Get Volume from ImperialBeerBarrels.
-        /// </summary>
-        public static Volume FromImperialBeerBarrels(long imperialbeerbarrels)
-        {
-            return new Volume(imperialbeerbarrels*0.16365924);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from ImperialBeerBarrels of type decimal.
-        /// </summary>
-        public static Volume FromImperialBeerBarrels(decimal imperialbeerbarrels)
-        {
-            return new Volume(Convert.ToDouble(imperialbeerbarrels)*0.16365924);
+            double value = (double) imperialbeerbarrels;
+            return new Volume((value*0.16365924));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromImperialGallons(double imperialgallons)
         {
-            return new Volume(imperialgallons*0.00454609000000181429905810072407);
+            double value = (double) imperialgallons;
+            return new Volume(value*0.00454609000000181429905810072407);
         }
-
-        /// <summary>
-        ///     Get Volume from ImperialGallons.
-        /// </summary>
-        public static Volume FromImperialGallons(int imperialgallons)
+#else
+        public static Volume FromImperialGallons(QuantityValue imperialgallons)
         {
-            return new Volume(imperialgallons*0.00454609000000181429905810072407);
-        }
-
-        /// <summary>
-        ///     Get Volume from ImperialGallons.
-        /// </summary>
-        public static Volume FromImperialGallons(long imperialgallons)
-        {
-            return new Volume(imperialgallons*0.00454609000000181429905810072407);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from ImperialGallons of type decimal.
-        /// </summary>
-        public static Volume FromImperialGallons(decimal imperialgallons)
-        {
-            return new Volume(Convert.ToDouble(imperialgallons)*0.00454609000000181429905810072407);
+            double value = (double) imperialgallons;
+            return new Volume((value*0.00454609000000181429905810072407));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from ImperialOunces.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromImperialOunces(double imperialounces)
         {
-            return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
+            double value = (double) imperialounces;
+            return new Volume(value*2.8413062499962901241875439064617e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from ImperialOunces.
-        /// </summary>
-        public static Volume FromImperialOunces(int imperialounces)
+#else
+        public static Volume FromImperialOunces(QuantityValue imperialounces)
         {
-            return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from ImperialOunces.
-        /// </summary>
-        public static Volume FromImperialOunces(long imperialounces)
-        {
-            return new Volume(imperialounces*2.8413062499962901241875439064617e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from ImperialOunces of type decimal.
-        /// </summary>
-        public static Volume FromImperialOunces(decimal imperialounces)
-        {
-            return new Volume(Convert.ToDouble(imperialounces)*2.8413062499962901241875439064617e-5);
+            double value = (double) imperialounces;
+            return new Volume((value*2.8413062499962901241875439064617e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromKilocubicFeet(double kilocubicfeet)
         {
-            return new Volume((kilocubicfeet*0.0283168) * 1e3d);
+            double value = (double) kilocubicfeet;
+            return new Volume((value*0.0283168) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Volume from KilocubicFeet.
-        /// </summary>
-        public static Volume FromKilocubicFeet(int kilocubicfeet)
+#else
+        public static Volume FromKilocubicFeet(QuantityValue kilocubicfeet)
         {
-            return new Volume((kilocubicfeet*0.0283168) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Volume from KilocubicFeet.
-        /// </summary>
-        public static Volume FromKilocubicFeet(long kilocubicfeet)
-        {
-            return new Volume((kilocubicfeet*0.0283168) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from KilocubicFeet of type decimal.
-        /// </summary>
-        public static Volume FromKilocubicFeet(decimal kilocubicfeet)
-        {
-            return new Volume((Convert.ToDouble(kilocubicfeet)*0.0283168) * 1e3d);
+            double value = (double) kilocubicfeet;
+            return new Volume(((value*0.0283168) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from KilocubicMeters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromKilocubicMeters(double kilocubicmeters)
         {
-            return new Volume((kilocubicmeters) * 1e3d);
+            double value = (double) kilocubicmeters;
+            return new Volume((value) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Volume from KilocubicMeters.
-        /// </summary>
-        public static Volume FromKilocubicMeters(int kilocubicmeters)
+#else
+        public static Volume FromKilocubicMeters(QuantityValue kilocubicmeters)
         {
-            return new Volume((kilocubicmeters) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Volume from KilocubicMeters.
-        /// </summary>
-        public static Volume FromKilocubicMeters(long kilocubicmeters)
-        {
-            return new Volume((kilocubicmeters) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from KilocubicMeters of type decimal.
-        /// </summary>
-        public static Volume FromKilocubicMeters(decimal kilocubicmeters)
-        {
-            return new Volume((Convert.ToDouble(kilocubicmeters)) * 1e3d);
+            double value = (double) kilocubicmeters;
+            return new Volume(((value) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromKiloimperialGallons(double kiloimperialgallons)
         {
-            return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
+            double value = (double) kiloimperialgallons;
+            return new Volume((value*0.00454609000000181429905810072407) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Volume from KiloimperialGallons.
-        /// </summary>
-        public static Volume FromKiloimperialGallons(int kiloimperialgallons)
+#else
+        public static Volume FromKiloimperialGallons(QuantityValue kiloimperialgallons)
         {
-            return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Volume from KiloimperialGallons.
-        /// </summary>
-        public static Volume FromKiloimperialGallons(long kiloimperialgallons)
-        {
-            return new Volume((kiloimperialgallons*0.00454609000000181429905810072407) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from KiloimperialGallons of type decimal.
-        /// </summary>
-        public static Volume FromKiloimperialGallons(decimal kiloimperialgallons)
-        {
-            return new Volume((Convert.ToDouble(kiloimperialgallons)*0.00454609000000181429905810072407) * 1e3d);
+            double value = (double) kiloimperialgallons;
+            return new Volume(((value*0.00454609000000181429905810072407) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from KilousGallons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromKilousGallons(double kilousgallons)
         {
-            return new Volume((kilousgallons*0.00378541) * 1e3d);
+            double value = (double) kilousgallons;
+            return new Volume((value*0.00378541) * 1e3d);
         }
-
-        /// <summary>
-        ///     Get Volume from KilousGallons.
-        /// </summary>
-        public static Volume FromKilousGallons(int kilousgallons)
+#else
+        public static Volume FromKilousGallons(QuantityValue kilousgallons)
         {
-            return new Volume((kilousgallons*0.00378541) * 1e3d);
-        }
-
-        /// <summary>
-        ///     Get Volume from KilousGallons.
-        /// </summary>
-        public static Volume FromKilousGallons(long kilousgallons)
-        {
-            return new Volume((kilousgallons*0.00378541) * 1e3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from KilousGallons of type decimal.
-        /// </summary>
-        public static Volume FromKilousGallons(decimal kilousgallons)
-        {
-            return new Volume((Convert.ToDouble(kilousgallons)*0.00378541) * 1e3d);
+            double value = (double) kilousgallons;
+            return new Volume(((value*0.00378541) * 1e3d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromLiters(double liters)
         {
-            return new Volume(liters/1e3);
+            double value = (double) liters;
+            return new Volume(value/1e3);
         }
-
-        /// <summary>
-        ///     Get Volume from Liters.
-        /// </summary>
-        public static Volume FromLiters(int liters)
+#else
+        public static Volume FromLiters(QuantityValue liters)
         {
-            return new Volume(liters/1e3);
-        }
-
-        /// <summary>
-        ///     Get Volume from Liters.
-        /// </summary>
-        public static Volume FromLiters(long liters)
-        {
-            return new Volume(liters/1e3);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Liters of type decimal.
-        /// </summary>
-        public static Volume FromLiters(decimal liters)
-        {
-            return new Volume(Convert.ToDouble(liters)/1e3);
+            double value = (double) liters;
+            return new Volume((value/1e3));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from MegacubicFeet.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMegacubicFeet(double megacubicfeet)
         {
-            return new Volume((megacubicfeet*0.0283168) * 1e6d);
+            double value = (double) megacubicfeet;
+            return new Volume((value*0.0283168) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Volume from MegacubicFeet.
-        /// </summary>
-        public static Volume FromMegacubicFeet(int megacubicfeet)
+#else
+        public static Volume FromMegacubicFeet(QuantityValue megacubicfeet)
         {
-            return new Volume((megacubicfeet*0.0283168) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Volume from MegacubicFeet.
-        /// </summary>
-        public static Volume FromMegacubicFeet(long megacubicfeet)
-        {
-            return new Volume((megacubicfeet*0.0283168) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from MegacubicFeet of type decimal.
-        /// </summary>
-        public static Volume FromMegacubicFeet(decimal megacubicfeet)
-        {
-            return new Volume((Convert.ToDouble(megacubicfeet)*0.0283168) * 1e6d);
+            double value = (double) megacubicfeet;
+            return new Volume(((value*0.0283168) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMegaimperialGallons(double megaimperialgallons)
         {
-            return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
+            double value = (double) megaimperialgallons;
+            return new Volume((value*0.00454609000000181429905810072407) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Volume from MegaimperialGallons.
-        /// </summary>
-        public static Volume FromMegaimperialGallons(int megaimperialgallons)
+#else
+        public static Volume FromMegaimperialGallons(QuantityValue megaimperialgallons)
         {
-            return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Volume from MegaimperialGallons.
-        /// </summary>
-        public static Volume FromMegaimperialGallons(long megaimperialgallons)
-        {
-            return new Volume((megaimperialgallons*0.00454609000000181429905810072407) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from MegaimperialGallons of type decimal.
-        /// </summary>
-        public static Volume FromMegaimperialGallons(decimal megaimperialgallons)
-        {
-            return new Volume((Convert.ToDouble(megaimperialgallons)*0.00454609000000181429905810072407) * 1e6d);
+            double value = (double) megaimperialgallons;
+            return new Volume(((value*0.00454609000000181429905810072407) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from MegausGallons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMegausGallons(double megausgallons)
         {
-            return new Volume((megausgallons*0.00378541) * 1e6d);
+            double value = (double) megausgallons;
+            return new Volume((value*0.00378541) * 1e6d);
         }
-
-        /// <summary>
-        ///     Get Volume from MegausGallons.
-        /// </summary>
-        public static Volume FromMegausGallons(int megausgallons)
+#else
+        public static Volume FromMegausGallons(QuantityValue megausgallons)
         {
-            return new Volume((megausgallons*0.00378541) * 1e6d);
-        }
-
-        /// <summary>
-        ///     Get Volume from MegausGallons.
-        /// </summary>
-        public static Volume FromMegausGallons(long megausgallons)
-        {
-            return new Volume((megausgallons*0.00378541) * 1e6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from MegausGallons of type decimal.
-        /// </summary>
-        public static Volume FromMegausGallons(decimal megausgallons)
-        {
-            return new Volume((Convert.ToDouble(megausgallons)*0.00378541) * 1e6d);
+            double value = (double) megausgallons;
+            return new Volume(((value*0.00378541) * 1e6d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMetricCups(double metriccups)
         {
-            return new Volume(metriccups*0.00025);
+            double value = (double) metriccups;
+            return new Volume(value*0.00025);
         }
-
-        /// <summary>
-        ///     Get Volume from MetricCups.
-        /// </summary>
-        public static Volume FromMetricCups(int metriccups)
+#else
+        public static Volume FromMetricCups(QuantityValue metriccups)
         {
-            return new Volume(metriccups*0.00025);
-        }
-
-        /// <summary>
-        ///     Get Volume from MetricCups.
-        /// </summary>
-        public static Volume FromMetricCups(long metriccups)
-        {
-            return new Volume(metriccups*0.00025);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from MetricCups of type decimal.
-        /// </summary>
-        public static Volume FromMetricCups(decimal metriccups)
-        {
-            return new Volume(Convert.ToDouble(metriccups)*0.00025);
+            double value = (double) metriccups;
+            return new Volume((value*0.00025));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from MetricTeaspoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMetricTeaspoons(double metricteaspoons)
         {
-            return new Volume(metricteaspoons*0.5e-5);
+            double value = (double) metricteaspoons;
+            return new Volume(value*0.5e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from MetricTeaspoons.
-        /// </summary>
-        public static Volume FromMetricTeaspoons(int metricteaspoons)
+#else
+        public static Volume FromMetricTeaspoons(QuantityValue metricteaspoons)
         {
-            return new Volume(metricteaspoons*0.5e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from MetricTeaspoons.
-        /// </summary>
-        public static Volume FromMetricTeaspoons(long metricteaspoons)
-        {
-            return new Volume(metricteaspoons*0.5e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from MetricTeaspoons of type decimal.
-        /// </summary>
-        public static Volume FromMetricTeaspoons(decimal metricteaspoons)
-        {
-            return new Volume(Convert.ToDouble(metricteaspoons)*0.5e-5);
+            double value = (double) metricteaspoons;
+            return new Volume((value*0.5e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMicroliters(double microliters)
         {
-            return new Volume((microliters/1e3) * 1e-6d);
+            double value = (double) microliters;
+            return new Volume((value/1e3) * 1e-6d);
         }
-
-        /// <summary>
-        ///     Get Volume from Microliters.
-        /// </summary>
-        public static Volume FromMicroliters(int microliters)
+#else
+        public static Volume FromMicroliters(QuantityValue microliters)
         {
-            return new Volume((microliters/1e3) * 1e-6d);
-        }
-
-        /// <summary>
-        ///     Get Volume from Microliters.
-        /// </summary>
-        public static Volume FromMicroliters(long microliters)
-        {
-            return new Volume((microliters/1e3) * 1e-6d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Microliters of type decimal.
-        /// </summary>
-        public static Volume FromMicroliters(decimal microliters)
-        {
-            return new Volume((Convert.ToDouble(microliters)/1e3) * 1e-6d);
+            double value = (double) microliters;
+            return new Volume(((value/1e3) * 1e-6d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromMilliliters(double milliliters)
         {
-            return new Volume((milliliters/1e3) * 1e-3d);
+            double value = (double) milliliters;
+            return new Volume((value/1e3) * 1e-3d);
         }
-
-        /// <summary>
-        ///     Get Volume from Milliliters.
-        /// </summary>
-        public static Volume FromMilliliters(int milliliters)
+#else
+        public static Volume FromMilliliters(QuantityValue milliliters)
         {
-            return new Volume((milliliters/1e3) * 1e-3d);
-        }
-
-        /// <summary>
-        ///     Get Volume from Milliliters.
-        /// </summary>
-        public static Volume FromMilliliters(long milliliters)
-        {
-            return new Volume((milliliters/1e3) * 1e-3d);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Milliliters of type decimal.
-        /// </summary>
-        public static Volume FromMilliliters(decimal milliliters)
-        {
-            return new Volume((Convert.ToDouble(milliliters)/1e3) * 1e-3d);
+            double value = (double) milliliters;
+            return new Volume(((value/1e3) * 1e-3d));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromOilBarrels(double oilbarrels)
         {
-            return new Volume(oilbarrels*0.158987294928);
+            double value = (double) oilbarrels;
+            return new Volume(value*0.158987294928);
         }
-
-        /// <summary>
-        ///     Get Volume from OilBarrels.
-        /// </summary>
-        public static Volume FromOilBarrels(int oilbarrels)
+#else
+        public static Volume FromOilBarrels(QuantityValue oilbarrels)
         {
-            return new Volume(oilbarrels*0.158987294928);
-        }
-
-        /// <summary>
-        ///     Get Volume from OilBarrels.
-        /// </summary>
-        public static Volume FromOilBarrels(long oilbarrels)
-        {
-            return new Volume(oilbarrels*0.158987294928);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from OilBarrels of type decimal.
-        /// </summary>
-        public static Volume FromOilBarrels(decimal oilbarrels)
-        {
-            return new Volume(Convert.ToDouble(oilbarrels)*0.158987294928);
+            double value = (double) oilbarrels;
+            return new Volume((value*0.158987294928));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Tablespoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromTablespoons(double tablespoons)
         {
-            return new Volume(tablespoons*1.478676478125e-5);
+            double value = (double) tablespoons;
+            return new Volume(value*1.478676478125e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from Tablespoons.
-        /// </summary>
-        public static Volume FromTablespoons(int tablespoons)
+#else
+        public static Volume FromTablespoons(QuantityValue tablespoons)
         {
-            return new Volume(tablespoons*1.478676478125e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from Tablespoons.
-        /// </summary>
-        public static Volume FromTablespoons(long tablespoons)
-        {
-            return new Volume(tablespoons*1.478676478125e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Tablespoons of type decimal.
-        /// </summary>
-        public static Volume FromTablespoons(decimal tablespoons)
-        {
-            return new Volume(Convert.ToDouble(tablespoons)*1.478676478125e-5);
+            double value = (double) tablespoons;
+            return new Volume((value*1.478676478125e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from Teaspoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromTeaspoons(double teaspoons)
         {
-            return new Volume(teaspoons*4.92892159375e-6);
+            double value = (double) teaspoons;
+            return new Volume(value*4.92892159375e-6);
         }
-
-        /// <summary>
-        ///     Get Volume from Teaspoons.
-        /// </summary>
-        public static Volume FromTeaspoons(int teaspoons)
+#else
+        public static Volume FromTeaspoons(QuantityValue teaspoons)
         {
-            return new Volume(teaspoons*4.92892159375e-6);
-        }
-
-        /// <summary>
-        ///     Get Volume from Teaspoons.
-        /// </summary>
-        public static Volume FromTeaspoons(long teaspoons)
-        {
-            return new Volume(teaspoons*4.92892159375e-6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from Teaspoons of type decimal.
-        /// </summary>
-        public static Volume FromTeaspoons(decimal teaspoons)
-        {
-            return new Volume(Convert.ToDouble(teaspoons)*4.92892159375e-6);
+            double value = (double) teaspoons;
+            return new Volume((value*4.92892159375e-6));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUkTablespoons(double uktablespoons)
         {
-            return new Volume(uktablespoons*1.5e-5);
+            double value = (double) uktablespoons;
+            return new Volume(value*1.5e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from UkTablespoons.
-        /// </summary>
-        public static Volume FromUkTablespoons(int uktablespoons)
+#else
+        public static Volume FromUkTablespoons(QuantityValue uktablespoons)
         {
-            return new Volume(uktablespoons*1.5e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from UkTablespoons.
-        /// </summary>
-        public static Volume FromUkTablespoons(long uktablespoons)
-        {
-            return new Volume(uktablespoons*1.5e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UkTablespoons of type decimal.
-        /// </summary>
-        public static Volume FromUkTablespoons(decimal uktablespoons)
-        {
-            return new Volume(Convert.ToDouble(uktablespoons)*1.5e-5);
+            double value = (double) uktablespoons;
+            return new Volume((value*1.5e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsBeerBarrels(double usbeerbarrels)
         {
-            return new Volume(usbeerbarrels*0.1173477658);
+            double value = (double) usbeerbarrels;
+            return new Volume(value*0.1173477658);
         }
-
-        /// <summary>
-        ///     Get Volume from UsBeerBarrels.
-        /// </summary>
-        public static Volume FromUsBeerBarrels(int usbeerbarrels)
+#else
+        public static Volume FromUsBeerBarrels(QuantityValue usbeerbarrels)
         {
-            return new Volume(usbeerbarrels*0.1173477658);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsBeerBarrels.
-        /// </summary>
-        public static Volume FromUsBeerBarrels(long usbeerbarrels)
-        {
-            return new Volume(usbeerbarrels*0.1173477658);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsBeerBarrels of type decimal.
-        /// </summary>
-        public static Volume FromUsBeerBarrels(decimal usbeerbarrels)
-        {
-            return new Volume(Convert.ToDouble(usbeerbarrels)*0.1173477658);
+            double value = (double) usbeerbarrels;
+            return new Volume((value*0.1173477658));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsCustomaryCups.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsCustomaryCups(double uscustomarycups)
         {
-            return new Volume(uscustomarycups*0.0002365882365);
+            double value = (double) uscustomarycups;
+            return new Volume(value*0.0002365882365);
         }
-
-        /// <summary>
-        ///     Get Volume from UsCustomaryCups.
-        /// </summary>
-        public static Volume FromUsCustomaryCups(int uscustomarycups)
+#else
+        public static Volume FromUsCustomaryCups(QuantityValue uscustomarycups)
         {
-            return new Volume(uscustomarycups*0.0002365882365);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsCustomaryCups.
-        /// </summary>
-        public static Volume FromUsCustomaryCups(long uscustomarycups)
-        {
-            return new Volume(uscustomarycups*0.0002365882365);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsCustomaryCups of type decimal.
-        /// </summary>
-        public static Volume FromUsCustomaryCups(decimal uscustomarycups)
-        {
-            return new Volume(Convert.ToDouble(uscustomarycups)*0.0002365882365);
+            double value = (double) uscustomarycups;
+            return new Volume((value*0.0002365882365));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsGallons(double usgallons)
         {
-            return new Volume(usgallons*0.00378541);
+            double value = (double) usgallons;
+            return new Volume(value*0.00378541);
         }
-
-        /// <summary>
-        ///     Get Volume from UsGallons.
-        /// </summary>
-        public static Volume FromUsGallons(int usgallons)
+#else
+        public static Volume FromUsGallons(QuantityValue usgallons)
         {
-            return new Volume(usgallons*0.00378541);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsGallons.
-        /// </summary>
-        public static Volume FromUsGallons(long usgallons)
-        {
-            return new Volume(usgallons*0.00378541);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsGallons of type decimal.
-        /// </summary>
-        public static Volume FromUsGallons(decimal usgallons)
-        {
-            return new Volume(Convert.ToDouble(usgallons)*0.00378541);
+            double value = (double) usgallons;
+            return new Volume((value*0.00378541));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsLegalCups.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsLegalCups(double uslegalcups)
         {
-            return new Volume(uslegalcups*0.00024);
+            double value = (double) uslegalcups;
+            return new Volume(value*0.00024);
         }
-
-        /// <summary>
-        ///     Get Volume from UsLegalCups.
-        /// </summary>
-        public static Volume FromUsLegalCups(int uslegalcups)
+#else
+        public static Volume FromUsLegalCups(QuantityValue uslegalcups)
         {
-            return new Volume(uslegalcups*0.00024);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsLegalCups.
-        /// </summary>
-        public static Volume FromUsLegalCups(long uslegalcups)
-        {
-            return new Volume(uslegalcups*0.00024);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsLegalCups of type decimal.
-        /// </summary>
-        public static Volume FromUsLegalCups(decimal uslegalcups)
-        {
-            return new Volume(Convert.ToDouble(uslegalcups)*0.00024);
+            double value = (double) uslegalcups;
+            return new Volume((value*0.00024));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsOunces(double usounces)
         {
-            return new Volume(usounces*2.957352956253760505068307980135e-5);
+            double value = (double) usounces;
+            return new Volume(value*2.957352956253760505068307980135e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from UsOunces.
-        /// </summary>
-        public static Volume FromUsOunces(int usounces)
+#else
+        public static Volume FromUsOunces(QuantityValue usounces)
         {
-            return new Volume(usounces*2.957352956253760505068307980135e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsOunces.
-        /// </summary>
-        public static Volume FromUsOunces(long usounces)
-        {
-            return new Volume(usounces*2.957352956253760505068307980135e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsOunces of type decimal.
-        /// </summary>
-        public static Volume FromUsOunces(decimal usounces)
-        {
-            return new Volume(Convert.ToDouble(usounces)*2.957352956253760505068307980135e-5);
+            double value = (double) usounces;
+            return new Volume((value*2.957352956253760505068307980135e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsTablespoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsTablespoons(double ustablespoons)
         {
-            return new Volume(ustablespoons*1.478676478125e-5);
+            double value = (double) ustablespoons;
+            return new Volume(value*1.478676478125e-5);
         }
-
-        /// <summary>
-        ///     Get Volume from UsTablespoons.
-        /// </summary>
-        public static Volume FromUsTablespoons(int ustablespoons)
+#else
+        public static Volume FromUsTablespoons(QuantityValue ustablespoons)
         {
-            return new Volume(ustablespoons*1.478676478125e-5);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsTablespoons.
-        /// </summary>
-        public static Volume FromUsTablespoons(long ustablespoons)
-        {
-            return new Volume(ustablespoons*1.478676478125e-5);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsTablespoons of type decimal.
-        /// </summary>
-        public static Volume FromUsTablespoons(decimal ustablespoons)
-        {
-            return new Volume(Convert.ToDouble(ustablespoons)*1.478676478125e-5);
+            double value = (double) ustablespoons;
+            return new Volume((value*1.478676478125e-5));
         }
 #endif
 
         /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
-#if NETFX_CORE
+#if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
-#endif
         public static Volume FromUsTeaspoons(double usteaspoons)
         {
-            return new Volume(usteaspoons*4.92892159375e-6);
+            double value = (double) usteaspoons;
+            return new Volume(value*4.92892159375e-6);
         }
-
-        /// <summary>
-        ///     Get Volume from UsTeaspoons.
-        /// </summary>
-        public static Volume FromUsTeaspoons(int usteaspoons)
+#else
+        public static Volume FromUsTeaspoons(QuantityValue usteaspoons)
         {
-            return new Volume(usteaspoons*4.92892159375e-6);
-        }
-
-        /// <summary>
-        ///     Get Volume from UsTeaspoons.
-        /// </summary>
-        public static Volume FromUsTeaspoons(long usteaspoons)
-        {
-            return new Volume(usteaspoons*4.92892159375e-6);
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get Volume from UsTeaspoons of type decimal.
-        /// </summary>
-        public static Volume FromUsTeaspoons(decimal usteaspoons)
-        {
-            return new Volume(Convert.ToDouble(usteaspoons)*4.92892159375e-6);
+            double value = (double) usteaspoons;
+            return new Volume((value*4.92892159375e-6));
         }
 #endif
 
@@ -2077,52 +1237,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable AuTablespoons.
         /// </summary>
-        public static Volume? FromAuTablespoons(double? autablespoons)
-        {
-            if (autablespoons.HasValue)
-            {
-                return FromAuTablespoons(autablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable AuTablespoons.
-        /// </summary>
-        public static Volume? FromAuTablespoons(int? autablespoons)
-        {
-            if (autablespoons.HasValue)
-            {
-                return FromAuTablespoons(autablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable AuTablespoons.
-        /// </summary>
-        public static Volume? FromAuTablespoons(long? autablespoons)
-        {
-            if (autablespoons.HasValue)
-            {
-                return FromAuTablespoons(autablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from AuTablespoons of type decimal.
-        /// </summary>
-        public static Volume? FromAuTablespoons(decimal? autablespoons)
+        public static Volume? FromAuTablespoons(QuantityValue? autablespoons)
         {
             if (autablespoons.HasValue)
             {
@@ -2137,52 +1252,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Centiliters.
         /// </summary>
-        public static Volume? FromCentiliters(double? centiliters)
-        {
-            if (centiliters.HasValue)
-            {
-                return FromCentiliters(centiliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Centiliters.
-        /// </summary>
-        public static Volume? FromCentiliters(int? centiliters)
-        {
-            if (centiliters.HasValue)
-            {
-                return FromCentiliters(centiliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Centiliters.
-        /// </summary>
-        public static Volume? FromCentiliters(long? centiliters)
-        {
-            if (centiliters.HasValue)
-            {
-                return FromCentiliters(centiliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Centiliters of type decimal.
-        /// </summary>
-        public static Volume? FromCentiliters(decimal? centiliters)
+        public static Volume? FromCentiliters(QuantityValue? centiliters)
         {
             if (centiliters.HasValue)
             {
@@ -2197,52 +1267,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicCentimeters.
         /// </summary>
-        public static Volume? FromCubicCentimeters(double? cubiccentimeters)
-        {
-            if (cubiccentimeters.HasValue)
-            {
-                return FromCubicCentimeters(cubiccentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicCentimeters.
-        /// </summary>
-        public static Volume? FromCubicCentimeters(int? cubiccentimeters)
-        {
-            if (cubiccentimeters.HasValue)
-            {
-                return FromCubicCentimeters(cubiccentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicCentimeters.
-        /// </summary>
-        public static Volume? FromCubicCentimeters(long? cubiccentimeters)
-        {
-            if (cubiccentimeters.HasValue)
-            {
-                return FromCubicCentimeters(cubiccentimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicCentimeters of type decimal.
-        /// </summary>
-        public static Volume? FromCubicCentimeters(decimal? cubiccentimeters)
+        public static Volume? FromCubicCentimeters(QuantityValue? cubiccentimeters)
         {
             if (cubiccentimeters.HasValue)
             {
@@ -2257,52 +1282,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicDecimeters.
         /// </summary>
-        public static Volume? FromCubicDecimeters(double? cubicdecimeters)
-        {
-            if (cubicdecimeters.HasValue)
-            {
-                return FromCubicDecimeters(cubicdecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicDecimeters.
-        /// </summary>
-        public static Volume? FromCubicDecimeters(int? cubicdecimeters)
-        {
-            if (cubicdecimeters.HasValue)
-            {
-                return FromCubicDecimeters(cubicdecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicDecimeters.
-        /// </summary>
-        public static Volume? FromCubicDecimeters(long? cubicdecimeters)
-        {
-            if (cubicdecimeters.HasValue)
-            {
-                return FromCubicDecimeters(cubicdecimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicDecimeters of type decimal.
-        /// </summary>
-        public static Volume? FromCubicDecimeters(decimal? cubicdecimeters)
+        public static Volume? FromCubicDecimeters(QuantityValue? cubicdecimeters)
         {
             if (cubicdecimeters.HasValue)
             {
@@ -2317,52 +1297,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicFeet.
         /// </summary>
-        public static Volume? FromCubicFeet(double? cubicfeet)
-        {
-            if (cubicfeet.HasValue)
-            {
-                return FromCubicFeet(cubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicFeet.
-        /// </summary>
-        public static Volume? FromCubicFeet(int? cubicfeet)
-        {
-            if (cubicfeet.HasValue)
-            {
-                return FromCubicFeet(cubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicFeet.
-        /// </summary>
-        public static Volume? FromCubicFeet(long? cubicfeet)
-        {
-            if (cubicfeet.HasValue)
-            {
-                return FromCubicFeet(cubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicFeet of type decimal.
-        /// </summary>
-        public static Volume? FromCubicFeet(decimal? cubicfeet)
+        public static Volume? FromCubicFeet(QuantityValue? cubicfeet)
         {
             if (cubicfeet.HasValue)
             {
@@ -2377,52 +1312,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicInches.
         /// </summary>
-        public static Volume? FromCubicInches(double? cubicinches)
-        {
-            if (cubicinches.HasValue)
-            {
-                return FromCubicInches(cubicinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicInches.
-        /// </summary>
-        public static Volume? FromCubicInches(int? cubicinches)
-        {
-            if (cubicinches.HasValue)
-            {
-                return FromCubicInches(cubicinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicInches.
-        /// </summary>
-        public static Volume? FromCubicInches(long? cubicinches)
-        {
-            if (cubicinches.HasValue)
-            {
-                return FromCubicInches(cubicinches.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicInches of type decimal.
-        /// </summary>
-        public static Volume? FromCubicInches(decimal? cubicinches)
+        public static Volume? FromCubicInches(QuantityValue? cubicinches)
         {
             if (cubicinches.HasValue)
             {
@@ -2437,52 +1327,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicKilometers.
         /// </summary>
-        public static Volume? FromCubicKilometers(double? cubickilometers)
-        {
-            if (cubickilometers.HasValue)
-            {
-                return FromCubicKilometers(cubickilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicKilometers.
-        /// </summary>
-        public static Volume? FromCubicKilometers(int? cubickilometers)
-        {
-            if (cubickilometers.HasValue)
-            {
-                return FromCubicKilometers(cubickilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicKilometers.
-        /// </summary>
-        public static Volume? FromCubicKilometers(long? cubickilometers)
-        {
-            if (cubickilometers.HasValue)
-            {
-                return FromCubicKilometers(cubickilometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicKilometers of type decimal.
-        /// </summary>
-        public static Volume? FromCubicKilometers(decimal? cubickilometers)
+        public static Volume? FromCubicKilometers(QuantityValue? cubickilometers)
         {
             if (cubickilometers.HasValue)
             {
@@ -2497,52 +1342,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicMeters.
         /// </summary>
-        public static Volume? FromCubicMeters(double? cubicmeters)
-        {
-            if (cubicmeters.HasValue)
-            {
-                return FromCubicMeters(cubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMeters.
-        /// </summary>
-        public static Volume? FromCubicMeters(int? cubicmeters)
-        {
-            if (cubicmeters.HasValue)
-            {
-                return FromCubicMeters(cubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMeters.
-        /// </summary>
-        public static Volume? FromCubicMeters(long? cubicmeters)
-        {
-            if (cubicmeters.HasValue)
-            {
-                return FromCubicMeters(cubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicMeters of type decimal.
-        /// </summary>
-        public static Volume? FromCubicMeters(decimal? cubicmeters)
+        public static Volume? FromCubicMeters(QuantityValue? cubicmeters)
         {
             if (cubicmeters.HasValue)
             {
@@ -2557,52 +1357,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicMicrometers.
         /// </summary>
-        public static Volume? FromCubicMicrometers(double? cubicmicrometers)
-        {
-            if (cubicmicrometers.HasValue)
-            {
-                return FromCubicMicrometers(cubicmicrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMicrometers.
-        /// </summary>
-        public static Volume? FromCubicMicrometers(int? cubicmicrometers)
-        {
-            if (cubicmicrometers.HasValue)
-            {
-                return FromCubicMicrometers(cubicmicrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMicrometers.
-        /// </summary>
-        public static Volume? FromCubicMicrometers(long? cubicmicrometers)
-        {
-            if (cubicmicrometers.HasValue)
-            {
-                return FromCubicMicrometers(cubicmicrometers.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicMicrometers of type decimal.
-        /// </summary>
-        public static Volume? FromCubicMicrometers(decimal? cubicmicrometers)
+        public static Volume? FromCubicMicrometers(QuantityValue? cubicmicrometers)
         {
             if (cubicmicrometers.HasValue)
             {
@@ -2617,52 +1372,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicMiles.
         /// </summary>
-        public static Volume? FromCubicMiles(double? cubicmiles)
-        {
-            if (cubicmiles.HasValue)
-            {
-                return FromCubicMiles(cubicmiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMiles.
-        /// </summary>
-        public static Volume? FromCubicMiles(int? cubicmiles)
-        {
-            if (cubicmiles.HasValue)
-            {
-                return FromCubicMiles(cubicmiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMiles.
-        /// </summary>
-        public static Volume? FromCubicMiles(long? cubicmiles)
-        {
-            if (cubicmiles.HasValue)
-            {
-                return FromCubicMiles(cubicmiles.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicMiles of type decimal.
-        /// </summary>
-        public static Volume? FromCubicMiles(decimal? cubicmiles)
+        public static Volume? FromCubicMiles(QuantityValue? cubicmiles)
         {
             if (cubicmiles.HasValue)
             {
@@ -2677,52 +1387,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicMillimeters.
         /// </summary>
-        public static Volume? FromCubicMillimeters(double? cubicmillimeters)
-        {
-            if (cubicmillimeters.HasValue)
-            {
-                return FromCubicMillimeters(cubicmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMillimeters.
-        /// </summary>
-        public static Volume? FromCubicMillimeters(int? cubicmillimeters)
-        {
-            if (cubicmillimeters.HasValue)
-            {
-                return FromCubicMillimeters(cubicmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicMillimeters.
-        /// </summary>
-        public static Volume? FromCubicMillimeters(long? cubicmillimeters)
-        {
-            if (cubicmillimeters.HasValue)
-            {
-                return FromCubicMillimeters(cubicmillimeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicMillimeters of type decimal.
-        /// </summary>
-        public static Volume? FromCubicMillimeters(decimal? cubicmillimeters)
+        public static Volume? FromCubicMillimeters(QuantityValue? cubicmillimeters)
         {
             if (cubicmillimeters.HasValue)
             {
@@ -2737,52 +1402,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable CubicYards.
         /// </summary>
-        public static Volume? FromCubicYards(double? cubicyards)
-        {
-            if (cubicyards.HasValue)
-            {
-                return FromCubicYards(cubicyards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicYards.
-        /// </summary>
-        public static Volume? FromCubicYards(int? cubicyards)
-        {
-            if (cubicyards.HasValue)
-            {
-                return FromCubicYards(cubicyards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable CubicYards.
-        /// </summary>
-        public static Volume? FromCubicYards(long? cubicyards)
-        {
-            if (cubicyards.HasValue)
-            {
-                return FromCubicYards(cubicyards.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from CubicYards of type decimal.
-        /// </summary>
-        public static Volume? FromCubicYards(decimal? cubicyards)
+        public static Volume? FromCubicYards(QuantityValue? cubicyards)
         {
             if (cubicyards.HasValue)
             {
@@ -2797,52 +1417,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Deciliters.
         /// </summary>
-        public static Volume? FromDeciliters(double? deciliters)
-        {
-            if (deciliters.HasValue)
-            {
-                return FromDeciliters(deciliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Deciliters.
-        /// </summary>
-        public static Volume? FromDeciliters(int? deciliters)
-        {
-            if (deciliters.HasValue)
-            {
-                return FromDeciliters(deciliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Deciliters.
-        /// </summary>
-        public static Volume? FromDeciliters(long? deciliters)
-        {
-            if (deciliters.HasValue)
-            {
-                return FromDeciliters(deciliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Deciliters of type decimal.
-        /// </summary>
-        public static Volume? FromDeciliters(decimal? deciliters)
+        public static Volume? FromDeciliters(QuantityValue? deciliters)
         {
             if (deciliters.HasValue)
             {
@@ -2857,52 +1432,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable HectocubicFeet.
         /// </summary>
-        public static Volume? FromHectocubicFeet(double? hectocubicfeet)
-        {
-            if (hectocubicfeet.HasValue)
-            {
-                return FromHectocubicFeet(hectocubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable HectocubicFeet.
-        /// </summary>
-        public static Volume? FromHectocubicFeet(int? hectocubicfeet)
-        {
-            if (hectocubicfeet.HasValue)
-            {
-                return FromHectocubicFeet(hectocubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable HectocubicFeet.
-        /// </summary>
-        public static Volume? FromHectocubicFeet(long? hectocubicfeet)
-        {
-            if (hectocubicfeet.HasValue)
-            {
-                return FromHectocubicFeet(hectocubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from HectocubicFeet of type decimal.
-        /// </summary>
-        public static Volume? FromHectocubicFeet(decimal? hectocubicfeet)
+        public static Volume? FromHectocubicFeet(QuantityValue? hectocubicfeet)
         {
             if (hectocubicfeet.HasValue)
             {
@@ -2917,52 +1447,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable HectocubicMeters.
         /// </summary>
-        public static Volume? FromHectocubicMeters(double? hectocubicmeters)
-        {
-            if (hectocubicmeters.HasValue)
-            {
-                return FromHectocubicMeters(hectocubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable HectocubicMeters.
-        /// </summary>
-        public static Volume? FromHectocubicMeters(int? hectocubicmeters)
-        {
-            if (hectocubicmeters.HasValue)
-            {
-                return FromHectocubicMeters(hectocubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable HectocubicMeters.
-        /// </summary>
-        public static Volume? FromHectocubicMeters(long? hectocubicmeters)
-        {
-            if (hectocubicmeters.HasValue)
-            {
-                return FromHectocubicMeters(hectocubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from HectocubicMeters of type decimal.
-        /// </summary>
-        public static Volume? FromHectocubicMeters(decimal? hectocubicmeters)
+        public static Volume? FromHectocubicMeters(QuantityValue? hectocubicmeters)
         {
             if (hectocubicmeters.HasValue)
             {
@@ -2977,52 +1462,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Hectoliters.
         /// </summary>
-        public static Volume? FromHectoliters(double? hectoliters)
-        {
-            if (hectoliters.HasValue)
-            {
-                return FromHectoliters(hectoliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Hectoliters.
-        /// </summary>
-        public static Volume? FromHectoliters(int? hectoliters)
-        {
-            if (hectoliters.HasValue)
-            {
-                return FromHectoliters(hectoliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Hectoliters.
-        /// </summary>
-        public static Volume? FromHectoliters(long? hectoliters)
-        {
-            if (hectoliters.HasValue)
-            {
-                return FromHectoliters(hectoliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Hectoliters of type decimal.
-        /// </summary>
-        public static Volume? FromHectoliters(decimal? hectoliters)
+        public static Volume? FromHectoliters(QuantityValue? hectoliters)
         {
             if (hectoliters.HasValue)
             {
@@ -3037,52 +1477,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable ImperialBeerBarrels.
         /// </summary>
-        public static Volume? FromImperialBeerBarrels(double? imperialbeerbarrels)
-        {
-            if (imperialbeerbarrels.HasValue)
-            {
-                return FromImperialBeerBarrels(imperialbeerbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable ImperialBeerBarrels.
-        /// </summary>
-        public static Volume? FromImperialBeerBarrels(int? imperialbeerbarrels)
-        {
-            if (imperialbeerbarrels.HasValue)
-            {
-                return FromImperialBeerBarrels(imperialbeerbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable ImperialBeerBarrels.
-        /// </summary>
-        public static Volume? FromImperialBeerBarrels(long? imperialbeerbarrels)
-        {
-            if (imperialbeerbarrels.HasValue)
-            {
-                return FromImperialBeerBarrels(imperialbeerbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from ImperialBeerBarrels of type decimal.
-        /// </summary>
-        public static Volume? FromImperialBeerBarrels(decimal? imperialbeerbarrels)
+        public static Volume? FromImperialBeerBarrels(QuantityValue? imperialbeerbarrels)
         {
             if (imperialbeerbarrels.HasValue)
             {
@@ -3097,52 +1492,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable ImperialGallons.
         /// </summary>
-        public static Volume? FromImperialGallons(double? imperialgallons)
-        {
-            if (imperialgallons.HasValue)
-            {
-                return FromImperialGallons(imperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable ImperialGallons.
-        /// </summary>
-        public static Volume? FromImperialGallons(int? imperialgallons)
-        {
-            if (imperialgallons.HasValue)
-            {
-                return FromImperialGallons(imperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable ImperialGallons.
-        /// </summary>
-        public static Volume? FromImperialGallons(long? imperialgallons)
-        {
-            if (imperialgallons.HasValue)
-            {
-                return FromImperialGallons(imperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from ImperialGallons of type decimal.
-        /// </summary>
-        public static Volume? FromImperialGallons(decimal? imperialgallons)
+        public static Volume? FromImperialGallons(QuantityValue? imperialgallons)
         {
             if (imperialgallons.HasValue)
             {
@@ -3157,52 +1507,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable ImperialOunces.
         /// </summary>
-        public static Volume? FromImperialOunces(double? imperialounces)
-        {
-            if (imperialounces.HasValue)
-            {
-                return FromImperialOunces(imperialounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable ImperialOunces.
-        /// </summary>
-        public static Volume? FromImperialOunces(int? imperialounces)
-        {
-            if (imperialounces.HasValue)
-            {
-                return FromImperialOunces(imperialounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable ImperialOunces.
-        /// </summary>
-        public static Volume? FromImperialOunces(long? imperialounces)
-        {
-            if (imperialounces.HasValue)
-            {
-                return FromImperialOunces(imperialounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from ImperialOunces of type decimal.
-        /// </summary>
-        public static Volume? FromImperialOunces(decimal? imperialounces)
+        public static Volume? FromImperialOunces(QuantityValue? imperialounces)
         {
             if (imperialounces.HasValue)
             {
@@ -3217,52 +1522,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable KilocubicFeet.
         /// </summary>
-        public static Volume? FromKilocubicFeet(double? kilocubicfeet)
-        {
-            if (kilocubicfeet.HasValue)
-            {
-                return FromKilocubicFeet(kilocubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KilocubicFeet.
-        /// </summary>
-        public static Volume? FromKilocubicFeet(int? kilocubicfeet)
-        {
-            if (kilocubicfeet.HasValue)
-            {
-                return FromKilocubicFeet(kilocubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KilocubicFeet.
-        /// </summary>
-        public static Volume? FromKilocubicFeet(long? kilocubicfeet)
-        {
-            if (kilocubicfeet.HasValue)
-            {
-                return FromKilocubicFeet(kilocubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from KilocubicFeet of type decimal.
-        /// </summary>
-        public static Volume? FromKilocubicFeet(decimal? kilocubicfeet)
+        public static Volume? FromKilocubicFeet(QuantityValue? kilocubicfeet)
         {
             if (kilocubicfeet.HasValue)
             {
@@ -3277,52 +1537,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable KilocubicMeters.
         /// </summary>
-        public static Volume? FromKilocubicMeters(double? kilocubicmeters)
-        {
-            if (kilocubicmeters.HasValue)
-            {
-                return FromKilocubicMeters(kilocubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KilocubicMeters.
-        /// </summary>
-        public static Volume? FromKilocubicMeters(int? kilocubicmeters)
-        {
-            if (kilocubicmeters.HasValue)
-            {
-                return FromKilocubicMeters(kilocubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KilocubicMeters.
-        /// </summary>
-        public static Volume? FromKilocubicMeters(long? kilocubicmeters)
-        {
-            if (kilocubicmeters.HasValue)
-            {
-                return FromKilocubicMeters(kilocubicmeters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from KilocubicMeters of type decimal.
-        /// </summary>
-        public static Volume? FromKilocubicMeters(decimal? kilocubicmeters)
+        public static Volume? FromKilocubicMeters(QuantityValue? kilocubicmeters)
         {
             if (kilocubicmeters.HasValue)
             {
@@ -3337,52 +1552,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable KiloimperialGallons.
         /// </summary>
-        public static Volume? FromKiloimperialGallons(double? kiloimperialgallons)
-        {
-            if (kiloimperialgallons.HasValue)
-            {
-                return FromKiloimperialGallons(kiloimperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KiloimperialGallons.
-        /// </summary>
-        public static Volume? FromKiloimperialGallons(int? kiloimperialgallons)
-        {
-            if (kiloimperialgallons.HasValue)
-            {
-                return FromKiloimperialGallons(kiloimperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KiloimperialGallons.
-        /// </summary>
-        public static Volume? FromKiloimperialGallons(long? kiloimperialgallons)
-        {
-            if (kiloimperialgallons.HasValue)
-            {
-                return FromKiloimperialGallons(kiloimperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from KiloimperialGallons of type decimal.
-        /// </summary>
-        public static Volume? FromKiloimperialGallons(decimal? kiloimperialgallons)
+        public static Volume? FromKiloimperialGallons(QuantityValue? kiloimperialgallons)
         {
             if (kiloimperialgallons.HasValue)
             {
@@ -3397,52 +1567,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable KilousGallons.
         /// </summary>
-        public static Volume? FromKilousGallons(double? kilousgallons)
-        {
-            if (kilousgallons.HasValue)
-            {
-                return FromKilousGallons(kilousgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KilousGallons.
-        /// </summary>
-        public static Volume? FromKilousGallons(int? kilousgallons)
-        {
-            if (kilousgallons.HasValue)
-            {
-                return FromKilousGallons(kilousgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable KilousGallons.
-        /// </summary>
-        public static Volume? FromKilousGallons(long? kilousgallons)
-        {
-            if (kilousgallons.HasValue)
-            {
-                return FromKilousGallons(kilousgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from KilousGallons of type decimal.
-        /// </summary>
-        public static Volume? FromKilousGallons(decimal? kilousgallons)
+        public static Volume? FromKilousGallons(QuantityValue? kilousgallons)
         {
             if (kilousgallons.HasValue)
             {
@@ -3457,52 +1582,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Liters.
         /// </summary>
-        public static Volume? FromLiters(double? liters)
-        {
-            if (liters.HasValue)
-            {
-                return FromLiters(liters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Liters.
-        /// </summary>
-        public static Volume? FromLiters(int? liters)
-        {
-            if (liters.HasValue)
-            {
-                return FromLiters(liters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Liters.
-        /// </summary>
-        public static Volume? FromLiters(long? liters)
-        {
-            if (liters.HasValue)
-            {
-                return FromLiters(liters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Liters of type decimal.
-        /// </summary>
-        public static Volume? FromLiters(decimal? liters)
+        public static Volume? FromLiters(QuantityValue? liters)
         {
             if (liters.HasValue)
             {
@@ -3517,52 +1597,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable MegacubicFeet.
         /// </summary>
-        public static Volume? FromMegacubicFeet(double? megacubicfeet)
-        {
-            if (megacubicfeet.HasValue)
-            {
-                return FromMegacubicFeet(megacubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MegacubicFeet.
-        /// </summary>
-        public static Volume? FromMegacubicFeet(int? megacubicfeet)
-        {
-            if (megacubicfeet.HasValue)
-            {
-                return FromMegacubicFeet(megacubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MegacubicFeet.
-        /// </summary>
-        public static Volume? FromMegacubicFeet(long? megacubicfeet)
-        {
-            if (megacubicfeet.HasValue)
-            {
-                return FromMegacubicFeet(megacubicfeet.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from MegacubicFeet of type decimal.
-        /// </summary>
-        public static Volume? FromMegacubicFeet(decimal? megacubicfeet)
+        public static Volume? FromMegacubicFeet(QuantityValue? megacubicfeet)
         {
             if (megacubicfeet.HasValue)
             {
@@ -3577,52 +1612,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable MegaimperialGallons.
         /// </summary>
-        public static Volume? FromMegaimperialGallons(double? megaimperialgallons)
-        {
-            if (megaimperialgallons.HasValue)
-            {
-                return FromMegaimperialGallons(megaimperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MegaimperialGallons.
-        /// </summary>
-        public static Volume? FromMegaimperialGallons(int? megaimperialgallons)
-        {
-            if (megaimperialgallons.HasValue)
-            {
-                return FromMegaimperialGallons(megaimperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MegaimperialGallons.
-        /// </summary>
-        public static Volume? FromMegaimperialGallons(long? megaimperialgallons)
-        {
-            if (megaimperialgallons.HasValue)
-            {
-                return FromMegaimperialGallons(megaimperialgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from MegaimperialGallons of type decimal.
-        /// </summary>
-        public static Volume? FromMegaimperialGallons(decimal? megaimperialgallons)
+        public static Volume? FromMegaimperialGallons(QuantityValue? megaimperialgallons)
         {
             if (megaimperialgallons.HasValue)
             {
@@ -3637,52 +1627,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable MegausGallons.
         /// </summary>
-        public static Volume? FromMegausGallons(double? megausgallons)
-        {
-            if (megausgallons.HasValue)
-            {
-                return FromMegausGallons(megausgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MegausGallons.
-        /// </summary>
-        public static Volume? FromMegausGallons(int? megausgallons)
-        {
-            if (megausgallons.HasValue)
-            {
-                return FromMegausGallons(megausgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MegausGallons.
-        /// </summary>
-        public static Volume? FromMegausGallons(long? megausgallons)
-        {
-            if (megausgallons.HasValue)
-            {
-                return FromMegausGallons(megausgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from MegausGallons of type decimal.
-        /// </summary>
-        public static Volume? FromMegausGallons(decimal? megausgallons)
+        public static Volume? FromMegausGallons(QuantityValue? megausgallons)
         {
             if (megausgallons.HasValue)
             {
@@ -3697,52 +1642,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable MetricCups.
         /// </summary>
-        public static Volume? FromMetricCups(double? metriccups)
-        {
-            if (metriccups.HasValue)
-            {
-                return FromMetricCups(metriccups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MetricCups.
-        /// </summary>
-        public static Volume? FromMetricCups(int? metriccups)
-        {
-            if (metriccups.HasValue)
-            {
-                return FromMetricCups(metriccups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MetricCups.
-        /// </summary>
-        public static Volume? FromMetricCups(long? metriccups)
-        {
-            if (metriccups.HasValue)
-            {
-                return FromMetricCups(metriccups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from MetricCups of type decimal.
-        /// </summary>
-        public static Volume? FromMetricCups(decimal? metriccups)
+        public static Volume? FromMetricCups(QuantityValue? metriccups)
         {
             if (metriccups.HasValue)
             {
@@ -3757,52 +1657,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable MetricTeaspoons.
         /// </summary>
-        public static Volume? FromMetricTeaspoons(double? metricteaspoons)
-        {
-            if (metricteaspoons.HasValue)
-            {
-                return FromMetricTeaspoons(metricteaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MetricTeaspoons.
-        /// </summary>
-        public static Volume? FromMetricTeaspoons(int? metricteaspoons)
-        {
-            if (metricteaspoons.HasValue)
-            {
-                return FromMetricTeaspoons(metricteaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable MetricTeaspoons.
-        /// </summary>
-        public static Volume? FromMetricTeaspoons(long? metricteaspoons)
-        {
-            if (metricteaspoons.HasValue)
-            {
-                return FromMetricTeaspoons(metricteaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from MetricTeaspoons of type decimal.
-        /// </summary>
-        public static Volume? FromMetricTeaspoons(decimal? metricteaspoons)
+        public static Volume? FromMetricTeaspoons(QuantityValue? metricteaspoons)
         {
             if (metricteaspoons.HasValue)
             {
@@ -3817,52 +1672,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Microliters.
         /// </summary>
-        public static Volume? FromMicroliters(double? microliters)
-        {
-            if (microliters.HasValue)
-            {
-                return FromMicroliters(microliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Microliters.
-        /// </summary>
-        public static Volume? FromMicroliters(int? microliters)
-        {
-            if (microliters.HasValue)
-            {
-                return FromMicroliters(microliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Microliters.
-        /// </summary>
-        public static Volume? FromMicroliters(long? microliters)
-        {
-            if (microliters.HasValue)
-            {
-                return FromMicroliters(microliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Microliters of type decimal.
-        /// </summary>
-        public static Volume? FromMicroliters(decimal? microliters)
+        public static Volume? FromMicroliters(QuantityValue? microliters)
         {
             if (microliters.HasValue)
             {
@@ -3877,52 +1687,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Milliliters.
         /// </summary>
-        public static Volume? FromMilliliters(double? milliliters)
-        {
-            if (milliliters.HasValue)
-            {
-                return FromMilliliters(milliliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Milliliters.
-        /// </summary>
-        public static Volume? FromMilliliters(int? milliliters)
-        {
-            if (milliliters.HasValue)
-            {
-                return FromMilliliters(milliliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Milliliters.
-        /// </summary>
-        public static Volume? FromMilliliters(long? milliliters)
-        {
-            if (milliliters.HasValue)
-            {
-                return FromMilliliters(milliliters.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Milliliters of type decimal.
-        /// </summary>
-        public static Volume? FromMilliliters(decimal? milliliters)
+        public static Volume? FromMilliliters(QuantityValue? milliliters)
         {
             if (milliliters.HasValue)
             {
@@ -3937,52 +1702,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable OilBarrels.
         /// </summary>
-        public static Volume? FromOilBarrels(double? oilbarrels)
-        {
-            if (oilbarrels.HasValue)
-            {
-                return FromOilBarrels(oilbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable OilBarrels.
-        /// </summary>
-        public static Volume? FromOilBarrels(int? oilbarrels)
-        {
-            if (oilbarrels.HasValue)
-            {
-                return FromOilBarrels(oilbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable OilBarrels.
-        /// </summary>
-        public static Volume? FromOilBarrels(long? oilbarrels)
-        {
-            if (oilbarrels.HasValue)
-            {
-                return FromOilBarrels(oilbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from OilBarrels of type decimal.
-        /// </summary>
-        public static Volume? FromOilBarrels(decimal? oilbarrels)
+        public static Volume? FromOilBarrels(QuantityValue? oilbarrels)
         {
             if (oilbarrels.HasValue)
             {
@@ -3997,52 +1717,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Tablespoons.
         /// </summary>
-        public static Volume? FromTablespoons(double? tablespoons)
-        {
-            if (tablespoons.HasValue)
-            {
-                return FromTablespoons(tablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Tablespoons.
-        /// </summary>
-        public static Volume? FromTablespoons(int? tablespoons)
-        {
-            if (tablespoons.HasValue)
-            {
-                return FromTablespoons(tablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Tablespoons.
-        /// </summary>
-        public static Volume? FromTablespoons(long? tablespoons)
-        {
-            if (tablespoons.HasValue)
-            {
-                return FromTablespoons(tablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Tablespoons of type decimal.
-        /// </summary>
-        public static Volume? FromTablespoons(decimal? tablespoons)
+        public static Volume? FromTablespoons(QuantityValue? tablespoons)
         {
             if (tablespoons.HasValue)
             {
@@ -4057,52 +1732,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable Teaspoons.
         /// </summary>
-        public static Volume? FromTeaspoons(double? teaspoons)
-        {
-            if (teaspoons.HasValue)
-            {
-                return FromTeaspoons(teaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Teaspoons.
-        /// </summary>
-        public static Volume? FromTeaspoons(int? teaspoons)
-        {
-            if (teaspoons.HasValue)
-            {
-                return FromTeaspoons(teaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable Teaspoons.
-        /// </summary>
-        public static Volume? FromTeaspoons(long? teaspoons)
-        {
-            if (teaspoons.HasValue)
-            {
-                return FromTeaspoons(teaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from Teaspoons of type decimal.
-        /// </summary>
-        public static Volume? FromTeaspoons(decimal? teaspoons)
+        public static Volume? FromTeaspoons(QuantityValue? teaspoons)
         {
             if (teaspoons.HasValue)
             {
@@ -4117,52 +1747,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UkTablespoons.
         /// </summary>
-        public static Volume? FromUkTablespoons(double? uktablespoons)
-        {
-            if (uktablespoons.HasValue)
-            {
-                return FromUkTablespoons(uktablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UkTablespoons.
-        /// </summary>
-        public static Volume? FromUkTablespoons(int? uktablespoons)
-        {
-            if (uktablespoons.HasValue)
-            {
-                return FromUkTablespoons(uktablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UkTablespoons.
-        /// </summary>
-        public static Volume? FromUkTablespoons(long? uktablespoons)
-        {
-            if (uktablespoons.HasValue)
-            {
-                return FromUkTablespoons(uktablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UkTablespoons of type decimal.
-        /// </summary>
-        public static Volume? FromUkTablespoons(decimal? uktablespoons)
+        public static Volume? FromUkTablespoons(QuantityValue? uktablespoons)
         {
             if (uktablespoons.HasValue)
             {
@@ -4177,52 +1762,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsBeerBarrels.
         /// </summary>
-        public static Volume? FromUsBeerBarrels(double? usbeerbarrels)
-        {
-            if (usbeerbarrels.HasValue)
-            {
-                return FromUsBeerBarrels(usbeerbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsBeerBarrels.
-        /// </summary>
-        public static Volume? FromUsBeerBarrels(int? usbeerbarrels)
-        {
-            if (usbeerbarrels.HasValue)
-            {
-                return FromUsBeerBarrels(usbeerbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsBeerBarrels.
-        /// </summary>
-        public static Volume? FromUsBeerBarrels(long? usbeerbarrels)
-        {
-            if (usbeerbarrels.HasValue)
-            {
-                return FromUsBeerBarrels(usbeerbarrels.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsBeerBarrels of type decimal.
-        /// </summary>
-        public static Volume? FromUsBeerBarrels(decimal? usbeerbarrels)
+        public static Volume? FromUsBeerBarrels(QuantityValue? usbeerbarrels)
         {
             if (usbeerbarrels.HasValue)
             {
@@ -4237,52 +1777,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsCustomaryCups.
         /// </summary>
-        public static Volume? FromUsCustomaryCups(double? uscustomarycups)
-        {
-            if (uscustomarycups.HasValue)
-            {
-                return FromUsCustomaryCups(uscustomarycups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsCustomaryCups.
-        /// </summary>
-        public static Volume? FromUsCustomaryCups(int? uscustomarycups)
-        {
-            if (uscustomarycups.HasValue)
-            {
-                return FromUsCustomaryCups(uscustomarycups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsCustomaryCups.
-        /// </summary>
-        public static Volume? FromUsCustomaryCups(long? uscustomarycups)
-        {
-            if (uscustomarycups.HasValue)
-            {
-                return FromUsCustomaryCups(uscustomarycups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsCustomaryCups of type decimal.
-        /// </summary>
-        public static Volume? FromUsCustomaryCups(decimal? uscustomarycups)
+        public static Volume? FromUsCustomaryCups(QuantityValue? uscustomarycups)
         {
             if (uscustomarycups.HasValue)
             {
@@ -4297,52 +1792,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsGallons.
         /// </summary>
-        public static Volume? FromUsGallons(double? usgallons)
-        {
-            if (usgallons.HasValue)
-            {
-                return FromUsGallons(usgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsGallons.
-        /// </summary>
-        public static Volume? FromUsGallons(int? usgallons)
-        {
-            if (usgallons.HasValue)
-            {
-                return FromUsGallons(usgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsGallons.
-        /// </summary>
-        public static Volume? FromUsGallons(long? usgallons)
-        {
-            if (usgallons.HasValue)
-            {
-                return FromUsGallons(usgallons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsGallons of type decimal.
-        /// </summary>
-        public static Volume? FromUsGallons(decimal? usgallons)
+        public static Volume? FromUsGallons(QuantityValue? usgallons)
         {
             if (usgallons.HasValue)
             {
@@ -4357,52 +1807,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsLegalCups.
         /// </summary>
-        public static Volume? FromUsLegalCups(double? uslegalcups)
-        {
-            if (uslegalcups.HasValue)
-            {
-                return FromUsLegalCups(uslegalcups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsLegalCups.
-        /// </summary>
-        public static Volume? FromUsLegalCups(int? uslegalcups)
-        {
-            if (uslegalcups.HasValue)
-            {
-                return FromUsLegalCups(uslegalcups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsLegalCups.
-        /// </summary>
-        public static Volume? FromUsLegalCups(long? uslegalcups)
-        {
-            if (uslegalcups.HasValue)
-            {
-                return FromUsLegalCups(uslegalcups.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsLegalCups of type decimal.
-        /// </summary>
-        public static Volume? FromUsLegalCups(decimal? uslegalcups)
+        public static Volume? FromUsLegalCups(QuantityValue? uslegalcups)
         {
             if (uslegalcups.HasValue)
             {
@@ -4417,52 +1822,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsOunces.
         /// </summary>
-        public static Volume? FromUsOunces(double? usounces)
-        {
-            if (usounces.HasValue)
-            {
-                return FromUsOunces(usounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsOunces.
-        /// </summary>
-        public static Volume? FromUsOunces(int? usounces)
-        {
-            if (usounces.HasValue)
-            {
-                return FromUsOunces(usounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsOunces.
-        /// </summary>
-        public static Volume? FromUsOunces(long? usounces)
-        {
-            if (usounces.HasValue)
-            {
-                return FromUsOunces(usounces.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsOunces of type decimal.
-        /// </summary>
-        public static Volume? FromUsOunces(decimal? usounces)
+        public static Volume? FromUsOunces(QuantityValue? usounces)
         {
             if (usounces.HasValue)
             {
@@ -4477,52 +1837,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsTablespoons.
         /// </summary>
-        public static Volume? FromUsTablespoons(double? ustablespoons)
-        {
-            if (ustablespoons.HasValue)
-            {
-                return FromUsTablespoons(ustablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsTablespoons.
-        /// </summary>
-        public static Volume? FromUsTablespoons(int? ustablespoons)
-        {
-            if (ustablespoons.HasValue)
-            {
-                return FromUsTablespoons(ustablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsTablespoons.
-        /// </summary>
-        public static Volume? FromUsTablespoons(long? ustablespoons)
-        {
-            if (ustablespoons.HasValue)
-            {
-                return FromUsTablespoons(ustablespoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsTablespoons of type decimal.
-        /// </summary>
-        public static Volume? FromUsTablespoons(decimal? ustablespoons)
+        public static Volume? FromUsTablespoons(QuantityValue? ustablespoons)
         {
             if (ustablespoons.HasValue)
             {
@@ -4537,52 +1852,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable Volume from nullable UsTeaspoons.
         /// </summary>
-        public static Volume? FromUsTeaspoons(double? usteaspoons)
-        {
-            if (usteaspoons.HasValue)
-            {
-                return FromUsTeaspoons(usteaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsTeaspoons.
-        /// </summary>
-        public static Volume? FromUsTeaspoons(int? usteaspoons)
-        {
-            if (usteaspoons.HasValue)
-            {
-                return FromUsTeaspoons(usteaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from nullable UsTeaspoons.
-        /// </summary>
-        public static Volume? FromUsTeaspoons(long? usteaspoons)
-        {
-            if (usteaspoons.HasValue)
-            {
-                return FromUsTeaspoons(usteaspoons.Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable Volume from UsTeaspoons of type decimal.
-        /// </summary>
-        public static Volume? FromUsTeaspoons(decimal? usteaspoons)
+        public static Volume? FromUsTeaspoons(QuantityValue? usteaspoons)
         {
             if (usteaspoons.HasValue)
             {
@@ -4599,97 +1869,103 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="VolumeUnit" /> to <see cref="Volume" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Volume unit value.</returns>
-        public static Volume From(double val, VolumeUnit fromUnit)
+#if WINDOWS_UWP
+        // Fix name conflict with parameter "value"
+        [return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+        public static Volume From(double value, VolumeUnit fromUnit)
+#else
+        public static Volume From(QuantityValue value, VolumeUnit fromUnit)
+#endif
         {
             switch (fromUnit)
             {
                 case VolumeUnit.AuTablespoon:
-                    return FromAuTablespoons(val);
+                    return FromAuTablespoons(value);
                 case VolumeUnit.Centiliter:
-                    return FromCentiliters(val);
+                    return FromCentiliters(value);
                 case VolumeUnit.CubicCentimeter:
-                    return FromCubicCentimeters(val);
+                    return FromCubicCentimeters(value);
                 case VolumeUnit.CubicDecimeter:
-                    return FromCubicDecimeters(val);
+                    return FromCubicDecimeters(value);
                 case VolumeUnit.CubicFoot:
-                    return FromCubicFeet(val);
+                    return FromCubicFeet(value);
                 case VolumeUnit.CubicInch:
-                    return FromCubicInches(val);
+                    return FromCubicInches(value);
                 case VolumeUnit.CubicKilometer:
-                    return FromCubicKilometers(val);
+                    return FromCubicKilometers(value);
                 case VolumeUnit.CubicMeter:
-                    return FromCubicMeters(val);
+                    return FromCubicMeters(value);
                 case VolumeUnit.CubicMicrometer:
-                    return FromCubicMicrometers(val);
+                    return FromCubicMicrometers(value);
                 case VolumeUnit.CubicMile:
-                    return FromCubicMiles(val);
+                    return FromCubicMiles(value);
                 case VolumeUnit.CubicMillimeter:
-                    return FromCubicMillimeters(val);
+                    return FromCubicMillimeters(value);
                 case VolumeUnit.CubicYard:
-                    return FromCubicYards(val);
+                    return FromCubicYards(value);
                 case VolumeUnit.Deciliter:
-                    return FromDeciliters(val);
+                    return FromDeciliters(value);
                 case VolumeUnit.HectocubicFoot:
-                    return FromHectocubicFeet(val);
+                    return FromHectocubicFeet(value);
                 case VolumeUnit.HectocubicMeter:
-                    return FromHectocubicMeters(val);
+                    return FromHectocubicMeters(value);
                 case VolumeUnit.Hectoliter:
-                    return FromHectoliters(val);
+                    return FromHectoliters(value);
                 case VolumeUnit.ImperialBeerBarrel:
-                    return FromImperialBeerBarrels(val);
+                    return FromImperialBeerBarrels(value);
                 case VolumeUnit.ImperialGallon:
-                    return FromImperialGallons(val);
+                    return FromImperialGallons(value);
                 case VolumeUnit.ImperialOunce:
-                    return FromImperialOunces(val);
+                    return FromImperialOunces(value);
                 case VolumeUnit.KilocubicFoot:
-                    return FromKilocubicFeet(val);
+                    return FromKilocubicFeet(value);
                 case VolumeUnit.KilocubicMeter:
-                    return FromKilocubicMeters(val);
+                    return FromKilocubicMeters(value);
                 case VolumeUnit.KiloimperialGallon:
-                    return FromKiloimperialGallons(val);
+                    return FromKiloimperialGallons(value);
                 case VolumeUnit.KilousGallon:
-                    return FromKilousGallons(val);
+                    return FromKilousGallons(value);
                 case VolumeUnit.Liter:
-                    return FromLiters(val);
+                    return FromLiters(value);
                 case VolumeUnit.MegacubicFoot:
-                    return FromMegacubicFeet(val);
+                    return FromMegacubicFeet(value);
                 case VolumeUnit.MegaimperialGallon:
-                    return FromMegaimperialGallons(val);
+                    return FromMegaimperialGallons(value);
                 case VolumeUnit.MegausGallon:
-                    return FromMegausGallons(val);
+                    return FromMegausGallons(value);
                 case VolumeUnit.MetricCup:
-                    return FromMetricCups(val);
+                    return FromMetricCups(value);
                 case VolumeUnit.MetricTeaspoon:
-                    return FromMetricTeaspoons(val);
+                    return FromMetricTeaspoons(value);
                 case VolumeUnit.Microliter:
-                    return FromMicroliters(val);
+                    return FromMicroliters(value);
                 case VolumeUnit.Milliliter:
-                    return FromMilliliters(val);
+                    return FromMilliliters(value);
                 case VolumeUnit.OilBarrel:
-                    return FromOilBarrels(val);
+                    return FromOilBarrels(value);
                 case VolumeUnit.Tablespoon:
-                    return FromTablespoons(val);
+                    return FromTablespoons(value);
                 case VolumeUnit.Teaspoon:
-                    return FromTeaspoons(val);
+                    return FromTeaspoons(value);
                 case VolumeUnit.UkTablespoon:
-                    return FromUkTablespoons(val);
+                    return FromUkTablespoons(value);
                 case VolumeUnit.UsBeerBarrel:
-                    return FromUsBeerBarrels(val);
+                    return FromUsBeerBarrels(value);
                 case VolumeUnit.UsCustomaryCup:
-                    return FromUsCustomaryCups(val);
+                    return FromUsCustomaryCups(value);
                 case VolumeUnit.UsGallon:
-                    return FromUsGallons(val);
+                    return FromUsGallons(value);
                 case VolumeUnit.UsLegalCup:
-                    return FromUsLegalCups(val);
+                    return FromUsLegalCups(value);
                 case VolumeUnit.UsOunce:
-                    return FromUsOunces(val);
+                    return FromUsOunces(value);
                 case VolumeUnit.UsTablespoon:
-                    return FromUsTablespoons(val);
+                    return FromUsTablespoons(value);
                 case VolumeUnit.UsTeaspoon:
-                    return FromUsTeaspoons(val);
+                    return FromUsTeaspoons(value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -4704,7 +1980,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>Volume unit value.</returns>
-        public static Volume? From(double? value, VolumeUnit fromUnit)
+        public static Volume? From(QuantityValue? value, VolumeUnit fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -40,7 +40,7 @@ namespace UnitsNet
 
         // Obsolete is used to communicate how they should use this type, instead of making the constructor private and have them figure it out
         [Obsolete("Do not use this constructor. Instead pass any numeric value such as int, long, float, double, decimal, short or byte directly and it will be implicitly casted to double.")]
-        public QuantityValue(double val)
+        private QuantityValue(double val)
         {
             _value = val;
         }

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -1,0 +1,68 @@
+﻿// Copyright © 2007 Andreas Gullberg Larsen (angularsen@gmail.com).
+// https://github.com/angularsen/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Operator overloads not supported in Windows Runtime Components, we use 'double' type instead
+#if !WINDOWS_UWP
+using System;
+
+namespace UnitsNet
+{
+    /// <summary>
+    ///     Pass it any numeric value (int, double, decimal, float..) and it will be implicitly converted to a <see cref="double" />, the quantity value representation used in UnitsNet.
+    ///     This is used to avoid an explosion of overloads for methods taking N numeric types for all our 500+ units.
+    /// </summary>
+    /// <remarks>
+    ///     At the time of this writing, this reduces the number of From() overloads to 1/4th:
+    ///     From 8 (int, long, double, decimal + each nullable) down to 2 (QuantityValue and QuantityValue?).
+    ///     This also adds more numeric types with no extra overhead, such as float, short and byte.
+    /// </remarks>
+    public struct QuantityValue
+    {
+        private readonly double _value;
+
+        // Obsolete is used to communicate how they should use this type, instead of making the constructor private and have them figure it out
+        [Obsolete("Do not use this constructor. Instead pass any numeric value such as int, long, float, double, decimal, short or byte directly and it will be implicitly casted to double.")]
+        public QuantityValue(double val)
+        {
+            _value = val;
+        }
+
+        #region To QuantityValue
+
+#pragma warning disable 618
+        public static implicit operator QuantityValue(double val) => new QuantityValue(val);
+        public static implicit operator QuantityValue(float val) => new QuantityValue(val);
+        public static implicit operator QuantityValue(long val) => new QuantityValue(val);
+        public static implicit operator QuantityValue(decimal val) => new QuantityValue(Convert.ToDouble(val));
+        public static implicit operator QuantityValue(short val) => new QuantityValue(val);
+        public static implicit operator QuantityValue(byte val) => new QuantityValue(val);
+#pragma warning restore 618
+        
+        #endregion
+
+        #region To double
+
+        public static implicit operator double(QuantityValue number) => number._value;
+
+        #endregion
+    }
+}
+#endif

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -60,7 +60,7 @@ namespace UnitsNet
 
         #region To double
 
-        public static implicit operator double(QuantityValue number) => number._value;
+        public static explicit operator double(QuantityValue number) => number._value;
 
         #endregion
     }

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -83,8 +83,10 @@ using UnitsNet.Units;
 // Windows Runtime Component does not support CultureInfo type, so use culture name string instead for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
 #if WINDOWS_UWP
 using Culture = System.String;
+using FromValue = System.Double;
 #else
 using Culture = System.IFormatProvider;
+using FromValue = UnitsNet.QuantityValue;
 #endif
 
 // ReSharper disable once CheckNamespace
@@ -202,37 +204,10 @@ namespace UnitsNet
 #if NETFX_CORE
         [Windows.Foundation.Metadata.DefaultOverload]
 #endif
-        public static $quantityName From$($unit.PluralName)(double $valueParamName)
+        public static $quantityName From$($unit.PluralName)(FromValue $valueParamName)
         {
             return new $quantityName($func);
         }
-
-        /// <summary>
-        ///     Get $quantityName from $($unit.PluralName).
-        /// </summary>
-        public static $quantityName From$($unit.PluralName)(int $valueParamName)
-        {
-            return new $quantityName($($func));
-        }
-
-        /// <summary>
-        ///     Get $quantityName from $($unit.PluralName).
-        /// </summary>
-        public static $quantityName From$($unit.PluralName)(long $valueParamName)
-        {
-            return new $quantityName($($func));
-        }
-
-        // Windows Runtime Component does not support decimal type
-#if !WINDOWS_UWP
-        /// <summary>
-        ///     Get $quantityName from $($unit.PluralName) of type decimal.
-        /// </summary>
-        public static $($quantityName) From$($unit.PluralName)(decimal $valueParamName)
-        {
-            return new $quantityName($($decimalFunc));
-        }
-#endif
 
 "@; }@"
         // Windows Runtime Component does not support nullable types (double?): https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -243,52 +218,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get nullable $quantityName from nullable $($unit.PluralName).
         /// </summary>
-        public static $($quantityName)? From$($unit.PluralName)(double? $valueParamName)
-        {
-            if ($($valueParamName).HasValue)
-            {
-                return From$($unit.PluralName)($($valueParamName).Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable $quantityName from nullable $($unit.PluralName).
-        /// </summary>
-        public static $($quantityName)? From$($unit.PluralName)(int? $valueParamName)
-        {
-            if ($($valueParamName).HasValue)
-            {
-                return From$($unit.PluralName)($($valueParamName).Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable $quantityName from nullable $($unit.PluralName).
-        /// </summary>
-        public static $($quantityName)? From$($unit.PluralName)(long? $valueParamName)
-        {
-            if ($($valueParamName).HasValue)
-            {
-                return From$($unit.PluralName)($($valueParamName).Value);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        ///     Get nullable $quantityName from $($unit.PluralName) of type decimal.
-        /// </summary>
-        public static $($quantityName)? From$($unit.PluralName)(decimal? $valueParamName)
+        public static $($quantityName)? From$($unit.PluralName)(FromValue? $valueParamName)
         {
             if ($($valueParamName).HasValue)
             {
@@ -306,16 +236,20 @@ namespace UnitsNet
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="$unitEnumName" /> to <see cref="$quantityName" />.
         /// </summary>
-        /// <param name="val">Value to convert from.</param>
+        /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>$quantityName unit value.</returns>
-        public static $quantityName From(double val, $unitEnumName fromUnit)
+#if WINDOWS_UWP
+		// Fix name conflict with parameter "value"
+		[return: System.Runtime.InteropServices.WindowsRuntime.ReturnValueName("returnValue")]
+#endif
+        public static $quantityName From(FromValue value, $unitEnumName fromUnit)
         {
             switch (fromUnit)
             {
 "@; foreach ($unit in $units) {@"
                 case $unitEnumName.$($unit.SingularName):
-                    return From$($unit.PluralName)(val);
+                    return From$($unit.PluralName)(value);
 "@; }@"
 
                 default:
@@ -331,7 +265,7 @@ namespace UnitsNet
         /// <param name="value">Value to convert from.</param>
         /// <param name="fromUnit">Unit to convert from.</param>
         /// <returns>$quantityName unit value.</returns>
-        public static $($quantityName)? From(double? value, $unitEnumName fromUnit)
+        public static $($quantityName)? From(FromValue? value, $unitEnumName fromUnit)
         {
             if (!value.HasValue)
             {

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -26,10 +26,10 @@ using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 #if WINDOWS_UWP
 using Culture = System.String;
-
+using FromValue = System.Double;
 #else
 using Culture = System.IFormatProvider;
-
+using FromValue = UnitsNet.QuantityValue;
 #endif
 
 namespace UnitsNet
@@ -71,7 +71,7 @@ namespace UnitsNet
         /// <returns>Output value as the result of converting to <paramref name="toUnit" />.</returns>
         /// <exception cref="UnitNotFoundException">No units match the abbreviation.</exception>
         /// <exception cref="AmbiguousUnitParseException">More than one unit matches the abbrevation.</exception>
-        public static double ConvertByName(double fromValue, string quantityName, string fromUnit, string toUnit)
+        public static double ConvertByName(FromValue fromValue, string quantityName, string fromUnit, string toUnit)
         {
             Type quantityType = GetQuantityType(quantityName);
             Type unitType = GetUnitType(quantityName);
@@ -115,7 +115,7 @@ namespace UnitsNet
         /// <param name="result">Result if conversion was successful, 0 if not.</param>
         /// <example>bool ok = TryConvertByName(5, "Length", "Meter", "Centimeter", out double centimeters); // 500</example>
         /// <returns>True if conversion was successful.</returns>
-        public static bool TryConvertByName(double inputValue, string quantityName, string fromUnit, string toUnit, out double result)
+        public static bool TryConvertByName(FromValue inputValue, string quantityName, string fromUnit, string toUnit, out double result)
         {
             try
             {
@@ -157,7 +157,7 @@ namespace UnitsNet
         /// </param>
         /// <example>double centimeters = ConvertByName(5, "Length", "m", "cm"); // 500</example>
         /// <returns>Output value as the result of converting to <paramref name="toUnitAbbrev" />.</returns>
-        public static double ConvertByAbbreviation(double fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev)
+        public static double ConvertByAbbreviation(FromValue fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev)
         {
             // WindowsRuntimeComponent does not support default values on public methods
             // ReSharper disable once IntroduceOptionalParameters.Global
@@ -194,7 +194,7 @@ namespace UnitsNet
         /// <exception cref="QuantityNotFoundException">No quantity types match the <paramref name="quantityName"/>.</exception>
         /// <exception cref="UnitNotFoundException">No unit types match the prefix of <paramref name="quantityName"/> or no units are mapped to the abbreviation.</exception>
         /// <exception cref="AmbiguousUnitParseException">More than one unit matches the abbrevation.</exception>
-        public static double ConvertByAbbreviation(double fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev, string culture)
+        public static double ConvertByAbbreviation(FromValue fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev, string culture)
         {
             Type quantityType = GetQuantityType(quantityName);
             Type unitType = GetUnitType(quantityName);
@@ -239,7 +239,7 @@ namespace UnitsNet
         /// <param name="result">Result if conversion was successful, 0 if not.</param>
         /// <example>double centimeters = ConvertByName(5, "Length", "m", "cm"); // 500</example>
         /// <returns>True if conversion was successful.</returns>
-        public static bool TryConvertByAbbreviation(double fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev, out double result)
+        public static bool TryConvertByAbbreviation(FromValue fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev, out double result)
         {
             return TryConvertByAbbreviation(fromValue, quantityName, fromUnitAbbrev, toUnitAbbrev, out result, null);
         }
@@ -272,7 +272,7 @@ namespace UnitsNet
         /// <param name="result">Result if conversion was successful, 0 if not.</param>
         /// <example>double centimeters = ConvertByName(5, "Length", "m", "cm"); // 500</example>
         /// <returns>True if conversion was successful.</returns>
-        public static bool TryConvertByAbbreviation(double fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev, out double result,
+        public static bool TryConvertByAbbreviation(FromValue fromValue, string quantityName, string fromUnitAbbrev, string toUnitAbbrev, out double result,
             string culture)
         {
             try
@@ -310,7 +310,7 @@ namespace UnitsNet
                 .Single(m => m.Name == "From" &&
                              m.IsStatic &&
                              m.IsPublic &&
-                             HasParameterTypes(m, typeof(double), unitType) &&
+                             HasParameterTypes(m, typeof(FromValue), unitType) &&
                              m.ReturnType == quantityType);
         }
 


### PR DESCRIPTION
This is a follow up of #298 where many new overloads were introduced for each of the 550+ units.

This PR tries to mitigate this by:
* Add new `struct QuantityValue` type, with implicit cast overloads from all numeric types and implicit cast back to `double`. The overload hit is done once - instead of 550 times for all units.
* Use `FromValue` namespace alias to simplify compatibility with Windows Runtime Component (reduce the amount of #if sections)

I tried using generic type constraints, but I couldn't get it to infer the numeric types for the nullable overloads.

#### Result

UnitsNet.dll is reduced from **870 to 800 kB** for 50 quantities and 550 units. The reduction is also a proportional to the number of units and will grow better as we add more units. The number of overloads was reduced to 1/4th, while also adding support for three new numeric types: short, float and byte.
We still need to have two overloads for nullability.