### PR TITLE
Read units with UTF8 encoding

### DIFF
--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -2713,82 +2713,82 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilogramForcePerCubicCentimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kgf/cmÂ³"),
+                                new AbbreviationsForCulture("en-US", "kgf/cm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilogramForcePerCubicMeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kgf/mÂ³"),
+                                new AbbreviationsForCulture("en-US", "kgf/m³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilogramForcePerCubicMillimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kgf/mmÂ³"),
+                                new AbbreviationsForCulture("en-US", "kgf/mm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilonewtonPerCubicCentimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kN/cmÂ³"),
+                                new AbbreviationsForCulture("en-US", "kN/cm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilonewtonPerCubicMeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kN/mÂ³"),
+                                new AbbreviationsForCulture("en-US", "kN/m³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilonewtonPerCubicMillimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kN/mmÂ³"),
+                                new AbbreviationsForCulture("en-US", "kN/mm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilopoundForcePerCubicFoot,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kipf/ftÂ³"),
+                                new AbbreviationsForCulture("en-US", "kipf/ft³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.KilopoundForcePerCubicInch,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "kipf/inÂ³"),
+                                new AbbreviationsForCulture("en-US", "kipf/in³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.NewtonPerCubicCentimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "N/cmÂ³"),
+                                new AbbreviationsForCulture("en-US", "N/cm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.NewtonPerCubicMeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "N/mÂ³"),
+                                new AbbreviationsForCulture("en-US", "N/m³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.NewtonPerCubicMillimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "N/mmÂ³"),
+                                new AbbreviationsForCulture("en-US", "N/mm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.PoundForcePerCubicFoot,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "lbf/ftÂ³"),
+                                new AbbreviationsForCulture("en-US", "lbf/ft³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.PoundForcePerCubicInch,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "lbf/inÂ³"),
+                                new AbbreviationsForCulture("en-US", "lbf/in³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.TonneForcePerCubicCentimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "tf/cmÂ³"),
+                                new AbbreviationsForCulture("en-US", "tf/cm³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.TonneForcePerCubicMeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "tf/mÂ³"),
+                                new AbbreviationsForCulture("en-US", "tf/m³"),
                             }),
                         new CulturesForEnumValue((int) SpecificWeightUnit.TonneForcePerCubicMillimeter,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "tf/mmÂ³"),
+                                new AbbreviationsForCulture("en-US", "tf/mm³"),
                             }),
                     }),
                 new UnitLocalization(typeof (SpeedUnit),

--- a/UnitsNet/Scripts/GenerateUnits.ps1
+++ b/UnitsNet/Scripts/GenerateUnits.ps1
@@ -272,7 +272,7 @@ $pad = 25
 
 # Parse unit definitions from .json files and populate properties
 $quantities = Get-ChildItem -Path $templatesDir -filter "*.json" `
-    | %{(Get-Content $_.FullName | Out-String)} `
+    | %{(Get-Content $_.FullName -Encoding "UTF8" | Out-String)} `
     | ConvertFrom-Json `
     | Add-PrefixUnits `
     | Set-DefaultValues `

--- a/UnitsNet/UnitDefinitions/ThermalResistance.json
+++ b/UnitsNet/UnitDefinitions/ThermalResistance.json
@@ -1,4 +1,4 @@
-{
+ï»¿{
   "Name": "ThermalResistance",
   "BaseUnit": "SquareMeterKelvinPerKilowatt",
   "XmlDoc": "Heat Transfer Coefficient or Thermal conductivity - indicates a materials ability to conduct heat.",
@@ -11,7 +11,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "m²K/kW" ]
+          "Abbreviations": [ "mÂ²K/kW" ]
         }
       ]
     },
@@ -23,7 +23,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "m²°C/W" ]
+          "Abbreviations": [ "mÂ²Â°C/W" ]
         }
       ]
     },
@@ -35,7 +35,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "cm²K/W" ]
+          "Abbreviations": [ "cmÂ²K/W" ]
         }
       ]
     },
@@ -47,7 +47,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "cm²Hr°C/kcal" ]
+          "Abbreviations": [ "cmÂ²HrÂ°C/kcal" ]
         }
       ]
     },
@@ -59,7 +59,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "Hrft²°F/Btu" ]
+          "Abbreviations": [ "HrftÂ²Â°F/Btu" ]
         }
       ]
     }


### PR DESCRIPTION
We always write generated files in UTF8, but do not read .json files as UTF8 files.
Default Get-Content do not read right some Unicode chars (like Cube (0x0179), Celseum, etc.).
Adding Encoding to Get-Content solved the issue.