### PR TITLE
Added Area FromCircle methods

### DIFF
--- a/UnitsNet.Tests/CustomCode/AreaTests.cs
+++ b/UnitsNet.Tests/CustomCode/AreaTests.cs
@@ -63,5 +63,33 @@ namespace UnitsNet.Tests.CustomCode
             MassFlow massFlow = Area.FromSquareMeters(20) * MassFlux.FromKilogramsPerSecondPerSquareMeter(2);
             Assert.Equal(massFlow, MassFlow.FromKilogramsPerSecond(40));
         }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0.5, 0.19634954084936208)]
+        [InlineData(1, 0.7853981633974483)]
+        [InlineData(2, 3.141592653589793)]
+        public void AreaFromCicleDiameterCalculatedCorrectly(double diameterMeters, double expected)
+        {
+            Length diameter = Length.FromMeters(diameterMeters);
+
+            double actual = Area.FromCircleDiameter(diameter).SquareMeters;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0.5, 0.7853981633974483)]
+        [InlineData(1, 3.141592653589793)]
+        [InlineData(2, 12.566370614359173)]
+        public void AreaFromCicleRadiusCalculatedCorrectly(double radiusMeters, double expected)
+        {
+            Length radius = Length.FromMeters(radiusMeters);
+
+            double actual = Area.FromCircleRadius(radius).SquareMeters;
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Area.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Area.extra.cs
@@ -41,6 +41,16 @@ namespace UnitsNet
         {
             return MassFlow.FromGramsPerSecond(area.SquareMeters * massFlux.GramsPerSecondPerSquareMeter);
         }
+
+        public static Area FromCircleDiameter(Length diameter)
+        {
+            return System.Math.PI * diameter * diameter / 4;
+        }
+
+        public static Area FromCircleRadius(Length radius)
+        {
+            return System.Math.PI * radius * radius;
+        }
 #endif
     }
 }


### PR DESCRIPTION
Fixes https://github.com/angularsen/UnitsNet/issues/377

Concerns:
How to handle negative radius/diameter
1. Should we throw exception?
2. Should we just ignore (or absolute value)?
   - Current implementation is ignored which implicitly gets absolute value since it squares the value

Need to add tests either case.

Note:
[High precision area of circle online calculator](http://keisan.casio.com/exec/system/1228460515)