### PR TITLE
changed expressions in term of algebraic operations with corresponding numeric results

### DIFF
--- a/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
@@ -27,9 +27,9 @@ namespace UnitsNet.Tests.CustomCode
     {
         protected override double JoulesPerKilogramInOneJoulePerKilogram => 1.0;
 
-        protected override double CaloriesPerGramInOneJoulePerKilogram => 1.0/4.184E3;
+        protected override double CaloriesPerGramInOneJoulePerKilogram => 2.410800386e-4;
 
-        protected override double KilocaloriesPerGramInOneJoulePerKilogram => 1.0/4.184E6;
+        protected override double KilocaloriesPerGramInOneJoulePerKilogram => 2.410800386e-7;
 
 
         protected override double KilojoulesPerKilogramInOneJoulePerKilogram => 1.0E-3;
@@ -40,7 +40,7 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double MegawattHoursPerKilogramInOneJoulePerKilogram => 2.77777778E-10;
 
-        protected override double WattHoursPerKilogramInOneJoulePerKilogram => 1.0/3.6e3;
+        protected override double WattHoursPerKilogramInOneJoulePerKilogram => 2.77777e-4;
 
         [Fact]
         public void MassTimesSpecificEnergyEqualsEnergy()

--- a/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
@@ -26,20 +26,13 @@ namespace UnitsNet.Tests.CustomCode
     public class SpecificEnergyTests : SpecificEnergyTestsBase
     {
         protected override double JoulesPerKilogramInOneJoulePerKilogram => 1e0;
-
-
+        protected override double KilojoulesPerKilogramInOneJoulePerKilogram => 1e-3;
+        protected override double MegajoulesPerKilogramInOneJoulePerKilogram => 1e-6;
         protected override double CaloriesPerGramInOneJoulePerKilogram => 2.3900573613766730401529636711281e-4;
         protected override double KilocaloriesPerGramInOneJoulePerKilogram => 2.3900573613766730401529636711281e-7;
-
-        protected override double KilojoulesPerKilogramInOneJoulePerKilogram => 1e-3;
-
-        protected override double KilowattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-7;
-
-        protected override double MegajoulesPerKilogramInOneJoulePerKilogram => 1e-6;
-
-        protected override double MegawattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-10;
-
         protected override double WattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-4;
+        protected override double KilowattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-7;
+        protected override double MegawattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-10;
 
         [Fact]
         public void MassTimesSpecificEnergyEqualsEnergy()

--- a/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
@@ -25,19 +25,19 @@ namespace UnitsNet.Tests.CustomCode
 {
     public class SpecificEnergyTests : SpecificEnergyTestsBase
     {
-        protected override double JoulesPerKilogramInOneJoulePerKilogram => 1.0;
+        protected override double JoulesPerKilogramInOneJoulePerKilogram => 1e0;
 
 
         protected override double CaloriesPerGramInOneJoulePerKilogram => 2.3900573613766730401529636711281e-4;
         protected override double KilocaloriesPerGramInOneJoulePerKilogram => 2.3900573613766730401529636711281e-7;
 
-        protected override double KilojoulesPerKilogramInOneJoulePerKilogram => 1.0E-3;
+        protected override double KilojoulesPerKilogramInOneJoulePerKilogram => 1e-3;
 
         protected override double KilowattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-7;
 
-        protected override double MegajoulesPerKilogramInOneJoulePerKilogram => 1.0E-6;
+        protected override double MegajoulesPerKilogramInOneJoulePerKilogram => 1e-6;
 
-        protected override double MegawattHoursPerKilogramInOneJoulePerKilogram => 2.77777778E-10;
+        protected override double MegawattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-10;
 
         protected override double WattHoursPerKilogramInOneJoulePerKilogram => 2.77777e-4;
 

--- a/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
@@ -39,7 +39,7 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double MegawattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-10;
 
-        protected override double WattHoursPerKilogramInOneJoulePerKilogram => 2.77777e-4;
+        protected override double WattHoursPerKilogramInOneJoulePerKilogram => 2.77777778e-4;
 
         [Fact]
         public void MassTimesSpecificEnergyEqualsEnergy()

--- a/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
@@ -27,10 +27,9 @@ namespace UnitsNet.Tests.CustomCode
     {
         protected override double JoulesPerKilogramInOneJoulePerKilogram => 1.0;
 
-        protected override double CaloriesPerGramInOneJoulePerKilogram => 2.410800386e-4;
 
-        protected override double KilocaloriesPerGramInOneJoulePerKilogram => 2.410800386e-7;
-
+        protected override double CaloriesPerGramInOneJoulePerKilogram => 2.3900573613766730401529636711281e-4;
+        protected override double KilocaloriesPerGramInOneJoulePerKilogram => 2.3900573613766730401529636711281e-7;
 
         protected override double KilojoulesPerKilogramInOneJoulePerKilogram => 1.0E-3;
 


### PR DESCRIPTION
as it is on demand, conversion values of a property in `UnitDefinition/*.json` files and those in `CustomCode/*.cs` files must be expressed differently in order to lead tests to reasonable execution. in case of specific energy, I noticed that there is no such consistency. on both side conversion factors from/to base unit are expressed identically. For instance,

in UnitDefinition : ` "FromBaseToUnitFunc": "x/4.184e3" `
in CustomCode : ` "CaloriesPerGramInOneJoulePerKilogram": "x/4.184e3",`