### PR TITLE
Added Mega prefix to ForcePerLength - NewtonPerMeter unit

### DIFF
--- a/UnitsNet.Tests/CustomCode/ForcePerLengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForcePerLengthTests.cs
@@ -50,6 +50,7 @@ namespace UnitsNet.Tests.CustomCode
         protected override double MillinewtonsPerMeterInOneNewtonPerMeter => 1E3;
         protected override double NanonewtonsPerMeterInOneNewtonPerMeter => 1E9;
         protected override double NewtonsPerMeterInOneNewtonPerMeter => 1;
+        protected override double MeganewtonsPerMeterInOneNewtonPerMeter => 1E-6;
 
         [Fact]
         public void ForcePerLengthDividedByLengthEqualsPressure()

--- a/UnitsNet.Tests/GeneratedCode/ForcePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForcePerLengthTestsBase.g.cs
@@ -56,6 +56,7 @@ namespace UnitsNet.Tests
         protected abstract double DecinewtonsPerMeterInOneNewtonPerMeter { get; }
         protected abstract double KilogramsForcePerMeterInOneNewtonPerMeter { get; }
         protected abstract double KilonewtonsPerMeterInOneNewtonPerMeter { get; }
+        protected abstract double MeganewtonsPerMeterInOneNewtonPerMeter { get; }
         protected abstract double MicronewtonsPerMeterInOneNewtonPerMeter { get; }
         protected abstract double MillinewtonsPerMeterInOneNewtonPerMeter { get; }
         protected abstract double NanonewtonsPerMeterInOneNewtonPerMeter { get; }
@@ -66,6 +67,7 @@ namespace UnitsNet.Tests
         protected virtual double DecinewtonsPerMeterTolerance { get { return 1e-5; } }
         protected virtual double KilogramsForcePerMeterTolerance { get { return 1e-5; } }
         protected virtual double KilonewtonsPerMeterTolerance { get { return 1e-5; } }
+        protected virtual double MeganewtonsPerMeterTolerance { get { return 1e-5; } }
         protected virtual double MicronewtonsPerMeterTolerance { get { return 1e-5; } }
         protected virtual double MillinewtonsPerMeterTolerance { get { return 1e-5; } }
         protected virtual double NanonewtonsPerMeterTolerance { get { return 1e-5; } }
@@ -80,6 +82,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DecinewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.DecinewtonsPerMeter, DecinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(KilogramsForcePerMeterInOneNewtonPerMeter, newtonpermeter.KilogramsForcePerMeter, KilogramsForcePerMeterTolerance);
             AssertEx.EqualTolerance(KilonewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.KilonewtonsPerMeter, KilonewtonsPerMeterTolerance);
+            AssertEx.EqualTolerance(MeganewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.MeganewtonsPerMeter, MeganewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(MicronewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.MicronewtonsPerMeter, MicronewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(MillinewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.MillinewtonsPerMeter, MillinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(NanonewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.NanonewtonsPerMeter, NanonewtonsPerMeterTolerance);
@@ -93,6 +96,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.DecinewtonPerMeter).DecinewtonsPerMeter, DecinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.KilogramForcePerMeter).KilogramsForcePerMeter, KilogramsForcePerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.KilonewtonPerMeter).KilonewtonsPerMeter, KilonewtonsPerMeterTolerance);
+            AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.MeganewtonPerMeter).MeganewtonsPerMeter, MeganewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.MicronewtonPerMeter).MicronewtonsPerMeter, MicronewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.MillinewtonPerMeter).MillinewtonsPerMeter, MillinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.NanonewtonPerMeter).NanonewtonsPerMeter, NanonewtonsPerMeterTolerance);
@@ -107,6 +111,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DecinewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.DecinewtonPerMeter), DecinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(KilogramsForcePerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.KilogramForcePerMeter), KilogramsForcePerMeterTolerance);
             AssertEx.EqualTolerance(KilonewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.KilonewtonPerMeter), KilonewtonsPerMeterTolerance);
+            AssertEx.EqualTolerance(MeganewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.MeganewtonPerMeter), MeganewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(MicronewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.MicronewtonPerMeter), MicronewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(MillinewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.MillinewtonPerMeter), MillinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(NanonewtonsPerMeterInOneNewtonPerMeter, newtonpermeter.As(ForcePerLengthUnit.NanonewtonPerMeter), NanonewtonsPerMeterTolerance);
@@ -121,6 +126,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ForcePerLength.FromDecinewtonsPerMeter(newtonpermeter.DecinewtonsPerMeter).NewtonsPerMeter, DecinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.FromKilogramsForcePerMeter(newtonpermeter.KilogramsForcePerMeter).NewtonsPerMeter, KilogramsForcePerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.FromKilonewtonsPerMeter(newtonpermeter.KilonewtonsPerMeter).NewtonsPerMeter, KilonewtonsPerMeterTolerance);
+            AssertEx.EqualTolerance(1, ForcePerLength.FromMeganewtonsPerMeter(newtonpermeter.MeganewtonsPerMeter).NewtonsPerMeter, MeganewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.FromMicronewtonsPerMeter(newtonpermeter.MicronewtonsPerMeter).NewtonsPerMeter, MicronewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.FromMillinewtonsPerMeter(newtonpermeter.MillinewtonsPerMeter).NewtonsPerMeter, MillinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.FromNanonewtonsPerMeter(newtonpermeter.NanonewtonsPerMeter).NewtonsPerMeter, NanonewtonsPerMeterTolerance);

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToForcePerLengthExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToForcePerLengthExtensions.g.cs
@@ -180,6 +180,40 @@ namespace UnitsNet.Extensions.NumberToForcePerLength
 
         #endregion
 
+        #region MeganewtonPerMeter
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double)"/>
+        public static ForcePerLength MeganewtonsPerMeter(this int value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double?)"/>
+        public static ForcePerLength? MeganewtonsPerMeter(this int? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double)"/>
+        public static ForcePerLength MeganewtonsPerMeter(this long value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double?)"/>
+        public static ForcePerLength? MeganewtonsPerMeter(this long? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double)"/>
+        public static ForcePerLength MeganewtonsPerMeter(this double value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double?)"/>
+        public static ForcePerLength? MeganewtonsPerMeter(this double? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double)"/>
+        public static ForcePerLength MeganewtonsPerMeter(this float value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double?)"/>
+        public static ForcePerLength? MeganewtonsPerMeter(this float? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double)"/>
+        public static ForcePerLength MeganewtonsPerMeter(this decimal value) => ForcePerLength.FromMeganewtonsPerMeter(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(double?)"/>
+        public static ForcePerLength? MeganewtonsPerMeter(this decimal? value) => ForcePerLength.FromMeganewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
         #region MicronewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(double)"/>

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -162,6 +162,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get ForcePerLength in MeganewtonsPerMeter.
+        /// </summary>
+        public double MeganewtonsPerMeter
+        {
+            get { return (_newtonsPerMeter) / 1e6d; }
+        }
+
+        /// <summary>
         ///     Get ForcePerLength in MicronewtonsPerMeter.
         /// </summary>
         public double MicronewtonsPerMeter
@@ -271,6 +279,24 @@ namespace UnitsNet
         {
             double value = (double) kilonewtonspermeter;
             return new ForcePerLength(((value) * 1e3d));
+        }
+#endif
+
+        /// <summary>
+        ///     Get ForcePerLength from MeganewtonsPerMeter.
+        /// </summary>
+#if WINDOWS_UWP
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static ForcePerLength FromMeganewtonsPerMeter(double meganewtonspermeter)
+        {
+            double value = (double) meganewtonspermeter;
+            return new ForcePerLength((value) * 1e6d);
+        }
+#else
+        public static ForcePerLength FromMeganewtonsPerMeter(QuantityValue meganewtonspermeter)
+        {
+            double value = (double) meganewtonspermeter;
+            return new ForcePerLength(((value) * 1e6d));
         }
 #endif
 
@@ -409,6 +435,21 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get nullable ForcePerLength from nullable MeganewtonsPerMeter.
+        /// </summary>
+        public static ForcePerLength? FromMeganewtonsPerMeter(QuantityValue? meganewtonspermeter)
+        {
+            if (meganewtonspermeter.HasValue)
+            {
+                return FromMeganewtonsPerMeter(meganewtonspermeter.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         ///     Get nullable ForcePerLength from nullable MicronewtonsPerMeter.
         /// </summary>
         public static ForcePerLength? FromMicronewtonsPerMeter(QuantityValue? micronewtonspermeter)
@@ -494,6 +535,8 @@ namespace UnitsNet
                     return FromKilogramsForcePerMeter(value);
                 case ForcePerLengthUnit.KilonewtonPerMeter:
                     return FromKilonewtonsPerMeter(value);
+                case ForcePerLengthUnit.MeganewtonPerMeter:
+                    return FromMeganewtonsPerMeter(value);
                 case ForcePerLengthUnit.MicronewtonPerMeter:
                     return FromMicronewtonsPerMeter(value);
                 case ForcePerLengthUnit.MillinewtonPerMeter:
@@ -532,6 +575,8 @@ namespace UnitsNet
                     return FromKilogramsForcePerMeter(value.Value);
                 case ForcePerLengthUnit.KilonewtonPerMeter:
                     return FromKilonewtonsPerMeter(value.Value);
+                case ForcePerLengthUnit.MeganewtonPerMeter:
+                    return FromMeganewtonsPerMeter(value.Value);
                 case ForcePerLengthUnit.MicronewtonPerMeter:
                     return FromMicronewtonsPerMeter(value.Value);
                 case ForcePerLengthUnit.MillinewtonPerMeter:
@@ -721,6 +766,8 @@ namespace UnitsNet
                     return KilogramsForcePerMeter;
                 case ForcePerLengthUnit.KilonewtonPerMeter:
                     return KilonewtonsPerMeter;
+                case ForcePerLengthUnit.MeganewtonPerMeter:
+                    return MeganewtonsPerMeter;
                 case ForcePerLengthUnit.MicronewtonPerMeter:
                     return MicronewtonsPerMeter;
                 case ForcePerLengthUnit.MillinewtonPerMeter:

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -1661,6 +1661,11 @@ namespace UnitsNet
                             {
                                 new AbbreviationsForCulture("en-US", "kN/m"),
                             }),
+                        new CulturesForEnumValue((int) ForcePerLengthUnit.MeganewtonPerMeter,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "MN/m"),
+                            }),
                         new CulturesForEnumValue((int) ForcePerLengthUnit.MicronewtonPerMeter,
                             new[]
                             {

--- a/UnitsNet/GeneratedCode/Units/ForcePerLengthUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ForcePerLengthUnit.g.cs
@@ -46,6 +46,7 @@ namespace UnitsNet.Units
         DecinewtonPerMeter,
         KilogramForcePerMeter,
         KilonewtonPerMeter,
+        MeganewtonPerMeter,
         MicronewtonPerMeter,
         MillinewtonPerMeter,
         NanonewtonPerMeter,

--- a/UnitsNet/UnitDefinitions/ForcePerLength.json
+++ b/UnitsNet/UnitDefinitions/ForcePerLength.json
@@ -7,7 +7,7 @@
       "PluralName": "NewtonsPerMeter",
       "FromUnitToBaseFunc": "x",
       "FromBaseToUnitFunc": "x",
-      "Prefixes": [ "Nano", "Micro", "Milli", "Centi", "Deci", "Kilo" ],
+      "Prefixes": [ "Nano", "Micro", "Milli", "Centi", "Deci", "Kilo", "Mega" ],
       "Localization": [
         {
           "Culture": "en-US",


### PR DESCRIPTION
Added the "Mega" prefix to the NewtonPerMeter unit in ForcePerLength

1 N/m = 1e-6 MN/m