### PR TITLE
Fix operator overloads using TimeSpan.Seconds

### DIFF
--- a/UnitsNet.Tests/CustomCode/VolumeFlowTests.cs
+++ b/UnitsNet.Tests/CustomCode/VolumeFlowTests.cs
@@ -92,11 +92,13 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double UsGallonsPerSecondInOneCubicMeterPerSecond => 2.64172052358148E2;
 
-        [Fact]
-        public void VolumeFlowTimesTimeSpanEqualsVolume()
+        [Theory]
+        [InlineData(20, 2, 40)]
+        [InlineData(20, 62, 1240)]
+        public void VolumeFlowTimesTimeSpanEqualsVolume(double cubicMetersPerSecond, double seconds, double expectedCubicMeters)
         {
-            Volume volume = VolumeFlow.FromCubicMetersPerSecond(20) * TimeSpan.FromSeconds(2);
-            Assert.Equal(Volume.FromCubicMeters(40), volume);
+            Volume volume = VolumeFlow.FromCubicMetersPerSecond(cubicMetersPerSecond) * TimeSpan.FromSeconds(seconds);
+            Assert.Equal(Volume.FromCubicMeters(expectedCubicMeters), volume);
         }
 
         [Fact]

--- a/UnitsNet.Tests/CustomCode/VolumeTests.cs
+++ b/UnitsNet.Tests/CustomCode/VolumeTests.cs
@@ -127,11 +127,13 @@ namespace UnitsNet.Tests.CustomCode
             Assert.Equal(mass, Mass.FromKilograms(6));
         }
 
-        [Fact]
-        public void VolumeDividedByTimeSpanEqualsVolumeFlow()
+        [Theory]
+        [InlineData(20, 2, 10)]
+        [InlineData(20, 80, 0.25)]
+        public void VolumeDividedByTimeSpanEqualsVolumeFlow(double cubicMeters, double seconds, double expectedCubicMetersPerSecond)
         {
-            VolumeFlow volumeFlow = Volume.FromCubicMeters(20) / TimeSpan.FromSeconds(2);
-            Assert.Equal(VolumeFlow.FromCubicMetersPerSecond(10), volumeFlow);
+            VolumeFlow volumeFlow = Volume.FromCubicMeters(cubicMeters) / TimeSpan.FromSeconds(seconds);
+            Assert.Equal(VolumeFlow.FromCubicMetersPerSecond(expectedCubicMetersPerSecond), volumeFlow);
         }
 
         [Fact]

--- a/UnitsNet/CustomCode/Quantities/Volume.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Volume.extra.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         public static VolumeFlow operator /(Volume volume, TimeSpan timeSpan)
         {
-            return VolumeFlow.FromCubicMetersPerSecond(volume.CubicMeters / timeSpan.Seconds);
+            return VolumeFlow.FromCubicMetersPerSecond(volume.CubicMeters / timeSpan.TotalSeconds);
         }
 
         public static TimeSpan operator /(Volume volume, VolumeFlow volumeFlow)

--- a/UnitsNet/CustomCode/Quantities/VolumeFlow.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/VolumeFlow.extra.cs
@@ -36,7 +36,7 @@ namespace UnitsNet
 #if !WINDOWS_UWP
         public static Volume operator *(VolumeFlow volumeFlow, TimeSpan timeSpan)
         {
-            return Volume.FromCubicMeters(volumeFlow.CubicMetersPerSecond * timeSpan.Seconds);
+            return Volume.FromCubicMeters(volumeFlow.CubicMetersPerSecond * timeSpan.TotalSeconds);
         }
 
         public static Volume operator *(VolumeFlow volumeFlow, Duration duration)


### PR DESCRIPTION
operator overloads should use TimeSpan.TotalSeconds