### PR TITLE
Create test project for UnitsNet.Serialization.JsonNet library in Nuget

### DIFF
--- a/Build/build-functions.psm1
+++ b/Build/build-functions.psm1
@@ -58,7 +58,8 @@ function Start-Build([boolean] $skipUWP = $false) {
 function Start-Tests {
   $projectPaths = @(
     "UnitsNet.Tests\UnitsNet.Tests.NetCore.csproj",
-    "UnitsNet.Serialization.JsonNet.Tests\UnitsNet.Serialization.JsonNet.Tests.NetCore.csproj"
+    "UnitsNet.Serialization.JsonNet.Tests\UnitsNet.Serialization.JsonNet.Tests.NetCore.csproj",
+		"UnitsNet.Serialization.JsonNet.CompatibilityTests\UnitsNet.Serialization.JsonNet.CompatibilityTests.NetCore.csproj"
     )
 
   # Parent dir must exist before xunit tries to write files to it

--- a/Build/build-functions.psm1
+++ b/Build/build-functions.psm1
@@ -59,7 +59,7 @@ function Start-Tests {
   $projectPaths = @(
     "UnitsNet.Tests\UnitsNet.Tests.NetCore.csproj",
     "UnitsNet.Serialization.JsonNet.Tests\UnitsNet.Serialization.JsonNet.Tests.NetCore.csproj",
-		"UnitsNet.Serialization.JsonNet.CompatibilityTests\UnitsNet.Serialization.JsonNet.CompatibilityTests.NetCore.csproj"
+    "UnitsNet.Serialization.JsonNet.CompatibilityTests\UnitsNet.Serialization.JsonNet.CompatibilityTests.NetCore.csproj"
     )
 
   # Parent dir must exist before xunit tries to write files to it

--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 
 </Project>

--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -24,5 +24,9 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
-
+	
+	<ItemGroup>
+		<!--Reference the UnitsNet project to test the UnitsNet.Serialization.JsonNet Nuget with-->
+		<ProjectReference Include="..\UnitsNet\UnitsNet.NetStandard10.csproj" />
+	</ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <RootNamespace>UnitsNet.Serialization.JsonNet.CompatibilityTests</RootNamespace>
+    <OutputPath>..\Artifacts\$(MSBuildProjectName)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\UnitsNet.Serialization.JsonNet.Tests\UnitsNetJsonConverterTests.cs" Link="UnitsNetJsonConverterTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--Get the latest released version of UnitsNet.Serialization.JsonNet in Nuget-->
+    <PackageReference Include="UnitsNet.Serialization.JsonNet" Version="*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
+  </ItemGroup>
+
+</Project>

--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -26,7 +26,8 @@
   </ItemGroup>
 	
 	<ItemGroup>
-		<!--Reference the UnitsNet project to test the UnitsNet.Serialization.JsonNet Nuget with-->
+		<!--Reference the UnitsNet project to test the UnitsNet.Serialization.JsonNet Nuget with
+        the latest UnitsNet code to catch backwards compatibility issues. -->
 		<ProjectReference Include="..\UnitsNet\UnitsNet.NetStandard10.csproj" />
 	</ItemGroup>
 </Project>

--- a/UnitsNet.sln
+++ b/UnitsNet.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitsNet.Serialization.Json
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitsNet.Tests", "UnitsNet.Tests\UnitsNet.Tests.csproj", "{0E3B7567-5DF2-44BD-88DB-CCF050D3F943}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitsNet.Serialization.JsonNet.CompatibilityTests", "UnitsNet.Serialization.JsonNet.CompatibilityTests\UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj", "{21F2FFAC-BF39-487F-9ADE-37100162F955}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,22 @@ Global
 		{0E3B7567-5DF2-44BD-88DB-CCF050D3F943}.Release|x64.Build.0 = Release|Any CPU
 		{0E3B7567-5DF2-44BD-88DB-CCF050D3F943}.Release|x86.ActiveCfg = Release|Any CPU
 		{0E3B7567-5DF2-44BD-88DB-CCF050D3F943}.Release|x86.Build.0 = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|ARM.Build.0 = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|x64.Build.0 = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Debug|x86.Build.0 = Debug|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|ARM.ActiveCfg = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|ARM.Build.0 = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|x64.ActiveCfg = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|x64.Build.0 = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|x86.ActiveCfg = Release|Any CPU
+		{21F2FFAC-BF39-487F-9ADE-37100162F955}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes https://github.com/angularsen/UnitsNet/issues/417
This is another solution as discussed in https://github.com/angularsen/UnitsNet/pull/423#issuecomment-375937926

The new test project is UnitsNet.Serialization.JsonNet.CompatibilityTests.

UnitsNetJsonConverterTests.cs is added as a link.
`    <Compile Include="..\UnitsNet.Serialization.JsonNet.Tests\UnitsNetJsonConverterTests.cs" Link="UnitsNetJsonConverterTests.cs" />`

The project runs the serialization tests on the latest version of the UnitsNet.Serialization.JsonNet library in Nuget.
`<PackageReference Include="UnitsNet.Serialization.JsonNet" Version="*" />`