### PR TITLE
Run UnitsNet JSON serialization tests on the latest UnitsNet libraries in Nuget

### DIFF
--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -17,10 +17,11 @@
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+		<PackageReference Condition="'$(Configuration)'=='Release'" Include="UnitsNet.Serialization.JsonNet" Version="*" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\UnitsNet.Serialization.JsonNet\UnitsNet.Serialization.JsonNet.csproj" />
+    <ProjectReference Condition="'$(Configuration)'=='Debug'" Include="..\UnitsNet.Serialization.JsonNet\UnitsNet.Serialization.JsonNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -17,10 +17,13 @@
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+		
+		<!--When in Release configuration, use the UnitsNet.Serialization.JsonNet and UnitsNet latest released libraries in Nuget-->
 		<PackageReference Condition="'$(Configuration)'=='Release'" Include="UnitsNet.Serialization.JsonNet" Version="*" />
   </ItemGroup>
 
   <ItemGroup>
+		<!--When in Debug configuration, use the UnitsNet.Serialization.JsonNet project-->
     <ProjectReference Condition="'$(Configuration)'=='Debug'" Include="..\UnitsNet.Serialization.JsonNet\UnitsNet.Serialization.JsonNet.csproj" />
   </ItemGroup>
 

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -25,6 +25,9 @@
   <ItemGroup>
 		<!--When in Debug configuration, use the UnitsNet.Serialization.JsonNet project-->
     <ProjectReference Condition="'$(Configuration)'=='Debug'" Include="..\UnitsNet.Serialization.JsonNet\UnitsNet.Serialization.JsonNet.csproj" />
+		
+		<!--When in Release configuration, use the UnitsNet project-->
+		<ProjectReference Condition="'$(Configuration)'=='Release'" Include="..\UnitsNet\UnitsNet.NetStandard10.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/angularsen/UnitsNet/issues/417

The main idea is to use build configuration to switch the UnitsNet reference of the serialization test project:
If in debug configuration, use the UnitsNet.Serialization project reference.
If in release configuration, use the latest version of UnitsNet.Serialization as well as UnitsNet in nuget.

I tested this by changing the Version to "1.2.2" ("*" in the commit). I then ran the build.bat file and it failed on some of the serialization tests as expected.

Hopefully this doesn't conflict with anything in the Appveyor. I'm not really familiar with that tool yet.