### PR TITLE
Fix prefix abbrevs

### DIFF
--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -1272,7 +1272,7 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) EnergyUnit.GigabritishThermalUnit,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "mmBTU"),
+                                new AbbreviationsForCulture("en-US", "GBTU"),
                             }),
                         new CulturesForEnumValue((int) EnergyUnit.GigawattHour,
                             new[]
@@ -1309,7 +1309,7 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) EnergyUnit.MegabritishThermalUnit,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "mBTU"),
+                                new AbbreviationsForCulture("en-US", "MBTU"),
                             }),
                         new CulturesForEnumValue((int) EnergyUnit.Megajoule,
                             new[]
@@ -2231,7 +2231,7 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) MassUnit.Kilopound,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "KLbs"),
+                                new AbbreviationsForCulture("en-US", "klb"),
                                 new AbbreviationsForCulture("ru-RU", "kфунт"),
                             }),
                         new CulturesForEnumValue((int) MassUnit.Kilotonne,
@@ -2254,7 +2254,7 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) MassUnit.Megapound,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "MLbs"),
+                                new AbbreviationsForCulture("en-US", "Mlb"),
                                 new AbbreviationsForCulture("ru-RU", "Mфунт"),
                             }),
                         new CulturesForEnumValue((int) MassUnit.Megatonne,

--- a/UnitsNet/UnitDefinitions/Energy.json
+++ b/UnitsNet/UnitDefinitions/Energy.json
@@ -38,8 +38,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "BTU" ],
-          "AbbreviationsWithPrefixes": [ "kBTU", "mBTU", "mmBTU" ]
+          "Abbreviations": [ "BTU" ]
         }
       ]
     },

--- a/UnitsNet/UnitDefinitions/Flow.json
+++ b/UnitsNet/UnitDefinitions/Flow.json
@@ -150,8 +150,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "LPS" ],
-          "AbbreviationsWithPrefixes": [ "nLPM", "μLPM", "mLPM", "cLPM", "dLPM", "kLPM" ]
+          "Abbreviations": [ "LPS" ]
         }
       ]
     },
@@ -165,8 +164,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "LPM" ],
-          "AbbreviationsWithPrefixes": [ "nLPM", "µLPM", "mLPM", "cLPM", "dLPM", "kLPM" ]
+          "Abbreviations": [ "LPM" ]
         }
       ]
     },

--- a/UnitsNet/UnitDefinitions/Mass.json
+++ b/UnitsNet/UnitDefinitions/Mass.json
@@ -85,8 +85,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb" ],
-          "AbbreviationsWithPrefixes": [ "KLbs", "MLbs" ]
+          "Abbreviations": [ "lb" ]
         },
         {
           "Culture": "ru-RU",

--- a/UnitsNet/UnitDefinitions/MassFlow.json
+++ b/UnitsNet/UnitDefinitions/MassFlow.json
@@ -53,8 +53,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/h" ],
-          "AbbreviationsWithPrefixes": [ "Mlb/h" ]
+          "Abbreviations": [ "lb/h" ]
         }
       ]
     },

--- a/UnitsNet/UnitDefinitions/Power.json
+++ b/UnitsNet/UnitDefinitions/Power.json
@@ -86,8 +86,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "Btu/hr" ],
-          "AbbreviationsWithPrefixes": [ "kBtu/hr" ]
+          "Abbreviations": [ "Btu/hr" ]
         }
       ]
     }

--- a/UnitsNet/UnitDefinitions/Pressure.json
+++ b/UnitsNet/UnitDefinitions/Pressure.json
@@ -111,8 +111,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "N/m²" ],
-          "AbbreviationsWithPrefixes": [ "kN/m²", "MN/m²" ]
+          "Abbreviations": [ "N/m²" ]
         },
         {
           "Culture": "ru-RU",
@@ -130,8 +129,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "N/cm²" ],
-          "AbbreviationsWithPrefixes": [ "kN/cm²" ]
+          "Abbreviations": [ "N/cm²" ]
         },
         {
           "Culture": "ru-RU",
@@ -149,8 +147,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "N/mm²" ],
-          "AbbreviationsWithPrefixes": [ "kN/mm²" ]
+          "Abbreviations": [ "N/mm²" ]
         },
         {
           "Culture": "ru-RU",

--- a/UnitsNet/UnitDefinitions/VolumeFlow.json
+++ b/UnitsNet/UnitDefinitions/VolumeFlow.json
@@ -139,8 +139,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "LPS" ],
-          "AbbreviationsWithPrefixes": [ "nLPM", "μLPM", "mLPM", "cLPM", "dLPM", "kLPM" ]
+          "Abbreviations": [ "LPS" ]
         }
       ]
     },
@@ -153,8 +152,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "LPM" ],
-          "AbbreviationsWithPrefixes": [ "nLPM", "µLPM", "mLPM", "cLPM", "dLPM", "kLPM" ]
+          "Abbreviations": [ "LPM" ]
         }
       ]
     },


### PR DESCRIPTION
Fixes several wrong abbreviations.
Removes redundant prefix abbreviations (`k`, `M` etc is prefixed by default for kilo, mega etc.)

#### Breaking changes
GigabritishThermalUnit: `mmBTU` => `GBTU`
MegabritishThermalUnit: `mBTU` => `MBTU`
Kilopound: `KLbs` => `klb` (neither is commonly used)
Megapound: `MLbs` => `Mlb` (neither is commonly used)