### PR TITLE
Changing Compare methods to compare current value to other in "this" …

### DIFF
--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -736,8 +736,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Acceleration)) throw new ArgumentException("Expected type Acceleration.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Acceleration)) throw new ArgumentException("Expected type Acceleration.", nameof(obj));
 
             return CompareTo((Acceleration)obj);
         }
@@ -923,7 +923,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1051,7 +1051,7 @@ namespace UnitsNet
 #endif
         static AccelerationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AccelerationUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -736,9 +736,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Acceleration)) throw new ArgumentException("Expected type Acceleration.", "obj");
-            return CompareTo((Acceleration) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Acceleration)) throw new ArgumentException("Expected type Acceleration.", "obj");
+
+            return CompareTo((Acceleration)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -749,7 +750,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Acceleration other)
         {
-            return AsBaseUnitMetersPerSecondSquared().CompareTo(other.AsBaseUnitMetersPerSecondSquared());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -769,9 +769,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is AmountOfSubstance)) throw new ArgumentException("Expected type AmountOfSubstance.", "obj");
-            return CompareTo((AmountOfSubstance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is AmountOfSubstance)) throw new ArgumentException("Expected type AmountOfSubstance.", "obj");
+
+            return CompareTo((AmountOfSubstance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -782,7 +783,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AmountOfSubstance other)
         {
-            return AsBaseUnitMoles().CompareTo(other.AsBaseUnitMoles());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -769,8 +769,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is AmountOfSubstance)) throw new ArgumentException("Expected type AmountOfSubstance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is AmountOfSubstance)) throw new ArgumentException("Expected type AmountOfSubstance.", nameof(obj));
 
             return CompareTo((AmountOfSubstance)obj);
         }
@@ -957,7 +957,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1085,7 +1085,7 @@ namespace UnitsNet
 #endif
         static AmountOfSubstanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AmountOfSubstanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -437,9 +437,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is AmplitudeRatio)) throw new ArgumentException("Expected type AmplitudeRatio.", "obj");
-            return CompareTo((AmplitudeRatio) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is AmplitudeRatio)) throw new ArgumentException("Expected type AmplitudeRatio.", "obj");
+
+            return CompareTo((AmplitudeRatio)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -450,7 +451,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AmplitudeRatio other)
         {
-            return AsBaseUnitDecibelVolts().CompareTo(other.AsBaseUnitDecibelVolts());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -437,8 +437,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is AmplitudeRatio)) throw new ArgumentException("Expected type AmplitudeRatio.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is AmplitudeRatio)) throw new ArgumentException("Expected type AmplitudeRatio.", nameof(obj));
 
             return CompareTo((AmplitudeRatio)obj);
         }
@@ -615,7 +615,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -743,7 +743,7 @@ namespace UnitsNet
 #endif
         static AmplitudeRatioUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AmplitudeRatioUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -759,8 +759,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Angle)) throw new ArgumentException("Expected type Angle.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Angle)) throw new ArgumentException("Expected type Angle.", nameof(obj));
 
             return CompareTo((Angle)obj);
         }
@@ -947,7 +947,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1075,7 +1075,7 @@ namespace UnitsNet
 #endif
         static AngleUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AngleUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -759,9 +759,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Angle)) throw new ArgumentException("Expected type Angle.", "obj");
-            return CompareTo((Angle) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Angle)) throw new ArgumentException("Expected type Angle.", "obj");
+
+            return CompareTo((Angle)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -772,7 +773,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Angle other)
         {
-            return AsBaseUnitDegrees().CompareTo(other.AsBaseUnitDegrees());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ApparentEnergy)) throw new ArgumentException("Expected type ApparentEnergy.", "obj");
-            return CompareTo((ApparentEnergy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ApparentEnergy)) throw new ArgumentException("Expected type ApparentEnergy.", "obj");
+
+            return CompareTo((ApparentEnergy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ApparentEnergy other)
         {
-            return AsBaseUnitVoltampereHours().CompareTo(other.AsBaseUnitVoltampereHours());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ApparentEnergy)) throw new ArgumentException("Expected type ApparentEnergy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ApparentEnergy)) throw new ArgumentException("Expected type ApparentEnergy.", nameof(obj));
 
             return CompareTo((ApparentEnergy)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static ApparentEnergyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ApparentEnergyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ApparentPower)) throw new ArgumentException("Expected type ApparentPower.", "obj");
-            return CompareTo((ApparentPower) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ApparentPower)) throw new ArgumentException("Expected type ApparentPower.", "obj");
+
+            return CompareTo((ApparentPower)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ApparentPower other)
         {
-            return AsBaseUnitVoltamperes().CompareTo(other.AsBaseUnitVoltamperes());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ApparentPower)) throw new ArgumentException("Expected type ApparentPower.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ApparentPower)) throw new ArgumentException("Expected type ApparentPower.", nameof(obj));
 
             return CompareTo((ApparentPower)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static ApparentPowerUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ApparentPowerUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -736,9 +736,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Area)) throw new ArgumentException("Expected type Area.", "obj");
-            return CompareTo((Area) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Area)) throw new ArgumentException("Expected type Area.", "obj");
+
+            return CompareTo((Area)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -749,7 +750,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Area other)
         {
-            return AsBaseUnitSquareMeters().CompareTo(other.AsBaseUnitSquareMeters());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -736,8 +736,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Area)) throw new ArgumentException("Expected type Area.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Area)) throw new ArgumentException("Expected type Area.", nameof(obj));
 
             return CompareTo((Area)obj);
         }
@@ -923,7 +923,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1051,7 +1051,7 @@ namespace UnitsNet
 #endif
         static AreaUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AreaUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is AreaDensity)) throw new ArgumentException("Expected type AreaDensity.", "obj");
-            return CompareTo((AreaDensity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is AreaDensity)) throw new ArgumentException("Expected type AreaDensity.", "obj");
+
+            return CompareTo((AreaDensity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AreaDensity other)
         {
-            return AsBaseUnitKilogramsPerSquareMeter().CompareTo(other.AsBaseUnitKilogramsPerSquareMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is AreaDensity)) throw new ArgumentException("Expected type AreaDensity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is AreaDensity)) throw new ArgumentException("Expected type AreaDensity.", nameof(obj));
 
             return CompareTo((AreaDensity)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static AreaDensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AreaDensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -505,9 +505,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is AreaMomentOfInertia)) throw new ArgumentException("Expected type AreaMomentOfInertia.", "obj");
-            return CompareTo((AreaMomentOfInertia) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is AreaMomentOfInertia)) throw new ArgumentException("Expected type AreaMomentOfInertia.", "obj");
+
+            return CompareTo((AreaMomentOfInertia)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -518,7 +519,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AreaMomentOfInertia other)
         {
-            return AsBaseUnitMetersToTheFourth().CompareTo(other.AsBaseUnitMetersToTheFourth());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -505,8 +505,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is AreaMomentOfInertia)) throw new ArgumentException("Expected type AreaMomentOfInertia.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is AreaMomentOfInertia)) throw new ArgumentException("Expected type AreaMomentOfInertia.", nameof(obj));
 
             return CompareTo((AreaMomentOfInertia)obj);
         }
@@ -685,7 +685,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -813,7 +813,7 @@ namespace UnitsNet
 #endif
         static AreaMomentOfInertiaUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<AreaMomentOfInertiaUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -1155,9 +1155,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is BitRate)) throw new ArgumentException("Expected type BitRate.", "obj");
-            return CompareTo((BitRate) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is BitRate)) throw new ArgumentException("Expected type BitRate.", "obj");
+
+            return CompareTo((BitRate)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1168,7 +1169,7 @@ namespace UnitsNet
 #endif
         int CompareTo(BitRate other)
         {
-            return AsBaseUnitBitsPerSecond().CompareTo(other.AsBaseUnitBitsPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -1155,8 +1155,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is BitRate)) throw new ArgumentException("Expected type BitRate.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is BitRate)) throw new ArgumentException("Expected type BitRate.", nameof(obj));
 
             return CompareTo((BitRate)obj);
         }
@@ -1352,7 +1352,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1480,7 +1480,7 @@ namespace UnitsNet
 #endif
         static BitRateUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<BitRateUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is BrakeSpecificFuelConsumption)) throw new ArgumentException("Expected type BrakeSpecificFuelConsumption.", "obj");
-            return CompareTo((BrakeSpecificFuelConsumption) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is BrakeSpecificFuelConsumption)) throw new ArgumentException("Expected type BrakeSpecificFuelConsumption.", "obj");
+
+            return CompareTo((BrakeSpecificFuelConsumption)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(BrakeSpecificFuelConsumption other)
         {
-            return AsBaseUnitKilogramsPerJoule().CompareTo(other.AsBaseUnitKilogramsPerJoule());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is BrakeSpecificFuelConsumption)) throw new ArgumentException("Expected type BrakeSpecificFuelConsumption.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is BrakeSpecificFuelConsumption)) throw new ArgumentException("Expected type BrakeSpecificFuelConsumption.", nameof(obj));
 
             return CompareTo((BrakeSpecificFuelConsumption)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static BrakeSpecificFuelConsumptionUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<BrakeSpecificFuelConsumptionUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Capacitance)) throw new ArgumentException("Expected type Capacitance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Capacitance)) throw new ArgumentException("Expected type Capacitance.", nameof(obj));
 
             return CompareTo((Capacitance)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static CapacitanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<CapacitanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Capacitance)) throw new ArgumentException("Expected type Capacitance.", "obj");
-            return CompareTo((Capacitance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Capacitance)) throw new ArgumentException("Expected type Capacitance.", "obj");
+
+            return CompareTo((Capacitance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Capacitance other)
         {
-            return AsBaseUnitFarads().CompareTo(other.AsBaseUnitFarads());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -1561,8 +1561,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Density)) throw new ArgumentException("Expected type Density.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Density)) throw new ArgumentException("Expected type Density.", nameof(obj));
 
             return CompareTo((Density)obj);
         }
@@ -1773,7 +1773,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1901,7 +1901,7 @@ namespace UnitsNet
 #endif
         static DensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<DensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -1561,9 +1561,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Density)) throw new ArgumentException("Expected type Density.", "obj");
-            return CompareTo((Density) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Density)) throw new ArgumentException("Expected type Density.", "obj");
+
+            return CompareTo((Density)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1574,7 +1575,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Density other)
         {
-            return AsBaseUnitKilogramsPerCubicMeter().CompareTo(other.AsBaseUnitKilogramsPerCubicMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -705,9 +705,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Duration)) throw new ArgumentException("Expected type Duration.", "obj");
-            return CompareTo((Duration) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Duration)) throw new ArgumentException("Expected type Duration.", "obj");
+
+            return CompareTo((Duration)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -718,7 +719,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Duration other)
         {
-            return AsBaseUnitSeconds().CompareTo(other.AsBaseUnitSeconds());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -705,8 +705,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Duration)) throw new ArgumentException("Expected type Duration.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Duration)) throw new ArgumentException("Expected type Duration.", nameof(obj));
 
             return CompareTo((Duration)obj);
         }
@@ -891,7 +891,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1019,7 +1019,7 @@ namespace UnitsNet
 #endif
         static DurationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<DurationUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -505,9 +505,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is DynamicViscosity)) throw new ArgumentException("Expected type DynamicViscosity.", "obj");
-            return CompareTo((DynamicViscosity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is DynamicViscosity)) throw new ArgumentException("Expected type DynamicViscosity.", "obj");
+
+            return CompareTo((DynamicViscosity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -518,7 +519,7 @@ namespace UnitsNet
 #endif
         int CompareTo(DynamicViscosity other)
         {
-            return AsBaseUnitNewtonSecondsPerMeterSquared().CompareTo(other.AsBaseUnitNewtonSecondsPerMeterSquared());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -505,8 +505,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is DynamicViscosity)) throw new ArgumentException("Expected type DynamicViscosity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is DynamicViscosity)) throw new ArgumentException("Expected type DynamicViscosity.", nameof(obj));
 
             return CompareTo((DynamicViscosity)obj);
         }
@@ -685,7 +685,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -813,7 +813,7 @@ namespace UnitsNet
 #endif
         static DynamicViscosityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<DynamicViscosityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricAdmittance)) throw new ArgumentException("Expected type ElectricAdmittance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricAdmittance)) throw new ArgumentException("Expected type ElectricAdmittance.", nameof(obj));
 
             return CompareTo((ElectricAdmittance)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static ElectricAdmittanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricAdmittanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricAdmittance)) throw new ArgumentException("Expected type ElectricAdmittance.", "obj");
-            return CompareTo((ElectricAdmittance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricAdmittance)) throw new ArgumentException("Expected type ElectricAdmittance.", "obj");
+
+            return CompareTo((ElectricAdmittance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricAdmittance other)
         {
-            return AsBaseUnitSiemens().CompareTo(other.AsBaseUnitSiemens());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricCharge)) throw new ArgumentException("Expected type ElectricCharge.", "obj");
-            return CompareTo((ElectricCharge) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricCharge)) throw new ArgumentException("Expected type ElectricCharge.", "obj");
+
+            return CompareTo((ElectricCharge)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCharge other)
         {
-            return AsBaseUnitCoulombs().CompareTo(other.AsBaseUnitCoulombs());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricCharge)) throw new ArgumentException("Expected type ElectricCharge.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricCharge)) throw new ArgumentException("Expected type ElectricCharge.", nameof(obj));
 
             return CompareTo((ElectricCharge)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricChargeUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricChargeUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricChargeDensity)) throw new ArgumentException("Expected type ElectricChargeDensity.", "obj");
-            return CompareTo((ElectricChargeDensity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricChargeDensity)) throw new ArgumentException("Expected type ElectricChargeDensity.", "obj");
+
+            return CompareTo((ElectricChargeDensity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricChargeDensity other)
         {
-            return AsBaseUnitCoulombsPerCubicMeter().CompareTo(other.AsBaseUnitCoulombsPerCubicMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricChargeDensity)) throw new ArgumentException("Expected type ElectricChargeDensity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricChargeDensity)) throw new ArgumentException("Expected type ElectricChargeDensity.", nameof(obj));
 
             return CompareTo((ElectricChargeDensity)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricChargeDensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricChargeDensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricConductance)) throw new ArgumentException("Expected type ElectricConductance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricConductance)) throw new ArgumentException("Expected type ElectricConductance.", nameof(obj));
 
             return CompareTo((ElectricConductance)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static ElectricConductanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricConductanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricConductance)) throw new ArgumentException("Expected type ElectricConductance.", "obj");
-            return CompareTo((ElectricConductance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricConductance)) throw new ArgumentException("Expected type ElectricConductance.", "obj");
+
+            return CompareTo((ElectricConductance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricConductance other)
         {
-            return AsBaseUnitSiemens().CompareTo(other.AsBaseUnitSiemens());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricConductivity)) throw new ArgumentException("Expected type ElectricConductivity.", "obj");
-            return CompareTo((ElectricConductivity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricConductivity)) throw new ArgumentException("Expected type ElectricConductivity.", "obj");
+
+            return CompareTo((ElectricConductivity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricConductivity other)
         {
-            return AsBaseUnitSiemensPerMeter().CompareTo(other.AsBaseUnitSiemensPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricConductivity)) throw new ArgumentException("Expected type ElectricConductivity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricConductivity)) throw new ArgumentException("Expected type ElectricConductivity.", nameof(obj));
 
             return CompareTo((ElectricConductivity)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricConductivityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricConductivityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -538,9 +538,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricCurrent)) throw new ArgumentException("Expected type ElectricCurrent.", "obj");
-            return CompareTo((ElectricCurrent) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricCurrent)) throw new ArgumentException("Expected type ElectricCurrent.", "obj");
+
+            return CompareTo((ElectricCurrent)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -551,7 +552,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCurrent other)
         {
-            return AsBaseUnitAmperes().CompareTo(other.AsBaseUnitAmperes());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -538,8 +538,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricCurrent)) throw new ArgumentException("Expected type ElectricCurrent.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricCurrent)) throw new ArgumentException("Expected type ElectricCurrent.", nameof(obj));
 
             return CompareTo((ElectricCurrent)obj);
         }
@@ -719,7 +719,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -847,7 +847,7 @@ namespace UnitsNet
 #endif
         static ElectricCurrentUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricCurrentUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricCurrentDensity)) throw new ArgumentException("Expected type ElectricCurrentDensity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricCurrentDensity)) throw new ArgumentException("Expected type ElectricCurrentDensity.", nameof(obj));
 
             return CompareTo((ElectricCurrentDensity)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricCurrentDensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricCurrentDensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricCurrentDensity)) throw new ArgumentException("Expected type ElectricCurrentDensity.", "obj");
-            return CompareTo((ElectricCurrentDensity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricCurrentDensity)) throw new ArgumentException("Expected type ElectricCurrentDensity.", "obj");
+
+            return CompareTo((ElectricCurrentDensity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCurrentDensity other)
         {
-            return AsBaseUnitAmperesPerSquareMeter().CompareTo(other.AsBaseUnitAmperesPerSquareMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricCurrentGradient)) throw new ArgumentException("Expected type ElectricCurrentGradient.", "obj");
-            return CompareTo((ElectricCurrentGradient) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricCurrentGradient)) throw new ArgumentException("Expected type ElectricCurrentGradient.", "obj");
+
+            return CompareTo((ElectricCurrentGradient)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCurrentGradient other)
         {
-            return AsBaseUnitAmperesPerSecond().CompareTo(other.AsBaseUnitAmperesPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricCurrentGradient)) throw new ArgumentException("Expected type ElectricCurrentGradient.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricCurrentGradient)) throw new ArgumentException("Expected type ElectricCurrentGradient.", nameof(obj));
 
             return CompareTo((ElectricCurrentGradient)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricCurrentGradientUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricCurrentGradientUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricField)) throw new ArgumentException("Expected type ElectricField.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricField)) throw new ArgumentException("Expected type ElectricField.", nameof(obj));
 
             return CompareTo((ElectricField)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricFieldUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricFieldUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricField)) throw new ArgumentException("Expected type ElectricField.", "obj");
-            return CompareTo((ElectricField) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricField)) throw new ArgumentException("Expected type ElectricField.", "obj");
+
+            return CompareTo((ElectricField)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricField other)
         {
-            return AsBaseUnitVoltsPerMeter().CompareTo(other.AsBaseUnitVoltsPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricInductance)) throw new ArgumentException("Expected type ElectricInductance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricInductance)) throw new ArgumentException("Expected type ElectricInductance.", nameof(obj));
 
             return CompareTo((ElectricInductance)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static ElectricInductanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricInductanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricInductance)) throw new ArgumentException("Expected type ElectricInductance.", "obj");
-            return CompareTo((ElectricInductance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricInductance)) throw new ArgumentException("Expected type ElectricInductance.", "obj");
+
+            return CompareTo((ElectricInductance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricInductance other)
         {
-            return AsBaseUnitHenries().CompareTo(other.AsBaseUnitHenries());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -472,9 +472,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricPotential)) throw new ArgumentException("Expected type ElectricPotential.", "obj");
-            return CompareTo((ElectricPotential) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricPotential)) throw new ArgumentException("Expected type ElectricPotential.", "obj");
+
+            return CompareTo((ElectricPotential)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -485,7 +486,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricPotential other)
         {
-            return AsBaseUnitVolts().CompareTo(other.AsBaseUnitVolts());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -472,8 +472,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricPotential)) throw new ArgumentException("Expected type ElectricPotential.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricPotential)) throw new ArgumentException("Expected type ElectricPotential.", nameof(obj));
 
             return CompareTo((ElectricPotential)obj);
         }
@@ -651,7 +651,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -779,7 +779,7 @@ namespace UnitsNet
 #endif
         static ElectricPotentialUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricPotentialUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -462,9 +462,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricPotentialAc)) throw new ArgumentException("Expected type ElectricPotentialAc.", "obj");
-            return CompareTo((ElectricPotentialAc) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricPotentialAc)) throw new ArgumentException("Expected type ElectricPotentialAc.", "obj");
+
+            return CompareTo((ElectricPotentialAc)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -475,7 +476,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricPotentialAc other)
         {
-            return AsBaseUnitVoltsAc().CompareTo(other.AsBaseUnitVoltsAc());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -462,8 +462,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricPotentialAc)) throw new ArgumentException("Expected type ElectricPotentialAc.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricPotentialAc)) throw new ArgumentException("Expected type ElectricPotentialAc.", nameof(obj));
 
             return CompareTo((ElectricPotentialAc)obj);
         }
@@ -641,7 +641,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -769,7 +769,7 @@ namespace UnitsNet
 #endif
         static ElectricPotentialAcUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricPotentialAcUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -462,8 +462,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricPotentialDc)) throw new ArgumentException("Expected type ElectricPotentialDc.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricPotentialDc)) throw new ArgumentException("Expected type ElectricPotentialDc.", nameof(obj));
 
             return CompareTo((ElectricPotentialDc)obj);
         }
@@ -641,7 +641,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -769,7 +769,7 @@ namespace UnitsNet
 #endif
         static ElectricPotentialDcUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricPotentialDcUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -462,9 +462,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricPotentialDc)) throw new ArgumentException("Expected type ElectricPotentialDc.", "obj");
-            return CompareTo((ElectricPotentialDc) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricPotentialDc)) throw new ArgumentException("Expected type ElectricPotentialDc.", "obj");
+
+            return CompareTo((ElectricPotentialDc)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -475,7 +476,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricPotentialDc other)
         {
-            return AsBaseUnitVoltsDc().CompareTo(other.AsBaseUnitVoltsDc());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricResistance)) throw new ArgumentException("Expected type ElectricResistance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricResistance)) throw new ArgumentException("Expected type ElectricResistance.", nameof(obj));
 
             return CompareTo((ElectricResistance)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static ElectricResistanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricResistanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricResistance)) throw new ArgumentException("Expected type ElectricResistance.", "obj");
-            return CompareTo((ElectricResistance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricResistance)) throw new ArgumentException("Expected type ElectricResistance.", "obj");
+
+            return CompareTo((ElectricResistance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricResistance other)
         {
-            return AsBaseUnitOhms().CompareTo(other.AsBaseUnitOhms());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ElectricResistivity)) throw new ArgumentException("Expected type ElectricResistivity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ElectricResistivity)) throw new ArgumentException("Expected type ElectricResistivity.", nameof(obj));
 
             return CompareTo((ElectricResistivity)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static ElectricResistivityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ElectricResistivityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ElectricResistivity)) throw new ArgumentException("Expected type ElectricResistivity.", "obj");
-            return CompareTo((ElectricResistivity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ElectricResistivity)) throw new ArgumentException("Expected type ElectricResistivity.", "obj");
+
+            return CompareTo((ElectricResistivity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricResistivity other)
         {
-            return AsBaseUnitOhmMeters().CompareTo(other.AsBaseUnitOhmMeters());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -1033,8 +1033,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Energy)) throw new ArgumentException("Expected type Energy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Energy)) throw new ArgumentException("Expected type Energy.", nameof(obj));
 
             return CompareTo((Energy)obj);
         }
@@ -1229,7 +1229,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1357,7 +1357,7 @@ namespace UnitsNet
 #endif
         static EnergyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<EnergyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -1033,9 +1033,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Energy)) throw new ArgumentException("Expected type Energy.", "obj");
-            return CompareTo((Energy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Energy)) throw new ArgumentException("Expected type Energy.", "obj");
+
+            return CompareTo((Energy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1046,7 +1047,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Energy other)
         {
-            return AsBaseUnitJoules().CompareTo(other.AsBaseUnitJoules());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -538,9 +538,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Entropy)) throw new ArgumentException("Expected type Entropy.", "obj");
-            return CompareTo((Entropy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Entropy)) throw new ArgumentException("Expected type Entropy.", "obj");
+
+            return CompareTo((Entropy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -551,7 +552,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Entropy other)
         {
-            return AsBaseUnitJoulesPerKelvin().CompareTo(other.AsBaseUnitJoulesPerKelvin());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -538,8 +538,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Entropy)) throw new ArgumentException("Expected type Entropy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Entropy)) throw new ArgumentException("Expected type Entropy.", nameof(obj));
 
             return CompareTo((Entropy)obj);
         }
@@ -719,7 +719,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -847,7 +847,7 @@ namespace UnitsNet
 #endif
         static EntropyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<EntropyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -1117,8 +1117,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Flow)) throw new ArgumentException("Expected type Flow.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Flow)) throw new ArgumentException("Expected type Flow.", nameof(obj));
 
             return CompareTo((Flow)obj);
         }
@@ -1315,7 +1315,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1443,7 +1443,7 @@ namespace UnitsNet
 #endif
         static FlowUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<FlowUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -1117,9 +1117,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Flow)) throw new ArgumentException("Expected type Flow.", "obj");
-            return CompareTo((Flow) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Flow)) throw new ArgumentException("Expected type Flow.", "obj");
+
+            return CompareTo((Flow)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1130,7 +1131,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Flow other)
         {
-            return AsBaseUnitCubicMetersPerSecond().CompareTo(other.AsBaseUnitCubicMetersPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -637,8 +637,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Force)) throw new ArgumentException("Expected type Force.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Force)) throw new ArgumentException("Expected type Force.", nameof(obj));
 
             return CompareTo((Force)obj);
         }
@@ -821,7 +821,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -949,7 +949,7 @@ namespace UnitsNet
 #endif
         static ForceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ForceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -637,9 +637,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Force)) throw new ArgumentException("Expected type Force.", "obj");
-            return CompareTo((Force) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Force)) throw new ArgumentException("Expected type Force.", "obj");
+
+            return CompareTo((Force)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -650,7 +651,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Force other)
         {
-            return AsBaseUnitNewtons().CompareTo(other.AsBaseUnitNewtons());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -670,9 +670,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ForceChangeRate)) throw new ArgumentException("Expected type ForceChangeRate.", "obj");
-            return CompareTo((ForceChangeRate) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ForceChangeRate)) throw new ArgumentException("Expected type ForceChangeRate.", "obj");
+
+            return CompareTo((ForceChangeRate)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -683,7 +684,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ForceChangeRate other)
         {
-            return AsBaseUnitNewtonsPerSecond().CompareTo(other.AsBaseUnitNewtonsPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -670,8 +670,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ForceChangeRate)) throw new ArgumentException("Expected type ForceChangeRate.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ForceChangeRate)) throw new ArgumentException("Expected type ForceChangeRate.", nameof(obj));
 
             return CompareTo((ForceChangeRate)obj);
         }
@@ -855,7 +855,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -983,7 +983,7 @@ namespace UnitsNet
 #endif
         static ForceChangeRateUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ForceChangeRateUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -604,8 +604,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ForcePerLength)) throw new ArgumentException("Expected type ForcePerLength.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ForcePerLength)) throw new ArgumentException("Expected type ForcePerLength.", nameof(obj));
 
             return CompareTo((ForcePerLength)obj);
         }
@@ -787,7 +787,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -915,7 +915,7 @@ namespace UnitsNet
 #endif
         static ForcePerLengthUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ForcePerLengthUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -604,9 +604,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ForcePerLength)) throw new ArgumentException("Expected type ForcePerLength.", "obj");
-            return CompareTo((ForcePerLength) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ForcePerLength)) throw new ArgumentException("Expected type ForcePerLength.", "obj");
+
+            return CompareTo((ForcePerLength)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -617,7 +618,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ForcePerLength other)
         {
-            return AsBaseUnitNewtonsPerMeter().CompareTo(other.AsBaseUnitNewtonsPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -571,9 +571,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Frequency)) throw new ArgumentException("Expected type Frequency.", "obj");
-            return CompareTo((Frequency) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Frequency)) throw new ArgumentException("Expected type Frequency.", "obj");
+
+            return CompareTo((Frequency)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -584,7 +585,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Frequency other)
         {
-            return AsBaseUnitHertz().CompareTo(other.AsBaseUnitHertz());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -571,8 +571,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Frequency)) throw new ArgumentException("Expected type Frequency.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Frequency)) throw new ArgumentException("Expected type Frequency.", nameof(obj));
 
             return CompareTo((Frequency)obj);
         }
@@ -753,7 +753,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -881,7 +881,7 @@ namespace UnitsNet
 #endif
         static FrequencyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<FrequencyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -835,8 +835,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is HeatFlux)) throw new ArgumentException("Expected type HeatFlux.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is HeatFlux)) throw new ArgumentException("Expected type HeatFlux.", nameof(obj));
 
             return CompareTo((HeatFlux)obj);
         }
@@ -1025,7 +1025,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1153,7 +1153,7 @@ namespace UnitsNet
 #endif
         static HeatFluxUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<HeatFluxUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -835,9 +835,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is HeatFlux)) throw new ArgumentException("Expected type HeatFlux.", "obj");
-            return CompareTo((HeatFlux) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is HeatFlux)) throw new ArgumentException("Expected type HeatFlux.", "obj");
+
+            return CompareTo((HeatFlux)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -848,7 +849,7 @@ namespace UnitsNet
 #endif
         int CompareTo(HeatFlux other)
         {
-            return AsBaseUnitWattsPerSquareMeter().CompareTo(other.AsBaseUnitWattsPerSquareMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -373,8 +373,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is HeatTransferCoefficient)) throw new ArgumentException("Expected type HeatTransferCoefficient.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is HeatTransferCoefficient)) throw new ArgumentException("Expected type HeatTransferCoefficient.", nameof(obj));
 
             return CompareTo((HeatTransferCoefficient)obj);
         }
@@ -549,7 +549,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -677,7 +677,7 @@ namespace UnitsNet
 #endif
         static HeatTransferCoefficientUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<HeatTransferCoefficientUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -373,9 +373,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is HeatTransferCoefficient)) throw new ArgumentException("Expected type HeatTransferCoefficient.", "obj");
-            return CompareTo((HeatTransferCoefficient) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is HeatTransferCoefficient)) throw new ArgumentException("Expected type HeatTransferCoefficient.", "obj");
+
+            return CompareTo((HeatTransferCoefficient)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -386,7 +387,7 @@ namespace UnitsNet
 #endif
         int CompareTo(HeatTransferCoefficient other)
         {
-            return AsBaseUnitWattsPerSquareMeterKelvin().CompareTo(other.AsBaseUnitWattsPerSquareMeterKelvin());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Illuminance)) throw new ArgumentException("Expected type Illuminance.", "obj");
-            return CompareTo((Illuminance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Illuminance)) throw new ArgumentException("Expected type Illuminance.", "obj");
+
+            return CompareTo((Illuminance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Illuminance other)
         {
-            return AsBaseUnitLux().CompareTo(other.AsBaseUnitLux());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Illuminance)) throw new ArgumentException("Expected type Illuminance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Illuminance)) throw new ArgumentException("Expected type Illuminance.", nameof(obj));
 
             return CompareTo((Illuminance)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static IlluminanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<IlluminanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -1155,8 +1155,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Information)) throw new ArgumentException("Expected type Information.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Information)) throw new ArgumentException("Expected type Information.", nameof(obj));
 
             return CompareTo((Information)obj);
         }
@@ -1352,7 +1352,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1480,7 +1480,7 @@ namespace UnitsNet
 #endif
         static InformationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<InformationUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -1155,9 +1155,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Information)) throw new ArgumentException("Expected type Information.", "obj");
-            return CompareTo((Information) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Information)) throw new ArgumentException("Expected type Information.", "obj");
+
+            return CompareTo((Information)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1168,7 +1169,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Information other)
         {
-            return AsBaseUnitBits().CompareTo(other.AsBaseUnitBits());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -373,8 +373,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Irradiance)) throw new ArgumentException("Expected type Irradiance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Irradiance)) throw new ArgumentException("Expected type Irradiance.", nameof(obj));
 
             return CompareTo((Irradiance)obj);
         }
@@ -549,7 +549,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -677,7 +677,7 @@ namespace UnitsNet
 #endif
         static IrradianceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<IrradianceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -373,9 +373,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Irradiance)) throw new ArgumentException("Expected type Irradiance.", "obj");
-            return CompareTo((Irradiance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Irradiance)) throw new ArgumentException("Expected type Irradiance.", "obj");
+
+            return CompareTo((Irradiance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -386,7 +387,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Irradiance other)
         {
-            return AsBaseUnitWattsPerSquareMeter().CompareTo(other.AsBaseUnitWattsPerSquareMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Irradiation)) throw new ArgumentException("Expected type Irradiation.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Irradiation)) throw new ArgumentException("Expected type Irradiation.", nameof(obj));
 
             return CompareTo((Irradiation)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static IrradiationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<IrradiationUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Irradiation)) throw new ArgumentException("Expected type Irradiation.", "obj");
-            return CompareTo((Irradiation) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Irradiation)) throw new ArgumentException("Expected type Irradiation.", "obj");
+
+            return CompareTo((Irradiation)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Irradiation other)
         {
-            return AsBaseUnitJoulesPerSquareMeter().CompareTo(other.AsBaseUnitJoulesPerSquareMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -571,9 +571,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is KinematicViscosity)) throw new ArgumentException("Expected type KinematicViscosity.", "obj");
-            return CompareTo((KinematicViscosity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is KinematicViscosity)) throw new ArgumentException("Expected type KinematicViscosity.", "obj");
+
+            return CompareTo((KinematicViscosity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -584,7 +585,7 @@ namespace UnitsNet
 #endif
         int CompareTo(KinematicViscosity other)
         {
-            return AsBaseUnitSquareMetersPerSecond().CompareTo(other.AsBaseUnitSquareMetersPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -571,8 +571,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is KinematicViscosity)) throw new ArgumentException("Expected type KinematicViscosity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is KinematicViscosity)) throw new ArgumentException("Expected type KinematicViscosity.", nameof(obj));
 
             return CompareTo((KinematicViscosity)obj);
         }
@@ -753,7 +753,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -881,7 +881,7 @@ namespace UnitsNet
 #endif
         static KinematicViscosityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<KinematicViscosityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is LapseRate)) throw new ArgumentException("Expected type LapseRate.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is LapseRate)) throw new ArgumentException("Expected type LapseRate.", nameof(obj));
 
             return CompareTo((LapseRate)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static LapseRateUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<LapseRateUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is LapseRate)) throw new ArgumentException("Expected type LapseRate.", "obj");
-            return CompareTo((LapseRate) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is LapseRate)) throw new ArgumentException("Expected type LapseRate.", "obj");
+
+            return CompareTo((LapseRate)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LapseRate other)
         {
-            return AsBaseUnitDegreesCelciusPerKilometer().CompareTo(other.AsBaseUnitDegreesCelciusPerKilometer());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -1033,9 +1033,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Length)) throw new ArgumentException("Expected type Length.", "obj");
-            return CompareTo((Length) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Length)) throw new ArgumentException("Expected type Length.", "obj");
+
+            return CompareTo((Length)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1046,7 +1047,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Length other)
         {
-            return AsBaseUnitMeters().CompareTo(other.AsBaseUnitMeters());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -1033,8 +1033,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Length)) throw new ArgumentException("Expected type Length.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Length)) throw new ArgumentException("Expected type Length.", nameof(obj));
 
             return CompareTo((Length)obj);
         }
@@ -1229,7 +1229,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1357,7 +1357,7 @@ namespace UnitsNet
 #endif
         static LengthUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<LengthUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -371,8 +371,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Level)) throw new ArgumentException("Expected type Level.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Level)) throw new ArgumentException("Expected type Level.", nameof(obj));
 
             return CompareTo((Level)obj);
         }
@@ -547,7 +547,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -675,7 +675,7 @@ namespace UnitsNet
 #endif
         static LevelUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<LevelUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -371,9 +371,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Level)) throw new ArgumentException("Expected type Level.", "obj");
-            return CompareTo((Level) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Level)) throw new ArgumentException("Expected type Level.", "obj");
+
+            return CompareTo((Level)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -384,7 +385,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Level other)
         {
-            return AsBaseUnitDecibels().CompareTo(other.AsBaseUnitDecibels());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is LinearDensity)) throw new ArgumentException("Expected type LinearDensity.", "obj");
-            return CompareTo((LinearDensity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is LinearDensity)) throw new ArgumentException("Expected type LinearDensity.", "obj");
+
+            return CompareTo((LinearDensity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LinearDensity other)
         {
-            return AsBaseUnitKilogramsPerMeter().CompareTo(other.AsBaseUnitKilogramsPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is LinearDensity)) throw new ArgumentException("Expected type LinearDensity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is LinearDensity)) throw new ArgumentException("Expected type LinearDensity.", nameof(obj));
 
             return CompareTo((LinearDensity)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static LinearDensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<LinearDensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is LuminousFlux)) throw new ArgumentException("Expected type LuminousFlux.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is LuminousFlux)) throw new ArgumentException("Expected type LuminousFlux.", nameof(obj));
 
             return CompareTo((LuminousFlux)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static LuminousFluxUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<LuminousFluxUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is LuminousFlux)) throw new ArgumentException("Expected type LuminousFlux.", "obj");
-            return CompareTo((LuminousFlux) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is LuminousFlux)) throw new ArgumentException("Expected type LuminousFlux.", "obj");
+
+            return CompareTo((LuminousFlux)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LuminousFlux other)
         {
-            return AsBaseUnitLumens().CompareTo(other.AsBaseUnitLumens());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is LuminousIntensity)) throw new ArgumentException("Expected type LuminousIntensity.", "obj");
-            return CompareTo((LuminousIntensity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is LuminousIntensity)) throw new ArgumentException("Expected type LuminousIntensity.", "obj");
+
+            return CompareTo((LuminousIntensity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LuminousIntensity other)
         {
-            return AsBaseUnitCandela().CompareTo(other.AsBaseUnitCandela());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is LuminousIntensity)) throw new ArgumentException("Expected type LuminousIntensity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is LuminousIntensity)) throw new ArgumentException("Expected type LuminousIntensity.", nameof(obj));
 
             return CompareTo((LuminousIntensity)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static LuminousIntensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<LuminousIntensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MagneticField)) throw new ArgumentException("Expected type MagneticField.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MagneticField)) throw new ArgumentException("Expected type MagneticField.", nameof(obj));
 
             return CompareTo((MagneticField)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static MagneticFieldUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MagneticFieldUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MagneticField)) throw new ArgumentException("Expected type MagneticField.", "obj");
-            return CompareTo((MagneticField) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MagneticField)) throw new ArgumentException("Expected type MagneticField.", "obj");
+
+            return CompareTo((MagneticField)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MagneticField other)
         {
-            return AsBaseUnitTeslas().CompareTo(other.AsBaseUnitTeslas());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MagneticFlux)) throw new ArgumentException("Expected type MagneticFlux.", "obj");
-            return CompareTo((MagneticFlux) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MagneticFlux)) throw new ArgumentException("Expected type MagneticFlux.", "obj");
+
+            return CompareTo((MagneticFlux)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MagneticFlux other)
         {
-            return AsBaseUnitWebers().CompareTo(other.AsBaseUnitWebers());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MagneticFlux)) throw new ArgumentException("Expected type MagneticFlux.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MagneticFlux)) throw new ArgumentException("Expected type MagneticFlux.", nameof(obj));
 
             return CompareTo((MagneticFlux)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static MagneticFluxUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MagneticFluxUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Magnetization)) throw new ArgumentException("Expected type Magnetization.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Magnetization)) throw new ArgumentException("Expected type Magnetization.", nameof(obj));
 
             return CompareTo((Magnetization)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static MagnetizationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MagnetizationUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Magnetization)) throw new ArgumentException("Expected type Magnetization.", "obj");
-            return CompareTo((Magnetization) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Magnetization)) throw new ArgumentException("Expected type Magnetization.", "obj");
+
+            return CompareTo((Magnetization)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Magnetization other)
         {
-            return AsBaseUnitAmperesPerMeter().CompareTo(other.AsBaseUnitAmperesPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -1000,9 +1000,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Mass)) throw new ArgumentException("Expected type Mass.", "obj");
-            return CompareTo((Mass) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Mass)) throw new ArgumentException("Expected type Mass.", "obj");
+
+            return CompareTo((Mass)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1013,7 +1014,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Mass other)
         {
-            return AsBaseUnitKilograms().CompareTo(other.AsBaseUnitKilograms());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -1000,8 +1000,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Mass)) throw new ArgumentException("Expected type Mass.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Mass)) throw new ArgumentException("Expected type Mass.", nameof(obj));
 
             return CompareTo((Mass)obj);
         }
@@ -1195,7 +1195,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1323,7 +1323,7 @@ namespace UnitsNet
 #endif
         static MassUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MassUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -802,8 +802,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MassFlow)) throw new ArgumentException("Expected type MassFlow.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MassFlow)) throw new ArgumentException("Expected type MassFlow.", nameof(obj));
 
             return CompareTo((MassFlow)obj);
         }
@@ -991,7 +991,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1119,7 +1119,7 @@ namespace UnitsNet
 #endif
         static MassFlowUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MassFlowUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -802,9 +802,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MassFlow)) throw new ArgumentException("Expected type MassFlow.", "obj");
-            return CompareTo((MassFlow) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MassFlow)) throw new ArgumentException("Expected type MassFlow.", "obj");
+
+            return CompareTo((MassFlow)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -815,7 +816,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MassFlow other)
         {
-            return AsBaseUnitGramsPerSecond().CompareTo(other.AsBaseUnitGramsPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -373,8 +373,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MassFlux)) throw new ArgumentException("Expected type MassFlux.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MassFlux)) throw new ArgumentException("Expected type MassFlux.", nameof(obj));
 
             return CompareTo((MassFlux)obj);
         }
@@ -549,7 +549,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -677,7 +677,7 @@ namespace UnitsNet
 #endif
         static MassFluxUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MassFluxUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -373,9 +373,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MassFlux)) throw new ArgumentException("Expected type MassFlux.", "obj");
-            return CompareTo((MassFlux) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MassFlux)) throw new ArgumentException("Expected type MassFlux.", "obj");
+
+            return CompareTo((MassFlux)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -386,7 +387,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MassFlux other)
         {
-            return AsBaseUnitKilogramsPerSecondPerSquareMeter().CompareTo(other.AsBaseUnitKilogramsPerSecondPerSquareMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -1165,9 +1165,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MassMomentOfInertia)) throw new ArgumentException("Expected type MassMomentOfInertia.", "obj");
-            return CompareTo((MassMomentOfInertia) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MassMomentOfInertia)) throw new ArgumentException("Expected type MassMomentOfInertia.", "obj");
+
+            return CompareTo((MassMomentOfInertia)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1178,7 +1179,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MassMomentOfInertia other)
         {
-            return AsBaseUnitKilogramSquareMeters().CompareTo(other.AsBaseUnitKilogramSquareMeters());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -1165,8 +1165,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MassMomentOfInertia)) throw new ArgumentException("Expected type MassMomentOfInertia.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MassMomentOfInertia)) throw new ArgumentException("Expected type MassMomentOfInertia.", nameof(obj));
 
             return CompareTo((MassMomentOfInertia)obj);
         }
@@ -1365,7 +1365,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1493,7 +1493,7 @@ namespace UnitsNet
 #endif
         static MassMomentOfInertiaUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MassMomentOfInertiaUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MolarEnergy)) throw new ArgumentException("Expected type MolarEnergy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MolarEnergy)) throw new ArgumentException("Expected type MolarEnergy.", nameof(obj));
 
             return CompareTo((MolarEnergy)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static MolarEnergyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MolarEnergyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MolarEnergy)) throw new ArgumentException("Expected type MolarEnergy.", "obj");
-            return CompareTo((MolarEnergy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MolarEnergy)) throw new ArgumentException("Expected type MolarEnergy.", "obj");
+
+            return CompareTo((MolarEnergy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MolarEnergy other)
         {
-            return AsBaseUnitJoulesPerMole().CompareTo(other.AsBaseUnitJoulesPerMole());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MolarEntropy)) throw new ArgumentException("Expected type MolarEntropy.", "obj");
-            return CompareTo((MolarEntropy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MolarEntropy)) throw new ArgumentException("Expected type MolarEntropy.", "obj");
+
+            return CompareTo((MolarEntropy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MolarEntropy other)
         {
-            return AsBaseUnitJoulesPerMoleKelvin().CompareTo(other.AsBaseUnitJoulesPerMoleKelvin());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MolarEntropy)) throw new ArgumentException("Expected type MolarEntropy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MolarEntropy)) throw new ArgumentException("Expected type MolarEntropy.", nameof(obj));
 
             return CompareTo((MolarEntropy)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static MolarEntropyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MolarEntropyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -703,8 +703,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is MolarMass)) throw new ArgumentException("Expected type MolarMass.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is MolarMass)) throw new ArgumentException("Expected type MolarMass.", nameof(obj));
 
             return CompareTo((MolarMass)obj);
         }
@@ -889,7 +889,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1017,7 +1017,7 @@ namespace UnitsNet
 #endif
         static MolarMassUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MolarMassUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -703,9 +703,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is MolarMass)) throw new ArgumentException("Expected type MolarMass.", "obj");
-            return CompareTo((MolarMass) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is MolarMass)) throw new ArgumentException("Expected type MolarMass.", "obj");
+
+            return CompareTo((MolarMass)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -716,7 +717,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MolarMass other)
         {
-            return AsBaseUnitKilogramsPerMole().CompareTo(other.AsBaseUnitKilogramsPerMole());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -571,8 +571,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Molarity)) throw new ArgumentException("Expected type Molarity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Molarity)) throw new ArgumentException("Expected type Molarity.", nameof(obj));
 
             return CompareTo((Molarity)obj);
         }
@@ -753,7 +753,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -881,7 +881,7 @@ namespace UnitsNet
 #endif
         static MolarityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<MolarityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -571,9 +571,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Molarity)) throw new ArgumentException("Expected type Molarity.", "obj");
-            return CompareTo((Molarity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Molarity)) throw new ArgumentException("Expected type Molarity.", "obj");
+
+            return CompareTo((Molarity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -584,7 +585,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Molarity other)
         {
-            return AsBaseUnitMolesPerCubicMeter().CompareTo(other.AsBaseUnitMolesPerCubicMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Permeability)) throw new ArgumentException("Expected type Permeability.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Permeability)) throw new ArgumentException("Expected type Permeability.", nameof(obj));
 
             return CompareTo((Permeability)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static PermeabilityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PermeabilityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Permeability)) throw new ArgumentException("Expected type Permeability.", "obj");
-            return CompareTo((Permeability) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Permeability)) throw new ArgumentException("Expected type Permeability.", "obj");
+
+            return CompareTo((Permeability)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Permeability other)
         {
-            return AsBaseUnitHenriesPerMeter().CompareTo(other.AsBaseUnitHenriesPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Permittivity)) throw new ArgumentException("Expected type Permittivity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Permittivity)) throw new ArgumentException("Expected type Permittivity.", nameof(obj));
 
             return CompareTo((Permittivity)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static PermittivityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PermittivityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Permittivity)) throw new ArgumentException("Expected type Permittivity.", "obj");
-            return CompareTo((Permittivity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Permittivity)) throw new ArgumentException("Expected type Permittivity.", "obj");
+
+            return CompareTo((Permittivity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Permittivity other)
         {
-            return AsBaseUnitFaradsPerMeter().CompareTo(other.AsBaseUnitFaradsPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -967,9 +967,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Power)) throw new ArgumentException("Expected type Power.", "obj");
-            return CompareTo((Power) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Power)) throw new ArgumentException("Expected type Power.", "obj");
+
+            return CompareTo((Power)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -980,7 +981,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Power other)
         {
-            return AsBaseUnitWatts().CompareTo(other.AsBaseUnitWatts());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -967,8 +967,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Power)) throw new ArgumentException("Expected type Power.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Power)) throw new ArgumentException("Expected type Power.", nameof(obj));
 
             return CompareTo((Power)obj);
         }
@@ -1158,7 +1158,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1286,7 +1286,7 @@ namespace UnitsNet
 #endif
         static PowerUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PowerUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -1759,9 +1759,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is PowerDensity)) throw new ArgumentException("Expected type PowerDensity.", "obj");
-            return CompareTo((PowerDensity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is PowerDensity)) throw new ArgumentException("Expected type PowerDensity.", "obj");
+
+            return CompareTo((PowerDensity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1772,7 +1773,7 @@ namespace UnitsNet
 #endif
         int CompareTo(PowerDensity other)
         {
-            return AsBaseUnitWattsPerCubicMeter().CompareTo(other.AsBaseUnitWattsPerCubicMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -1759,8 +1759,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is PowerDensity)) throw new ArgumentException("Expected type PowerDensity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is PowerDensity)) throw new ArgumentException("Expected type PowerDensity.", nameof(obj));
 
             return CompareTo((PowerDensity)obj);
         }
@@ -1977,7 +1977,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -2105,7 +2105,7 @@ namespace UnitsNet
 #endif
         static PowerDensityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PowerDensityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -371,9 +371,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is PowerRatio)) throw new ArgumentException("Expected type PowerRatio.", "obj");
-            return CompareTo((PowerRatio) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is PowerRatio)) throw new ArgumentException("Expected type PowerRatio.", "obj");
+
+            return CompareTo((PowerRatio)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -384,7 +385,7 @@ namespace UnitsNet
 #endif
         int CompareTo(PowerRatio other)
         {
-            return AsBaseUnitDecibelWatts().CompareTo(other.AsBaseUnitDecibelWatts());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -371,8 +371,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is PowerRatio)) throw new ArgumentException("Expected type PowerRatio.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is PowerRatio)) throw new ArgumentException("Expected type PowerRatio.", nameof(obj));
 
             return CompareTo((PowerRatio)obj);
         }
@@ -547,7 +547,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -675,7 +675,7 @@ namespace UnitsNet
 #endif
         static PowerRatioUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PowerRatioUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -1562,8 +1562,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Pressure)) throw new ArgumentException("Expected type Pressure.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Pressure)) throw new ArgumentException("Expected type Pressure.", nameof(obj));
 
             return CompareTo((Pressure)obj);
         }
@@ -1774,7 +1774,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1902,7 +1902,7 @@ namespace UnitsNet
 #endif
         static PressureUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PressureUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -1562,9 +1562,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Pressure)) throw new ArgumentException("Expected type Pressure.", "obj");
-            return CompareTo((Pressure) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Pressure)) throw new ArgumentException("Expected type Pressure.", "obj");
+
+            return CompareTo((Pressure)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1575,7 +1576,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Pressure other)
         {
-            return AsBaseUnitPascals().CompareTo(other.AsBaseUnitPascals());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is PressureChangeRate)) throw new ArgumentException("Expected type PressureChangeRate.", "obj");
-            return CompareTo((PressureChangeRate) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is PressureChangeRate)) throw new ArgumentException("Expected type PressureChangeRate.", "obj");
+
+            return CompareTo((PressureChangeRate)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(PressureChangeRate other)
         {
-            return AsBaseUnitPascalsPerSecond().CompareTo(other.AsBaseUnitPascalsPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is PressureChangeRate)) throw new ArgumentException("Expected type PressureChangeRate.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is PressureChangeRate)) throw new ArgumentException("Expected type PressureChangeRate.", nameof(obj));
 
             return CompareTo((PressureChangeRate)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static PressureChangeRateUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<PressureChangeRateUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -495,9 +495,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Ratio)) throw new ArgumentException("Expected type Ratio.", "obj");
-            return CompareTo((Ratio) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Ratio)) throw new ArgumentException("Expected type Ratio.", "obj");
+
+            return CompareTo((Ratio)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -508,7 +509,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Ratio other)
         {
-            return AsBaseUnitDecimalFractions().CompareTo(other.AsBaseUnitDecimalFractions());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -495,8 +495,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Ratio)) throw new ArgumentException("Expected type Ratio.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Ratio)) throw new ArgumentException("Expected type Ratio.", nameof(obj));
 
             return CompareTo((Ratio)obj);
         }
@@ -675,7 +675,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -803,7 +803,7 @@ namespace UnitsNet
 #endif
         static RatioUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<RatioUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ReactiveEnergy)) throw new ArgumentException("Expected type ReactiveEnergy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ReactiveEnergy)) throw new ArgumentException("Expected type ReactiveEnergy.", nameof(obj));
 
             return CompareTo((ReactiveEnergy)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static ReactiveEnergyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ReactiveEnergyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ReactiveEnergy)) throw new ArgumentException("Expected type ReactiveEnergy.", "obj");
-            return CompareTo((ReactiveEnergy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ReactiveEnergy)) throw new ArgumentException("Expected type ReactiveEnergy.", "obj");
+
+            return CompareTo((ReactiveEnergy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ReactiveEnergy other)
         {
-            return AsBaseUnitVoltampereReactiveHours().CompareTo(other.AsBaseUnitVoltampereReactiveHours());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -439,8 +439,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ReactivePower)) throw new ArgumentException("Expected type ReactivePower.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ReactivePower)) throw new ArgumentException("Expected type ReactivePower.", nameof(obj));
 
             return CompareTo((ReactivePower)obj);
         }
@@ -617,7 +617,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -745,7 +745,7 @@ namespace UnitsNet
 #endif
         static ReactivePowerUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ReactivePowerUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -439,9 +439,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ReactivePower)) throw new ArgumentException("Expected type ReactivePower.", "obj");
-            return CompareTo((ReactivePower) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ReactivePower)) throw new ArgumentException("Expected type ReactivePower.", "obj");
+
+            return CompareTo((ReactivePower)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -452,7 +453,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ReactivePower other)
         {
-            return AsBaseUnitVoltamperesReactive().CompareTo(other.AsBaseUnitVoltamperesReactive());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is RotationalAcceleration)) throw new ArgumentException("Expected type RotationalAcceleration.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is RotationalAcceleration)) throw new ArgumentException("Expected type RotationalAcceleration.", nameof(obj));
 
             return CompareTo((RotationalAcceleration)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static RotationalAccelerationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<RotationalAccelerationUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is RotationalAcceleration)) throw new ArgumentException("Expected type RotationalAcceleration.", "obj");
-            return CompareTo((RotationalAcceleration) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is RotationalAcceleration)) throw new ArgumentException("Expected type RotationalAcceleration.", "obj");
+
+            return CompareTo((RotationalAcceleration)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalAcceleration other)
         {
-            return AsBaseUnitRadiansPerSecondSquared().CompareTo(other.AsBaseUnitRadiansPerSecondSquared());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -736,8 +736,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is RotationalSpeed)) throw new ArgumentException("Expected type RotationalSpeed.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is RotationalSpeed)) throw new ArgumentException("Expected type RotationalSpeed.", nameof(obj));
 
             return CompareTo((RotationalSpeed)obj);
         }
@@ -923,7 +923,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1051,7 +1051,7 @@ namespace UnitsNet
 #endif
         static RotationalSpeedUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<RotationalSpeedUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -736,9 +736,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is RotationalSpeed)) throw new ArgumentException("Expected type RotationalSpeed.", "obj");
-            return CompareTo((RotationalSpeed) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is RotationalSpeed)) throw new ArgumentException("Expected type RotationalSpeed.", "obj");
+
+            return CompareTo((RotationalSpeed)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -749,7 +750,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalSpeed other)
         {
-            return AsBaseUnitRadiansPerSecond().CompareTo(other.AsBaseUnitRadiansPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is RotationalStiffness)) throw new ArgumentException("Expected type RotationalStiffness.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is RotationalStiffness)) throw new ArgumentException("Expected type RotationalStiffness.", nameof(obj));
 
             return CompareTo((RotationalStiffness)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static RotationalStiffnessUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<RotationalStiffnessUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is RotationalStiffness)) throw new ArgumentException("Expected type RotationalStiffness.", "obj");
-            return CompareTo((RotationalStiffness) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is RotationalStiffness)) throw new ArgumentException("Expected type RotationalStiffness.", "obj");
+
+            return CompareTo((RotationalStiffness)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalStiffness other)
         {
-            return AsBaseUnitNewtonMetersPerRadian().CompareTo(other.AsBaseUnitNewtonMetersPerRadian());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -406,8 +406,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is RotationalStiffnessPerLength)) throw new ArgumentException("Expected type RotationalStiffnessPerLength.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is RotationalStiffnessPerLength)) throw new ArgumentException("Expected type RotationalStiffnessPerLength.", nameof(obj));
 
             return CompareTo((RotationalStiffnessPerLength)obj);
         }
@@ -583,7 +583,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -711,7 +711,7 @@ namespace UnitsNet
 #endif
         static RotationalStiffnessPerLengthUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<RotationalStiffnessPerLengthUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -406,9 +406,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is RotationalStiffnessPerLength)) throw new ArgumentException("Expected type RotationalStiffnessPerLength.", "obj");
-            return CompareTo((RotationalStiffnessPerLength) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is RotationalStiffnessPerLength)) throw new ArgumentException("Expected type RotationalStiffnessPerLength.", "obj");
+
+            return CompareTo((RotationalStiffnessPerLength)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -419,7 +420,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalStiffnessPerLength other)
         {
-            return AsBaseUnitNewtonMetersPerRadianPerMeter().CompareTo(other.AsBaseUnitNewtonMetersPerRadianPerMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -330,9 +330,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is SolidAngle)) throw new ArgumentException("Expected type SolidAngle.", "obj");
-            return CompareTo((SolidAngle) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is SolidAngle)) throw new ArgumentException("Expected type SolidAngle.", "obj");
+
+            return CompareTo((SolidAngle)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -343,7 +344,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SolidAngle other)
         {
-            return AsBaseUnitSteradians().CompareTo(other.AsBaseUnitSteradians());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -330,8 +330,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is SolidAngle)) throw new ArgumentException("Expected type SolidAngle.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is SolidAngle)) throw new ArgumentException("Expected type SolidAngle.", nameof(obj));
 
             return CompareTo((SolidAngle)obj);
         }
@@ -505,7 +505,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -633,7 +633,7 @@ namespace UnitsNet
 #endif
         static SolidAngleUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<SolidAngleUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -571,9 +571,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is SpecificEnergy)) throw new ArgumentException("Expected type SpecificEnergy.", "obj");
-            return CompareTo((SpecificEnergy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is SpecificEnergy)) throw new ArgumentException("Expected type SpecificEnergy.", "obj");
+
+            return CompareTo((SpecificEnergy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -584,7 +585,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificEnergy other)
         {
-            return AsBaseUnitJoulesPerKilogram().CompareTo(other.AsBaseUnitJoulesPerKilogram());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -571,8 +571,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is SpecificEnergy)) throw new ArgumentException("Expected type SpecificEnergy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is SpecificEnergy)) throw new ArgumentException("Expected type SpecificEnergy.", nameof(obj));
 
             return CompareTo((SpecificEnergy)obj);
         }
@@ -753,7 +753,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -881,7 +881,7 @@ namespace UnitsNet
 #endif
         static SpecificEnergyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<SpecificEnergyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -571,8 +571,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is SpecificEntropy)) throw new ArgumentException("Expected type SpecificEntropy.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is SpecificEntropy)) throw new ArgumentException("Expected type SpecificEntropy.", nameof(obj));
 
             return CompareTo((SpecificEntropy)obj);
         }
@@ -753,7 +753,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -881,7 +881,7 @@ namespace UnitsNet
 #endif
         static SpecificEntropyUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<SpecificEntropyUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -571,9 +571,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is SpecificEntropy)) throw new ArgumentException("Expected type SpecificEntropy.", "obj");
-            return CompareTo((SpecificEntropy) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is SpecificEntropy)) throw new ArgumentException("Expected type SpecificEntropy.", "obj");
+
+            return CompareTo((SpecificEntropy)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -584,7 +585,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificEntropy other)
         {
-            return AsBaseUnitJoulesPerKilogramKelvin().CompareTo(other.AsBaseUnitJoulesPerKilogramKelvin());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -340,8 +340,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is SpecificVolume)) throw new ArgumentException("Expected type SpecificVolume.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is SpecificVolume)) throw new ArgumentException("Expected type SpecificVolume.", nameof(obj));
 
             return CompareTo((SpecificVolume)obj);
         }
@@ -515,7 +515,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -643,7 +643,7 @@ namespace UnitsNet
 #endif
         static SpecificVolumeUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<SpecificVolumeUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -340,9 +340,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is SpecificVolume)) throw new ArgumentException("Expected type SpecificVolume.", "obj");
-            return CompareTo((SpecificVolume) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is SpecificVolume)) throw new ArgumentException("Expected type SpecificVolume.", "obj");
+
+            return CompareTo((SpecificVolume)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -353,7 +354,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificVolume other)
         {
-            return AsBaseUnitCubicMetersPerKilogram().CompareTo(other.AsBaseUnitCubicMetersPerKilogram());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -868,9 +868,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is SpecificWeight)) throw new ArgumentException("Expected type SpecificWeight.", "obj");
-            return CompareTo((SpecificWeight) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is SpecificWeight)) throw new ArgumentException("Expected type SpecificWeight.", "obj");
+
+            return CompareTo((SpecificWeight)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -881,7 +882,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificWeight other)
         {
-            return AsBaseUnitNewtonsPerCubicMeter().CompareTo(other.AsBaseUnitNewtonsPerCubicMeter());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -868,8 +868,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is SpecificWeight)) throw new ArgumentException("Expected type SpecificWeight.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is SpecificWeight)) throw new ArgumentException("Expected type SpecificWeight.", nameof(obj));
 
             return CompareTo((SpecificWeight)obj);
         }
@@ -1059,7 +1059,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1187,7 +1187,7 @@ namespace UnitsNet
 #endif
         static SpecificWeightUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<SpecificWeightUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -1363,9 +1363,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Speed)) throw new ArgumentException("Expected type Speed.", "obj");
-            return CompareTo((Speed) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Speed)) throw new ArgumentException("Expected type Speed.", "obj");
+
+            return CompareTo((Speed)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1376,7 +1377,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Speed other)
         {
-            return AsBaseUnitMetersPerSecond().CompareTo(other.AsBaseUnitMetersPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -1363,8 +1363,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Speed)) throw new ArgumentException("Expected type Speed.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Speed)) throw new ArgumentException("Expected type Speed.", nameof(obj));
 
             return CompareTo((Speed)obj);
         }
@@ -1569,7 +1569,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1697,7 +1697,7 @@ namespace UnitsNet
 #endif
         static SpeedUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<SpeedUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -529,8 +529,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Temperature)) throw new ArgumentException("Expected type Temperature.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Temperature)) throw new ArgumentException("Expected type Temperature.", nameof(obj));
 
             return CompareTo((Temperature)obj);
         }
@@ -711,7 +711,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -839,7 +839,7 @@ namespace UnitsNet
 #endif
         static TemperatureUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<TemperatureUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -529,9 +529,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Temperature)) throw new ArgumentException("Expected type Temperature.", "obj");
-            return CompareTo((Temperature) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Temperature)) throw new ArgumentException("Expected type Temperature.", "obj");
+
+            return CompareTo((Temperature)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -542,7 +543,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Temperature other)
         {
-            return AsBaseUnitKelvins().CompareTo(other.AsBaseUnitKelvins());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -637,8 +637,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is TemperatureChangeRate)) throw new ArgumentException("Expected type TemperatureChangeRate.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is TemperatureChangeRate)) throw new ArgumentException("Expected type TemperatureChangeRate.", nameof(obj));
 
             return CompareTo((TemperatureChangeRate)obj);
         }
@@ -821,7 +821,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -949,7 +949,7 @@ namespace UnitsNet
 #endif
         static TemperatureChangeRateUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<TemperatureChangeRateUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -637,9 +637,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is TemperatureChangeRate)) throw new ArgumentException("Expected type TemperatureChangeRate.", "obj");
-            return CompareTo((TemperatureChangeRate) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is TemperatureChangeRate)) throw new ArgumentException("Expected type TemperatureChangeRate.", "obj");
+
+            return CompareTo((TemperatureChangeRate)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -650,7 +651,7 @@ namespace UnitsNet
 #endif
         int CompareTo(TemperatureChangeRate other)
         {
-            return AsBaseUnitDegreesCelsiusPerSecond().CompareTo(other.AsBaseUnitDegreesCelsiusPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -833,8 +833,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is TemperatureDelta)) throw new ArgumentException("Expected type TemperatureDelta.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is TemperatureDelta)) throw new ArgumentException("Expected type TemperatureDelta.", nameof(obj));
 
             return CompareTo((TemperatureDelta)obj);
         }
@@ -1023,7 +1023,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1151,7 +1151,7 @@ namespace UnitsNet
 #endif
         static TemperatureDeltaUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<TemperatureDeltaUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -833,9 +833,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is TemperatureDelta)) throw new ArgumentException("Expected type TemperatureDelta.", "obj");
-            return CompareTo((TemperatureDelta) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is TemperatureDelta)) throw new ArgumentException("Expected type TemperatureDelta.", "obj");
+
+            return CompareTo((TemperatureDelta)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -846,7 +847,7 @@ namespace UnitsNet
 #endif
         int CompareTo(TemperatureDelta other)
         {
-            return AsBaseUnitKelvins().CompareTo(other.AsBaseUnitKelvins());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -373,8 +373,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ThermalConductivity)) throw new ArgumentException("Expected type ThermalConductivity.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ThermalConductivity)) throw new ArgumentException("Expected type ThermalConductivity.", nameof(obj));
 
             return CompareTo((ThermalConductivity)obj);
         }
@@ -549,7 +549,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -677,7 +677,7 @@ namespace UnitsNet
 #endif
         static ThermalConductivityUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ThermalConductivityUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -373,9 +373,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ThermalConductivity)) throw new ArgumentException("Expected type ThermalConductivity.", "obj");
-            return CompareTo((ThermalConductivity) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ThermalConductivity)) throw new ArgumentException("Expected type ThermalConductivity.", "obj");
+
+            return CompareTo((ThermalConductivity)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -386,7 +387,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ThermalConductivity other)
         {
-            return AsBaseUnitWattsPerMeterKelvin().CompareTo(other.AsBaseUnitWattsPerMeterKelvin());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -472,8 +472,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is ThermalResistance)) throw new ArgumentException("Expected type ThermalResistance.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is ThermalResistance)) throw new ArgumentException("Expected type ThermalResistance.", nameof(obj));
 
             return CompareTo((ThermalResistance)obj);
         }
@@ -651,7 +651,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -779,7 +779,7 @@ namespace UnitsNet
 #endif
         static ThermalResistanceUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<ThermalResistanceUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -472,9 +472,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is ThermalResistance)) throw new ArgumentException("Expected type ThermalResistance.", "obj");
-            return CompareTo((ThermalResistance) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is ThermalResistance)) throw new ArgumentException("Expected type ThermalResistance.", "obj");
+
+            return CompareTo((ThermalResistance)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -485,7 +486,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ThermalResistance other)
         {
-            return AsBaseUnitSquareMeterKelvinsPerKilowatt().CompareTo(other.AsBaseUnitSquareMeterKelvinsPerKilowatt());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -1000,9 +1000,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Torque)) throw new ArgumentException("Expected type Torque.", "obj");
-            return CompareTo((Torque) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Torque)) throw new ArgumentException("Expected type Torque.", "obj");
+
+            return CompareTo((Torque)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1013,7 +1014,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Torque other)
         {
-            return AsBaseUnitNewtonMeters().CompareTo(other.AsBaseUnitNewtonMeters());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -1000,8 +1000,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Torque)) throw new ArgumentException("Expected type Torque.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Torque)) throw new ArgumentException("Expected type Torque.", nameof(obj));
 
             return CompareTo((Torque)obj);
         }
@@ -1195,7 +1195,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1323,7 +1323,7 @@ namespace UnitsNet
 #endif
         static TorqueUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<TorqueUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -330,9 +330,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is VitaminA)) throw new ArgumentException("Expected type VitaminA.", "obj");
-            return CompareTo((VitaminA) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is VitaminA)) throw new ArgumentException("Expected type VitaminA.", "obj");
+
+            return CompareTo((VitaminA)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -343,7 +344,7 @@ namespace UnitsNet
 #endif
         int CompareTo(VitaminA other)
         {
-            return AsBaseUnitInternationalUnits().CompareTo(other.AsBaseUnitInternationalUnits());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -330,8 +330,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is VitaminA)) throw new ArgumentException("Expected type VitaminA.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is VitaminA)) throw new ArgumentException("Expected type VitaminA.", nameof(obj));
 
             return CompareTo((VitaminA)obj);
         }
@@ -505,7 +505,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -633,7 +633,7 @@ namespace UnitsNet
 #endif
         static VitaminAUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<VitaminAUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -1761,9 +1761,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is Volume)) throw new ArgumentException("Expected type Volume.", "obj");
-            return CompareTo((Volume) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is Volume)) throw new ArgumentException("Expected type Volume.", "obj");
+
+            return CompareTo((Volume)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1774,7 +1775,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Volume other)
         {
-            return AsBaseUnitCubicMeters().CompareTo(other.AsBaseUnitCubicMeters());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -1761,8 +1761,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is Volume)) throw new ArgumentException("Expected type Volume.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is Volume)) throw new ArgumentException("Expected type Volume.", nameof(obj));
 
             return CompareTo((Volume)obj);
         }
@@ -1979,7 +1979,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -2107,7 +2107,7 @@ namespace UnitsNet
 #endif
         static VolumeUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<VolumeUnit>(str.Trim());

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -1099,9 +1099,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is VolumeFlow)) throw new ArgumentException("Expected type VolumeFlow.", "obj");
-            return CompareTo((VolumeFlow) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is VolumeFlow)) throw new ArgumentException("Expected type VolumeFlow.", "obj");
+
+            return CompareTo((VolumeFlow)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -1112,7 +1113,7 @@ namespace UnitsNet
 #endif
         int CompareTo(VolumeFlow other)
         {
-            return AsBaseUnitCubicMetersPerSecond().CompareTo(other.AsBaseUnitCubicMetersPerSecond());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -1099,8 +1099,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is VolumeFlow)) throw new ArgumentException("Expected type VolumeFlow.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is VolumeFlow)) throw new ArgumentException("Expected type VolumeFlow.", nameof(obj));
 
             return CompareTo((VolumeFlow)obj);
         }
@@ -1297,7 +1297,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1425,7 +1425,7 @@ namespace UnitsNet
 #endif
         static VolumeFlowUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<VolumeFlowUnit>(str.Trim());

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -35,7 +35,7 @@
 
     $obsoleteEqualityIfDouble = ''
     if ($quantity.BaseType -eq "double") {
-      $obsoleteEqualityIfDouble = '[Obsolete("It is not safe to compare equality due to using System.Double as the internal representation. It is very easy to get slightly different values due to floating point operations. Instead use Equals(other, maxError) to provide the max allowed error.")]' + "`n        "
+      $obsoleteEqualityIfDouble = '[Obsolete("It is not safe to compare equality due to using System.Double as the internal representation. It is very easy to get slightly different values due to floating point operations. Instead use Equals(other, maxError) to provide the max allowed error.")]' + "`r`n        "
     }
 
 @"
@@ -410,8 +410,8 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if(obj is null) throw new ArgumentNullException("obj");
-            if(!(obj is $quantityName)) throw new ArgumentException("Expected type $quantityName.", "obj");
+            if(obj is null) throw new ArgumentNullException(nameof(obj));
+            if(!(obj is $quantityName)) throw new ArgumentException("Expected type $quantityName.", nameof(obj));
 
             return CompareTo(($quantityName)obj);
         }
@@ -585,7 +585,7 @@ namespace UnitsNet
             [CanBeNull] IFormatProvider provider)
 #endif
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
 #if WINDOWS_UWP
             // Windows Runtime Component does not support CultureInfo and IFormatProvider types, so we use culture name for public methods: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -713,7 +713,7 @@ namespace UnitsNet
 #endif
         static $unitEnumName ParseUnit(string str, IFormatProvider provider = null)
         {
-            if (str == null) throw new ArgumentNullException("str");
+            if (str == null) throw new ArgumentNullException(nameof(str));
 
             var unitSystem = UnitSystem.GetCached(provider);
             var unit = unitSystem.Parse<$unitEnumName>(str.Trim());

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -410,9 +410,10 @@ namespace UnitsNet
 
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is $quantityName)) throw new ArgumentException("Expected type $quantityName.", "obj");
-            return CompareTo(($quantityName) obj);
+            if(obj is null) throw new ArgumentNullException("obj");
+            if(!(obj is $quantityName)) throw new ArgumentException("Expected type $quantityName.", "obj");
+
+            return CompareTo(($quantityName)obj);
         }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
@@ -423,7 +424,7 @@ namespace UnitsNet
 #endif
         int CompareTo($quantityName other)
         {
-            return AsBaseUnit$baseUnitPluralName().CompareTo(other.AsBaseUnit$baseUnitPluralName());
+            return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx


### PR DESCRIPTION
Changing Compare methods to compare current value to other in "this" units. This avoids scaling issues (and converting two quantities when we only need to potentially convert one) when both "this" and "other" are not defined in base units. "This" is the reference value.