### PR TITLE
Move common .csproj props into .props files

### DIFF
--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Common.props
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Common.props
@@ -1,19 +1,41 @@
 <Project>
+  <!-- NuGet properties -->
   <PropertyGroup>
-    <AssemblyName>UnitsNet.Serialization.JsonNet</AssemblyName>
-    <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>
     <PackageId>UnitsNet.Serialization.JsonNet</PackageId>
     <Version>1.2.1</Version>
     <Authors>Andreas Gullberg Larsen</Authors>
     <Title>Units.NET Serialization with Json.NET</Title>
     <Description>A helper library for serializing and deserializing types in Units.NET using Json.NET.</Description>
     <Copyright>Copyright (c) 2015 Andreas Gullberg Larsen</Copyright>
+    <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/angularsen/UnitsNet/blob/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>unit units measurement json Json.NET Newtonsoft serialize deserialize serialization deserialization</PackageTags>
+  </PropertyGroup>
+
+  <!-- Assembly and msbuild properties -->
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
+    <AssemblyName>UnitsNet.Serialization.JsonNet</AssemblyName>
+    <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>
+    <!-- Workaround for building with dotnet CLI and targeting .NET 3.5: https://github.com/Microsoft/msbuild/issues/1333#issuecomment-296346352 -->
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
     <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath>..\Artifacts\$(MSBuildProjectName)</OutputPath>
   </PropertyGroup>
+
+  <!-- NuGet references that work for both signed and unsigned -->
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+  <!-- Exclude certain files from default inclusion pattern -->
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
@@ -1,28 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Serialization.JsonNet.Common.props" />
+
+  <!-- Override some NuGet package properties -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
     <PackageId>UnitsNet.Serialization.JsonNet.Signed</PackageId>
     <Title>Units.NET Serialization with Json.NET (signed)</Title>
   </PropertyGroup>
+
+  <!-- Enable strong name signing -->
   <PropertyGroup>
-    <!-- Workaround for building with dotnet CLI
-         https://github.com/Microsoft/msbuild/issues/1333#issuecomment-296346352 -->
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Enable strong name signing -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\UnitsNet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="obj\**" />
-    <EmbeddedResource Remove="obj\**" />
-    <None Remove="obj\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="UnitsNet.Signed" Version="3.65.0-alpha3" />
   </ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -1,22 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Serialization.JsonNet.Common.props" />
-  <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Workaround for building with dotnet CLI
-         https://github.com/Microsoft/msbuild/issues/1333#issuecomment-296346352
-    -->
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="obj\**" />
-    <EmbeddedResource Remove="obj\**" />
-    <None Remove="obj\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="UnitsNet" Version="3.65.0-alpha3" />
   </ItemGroup>
 </Project>

--- a/UnitsNet/UnitsNet.Common.props
+++ b/UnitsNet/UnitsNet.Common.props
@@ -1,13 +1,13 @@
 <Project>
+  <!-- NuGet properties -->
   <PropertyGroup>
-    <AssemblyName>UnitsNet</AssemblyName>
-    <RootNamespace>UnitsNet</RootNamespace>
     <PackageId>UnitsNet</PackageId>
     <Version>3.88.0</Version>
     <Authors>Andreas Gullberg Larsen</Authors>
     <Title>Units.NET</Title>
     <Description>Get all the common units of measurement and the conversions between them. It is light-weight and thoroughly tested.</Description>
     <Copyright>Copyright (c) 2013 Andreas Gullberg Larsen</Copyright>
+    <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/angularsen/UnitsNet/blob/master/LICENSE</PackageLicenseUrl>
@@ -16,4 +16,27 @@
     <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath>..\Artifacts\$(MSBuildProjectName)</OutputPath>
   </PropertyGroup>
+
+  <!-- Assembly and msbuild properties -->
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
+    <AssemblyName>UnitsNet</AssemblyName>
+    <RootNamespace>UnitsNet</RootNamespace>
+    <!-- Workaround for building with dotnet CLI and targeting .NET 3.5: https://github.com/Microsoft/msbuild/issues/1333#issuecomment-296346352 -->
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+  </PropertyGroup>
+
+  <!-- NuGet references that work for both signed and unsigned -->
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <!-- Exclude certain files from default inclusion pattern -->
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <Compile Remove="Properties\AssemblyInfo*.cs" />
+    <Compile Remove="AssemblyInfo*.cs" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
 </Project>

--- a/UnitsNet/UnitsNet.NetStandard10.Signed.csproj
+++ b/UnitsNet/UnitsNet.NetStandard10.Signed.csproj
@@ -1,30 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Common.props" />
+
+  <!-- Override some NuGet package properties -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
     <PackageId>UnitsNet.Signed</PackageId>
     <Title>Units.NET (signed)</Title>
   </PropertyGroup>
+
+  <!-- Enable strong name signing -->
   <PropertyGroup>
-    <!-- Workaround for building with dotnet CLI
-         https://github.com/Microsoft/msbuild/issues/1333#issuecomment-296346352 -->
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Enable strong name signing -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\UnitsNet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="obj\**" />
-    <Compile Remove="Properties\AssemblyInfo*.cs" />
-    <EmbeddedResource Remove="obj\**" />
-    <None Remove="obj\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="AssemblyInfo.cs" />
-  </ItemGroup>
+
 </Project>

--- a/UnitsNet/UnitsNet.NetStandard10.csproj
+++ b/UnitsNet/UnitsNet.NetStandard10.csproj
@@ -1,25 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Common.props" />
-  <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net35;net40</TargetFrameworks>
-    <RootNamespace>UnitsNet</RootNamespace>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Workaround for building with dotnet CLI
-         https://github.com/Microsoft/msbuild/issues/1333#issuecomment-296346352
-    -->
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="obj\**" />
-    <Compile Remove="Properties\AssemblyInfo*.cs" />
-    <EmbeddedResource Remove="obj\**" />
-    <None Remove="obj\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="GeneratedCode\UnitClasses\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes a lot of duplicate definitions for signed/unsigned projects.