### PR TITLE
Fix: Missing Temperature / Temperature Operator

### DIFF
--- a/UnitsNet/CustomCode/Quantities/Temperature.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Temperature.extra.cs
@@ -73,6 +73,11 @@ namespace UnitsNet
         {
             return new TemperatureDelta(left.Kelvins - right.Kelvins);
         }
+
+        public static double operator /(Temperature left, Temperature right)
+        {
+            return left.Kelvins / right.Kelvins;
+        }
 #endif
 
         /// <summary>

--- a/UnitsNet/CustomCode/Quantities/TemperatureDelta.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/TemperatureDelta.extra.cs
@@ -36,7 +36,7 @@ namespace UnitsNet
 #if !WINDOWS_UWP
         public static LapseRate operator /(TemperatureDelta left, Length right)
         {
-            return LapseRate.FromDegreesCelciusPerKilometer(left.DegreesCelsiusDelta / right.Kilometers);
+            return LapseRate.FromDegreesCelciusPerKilometer(left.DegreesCelsius / right.Kilometers);
         }
 #endif
     }


### PR DESCRIPTION
 - Fixed missing `temperature / temperature` operator 

 - Fixed obsolete call to `.DegreeCelciusDelta` to `.DegreeCelcius` in the statement `return LapseRate.FromDegreesCelciusPerKilometer(left.DegreesCelsius / right.Kilometers);`