### PR TITLE
json: Use project reference and fix deserialization

### DIFF
--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
@@ -13,7 +13,8 @@
     <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\UnitsNet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <!-- Signed project references, will also generate the corresponding nuget dependencies -->
   <ItemGroup>
-    <PackageReference Include="UnitsNet.Signed" Version="3.65.0-alpha3" />
+    <ProjectReference Include="..\UnitsNet\UnitsNet.NetStandard10.Signed.csproj" />
   </ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="UnitsNet.Serialization.JsonNet.Common.props" />
 
+  <!-- Unsigned project references, will also generate the corresponding nuget dependencies -->
   <ItemGroup>
-    <PackageReference Include="UnitsNet" Version="3.65.0-alpha3" />
+    <ProjectReference Include="..\UnitsNet\UnitsNet.NetStandard10.csproj" />
   </ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -112,11 +112,14 @@ namespace UnitsNet.Serialization.JsonNet
                     !m.ReturnType.IsGenericType);
 #endif
 
+            // Implicit cast: we use this type to avoid explosion of method overloads to handle multiple number types
+            QuantityValue quantityValue = vu.Value;
+
             // Ex: Mass.From(55, MassUnit.Gram)
             // TODO: there is a possible loss of precision if base value requires higher precision than double can represent.
             // Example: Serializing Information.FromExabytes(100) then deserializing to Information 
             // will likely return a very different result. Not sure how we can handle this?
-            return fromMethod.Invoke(null, new[] {vu.Value, unit});
+            return fromMethod.Invoke(null, new[] {quantityValue, unit});
         }
 
         private static object TryDeserializeIComparable(JsonReader reader, JsonSerializer serializer)


### PR DESCRIPTION
In order to catch breaking changes in UnitsNet that was not observed because the nuget dependency was pointing to an older version of UnitsNet. With this change we always build against the latest (local checked out) UnitsNet project code.

See #387 for issue on change in UnitsNet that broke JSON serialization due to the new `QuantityValue` type not supporting `IConvertible`.

This PR addresses both building against the latest version of  `UnitsNet` as well as fixes #387 by passing in `QuantityValue` instead of double to the reflected `From(value, unit)` method.

#### Caveat
The nuget dependency version can no longer be controlled and will always
point to the latest version (the one in the checked out code). This means pushing a new
Json nuget will also increase its dependency version if a newer one is available.
I don't currently know of a way to both get project reference AND control the nuget dependency
version, but I consider this a fair tradeoff as it is fair that taking on a newer version of Json lib will
require a newer version of UnitsNet too.

Some articles mention combining BOTH `PackageReference` and `ProjectReference` in that order, but it did not seem to have any effect on the versioning in my experimentation.