### PR TITLE
Fix #436 Flaky test: UnitsNet.Tests.UnitSystemTests.PositiveInfinityFormatting

### DIFF
--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -20,8 +20,8 @@
     <!--Get the latest released version of UnitsNet.Serialization.JsonNet in Nuget-->
     <PackageReference Include="UnitsNet.Serialization.JsonNet" Version="*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 	

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -25,10 +25,7 @@ using UnitsNet.Units;
 
 namespace UnitsNet.Tests.CustomCode
 {
-    // Avoid accessing static prop DefaultToString in parallel from multiple tests:
-    // UnitSystemTests.DefaultToStringFormatting()
-    // LengthTests.ToStringReturnsCorrectNumberAndUnitWithCentimeterAsDefualtUnit()
-    [Collection("DefaultToString")] 
+    [Collection(nameof(UnitSystemFixture))]
     public class LengthTests : LengthTestsBase
     {
         protected override double CentimetersInOneMeter => 100;

--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -25,6 +25,9 @@ using UnitsNet.Units;
 
 namespace UnitsNet.Tests.CustomCode
 {
+    // Avoid accessing static prop DefaultToString in parallel from multiple tests:
+    // UnitSystemTests.DefaultToStringFormatting()
+    // LengthTests.ToStringReturnsCorrectNumberAndUnitWithCentimeterAsDefualtUnit()
     [Collection(nameof(UnitSystemFixture))]
     public class LengthTests : LengthTestsBase
     {

--- a/UnitsNet.Tests/QuantityTests.ToString.cs
+++ b/UnitsNet.Tests/QuantityTests.ToString.cs
@@ -25,6 +25,7 @@ using Xunit;
 
 namespace UnitsNet.Tests
 {
+    [Collection(nameof(UnitSystemFixture))]
     public partial class QuantityTests
     {
         public class ToString

--- a/UnitsNet.Tests/UnitSystemFixture.cs
+++ b/UnitsNet.Tests/UnitSystemFixture.cs
@@ -1,0 +1,18 @@
+﻿using Xunit;
+
+namespace UnitsNet.Tests
+{
+    [CollectionDefinition(nameof(UnitSystemFixture), DisableParallelization = true)]
+    public class UnitSystemFixture : ICollectionFixture<object>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+
+        // Apply this collection fixture to classes:
+        // 1. that rely on manipulating CultureInfo. See https://github.com/angularsen/UnitsNet/issues/436
+        // 2. to avoid accessing static prop DefaultToString in parallel from multiple tests:
+        //      a. UnitSystemTests.DefaultToStringFormatting()
+        //      b. LengthTests.ToStringReturnsCorrectNumberAndUnitWithCentimeterAsDefualtUnit()
+    }
+}

--- a/UnitsNet.Tests/UnitSystemTests.cs
+++ b/UnitsNet.Tests/UnitSystemTests.cs
@@ -444,7 +444,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void NegativeInfinityFormatting()
         {
-            Assert.Equal("-∞ m", Length.FromMeters(double.NegativeInfinity).ToString());
+            Assert.Equal("-Infinity m", Length.FromMeters(double.NegativeInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -476,7 +476,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void PositiveInfinityFormatting()
         {
-            Assert.Equal("∞ m", Length.FromMeters(double.PositiveInfinity).ToString());
+            Assert.Equal("Infinity m", Length.FromMeters(double.PositiveInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/UnitsNet.Tests/UnitSystemTests.cs
+++ b/UnitsNet.Tests/UnitSystemTests.cs
@@ -29,10 +29,7 @@ using System.Globalization;
 
 namespace UnitsNet.Tests
 {
-    // Avoid accessing static prop DefaultToString in parallel from multiple tests:
-    // UnitSystemTests.DefaultToStringFormatting()
-    // LengthTests.ToStringReturnsCorrectNumberAndUnitWithCentimeterAsDefualtUnit()
-    [Collection("DefaultToString")]
+    [Collection(nameof(UnitSystemFixture))]
     public class UnitSystemTests
     {
         private readonly ITestOutputHelper _output;
@@ -415,6 +412,9 @@ namespace UnitsNet.Tests
             // CurrentCulture affects number formatting, such as comma or dot as decimal separator.
             // CurrentUICulture affects localization, in this case the abbreviation.
             // Zulu (South Africa)
+            CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
+            CultureInfo oldCurrentUICulture = CultureInfo.CurrentUICulture;
+
             var zuluCulture = new CultureInfo("zu-ZA");
             UnitSystem zuluUnits = UnitSystem.GetCached(zuluCulture);
             CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = zuluCulture;
@@ -427,6 +427,9 @@ namespace UnitsNet.Tests
 
             // Assert
             Assert.Equal("US english abbreviation for Unit1", abbreviation);
+
+            CultureInfo.CurrentCulture = oldCurrentCulture;
+            CultureInfo.CurrentUICulture = oldCurrentUICulture;
         }
 
         [Fact]
@@ -441,7 +444,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void NegativeInfinityFormatting()
         {
-            Assert.Equal("-∞ m", Length.FromMeters(double.NegativeInfinity).ToString());
+            Assert.Equal("-∞ m", Length.FromMeters(double.NegativeInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -473,7 +476,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void PositiveInfinityFormatting()
         {
-            Assert.Equal("∞ m", Length.FromMeters(double.PositiveInfinity).ToString());
+            Assert.Equal("∞ m", Length.FromMeters(double.PositiveInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/UnitsNet.Tests/UnitSystemTests.cs
+++ b/UnitsNet.Tests/UnitSystemTests.cs
@@ -409,27 +409,32 @@ namespace UnitsNet.Tests
         [Fact]
         public void GetDefaultAbbreviationFallsBackToUsEnglishCulture()
         {
-            // CurrentCulture affects number formatting, such as comma or dot as decimal separator.
-            // CurrentUICulture affects localization, in this case the abbreviation.
-            // Zulu (South Africa)
             CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
             CultureInfo oldCurrentUICulture = CultureInfo.CurrentUICulture;
 
-            var zuluCulture = new CultureInfo("zu-ZA");
-            UnitSystem zuluUnits = UnitSystem.GetCached(zuluCulture);
-            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = zuluCulture;
+            try 
+            {
+                // CurrentCulture affects number formatting, such as comma or dot as decimal separator.
+                // CurrentUICulture affects localization, in this case the abbreviation.
+                // Zulu (South Africa)
+                var zuluCulture = new CultureInfo("zu-ZA");
+                UnitSystem zuluUnits = UnitSystem.GetCached(zuluCulture);
+                CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = zuluCulture;
 
-            UnitSystem usUnits = UnitSystem.GetCached(AmericanCultureName);
-            usUnits.MapUnitToAbbreviation(CustomUnit.Unit1, "US english abbreviation for Unit1");
+                UnitSystem usUnits = UnitSystem.GetCached(AmericanCultureName);
+                usUnits.MapUnitToAbbreviation(CustomUnit.Unit1, "US english abbreviation for Unit1");
 
-            // Act
-            string abbreviation = zuluUnits.GetDefaultAbbreviation(CustomUnit.Unit1);
+                // Act
+                string abbreviation = zuluUnits.GetDefaultAbbreviation(CustomUnit.Unit1);
 
-            // Assert
-            Assert.Equal("US english abbreviation for Unit1", abbreviation);
-
-            CultureInfo.CurrentCulture = oldCurrentCulture;
-            CultureInfo.CurrentUICulture = oldCurrentUICulture;
+                // Assert
+                Assert.Equal("US english abbreviation for Unit1", abbreviation);
+            }
+            finally 
+            {
+                CultureInfo.CurrentCulture = oldCurrentCulture;
+                CultureInfo.CurrentUICulture = oldCurrentUICulture;
+            }
         }
 
         [Fact]

--- a/UnitsNet.Tests/UnitSystemTests.cs
+++ b/UnitsNet.Tests/UnitSystemTests.cs
@@ -444,7 +444,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void NegativeInfinityFormatting()
         {
-            Assert.Equal("-∞ m", Length.FromMeters(double.NegativeInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
+            Assert.Equal("-∞ m", Length.FromMeters(double.NegativeInfinity).ToString());
         }
 
         [Fact]
@@ -476,7 +476,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void PositiveInfinityFormatting()
         {
-            Assert.Equal("∞ m", Length.FromMeters(double.PositiveInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
+            Assert.Equal("∞ m", Length.FromMeters(double.PositiveInfinity).ToString());
         }
 
         /// <summary>

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -15,8 +15,8 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/angularsen/UnitsNet/issues/436

Added `UnitSystemFixture` class which is a `CollectionDefinition` class used to group test classes:
1. that rely on manipulating CultureInfo. See https://github.com/angularsen/UnitsNet/issues/436
2. to avoid accessing static prop DefaultToString in parallel from multiple tests:
	a. UnitSystemTests.DefaultToStringFormatting()
	b. LengthTests.ToStringReturnsCorrectNumberAndUnitWithCentimeterAsDefualtUnit()

Applied `[Collection(nameof(UnitSystemFixture)]` attribute to test classes that:
  - Sets any of the following:
    - `UnitSystem.DefaultCulture`
    - `CultureInfo.CurrentCulture`
    - `CultureInfo.CurrentUICulture`
  - Originally uses `[Collection("DefaulToString")]` that also depends on `CultureInfo`
    - Only one `Collection` attribute per test class.

`UnitSystemTests.GetDefaultAbbreviationFallsBackToUsEnglishCulture`: Set CultureInfo properties back to their original values.

Updated to `xunit` and `xunit.runner.visualstudio` to v2.3.1 (was v2.3.0-beta4-build3742)
	- To have the [CollectionDefinition(DisableParallelization = true)] feature. See https://xunit.github.io/releases/2.3-beta5