### PR TITLE
Add .NET 4.0 target

### DIFF
--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Serialization.JsonNet.Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
     <PackageId>UnitsNet.Serialization.JsonNet.Signed</PackageId>
     <Title>Units.NET Serialization with Json.NET (signed)</Title>
   </PropertyGroup>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Serialization.JsonNet.Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for building with dotnet CLI

--- a/UnitsNet/UnitsNet.NetStandard10.Signed.csproj
+++ b/UnitsNet/UnitsNet.NetStandard10.Signed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
     <PackageId>UnitsNet.Signed</PackageId>
     <Title>Units.NET (signed)</Title>
   </PropertyGroup>

--- a/UnitsNet/UnitsNet.NetStandard10.csproj
+++ b/UnitsNet/UnitsNet.NetStandard10.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
     <RootNamespace>UnitsNet</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Consumers targeting 4.0 or 4.5 without the .NET Core SDK will have to load the old 3.5 runtime in order to run this library, which costs performance and memory.

Adding this target allows those consumers to stay on the 4.0 runtime.

NOTE: Do not merge this until it is clear whether netstandard 1.0 covers this usecase or not.

Fixes #334 