### PR TITLE
[WIP] Fix build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- This file will be implicitly linked by all projects in folder -folders -->
   <PropertyGroup>
+    <!-- Avoid sharing obj folder with multiple .csproj files in same folder -->
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj/$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath>$(MSBuildThisFileDirectory)Artifacts/$(MSBuildProjectName)</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #446 

Turns out the culprit was a change in behavior of how `<BaseIntermediateOutputPath>` is treated with .NET Core SDK 2.1 (not sure exactly what version introduced it). It mangled the intermediate outputs of the various UnitsNet and UnitsNet.Signed builds, causing havoc for its dependent UnitsNet.Serialization.JsonNet and UnitsNet.Serialization.JsonNet.Signed projects.

The fix is to use a new special `Directory.Build.props` file, whose properties are evaluated BEFORE some internal magic in the new build system.

The details and workarounds are outlined here:
https://github.com/dotnet/sdk/issues/1518#issuecomment-324638682