### PR TITLE
As conversions

### DIFF
--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Acceleration(double numericValue, AccelerationUnit unit)
+        Acceleration(double numericValue, AccelerationUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -749,7 +749,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Acceleration other)
         {
-            return AsBaseUnitMetersPerSecondSquared().CompareTo(other.AsBaseUnitMetersPerSecondSquared());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -797,7 +797,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitMetersPerSecondSquared().Equals(((Acceleration) obj).AsBaseUnitMetersPerSecondSquared());
+            return AsBaseUnit().Equals(((Acceleration) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -810,7 +810,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Acceleration other, Acceleration maxError)
         {
-            return Math.Abs(AsBaseUnitMetersPerSecondSquared() - other.AsBaseUnitMetersPerSecondSquared()) <= maxError.AsBaseUnitMetersPerSecondSquared();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -828,14 +828,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AccelerationUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AccelerationUnit.CentimeterPerSecondSquared: return (_value) * 1e-2d;
+                case AccelerationUnit.DecimeterPerSecondSquared: return (_value) * 1e-1d;
+                case AccelerationUnit.FootPerSecondSquared: return _value*0.304800;
+                case AccelerationUnit.InchPerSecondSquared: return _value*0.0254;
+                case AccelerationUnit.KilometerPerSecondSquared: return (_value) * 1e3d;
+                case AccelerationUnit.KnotPerHour: return _value*0.5144444444444/3600;
+                case AccelerationUnit.KnotPerMinute: return _value*0.5144444444444/60;
+                case AccelerationUnit.KnotPerSecond: return _value*0.5144444444444;
+                case AccelerationUnit.MeterPerSecondSquared: return _value;
+                case AccelerationUnit.MicrometerPerSecondSquared: return (_value) * 1e-6d;
+                case AccelerationUnit.MillimeterPerSecondSquared: return (_value) * 1e-3d;
+                case AccelerationUnit.NanometerPerSecondSquared: return (_value) * 1e-9d;
+                case AccelerationUnit.StandardGravity: return _value*9.80665;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitMetersPerSecondSquared();
+        private double AsBaseNumericType(AccelerationUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AccelerationUnit.CentimeterPerSecondSquared: return (baseUnitValue) / 1e-2d;
                 case AccelerationUnit.DecimeterPerSecondSquared: return (baseUnitValue) / 1e-1d;
@@ -850,9 +884,8 @@ namespace UnitsNet
                 case AccelerationUnit.MillimeterPerSecondSquared: return (baseUnitValue) / 1e-3d;
                 case AccelerationUnit.NanometerPerSecondSquared: return (baseUnitValue) / 1e-9d;
                 case AccelerationUnit.StandardGravity: return baseUnitValue/9.80665;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1201,38 +1234,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Acceleration
         /// </summary>
         public static Acceleration MinValue => new Acceleration(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitMetersPerSecondSquared()
-        {
-            if (Unit == AccelerationUnit.MeterPerSecondSquared) { return _value; }
-
-            switch (Unit)
-            {
-                case AccelerationUnit.CentimeterPerSecondSquared: return (_value) * 1e-2d;
-                case AccelerationUnit.DecimeterPerSecondSquared: return (_value) * 1e-1d;
-                case AccelerationUnit.FootPerSecondSquared: return _value*0.304800;
-                case AccelerationUnit.InchPerSecondSquared: return _value*0.0254;
-                case AccelerationUnit.KilometerPerSecondSquared: return (_value) * 1e3d;
-                case AccelerationUnit.KnotPerHour: return _value*0.5144444444444/3600;
-                case AccelerationUnit.KnotPerMinute: return _value*0.5144444444444/60;
-                case AccelerationUnit.KnotPerSecond: return _value*0.5144444444444;
-                case AccelerationUnit.MeterPerSecondSquared: return _value;
-                case AccelerationUnit.MicrometerPerSecondSquared: return (_value) * 1e-6d;
-                case AccelerationUnit.MillimeterPerSecondSquared: return (_value) * 1e-3d;
-                case AccelerationUnit.NanometerPerSecondSquared: return (_value) * 1e-9d;
-                case AccelerationUnit.StandardGravity: return _value*9.80665;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AccelerationUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          AmountOfSubstance(double numericValue, AmountOfSubstanceUnit unit)
+        AmountOfSubstance(double numericValue, AmountOfSubstanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -782,7 +782,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AmountOfSubstance other)
         {
-            return AsBaseUnitMoles().CompareTo(other.AsBaseUnitMoles());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -830,7 +830,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitMoles().Equals(((AmountOfSubstance) obj).AsBaseUnitMoles());
+            return AsBaseUnit().Equals(((AmountOfSubstance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -843,7 +843,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(AmountOfSubstance other, AmountOfSubstance maxError)
         {
-            return Math.Abs(AsBaseUnitMoles() - other.AsBaseUnitMoles()) <= maxError.AsBaseUnitMoles();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -861,14 +861,49 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AmountOfSubstanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AmountOfSubstanceUnit.Centimole: return (_value) * 1e-2d;
+                case AmountOfSubstanceUnit.CentipoundMole: return (_value*453.59237) * 1e-2d;
+                case AmountOfSubstanceUnit.Decimole: return (_value) * 1e-1d;
+                case AmountOfSubstanceUnit.DecipoundMole: return (_value*453.59237) * 1e-1d;
+                case AmountOfSubstanceUnit.Kilomole: return (_value) * 1e3d;
+                case AmountOfSubstanceUnit.KilopoundMole: return (_value*453.59237) * 1e3d;
+                case AmountOfSubstanceUnit.Micromole: return (_value) * 1e-6d;
+                case AmountOfSubstanceUnit.MicropoundMole: return (_value*453.59237) * 1e-6d;
+                case AmountOfSubstanceUnit.Millimole: return (_value) * 1e-3d;
+                case AmountOfSubstanceUnit.MillipoundMole: return (_value*453.59237) * 1e-3d;
+                case AmountOfSubstanceUnit.Mole: return _value;
+                case AmountOfSubstanceUnit.Nanomole: return (_value) * 1e-9d;
+                case AmountOfSubstanceUnit.NanopoundMole: return (_value*453.59237) * 1e-9d;
+                case AmountOfSubstanceUnit.PoundMole: return _value*453.59237;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitMoles();
+        private double AsBaseNumericType(AmountOfSubstanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AmountOfSubstanceUnit.Centimole: return (baseUnitValue) / 1e-2d;
                 case AmountOfSubstanceUnit.CentipoundMole: return (baseUnitValue/453.59237) / 1e-2d;
@@ -884,9 +919,8 @@ namespace UnitsNet
                 case AmountOfSubstanceUnit.Nanomole: return (baseUnitValue) / 1e-9d;
                 case AmountOfSubstanceUnit.NanopoundMole: return (baseUnitValue/453.59237) / 1e-9d;
                 case AmountOfSubstanceUnit.PoundMole: return baseUnitValue/453.59237;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1235,39 +1269,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of AmountOfSubstance
         /// </summary>
         public static AmountOfSubstance MinValue => new AmountOfSubstance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitMoles()
-        {
-            if (Unit == AmountOfSubstanceUnit.Mole) { return _value; }
-
-            switch (Unit)
-            {
-                case AmountOfSubstanceUnit.Centimole: return (_value) * 1e-2d;
-                case AmountOfSubstanceUnit.CentipoundMole: return (_value*453.59237) * 1e-2d;
-                case AmountOfSubstanceUnit.Decimole: return (_value) * 1e-1d;
-                case AmountOfSubstanceUnit.DecipoundMole: return (_value*453.59237) * 1e-1d;
-                case AmountOfSubstanceUnit.Kilomole: return (_value) * 1e3d;
-                case AmountOfSubstanceUnit.KilopoundMole: return (_value*453.59237) * 1e3d;
-                case AmountOfSubstanceUnit.Micromole: return (_value) * 1e-6d;
-                case AmountOfSubstanceUnit.MicropoundMole: return (_value*453.59237) * 1e-6d;
-                case AmountOfSubstanceUnit.Millimole: return (_value) * 1e-3d;
-                case AmountOfSubstanceUnit.MillipoundMole: return (_value*453.59237) * 1e-3d;
-                case AmountOfSubstanceUnit.Mole: return _value;
-                case AmountOfSubstanceUnit.Nanomole: return (_value) * 1e-9d;
-                case AmountOfSubstanceUnit.NanopoundMole: return (_value*453.59237) * 1e-9d;
-                case AmountOfSubstanceUnit.PoundMole: return _value*453.59237;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AmountOfSubstanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          AmplitudeRatio(double numericValue, AmplitudeRatioUnit unit)
+        AmplitudeRatio(double numericValue, AmplitudeRatioUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -450,7 +450,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AmplitudeRatio other)
         {
-            return AsBaseUnitDecibelVolts().CompareTo(other.AsBaseUnitDecibelVolts());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -498,7 +498,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDecibelVolts().Equals(((AmplitudeRatio) obj).AsBaseUnitDecibelVolts());
+            return AsBaseUnit().Equals(((AmplitudeRatio) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(AmplitudeRatio other, AmplitudeRatio maxError)
         {
-            return Math.Abs(AsBaseUnitDecibelVolts() - other.AsBaseUnitDecibelVolts()) <= maxError.AsBaseUnitDecibelVolts();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -529,22 +529,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AmplitudeRatioUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AmplitudeRatioUnit.DecibelMicrovolt: return _value - 120;
+                case AmplitudeRatioUnit.DecibelMillivolt: return _value - 60;
+                case AmplitudeRatioUnit.DecibelUnloaded: return _value - 2.218487499;
+                case AmplitudeRatioUnit.DecibelVolt: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDecibelVolts();
+        private double AsBaseNumericType(AmplitudeRatioUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AmplitudeRatioUnit.DecibelMicrovolt: return baseUnitValue + 120;
                 case AmplitudeRatioUnit.DecibelMillivolt: return baseUnitValue + 60;
                 case AmplitudeRatioUnit.DecibelUnloaded: return baseUnitValue + 2.218487499;
                 case AmplitudeRatioUnit.DecibelVolt: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -893,29 +917,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of AmplitudeRatio
         /// </summary>
         public static AmplitudeRatio MinValue => new AmplitudeRatio(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDecibelVolts()
-        {
-            if (Unit == AmplitudeRatioUnit.DecibelVolt) { return _value; }
-
-            switch (Unit)
-            {
-                case AmplitudeRatioUnit.DecibelMicrovolt: return _value - 120;
-                case AmplitudeRatioUnit.DecibelMillivolt: return _value - 60;
-                case AmplitudeRatioUnit.DecibelUnloaded: return _value - 2.218487499;
-                case AmplitudeRatioUnit.DecibelVolt: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AmplitudeRatioUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Angle(double numericValue, AngleUnit unit)
+        Angle(double numericValue, AngleUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -772,7 +772,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Angle other)
         {
-            return AsBaseUnitDegrees().CompareTo(other.AsBaseUnitDegrees());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -820,7 +820,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDegrees().Equals(((Angle) obj).AsBaseUnitDegrees());
+            return AsBaseUnit().Equals(((Angle) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -833,7 +833,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Angle other, Angle maxError)
         {
-            return Math.Abs(AsBaseUnitDegrees() - other.AsBaseUnitDegrees()) <= maxError.AsBaseUnitDegrees();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -851,14 +851,49 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AngleUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AngleUnit.Arcminute: return _value/60;
+                case AngleUnit.Arcsecond: return _value/3600;
+                case AngleUnit.Centiradian: return (_value*180/Math.PI) * 1e-2d;
+                case AngleUnit.Deciradian: return (_value*180/Math.PI) * 1e-1d;
+                case AngleUnit.Degree: return _value;
+                case AngleUnit.Gradian: return _value*0.9;
+                case AngleUnit.Microdegree: return (_value) * 1e-6d;
+                case AngleUnit.Microradian: return (_value*180/Math.PI) * 1e-6d;
+                case AngleUnit.Millidegree: return (_value) * 1e-3d;
+                case AngleUnit.Milliradian: return (_value*180/Math.PI) * 1e-3d;
+                case AngleUnit.Nanodegree: return (_value) * 1e-9d;
+                case AngleUnit.Nanoradian: return (_value*180/Math.PI) * 1e-9d;
+                case AngleUnit.Radian: return _value*180/Math.PI;
+                case AngleUnit.Revolution: return _value*360;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDegrees();
+        private double AsBaseNumericType(AngleUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AngleUnit.Arcminute: return baseUnitValue*60;
                 case AngleUnit.Arcsecond: return baseUnitValue*3600;
@@ -874,9 +909,8 @@ namespace UnitsNet
                 case AngleUnit.Nanoradian: return (baseUnitValue/180*Math.PI) / 1e-9d;
                 case AngleUnit.Radian: return baseUnitValue/180*Math.PI;
                 case AngleUnit.Revolution: return baseUnitValue/360;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1225,39 +1259,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Angle
         /// </summary>
         public static Angle MinValue => new Angle(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDegrees()
-        {
-            if (Unit == AngleUnit.Degree) { return _value; }
-
-            switch (Unit)
-            {
-                case AngleUnit.Arcminute: return _value/60;
-                case AngleUnit.Arcsecond: return _value/3600;
-                case AngleUnit.Centiradian: return (_value*180/Math.PI) * 1e-2d;
-                case AngleUnit.Deciradian: return (_value*180/Math.PI) * 1e-1d;
-                case AngleUnit.Degree: return _value;
-                case AngleUnit.Gradian: return _value*0.9;
-                case AngleUnit.Microdegree: return (_value) * 1e-6d;
-                case AngleUnit.Microradian: return (_value*180/Math.PI) * 1e-6d;
-                case AngleUnit.Millidegree: return (_value) * 1e-3d;
-                case AngleUnit.Milliradian: return (_value*180/Math.PI) * 1e-3d;
-                case AngleUnit.Nanodegree: return (_value) * 1e-9d;
-                case AngleUnit.Nanoradian: return (_value*180/Math.PI) * 1e-9d;
-                case AngleUnit.Radian: return _value*180/Math.PI;
-                case AngleUnit.Revolution: return _value*360;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AngleUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ApparentEnergy(double numericValue, ApparentEnergyUnit unit)
+        ApparentEnergy(double numericValue, ApparentEnergyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ApparentEnergy other)
         {
-            return AsBaseUnitVoltampereHours().CompareTo(other.AsBaseUnitVoltampereHours());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltampereHours().Equals(((ApparentEnergy) obj).AsBaseUnitVoltampereHours());
+            return AsBaseUnit().Equals(((ApparentEnergy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ApparentEnergy other, ApparentEnergy maxError)
         {
-            return Math.Abs(AsBaseUnitVoltampereHours() - other.AsBaseUnitVoltampereHours()) <= maxError.AsBaseUnitVoltampereHours();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ApparentEnergyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ApparentEnergyUnit.KilovoltampereHour: return (_value) * 1e3d;
+                case ApparentEnergyUnit.MegavoltampereHour: return (_value) * 1e6d;
+                case ApparentEnergyUnit.VoltampereHour: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltampereHours();
+        private double AsBaseNumericType(ApparentEnergyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ApparentEnergyUnit.KilovoltampereHour: return (baseUnitValue) / 1e3d;
                 case ApparentEnergyUnit.MegavoltampereHour: return (baseUnitValue) / 1e6d;
                 case ApparentEnergyUnit.VoltampereHour: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ApparentEnergy
         /// </summary>
         public static ApparentEnergy MinValue => new ApparentEnergy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltampereHours()
-        {
-            if (Unit == ApparentEnergyUnit.VoltampereHour) { return _value; }
-
-            switch (Unit)
-            {
-                case ApparentEnergyUnit.KilovoltampereHour: return (_value) * 1e3d;
-                case ApparentEnergyUnit.MegavoltampereHour: return (_value) * 1e6d;
-                case ApparentEnergyUnit.VoltampereHour: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ApparentEnergyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ApparentPower(double numericValue, ApparentPowerUnit unit)
+        ApparentPower(double numericValue, ApparentPowerUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ApparentPower other)
         {
-            return AsBaseUnitVoltamperes().CompareTo(other.AsBaseUnitVoltamperes());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltamperes().Equals(((ApparentPower) obj).AsBaseUnitVoltamperes());
+            return AsBaseUnit().Equals(((ApparentPower) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ApparentPower other, ApparentPower maxError)
         {
-            return Math.Abs(AsBaseUnitVoltamperes() - other.AsBaseUnitVoltamperes()) <= maxError.AsBaseUnitVoltamperes();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ApparentPowerUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ApparentPowerUnit.Gigavoltampere: return (_value) * 1e9d;
+                case ApparentPowerUnit.Kilovoltampere: return (_value) * 1e3d;
+                case ApparentPowerUnit.Megavoltampere: return (_value) * 1e6d;
+                case ApparentPowerUnit.Voltampere: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltamperes();
+        private double AsBaseNumericType(ApparentPowerUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ApparentPowerUnit.Gigavoltampere: return (baseUnitValue) / 1e9d;
                 case ApparentPowerUnit.Kilovoltampere: return (baseUnitValue) / 1e3d;
                 case ApparentPowerUnit.Megavoltampere: return (baseUnitValue) / 1e6d;
                 case ApparentPowerUnit.Voltampere: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ApparentPower
         /// </summary>
         public static ApparentPower MinValue => new ApparentPower(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltamperes()
-        {
-            if (Unit == ApparentPowerUnit.Voltampere) { return _value; }
-
-            switch (Unit)
-            {
-                case ApparentPowerUnit.Gigavoltampere: return (_value) * 1e9d;
-                case ApparentPowerUnit.Kilovoltampere: return (_value) * 1e3d;
-                case ApparentPowerUnit.Megavoltampere: return (_value) * 1e6d;
-                case ApparentPowerUnit.Voltampere: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ApparentPowerUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Area(double numericValue, AreaUnit unit)
+        Area(double numericValue, AreaUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -749,7 +749,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Area other)
         {
-            return AsBaseUnitSquareMeters().CompareTo(other.AsBaseUnitSquareMeters());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -797,7 +797,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSquareMeters().Equals(((Area) obj).AsBaseUnitSquareMeters());
+            return AsBaseUnit().Equals(((Area) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -810,7 +810,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Area other, Area maxError)
         {
-            return Math.Abs(AsBaseUnitSquareMeters() - other.AsBaseUnitSquareMeters()) <= maxError.AsBaseUnitSquareMeters();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -828,14 +828,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AreaUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AreaUnit.Acre: return _value*4046.85642;
+                case AreaUnit.Hectare: return _value*1e4;
+                case AreaUnit.SquareCentimeter: return _value*1e-4;
+                case AreaUnit.SquareDecimeter: return _value*1e-2;
+                case AreaUnit.SquareFoot: return _value*0.092903;
+                case AreaUnit.SquareInch: return _value*0.00064516;
+                case AreaUnit.SquareKilometer: return _value*1e6;
+                case AreaUnit.SquareMeter: return _value;
+                case AreaUnit.SquareMicrometer: return _value*1e-12;
+                case AreaUnit.SquareMile: return _value*2.59e6;
+                case AreaUnit.SquareMillimeter: return _value*1e-6;
+                case AreaUnit.SquareYard: return _value*0.836127;
+                case AreaUnit.UsSurveySquareFoot: return _value*0.09290341161;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSquareMeters();
+        private double AsBaseNumericType(AreaUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AreaUnit.Acre: return baseUnitValue/4046.85642;
                 case AreaUnit.Hectare: return baseUnitValue/1e4;
@@ -850,9 +884,8 @@ namespace UnitsNet
                 case AreaUnit.SquareMillimeter: return baseUnitValue/1e-6;
                 case AreaUnit.SquareYard: return baseUnitValue/0.836127;
                 case AreaUnit.UsSurveySquareFoot: return baseUnitValue/0.09290341161;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1201,38 +1234,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Area
         /// </summary>
         public static Area MinValue => new Area(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSquareMeters()
-        {
-            if (Unit == AreaUnit.SquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case AreaUnit.Acre: return _value*4046.85642;
-                case AreaUnit.Hectare: return _value*1e4;
-                case AreaUnit.SquareCentimeter: return _value*1e-4;
-                case AreaUnit.SquareDecimeter: return _value*1e-2;
-                case AreaUnit.SquareFoot: return _value*0.092903;
-                case AreaUnit.SquareInch: return _value*0.00064516;
-                case AreaUnit.SquareKilometer: return _value*1e6;
-                case AreaUnit.SquareMeter: return _value;
-                case AreaUnit.SquareMicrometer: return _value*1e-12;
-                case AreaUnit.SquareMile: return _value*2.59e6;
-                case AreaUnit.SquareMillimeter: return _value*1e-6;
-                case AreaUnit.SquareYard: return _value*0.836127;
-                case AreaUnit.UsSurveySquareFoot: return _value*0.09290341161;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AreaUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          AreaDensity(double numericValue, AreaDensityUnit unit)
+        AreaDensity(double numericValue, AreaDensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AreaDensity other)
         {
-            return AsBaseUnitKilogramsPerSquareMeter().CompareTo(other.AsBaseUnitKilogramsPerSquareMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramsPerSquareMeter().Equals(((AreaDensity) obj).AsBaseUnitKilogramsPerSquareMeter());
+            return AsBaseUnit().Equals(((AreaDensity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(AreaDensity other, AreaDensity maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramsPerSquareMeter() - other.AsBaseUnitKilogramsPerSquareMeter()) <= maxError.AsBaseUnitKilogramsPerSquareMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AreaDensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AreaDensityUnit.KilogramPerSquareMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramsPerSquareMeter();
+        private double AsBaseNumericType(AreaDensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AreaDensityUnit.KilogramPerSquareMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of AreaDensity
         /// </summary>
         public static AreaDensity MinValue => new AreaDensity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramsPerSquareMeter()
-        {
-            if (Unit == AreaDensityUnit.KilogramPerSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case AreaDensityUnit.KilogramPerSquareMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AreaDensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          AreaMomentOfInertia(double numericValue, AreaMomentOfInertiaUnit unit)
+        AreaMomentOfInertia(double numericValue, AreaMomentOfInertiaUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -518,7 +518,7 @@ namespace UnitsNet
 #endif
         int CompareTo(AreaMomentOfInertia other)
         {
-            return AsBaseUnitMetersToTheFourth().CompareTo(other.AsBaseUnitMetersToTheFourth());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -566,7 +566,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitMetersToTheFourth().Equals(((AreaMomentOfInertia) obj).AsBaseUnitMetersToTheFourth());
+            return AsBaseUnit().Equals(((AreaMomentOfInertia) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -579,7 +579,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(AreaMomentOfInertia other, AreaMomentOfInertia maxError)
         {
-            return Math.Abs(AsBaseUnitMetersToTheFourth() - other.AsBaseUnitMetersToTheFourth()) <= maxError.AsBaseUnitMetersToTheFourth();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -597,14 +597,41 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(AreaMomentOfInertiaUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case AreaMomentOfInertiaUnit.CentimeterToTheFourth: return _value/1e8;
+                case AreaMomentOfInertiaUnit.DecimeterToTheFourth: return _value/1e4;
+                case AreaMomentOfInertiaUnit.FootToTheFourth: return _value*Math.Pow(0.3048, 4);
+                case AreaMomentOfInertiaUnit.InchToTheFourth: return _value*Math.Pow(2.54e-2, 4);
+                case AreaMomentOfInertiaUnit.MeterToTheFourth: return _value;
+                case AreaMomentOfInertiaUnit.MillimeterToTheFourth: return _value/1e12;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitMetersToTheFourth();
+        private double AsBaseNumericType(AreaMomentOfInertiaUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case AreaMomentOfInertiaUnit.CentimeterToTheFourth: return baseUnitValue*1e8;
                 case AreaMomentOfInertiaUnit.DecimeterToTheFourth: return baseUnitValue*1e4;
@@ -612,9 +639,8 @@ namespace UnitsNet
                 case AreaMomentOfInertiaUnit.InchToTheFourth: return baseUnitValue/Math.Pow(2.54e-2, 4);
                 case AreaMomentOfInertiaUnit.MeterToTheFourth: return baseUnitValue;
                 case AreaMomentOfInertiaUnit.MillimeterToTheFourth: return baseUnitValue*1e12;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -963,31 +989,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of AreaMomentOfInertia
         /// </summary>
         public static AreaMomentOfInertia MinValue => new AreaMomentOfInertia(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitMetersToTheFourth()
-        {
-            if (Unit == AreaMomentOfInertiaUnit.MeterToTheFourth) { return _value; }
-
-            switch (Unit)
-            {
-                case AreaMomentOfInertiaUnit.CentimeterToTheFourth: return _value/1e8;
-                case AreaMomentOfInertiaUnit.DecimeterToTheFourth: return _value/1e4;
-                case AreaMomentOfInertiaUnit.FootToTheFourth: return _value*Math.Pow(0.3048, 4);
-                case AreaMomentOfInertiaUnit.InchToTheFourth: return _value*Math.Pow(2.54e-2, 4);
-                case AreaMomentOfInertiaUnit.MeterToTheFourth: return _value;
-                case AreaMomentOfInertiaUnit.MillimeterToTheFourth: return _value/1e12;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(AreaMomentOfInertiaUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          BitRate(decimal numericValue, BitRateUnit unit)
+        BitRate(decimal numericValue, BitRateUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1168,7 +1168,7 @@ namespace UnitsNet
 #endif
         int CompareTo(BitRate other)
         {
-            return AsBaseUnitBitsPerSecond().CompareTo(other.AsBaseUnitBitsPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1213,7 +1213,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitBitsPerSecond().Equals(((BitRate) obj).AsBaseUnitBitsPerSecond());
+            return AsBaseUnit().Equals(((BitRate) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1226,7 +1226,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(BitRate other, BitRate maxError)
         {
-            return Math.Abs(AsBaseUnitBitsPerSecond() - other.AsBaseUnitBitsPerSecond()) <= maxError.AsBaseUnitBitsPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1244,44 +1244,90 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(BitRateUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private decimal AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
-            }
-
-            decimal baseUnitValue = AsBaseUnitBitsPerSecond();
-
-            switch (unit)
-            {
-                case BitRateUnit.BitPerSecond: return Convert.ToDouble(baseUnitValue);
-                case BitRateUnit.BytePerSecond: return Convert.ToDouble(baseUnitValue/8m);
-                case BitRateUnit.ExabitPerSecond: return Convert.ToDouble((baseUnitValue) / 1e18m);
-                case BitRateUnit.ExabytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1e18m);
-                case BitRateUnit.ExbibitPerSecond: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.ExbibytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.GibibitPerSecond: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024));
-                case BitRateUnit.GibibytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024));
-                case BitRateUnit.GigabitPerSecond: return Convert.ToDouble((baseUnitValue) / 1e9m);
-                case BitRateUnit.GigabytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1e9m);
-                case BitRateUnit.KibibitPerSecond: return Convert.ToDouble((baseUnitValue) / 1024m);
-                case BitRateUnit.KibibytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1024m);
-                case BitRateUnit.KilobitPerSecond: return Convert.ToDouble((baseUnitValue) / 1e3m);
-                case BitRateUnit.KilobytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1e3m);
-                case BitRateUnit.MebibitPerSecond: return Convert.ToDouble((baseUnitValue) / (1024m * 1024));
-                case BitRateUnit.MebibytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024));
-                case BitRateUnit.MegabitPerSecond: return Convert.ToDouble((baseUnitValue) / 1e6m);
-                case BitRateUnit.MegabytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1e6m);
-                case BitRateUnit.PebibitPerSecond: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.PebibytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.PetabitPerSecond: return Convert.ToDouble((baseUnitValue) / 1e15m);
-                case BitRateUnit.PetabytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1e15m);
-                case BitRateUnit.TebibitPerSecond: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024 * 1024));
-                case BitRateUnit.TebibytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024));
-                case BitRateUnit.TerabitPerSecond: return Convert.ToDouble((baseUnitValue) / 1e12m);
-                case BitRateUnit.TerabytePerSecond: return Convert.ToDouble((baseUnitValue/8m) / 1e12m);
-
+                case BitRateUnit.BitPerSecond: return _value;
+                case BitRateUnit.BytePerSecond: return _value*8m;
+                case BitRateUnit.ExabitPerSecond: return (_value) * 1e18m;
+                case BitRateUnit.ExabytePerSecond: return (_value*8m) * 1e18m;
+                case BitRateUnit.ExbibitPerSecond: return (_value) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.ExbibytePerSecond: return (_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.GibibitPerSecond: return (_value) * (1024m * 1024 * 1024);
+                case BitRateUnit.GibibytePerSecond: return (_value*8m) * (1024m * 1024 * 1024);
+                case BitRateUnit.GigabitPerSecond: return (_value) * 1e9m;
+                case BitRateUnit.GigabytePerSecond: return (_value*8m) * 1e9m;
+                case BitRateUnit.KibibitPerSecond: return (_value) * 1024m;
+                case BitRateUnit.KibibytePerSecond: return (_value*8m) * 1024m;
+                case BitRateUnit.KilobitPerSecond: return (_value) * 1e3m;
+                case BitRateUnit.KilobytePerSecond: return (_value*8m) * 1e3m;
+                case BitRateUnit.MebibitPerSecond: return (_value) * (1024m * 1024);
+                case BitRateUnit.MebibytePerSecond: return (_value*8m) * (1024m * 1024);
+                case BitRateUnit.MegabitPerSecond: return (_value) * 1e6m;
+                case BitRateUnit.MegabytePerSecond: return (_value*8m) * 1e6m;
+                case BitRateUnit.PebibitPerSecond: return (_value) * (1024m * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.PebibytePerSecond: return (_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.PetabitPerSecond: return (_value) * 1e15m;
+                case BitRateUnit.PetabytePerSecond: return (_value*8m) * 1e15m;
+                case BitRateUnit.TebibitPerSecond: return (_value) * (1024m * 1024 * 1024 * 1024);
+                case BitRateUnit.TebibytePerSecond: return (_value*8m) * (1024m * 1024 * 1024 * 1024);
+                case BitRateUnit.TerabitPerSecond: return (_value) * 1e12m;
+                case BitRateUnit.TerabytePerSecond: return (_value*8m) * 1e12m;
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
+            }
+        }
+
+        private decimal AsBaseNumericType(BitRateUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
+
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
+            {
+                case BitRateUnit.BitPerSecond: return baseUnitValue;
+                case BitRateUnit.BytePerSecond: return baseUnitValue/8m;
+                case BitRateUnit.ExabitPerSecond: return (baseUnitValue) / 1e18m;
+                case BitRateUnit.ExabytePerSecond: return (baseUnitValue/8m) / 1e18m;
+                case BitRateUnit.ExbibitPerSecond: return (baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.ExbibytePerSecond: return (baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.GibibitPerSecond: return (baseUnitValue) / (1024m * 1024 * 1024);
+                case BitRateUnit.GibibytePerSecond: return (baseUnitValue/8m) / (1024m * 1024 * 1024);
+                case BitRateUnit.GigabitPerSecond: return (baseUnitValue) / 1e9m;
+                case BitRateUnit.GigabytePerSecond: return (baseUnitValue/8m) / 1e9m;
+                case BitRateUnit.KibibitPerSecond: return (baseUnitValue) / 1024m;
+                case BitRateUnit.KibibytePerSecond: return (baseUnitValue/8m) / 1024m;
+                case BitRateUnit.KilobitPerSecond: return (baseUnitValue) / 1e3m;
+                case BitRateUnit.KilobytePerSecond: return (baseUnitValue/8m) / 1e3m;
+                case BitRateUnit.MebibitPerSecond: return (baseUnitValue) / (1024m * 1024);
+                case BitRateUnit.MebibytePerSecond: return (baseUnitValue/8m) / (1024m * 1024);
+                case BitRateUnit.MegabitPerSecond: return (baseUnitValue) / 1e6m;
+                case BitRateUnit.MegabytePerSecond: return (baseUnitValue/8m) / 1e6m;
+                case BitRateUnit.PebibitPerSecond: return (baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.PebibytePerSecond: return (baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024);
+                case BitRateUnit.PetabitPerSecond: return (baseUnitValue) / 1e15m;
+                case BitRateUnit.PetabytePerSecond: return (baseUnitValue/8m) / 1e15m;
+                case BitRateUnit.TebibitPerSecond: return (baseUnitValue) / (1024m * 1024 * 1024 * 1024);
+                case BitRateUnit.TebibytePerSecond: return (baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024);
+                case BitRateUnit.TerabitPerSecond: return (baseUnitValue) / 1e12m;
+                case BitRateUnit.TerabytePerSecond: return (baseUnitValue/8m) / 1e12m;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1630,51 +1676,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of BitRate
         /// </summary>
         public static BitRate MinValue => new BitRate(decimal.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private decimal AsBaseUnitBitsPerSecond()
-        {
-            if (Unit == BitRateUnit.BitPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case BitRateUnit.BitPerSecond: return Convert.ToDecimal(_value);
-                case BitRateUnit.BytePerSecond: return Convert.ToDecimal(_value*8m);
-                case BitRateUnit.ExabitPerSecond: return Convert.ToDecimal((_value) * 1e18m);
-                case BitRateUnit.ExabytePerSecond: return Convert.ToDecimal((_value*8m) * 1e18m);
-                case BitRateUnit.ExbibitPerSecond: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.ExbibytePerSecond: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.GibibitPerSecond: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024));
-                case BitRateUnit.GibibytePerSecond: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024));
-                case BitRateUnit.GigabitPerSecond: return Convert.ToDecimal((_value) * 1e9m);
-                case BitRateUnit.GigabytePerSecond: return Convert.ToDecimal((_value*8m) * 1e9m);
-                case BitRateUnit.KibibitPerSecond: return Convert.ToDecimal((_value) * 1024m);
-                case BitRateUnit.KibibytePerSecond: return Convert.ToDecimal((_value*8m) * 1024m);
-                case BitRateUnit.KilobitPerSecond: return Convert.ToDecimal((_value) * 1e3m);
-                case BitRateUnit.KilobytePerSecond: return Convert.ToDecimal((_value*8m) * 1e3m);
-                case BitRateUnit.MebibitPerSecond: return Convert.ToDecimal((_value) * (1024m * 1024));
-                case BitRateUnit.MebibytePerSecond: return Convert.ToDecimal((_value*8m) * (1024m * 1024));
-                case BitRateUnit.MegabitPerSecond: return Convert.ToDecimal((_value) * 1e6m);
-                case BitRateUnit.MegabytePerSecond: return Convert.ToDecimal((_value*8m) * 1e6m);
-                case BitRateUnit.PebibitPerSecond: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.PebibytePerSecond: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024));
-                case BitRateUnit.PetabitPerSecond: return Convert.ToDecimal((_value) * 1e15m);
-                case BitRateUnit.PetabytePerSecond: return Convert.ToDecimal((_value*8m) * 1e15m);
-                case BitRateUnit.TebibitPerSecond: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024 * 1024));
-                case BitRateUnit.TebibytePerSecond: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024 * 1024));
-                case BitRateUnit.TerabitPerSecond: return Convert.ToDecimal((_value) * 1e12m);
-                case BitRateUnit.TerabytePerSecond: return Convert.ToDecimal((_value*8m) * 1e12m);
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private decimal AsBaseNumericType(BitRateUnit unit) => Convert.ToDecimal(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          BrakeSpecificFuelConsumption(double numericValue, BrakeSpecificFuelConsumptionUnit unit)
+        BrakeSpecificFuelConsumption(double numericValue, BrakeSpecificFuelConsumptionUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(BrakeSpecificFuelConsumption other)
         {
-            return AsBaseUnitKilogramsPerJoule().CompareTo(other.AsBaseUnitKilogramsPerJoule());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramsPerJoule().Equals(((BrakeSpecificFuelConsumption) obj).AsBaseUnitKilogramsPerJoule());
+            return AsBaseUnit().Equals(((BrakeSpecificFuelConsumption) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(BrakeSpecificFuelConsumption other, BrakeSpecificFuelConsumption maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramsPerJoule() - other.AsBaseUnitKilogramsPerJoule()) <= maxError.AsBaseUnitKilogramsPerJoule();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(BrakeSpecificFuelConsumptionUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour: return _value/3.6e9;
+                case BrakeSpecificFuelConsumptionUnit.KilogramPerJoule: return _value;
+                case BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour: return _value*1.689659410672e-7;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramsPerJoule();
+        private double AsBaseNumericType(BrakeSpecificFuelConsumptionUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour: return baseUnitValue*3.6e9;
                 case BrakeSpecificFuelConsumptionUnit.KilogramPerJoule: return baseUnitValue;
                 case BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour: return baseUnitValue/1.689659410672e-7;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of BrakeSpecificFuelConsumption
         /// </summary>
         public static BrakeSpecificFuelConsumption MinValue => new BrakeSpecificFuelConsumption(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramsPerJoule()
-        {
-            if (Unit == BrakeSpecificFuelConsumptionUnit.KilogramPerJoule) { return _value; }
-
-            switch (Unit)
-            {
-                case BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour: return _value/3.6e9;
-                case BrakeSpecificFuelConsumptionUnit.KilogramPerJoule: return _value;
-                case BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour: return _value*1.689659410672e-7;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(BrakeSpecificFuelConsumptionUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Capacitance(double numericValue, CapacitanceUnit unit)
+        Capacitance(double numericValue, CapacitanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Capacitance other)
         {
-            return AsBaseUnitFarads().CompareTo(other.AsBaseUnitFarads());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitFarads().Equals(((Capacitance) obj).AsBaseUnitFarads());
+            return AsBaseUnit().Equals(((Capacitance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Capacitance other, Capacitance maxError)
         {
-            return Math.Abs(AsBaseUnitFarads() - other.AsBaseUnitFarads()) <= maxError.AsBaseUnitFarads();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(CapacitanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case CapacitanceUnit.Farad: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitFarads();
+        private double AsBaseNumericType(CapacitanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case CapacitanceUnit.Farad: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Capacitance
         /// </summary>
         public static Capacitance MinValue => new Capacitance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitFarads()
-        {
-            if (Unit == CapacitanceUnit.Farad) { return _value; }
-
-            switch (Unit)
-            {
-                case CapacitanceUnit.Farad: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(CapacitanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Density(double numericValue, DensityUnit unit)
+        Density(double numericValue, DensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1574,7 +1574,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Density other)
         {
-            return AsBaseUnitKilogramsPerCubicMeter().CompareTo(other.AsBaseUnitKilogramsPerCubicMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1622,7 +1622,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramsPerCubicMeter().Equals(((Density) obj).AsBaseUnitKilogramsPerCubicMeter());
+            return AsBaseUnit().Equals(((Density) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1635,7 +1635,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Density other, Density maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramsPerCubicMeter() - other.AsBaseUnitKilogramsPerCubicMeter()) <= maxError.AsBaseUnitKilogramsPerCubicMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1653,14 +1653,73 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(DensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case DensityUnit.CentigramPerDeciliter: return (_value/1e-1) * 1e-2d;
+                case DensityUnit.CentigramPerLiter: return (_value/1) * 1e-2d;
+                case DensityUnit.CentigramPerMilliliter: return (_value/1e-3) * 1e-2d;
+                case DensityUnit.DecigramPerDeciliter: return (_value/1e-1) * 1e-1d;
+                case DensityUnit.DecigramPerLiter: return (_value/1) * 1e-1d;
+                case DensityUnit.DecigramPerMilliliter: return (_value/1e-3) * 1e-1d;
+                case DensityUnit.GramPerCubicCentimeter: return _value/1e-3;
+                case DensityUnit.GramPerCubicMeter: return _value/1e3;
+                case DensityUnit.GramPerCubicMillimeter: return _value/1e-6;
+                case DensityUnit.GramPerDeciliter: return _value/1e-1;
+                case DensityUnit.GramPerLiter: return _value/1;
+                case DensityUnit.GramPerMilliliter: return _value/1e-3;
+                case DensityUnit.KilogramPerCubicCentimeter: return (_value/1e-3) * 1e3d;
+                case DensityUnit.KilogramPerCubicMeter: return (_value/1e3) * 1e3d;
+                case DensityUnit.KilogramPerCubicMillimeter: return (_value/1e-6) * 1e3d;
+                case DensityUnit.KilopoundPerCubicFoot: return (_value/0.062427961) * 1e3d;
+                case DensityUnit.KilopoundPerCubicInch: return (_value/3.6127298147753e-5) * 1e3d;
+                case DensityUnit.MicrogramPerDeciliter: return (_value/1e-1) * 1e-6d;
+                case DensityUnit.MicrogramPerLiter: return (_value/1) * 1e-6d;
+                case DensityUnit.MicrogramPerMilliliter: return (_value/1e-3) * 1e-6d;
+                case DensityUnit.MilligramPerCubicMeter: return (_value/1e3) * 1e-3d;
+                case DensityUnit.MilligramPerDeciliter: return (_value/1e-1) * 1e-3d;
+                case DensityUnit.MilligramPerLiter: return (_value/1) * 1e-3d;
+                case DensityUnit.MilligramPerMilliliter: return (_value/1e-3) * 1e-3d;
+                case DensityUnit.NanogramPerDeciliter: return (_value/1e-1) * 1e-9d;
+                case DensityUnit.NanogramPerLiter: return (_value/1) * 1e-9d;
+                case DensityUnit.NanogramPerMilliliter: return (_value/1e-3) * 1e-9d;
+                case DensityUnit.PicogramPerDeciliter: return (_value/1e-1) * 1e-12d;
+                case DensityUnit.PicogramPerLiter: return (_value/1) * 1e-12d;
+                case DensityUnit.PicogramPerMilliliter: return (_value/1e-3) * 1e-12d;
+                case DensityUnit.PoundPerCubicFoot: return _value/0.062427961;
+                case DensityUnit.PoundPerCubicInch: return _value/3.6127298147753e-5;
+                case DensityUnit.PoundPerImperialGallon: return _value*9.9776398e1;
+                case DensityUnit.PoundPerUSGallon: return _value*1.19826427e2;
+                case DensityUnit.SlugPerCubicFoot: return _value*515.378818;
+                case DensityUnit.TonnePerCubicCentimeter: return _value/1e-9;
+                case DensityUnit.TonnePerCubicMeter: return _value/0.001;
+                case DensityUnit.TonnePerCubicMillimeter: return _value/1e-12;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramsPerCubicMeter();
+        private double AsBaseNumericType(DensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case DensityUnit.CentigramPerDeciliter: return (baseUnitValue*1e-1) / 1e-2d;
                 case DensityUnit.CentigramPerLiter: return (baseUnitValue*1) / 1e-2d;
@@ -1700,9 +1759,8 @@ namespace UnitsNet
                 case DensityUnit.TonnePerCubicCentimeter: return baseUnitValue*1e-9;
                 case DensityUnit.TonnePerCubicMeter: return baseUnitValue*0.001;
                 case DensityUnit.TonnePerCubicMillimeter: return baseUnitValue*1e-12;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -2051,63 +2109,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Density
         /// </summary>
         public static Density MinValue => new Density(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramsPerCubicMeter()
-        {
-            if (Unit == DensityUnit.KilogramPerCubicMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case DensityUnit.CentigramPerDeciliter: return (_value/1e-1) * 1e-2d;
-                case DensityUnit.CentigramPerLiter: return (_value/1) * 1e-2d;
-                case DensityUnit.CentigramPerMilliliter: return (_value/1e-3) * 1e-2d;
-                case DensityUnit.DecigramPerDeciliter: return (_value/1e-1) * 1e-1d;
-                case DensityUnit.DecigramPerLiter: return (_value/1) * 1e-1d;
-                case DensityUnit.DecigramPerMilliliter: return (_value/1e-3) * 1e-1d;
-                case DensityUnit.GramPerCubicCentimeter: return _value/1e-3;
-                case DensityUnit.GramPerCubicMeter: return _value/1e3;
-                case DensityUnit.GramPerCubicMillimeter: return _value/1e-6;
-                case DensityUnit.GramPerDeciliter: return _value/1e-1;
-                case DensityUnit.GramPerLiter: return _value/1;
-                case DensityUnit.GramPerMilliliter: return _value/1e-3;
-                case DensityUnit.KilogramPerCubicCentimeter: return (_value/1e-3) * 1e3d;
-                case DensityUnit.KilogramPerCubicMeter: return (_value/1e3) * 1e3d;
-                case DensityUnit.KilogramPerCubicMillimeter: return (_value/1e-6) * 1e3d;
-                case DensityUnit.KilopoundPerCubicFoot: return (_value/0.062427961) * 1e3d;
-                case DensityUnit.KilopoundPerCubicInch: return (_value/3.6127298147753e-5) * 1e3d;
-                case DensityUnit.MicrogramPerDeciliter: return (_value/1e-1) * 1e-6d;
-                case DensityUnit.MicrogramPerLiter: return (_value/1) * 1e-6d;
-                case DensityUnit.MicrogramPerMilliliter: return (_value/1e-3) * 1e-6d;
-                case DensityUnit.MilligramPerCubicMeter: return (_value/1e3) * 1e-3d;
-                case DensityUnit.MilligramPerDeciliter: return (_value/1e-1) * 1e-3d;
-                case DensityUnit.MilligramPerLiter: return (_value/1) * 1e-3d;
-                case DensityUnit.MilligramPerMilliliter: return (_value/1e-3) * 1e-3d;
-                case DensityUnit.NanogramPerDeciliter: return (_value/1e-1) * 1e-9d;
-                case DensityUnit.NanogramPerLiter: return (_value/1) * 1e-9d;
-                case DensityUnit.NanogramPerMilliliter: return (_value/1e-3) * 1e-9d;
-                case DensityUnit.PicogramPerDeciliter: return (_value/1e-1) * 1e-12d;
-                case DensityUnit.PicogramPerLiter: return (_value/1) * 1e-12d;
-                case DensityUnit.PicogramPerMilliliter: return (_value/1e-3) * 1e-12d;
-                case DensityUnit.PoundPerCubicFoot: return _value/0.062427961;
-                case DensityUnit.PoundPerCubicInch: return _value/3.6127298147753e-5;
-                case DensityUnit.PoundPerImperialGallon: return _value*9.9776398e1;
-                case DensityUnit.PoundPerUSGallon: return _value*1.19826427e2;
-                case DensityUnit.SlugPerCubicFoot: return _value*515.378818;
-                case DensityUnit.TonnePerCubicCentimeter: return _value/1e-9;
-                case DensityUnit.TonnePerCubicMeter: return _value/0.001;
-                case DensityUnit.TonnePerCubicMillimeter: return _value/1e-12;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(DensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Duration(double numericValue, DurationUnit unit)
+        Duration(double numericValue, DurationUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -718,7 +718,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Duration other)
         {
-            return AsBaseUnitSeconds().CompareTo(other.AsBaseUnitSeconds());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -766,7 +766,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSeconds().Equals(((Duration) obj).AsBaseUnitSeconds());
+            return AsBaseUnit().Equals(((Duration) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -779,7 +779,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Duration other, Duration maxError)
         {
-            return Math.Abs(AsBaseUnitSeconds() - other.AsBaseUnitSeconds()) <= maxError.AsBaseUnitSeconds();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -797,14 +797,47 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(DurationUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case DurationUnit.Day: return _value*24*3600;
+                case DurationUnit.Hour: return _value*3600;
+                case DurationUnit.Microsecond: return (_value) * 1e-6d;
+                case DurationUnit.Millisecond: return (_value) * 1e-3d;
+                case DurationUnit.Minute: return _value*60;
+                case DurationUnit.Month: return _value*30*24*3600;
+                case DurationUnit.Month30: return _value*30*24*3600;
+                case DurationUnit.Nanosecond: return (_value) * 1e-9d;
+                case DurationUnit.Second: return _value;
+                case DurationUnit.Week: return _value*7*24*3600;
+                case DurationUnit.Year: return _value*365*24*3600;
+                case DurationUnit.Year365: return _value*365*24*3600;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSeconds();
+        private double AsBaseNumericType(DurationUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case DurationUnit.Day: return baseUnitValue/(24*3600);
                 case DurationUnit.Hour: return baseUnitValue/3600;
@@ -818,9 +851,8 @@ namespace UnitsNet
                 case DurationUnit.Week: return baseUnitValue/(7*24*3600);
                 case DurationUnit.Year: return baseUnitValue/(365*24*3600);
                 case DurationUnit.Year365: return baseUnitValue/(365*24*3600);
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1169,37 +1201,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Duration
         /// </summary>
         public static Duration MinValue => new Duration(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSeconds()
-        {
-            if (Unit == DurationUnit.Second) { return _value; }
-
-            switch (Unit)
-            {
-                case DurationUnit.Day: return _value*24*3600;
-                case DurationUnit.Hour: return _value*3600;
-                case DurationUnit.Microsecond: return (_value) * 1e-6d;
-                case DurationUnit.Millisecond: return (_value) * 1e-3d;
-                case DurationUnit.Minute: return _value*60;
-                case DurationUnit.Month: return _value*30*24*3600;
-                case DurationUnit.Month30: return _value*30*24*3600;
-                case DurationUnit.Nanosecond: return (_value) * 1e-9d;
-                case DurationUnit.Second: return _value;
-                case DurationUnit.Week: return _value*7*24*3600;
-                case DurationUnit.Year: return _value*365*24*3600;
-                case DurationUnit.Year365: return _value*365*24*3600;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(DurationUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          DynamicViscosity(double numericValue, DynamicViscosityUnit unit)
+        DynamicViscosity(double numericValue, DynamicViscosityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -518,7 +518,7 @@ namespace UnitsNet
 #endif
         int CompareTo(DynamicViscosity other)
         {
-            return AsBaseUnitNewtonSecondsPerMeterSquared().CompareTo(other.AsBaseUnitNewtonSecondsPerMeterSquared());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -566,7 +566,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonSecondsPerMeterSquared().Equals(((DynamicViscosity) obj).AsBaseUnitNewtonSecondsPerMeterSquared());
+            return AsBaseUnit().Equals(((DynamicViscosity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -579,7 +579,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(DynamicViscosity other, DynamicViscosity maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonSecondsPerMeterSquared() - other.AsBaseUnitNewtonSecondsPerMeterSquared()) <= maxError.AsBaseUnitNewtonSecondsPerMeterSquared();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -597,14 +597,41 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(DynamicViscosityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case DynamicViscosityUnit.Centipoise: return (_value/10) * 1e-2d;
+                case DynamicViscosityUnit.MicropascalSecond: return (_value) * 1e-6d;
+                case DynamicViscosityUnit.MillipascalSecond: return (_value) * 1e-3d;
+                case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return _value;
+                case DynamicViscosityUnit.PascalSecond: return _value;
+                case DynamicViscosityUnit.Poise: return _value/10;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonSecondsPerMeterSquared();
+        private double AsBaseNumericType(DynamicViscosityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case DynamicViscosityUnit.Centipoise: return (baseUnitValue*10) / 1e-2d;
                 case DynamicViscosityUnit.MicropascalSecond: return (baseUnitValue) / 1e-6d;
@@ -612,9 +639,8 @@ namespace UnitsNet
                 case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return baseUnitValue;
                 case DynamicViscosityUnit.PascalSecond: return baseUnitValue;
                 case DynamicViscosityUnit.Poise: return baseUnitValue*10;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -963,31 +989,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of DynamicViscosity
         /// </summary>
         public static DynamicViscosity MinValue => new DynamicViscosity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonSecondsPerMeterSquared()
-        {
-            if (Unit == DynamicViscosityUnit.NewtonSecondPerMeterSquared) { return _value; }
-
-            switch (Unit)
-            {
-                case DynamicViscosityUnit.Centipoise: return (_value/10) * 1e-2d;
-                case DynamicViscosityUnit.MicropascalSecond: return (_value) * 1e-6d;
-                case DynamicViscosityUnit.MillipascalSecond: return (_value) * 1e-3d;
-                case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return _value;
-                case DynamicViscosityUnit.PascalSecond: return _value;
-                case DynamicViscosityUnit.Poise: return _value/10;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(DynamicViscosityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricAdmittance(double numericValue, ElectricAdmittanceUnit unit)
+        ElectricAdmittance(double numericValue, ElectricAdmittanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricAdmittance other)
         {
-            return AsBaseUnitSiemens().CompareTo(other.AsBaseUnitSiemens());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSiemens().Equals(((ElectricAdmittance) obj).AsBaseUnitSiemens());
+            return AsBaseUnit().Equals(((ElectricAdmittance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricAdmittance other, ElectricAdmittance maxError)
         {
-            return Math.Abs(AsBaseUnitSiemens() - other.AsBaseUnitSiemens()) <= maxError.AsBaseUnitSiemens();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricAdmittanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricAdmittanceUnit.Microsiemens: return (_value) * 1e-6d;
+                case ElectricAdmittanceUnit.Millisiemens: return (_value) * 1e-3d;
+                case ElectricAdmittanceUnit.Nanosiemens: return (_value) * 1e-9d;
+                case ElectricAdmittanceUnit.Siemens: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSiemens();
+        private double AsBaseNumericType(ElectricAdmittanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricAdmittanceUnit.Microsiemens: return (baseUnitValue) / 1e-6d;
                 case ElectricAdmittanceUnit.Millisiemens: return (baseUnitValue) / 1e-3d;
                 case ElectricAdmittanceUnit.Nanosiemens: return (baseUnitValue) / 1e-9d;
                 case ElectricAdmittanceUnit.Siemens: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricAdmittance
         /// </summary>
         public static ElectricAdmittance MinValue => new ElectricAdmittance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSiemens()
-        {
-            if (Unit == ElectricAdmittanceUnit.Siemens) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricAdmittanceUnit.Microsiemens: return (_value) * 1e-6d;
-                case ElectricAdmittanceUnit.Millisiemens: return (_value) * 1e-3d;
-                case ElectricAdmittanceUnit.Nanosiemens: return (_value) * 1e-9d;
-                case ElectricAdmittanceUnit.Siemens: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricAdmittanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricCharge(double numericValue, ElectricChargeUnit unit)
+        ElectricCharge(double numericValue, ElectricChargeUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCharge other)
         {
-            return AsBaseUnitCoulombs().CompareTo(other.AsBaseUnitCoulombs());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCoulombs().Equals(((ElectricCharge) obj).AsBaseUnitCoulombs());
+            return AsBaseUnit().Equals(((ElectricCharge) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricCharge other, ElectricCharge maxError)
         {
-            return Math.Abs(AsBaseUnitCoulombs() - other.AsBaseUnitCoulombs()) <= maxError.AsBaseUnitCoulombs();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricChargeUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricChargeUnit.Coulomb: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCoulombs();
+        private double AsBaseNumericType(ElectricChargeUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricChargeUnit.Coulomb: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricCharge
         /// </summary>
         public static ElectricCharge MinValue => new ElectricCharge(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCoulombs()
-        {
-            if (Unit == ElectricChargeUnit.Coulomb) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricChargeUnit.Coulomb: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricChargeUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricChargeDensity(double numericValue, ElectricChargeDensityUnit unit)
+        ElectricChargeDensity(double numericValue, ElectricChargeDensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricChargeDensity other)
         {
-            return AsBaseUnitCoulombsPerCubicMeter().CompareTo(other.AsBaseUnitCoulombsPerCubicMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCoulombsPerCubicMeter().Equals(((ElectricChargeDensity) obj).AsBaseUnitCoulombsPerCubicMeter());
+            return AsBaseUnit().Equals(((ElectricChargeDensity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricChargeDensity other, ElectricChargeDensity maxError)
         {
-            return Math.Abs(AsBaseUnitCoulombsPerCubicMeter() - other.AsBaseUnitCoulombsPerCubicMeter()) <= maxError.AsBaseUnitCoulombsPerCubicMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricChargeDensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricChargeDensityUnit.CoulombPerCubicMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCoulombsPerCubicMeter();
+        private double AsBaseNumericType(ElectricChargeDensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricChargeDensityUnit.CoulombPerCubicMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricChargeDensity
         /// </summary>
         public static ElectricChargeDensity MinValue => new ElectricChargeDensity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCoulombsPerCubicMeter()
-        {
-            if (Unit == ElectricChargeDensityUnit.CoulombPerCubicMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricChargeDensityUnit.CoulombPerCubicMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricChargeDensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricConductance(double numericValue, ElectricConductanceUnit unit)
+        ElectricConductance(double numericValue, ElectricConductanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricConductance other)
         {
-            return AsBaseUnitSiemens().CompareTo(other.AsBaseUnitSiemens());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSiemens().Equals(((ElectricConductance) obj).AsBaseUnitSiemens());
+            return AsBaseUnit().Equals(((ElectricConductance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricConductance other, ElectricConductance maxError)
         {
-            return Math.Abs(AsBaseUnitSiemens() - other.AsBaseUnitSiemens()) <= maxError.AsBaseUnitSiemens();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricConductanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricConductanceUnit.Microsiemens: return (_value) * 1e-6d;
+                case ElectricConductanceUnit.Millisiemens: return (_value) * 1e-3d;
+                case ElectricConductanceUnit.Siemens: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSiemens();
+        private double AsBaseNumericType(ElectricConductanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricConductanceUnit.Microsiemens: return (baseUnitValue) / 1e-6d;
                 case ElectricConductanceUnit.Millisiemens: return (baseUnitValue) / 1e-3d;
                 case ElectricConductanceUnit.Siemens: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricConductance
         /// </summary>
         public static ElectricConductance MinValue => new ElectricConductance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSiemens()
-        {
-            if (Unit == ElectricConductanceUnit.Siemens) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricConductanceUnit.Microsiemens: return (_value) * 1e-6d;
-                case ElectricConductanceUnit.Millisiemens: return (_value) * 1e-3d;
-                case ElectricConductanceUnit.Siemens: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricConductanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricConductivity(double numericValue, ElectricConductivityUnit unit)
+        ElectricConductivity(double numericValue, ElectricConductivityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricConductivity other)
         {
-            return AsBaseUnitSiemensPerMeter().CompareTo(other.AsBaseUnitSiemensPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSiemensPerMeter().Equals(((ElectricConductivity) obj).AsBaseUnitSiemensPerMeter());
+            return AsBaseUnit().Equals(((ElectricConductivity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricConductivity other, ElectricConductivity maxError)
         {
-            return Math.Abs(AsBaseUnitSiemensPerMeter() - other.AsBaseUnitSiemensPerMeter()) <= maxError.AsBaseUnitSiemensPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricConductivityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricConductivityUnit.SiemensPerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSiemensPerMeter();
+        private double AsBaseNumericType(ElectricConductivityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricConductivityUnit.SiemensPerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricConductivity
         /// </summary>
         public static ElectricConductivity MinValue => new ElectricConductivity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSiemensPerMeter()
-        {
-            if (Unit == ElectricConductivityUnit.SiemensPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricConductivityUnit.SiemensPerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricConductivityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricCurrent(double numericValue, ElectricCurrentUnit unit)
+        ElectricCurrent(double numericValue, ElectricCurrentUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -551,7 +551,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCurrent other)
         {
-            return AsBaseUnitAmperes().CompareTo(other.AsBaseUnitAmperes());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -599,7 +599,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitAmperes().Equals(((ElectricCurrent) obj).AsBaseUnitAmperes());
+            return AsBaseUnit().Equals(((ElectricCurrent) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -612,7 +612,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricCurrent other, ElectricCurrent maxError)
         {
-            return Math.Abs(AsBaseUnitAmperes() - other.AsBaseUnitAmperes()) <= maxError.AsBaseUnitAmperes();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -630,14 +630,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricCurrentUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricCurrentUnit.Ampere: return _value;
+                case ElectricCurrentUnit.Kiloampere: return (_value) * 1e3d;
+                case ElectricCurrentUnit.Megaampere: return (_value) * 1e6d;
+                case ElectricCurrentUnit.Microampere: return (_value) * 1e-6d;
+                case ElectricCurrentUnit.Milliampere: return (_value) * 1e-3d;
+                case ElectricCurrentUnit.Nanoampere: return (_value) * 1e-9d;
+                case ElectricCurrentUnit.Picoampere: return (_value) * 1e-12d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitAmperes();
+        private double AsBaseNumericType(ElectricCurrentUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricCurrentUnit.Ampere: return baseUnitValue;
                 case ElectricCurrentUnit.Kiloampere: return (baseUnitValue) / 1e3d;
@@ -646,9 +674,8 @@ namespace UnitsNet
                 case ElectricCurrentUnit.Milliampere: return (baseUnitValue) / 1e-3d;
                 case ElectricCurrentUnit.Nanoampere: return (baseUnitValue) / 1e-9d;
                 case ElectricCurrentUnit.Picoampere: return (baseUnitValue) / 1e-12d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -997,32 +1024,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricCurrent
         /// </summary>
         public static ElectricCurrent MinValue => new ElectricCurrent(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitAmperes()
-        {
-            if (Unit == ElectricCurrentUnit.Ampere) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricCurrentUnit.Ampere: return _value;
-                case ElectricCurrentUnit.Kiloampere: return (_value) * 1e3d;
-                case ElectricCurrentUnit.Megaampere: return (_value) * 1e6d;
-                case ElectricCurrentUnit.Microampere: return (_value) * 1e-6d;
-                case ElectricCurrentUnit.Milliampere: return (_value) * 1e-3d;
-                case ElectricCurrentUnit.Nanoampere: return (_value) * 1e-9d;
-                case ElectricCurrentUnit.Picoampere: return (_value) * 1e-12d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricCurrentUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricCurrentDensity(double numericValue, ElectricCurrentDensityUnit unit)
+        ElectricCurrentDensity(double numericValue, ElectricCurrentDensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCurrentDensity other)
         {
-            return AsBaseUnitAmperesPerSquareMeter().CompareTo(other.AsBaseUnitAmperesPerSquareMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitAmperesPerSquareMeter().Equals(((ElectricCurrentDensity) obj).AsBaseUnitAmperesPerSquareMeter());
+            return AsBaseUnit().Equals(((ElectricCurrentDensity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricCurrentDensity other, ElectricCurrentDensity maxError)
         {
-            return Math.Abs(AsBaseUnitAmperesPerSquareMeter() - other.AsBaseUnitAmperesPerSquareMeter()) <= maxError.AsBaseUnitAmperesPerSquareMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricCurrentDensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricCurrentDensityUnit.AmperePerSquareMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitAmperesPerSquareMeter();
+        private double AsBaseNumericType(ElectricCurrentDensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricCurrentDensityUnit.AmperePerSquareMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricCurrentDensity
         /// </summary>
         public static ElectricCurrentDensity MinValue => new ElectricCurrentDensity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitAmperesPerSquareMeter()
-        {
-            if (Unit == ElectricCurrentDensityUnit.AmperePerSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricCurrentDensityUnit.AmperePerSquareMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricCurrentDensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricCurrentGradient(double numericValue, ElectricCurrentGradientUnit unit)
+        ElectricCurrentGradient(double numericValue, ElectricCurrentGradientUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricCurrentGradient other)
         {
-            return AsBaseUnitAmperesPerSecond().CompareTo(other.AsBaseUnitAmperesPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitAmperesPerSecond().Equals(((ElectricCurrentGradient) obj).AsBaseUnitAmperesPerSecond());
+            return AsBaseUnit().Equals(((ElectricCurrentGradient) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricCurrentGradient other, ElectricCurrentGradient maxError)
         {
-            return Math.Abs(AsBaseUnitAmperesPerSecond() - other.AsBaseUnitAmperesPerSecond()) <= maxError.AsBaseUnitAmperesPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricCurrentGradientUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricCurrentGradientUnit.AmperePerSecond: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitAmperesPerSecond();
+        private double AsBaseNumericType(ElectricCurrentGradientUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricCurrentGradientUnit.AmperePerSecond: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricCurrentGradient
         /// </summary>
         public static ElectricCurrentGradient MinValue => new ElectricCurrentGradient(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitAmperesPerSecond()
-        {
-            if (Unit == ElectricCurrentGradientUnit.AmperePerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricCurrentGradientUnit.AmperePerSecond: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricCurrentGradientUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricField(double numericValue, ElectricFieldUnit unit)
+        ElectricField(double numericValue, ElectricFieldUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricField other)
         {
-            return AsBaseUnitVoltsPerMeter().CompareTo(other.AsBaseUnitVoltsPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltsPerMeter().Equals(((ElectricField) obj).AsBaseUnitVoltsPerMeter());
+            return AsBaseUnit().Equals(((ElectricField) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricField other, ElectricField maxError)
         {
-            return Math.Abs(AsBaseUnitVoltsPerMeter() - other.AsBaseUnitVoltsPerMeter()) <= maxError.AsBaseUnitVoltsPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricFieldUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricFieldUnit.VoltPerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltsPerMeter();
+        private double AsBaseNumericType(ElectricFieldUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricFieldUnit.VoltPerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricField
         /// </summary>
         public static ElectricField MinValue => new ElectricField(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltsPerMeter()
-        {
-            if (Unit == ElectricFieldUnit.VoltPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricFieldUnit.VoltPerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricFieldUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricInductance(double numericValue, ElectricInductanceUnit unit)
+        ElectricInductance(double numericValue, ElectricInductanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricInductance other)
         {
-            return AsBaseUnitHenries().CompareTo(other.AsBaseUnitHenries());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitHenries().Equals(((ElectricInductance) obj).AsBaseUnitHenries());
+            return AsBaseUnit().Equals(((ElectricInductance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricInductance other, ElectricInductance maxError)
         {
-            return Math.Abs(AsBaseUnitHenries() - other.AsBaseUnitHenries()) <= maxError.AsBaseUnitHenries();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricInductanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricInductanceUnit.Henry: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitHenries();
+        private double AsBaseNumericType(ElectricInductanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricInductanceUnit.Henry: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricInductance
         /// </summary>
         public static ElectricInductance MinValue => new ElectricInductance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitHenries()
-        {
-            if (Unit == ElectricInductanceUnit.Henry) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricInductanceUnit.Henry: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricInductanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricPotential(double numericValue, ElectricPotentialUnit unit)
+        ElectricPotential(double numericValue, ElectricPotentialUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -485,7 +485,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricPotential other)
         {
-            return AsBaseUnitVolts().CompareTo(other.AsBaseUnitVolts());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -533,7 +533,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVolts().Equals(((ElectricPotential) obj).AsBaseUnitVolts());
+            return AsBaseUnit().Equals(((ElectricPotential) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricPotential other, ElectricPotential maxError)
         {
-            return Math.Abs(AsBaseUnitVolts() - other.AsBaseUnitVolts()) <= maxError.AsBaseUnitVolts();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -564,23 +564,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricPotentialUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricPotentialUnit.Kilovolt: return (_value) * 1e3d;
+                case ElectricPotentialUnit.Megavolt: return (_value) * 1e6d;
+                case ElectricPotentialUnit.Microvolt: return (_value) * 1e-6d;
+                case ElectricPotentialUnit.Millivolt: return (_value) * 1e-3d;
+                case ElectricPotentialUnit.Volt: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVolts();
+        private double AsBaseNumericType(ElectricPotentialUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricPotentialUnit.Kilovolt: return (baseUnitValue) / 1e3d;
                 case ElectricPotentialUnit.Megavolt: return (baseUnitValue) / 1e6d;
                 case ElectricPotentialUnit.Microvolt: return (baseUnitValue) / 1e-6d;
                 case ElectricPotentialUnit.Millivolt: return (baseUnitValue) / 1e-3d;
                 case ElectricPotentialUnit.Volt: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -929,30 +954,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricPotential
         /// </summary>
         public static ElectricPotential MinValue => new ElectricPotential(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVolts()
-        {
-            if (Unit == ElectricPotentialUnit.Volt) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricPotentialUnit.Kilovolt: return (_value) * 1e3d;
-                case ElectricPotentialUnit.Megavolt: return (_value) * 1e6d;
-                case ElectricPotentialUnit.Microvolt: return (_value) * 1e-6d;
-                case ElectricPotentialUnit.Millivolt: return (_value) * 1e-3d;
-                case ElectricPotentialUnit.Volt: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricPotentialUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricPotentialAc(double numericValue, ElectricPotentialAcUnit unit)
+        ElectricPotentialAc(double numericValue, ElectricPotentialAcUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -475,7 +475,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricPotentialAc other)
         {
-            return AsBaseUnitVoltsAc().CompareTo(other.AsBaseUnitVoltsAc());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -523,7 +523,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltsAc().Equals(((ElectricPotentialAc) obj).AsBaseUnitVoltsAc());
+            return AsBaseUnit().Equals(((ElectricPotentialAc) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -536,7 +536,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricPotentialAc other, ElectricPotentialAc maxError)
         {
-            return Math.Abs(AsBaseUnitVoltsAc() - other.AsBaseUnitVoltsAc()) <= maxError.AsBaseUnitVoltsAc();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -554,23 +554,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricPotentialAcUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricPotentialAcUnit.KilovoltAc: return (_value) * 1e3d;
+                case ElectricPotentialAcUnit.MegavoltAc: return (_value) * 1e6d;
+                case ElectricPotentialAcUnit.MicrovoltAc: return (_value) * 1e-6d;
+                case ElectricPotentialAcUnit.MillivoltAc: return (_value) * 1e-3d;
+                case ElectricPotentialAcUnit.VoltAc: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltsAc();
+        private double AsBaseNumericType(ElectricPotentialAcUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricPotentialAcUnit.KilovoltAc: return (baseUnitValue) / 1e3d;
                 case ElectricPotentialAcUnit.MegavoltAc: return (baseUnitValue) / 1e6d;
                 case ElectricPotentialAcUnit.MicrovoltAc: return (baseUnitValue) / 1e-6d;
                 case ElectricPotentialAcUnit.MillivoltAc: return (baseUnitValue) / 1e-3d;
                 case ElectricPotentialAcUnit.VoltAc: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -919,30 +944,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricPotentialAc
         /// </summary>
         public static ElectricPotentialAc MinValue => new ElectricPotentialAc(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltsAc()
-        {
-            if (Unit == ElectricPotentialAcUnit.VoltAc) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricPotentialAcUnit.KilovoltAc: return (_value) * 1e3d;
-                case ElectricPotentialAcUnit.MegavoltAc: return (_value) * 1e6d;
-                case ElectricPotentialAcUnit.MicrovoltAc: return (_value) * 1e-6d;
-                case ElectricPotentialAcUnit.MillivoltAc: return (_value) * 1e-3d;
-                case ElectricPotentialAcUnit.VoltAc: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricPotentialAcUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricPotentialDc(double numericValue, ElectricPotentialDcUnit unit)
+        ElectricPotentialDc(double numericValue, ElectricPotentialDcUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -475,7 +475,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricPotentialDc other)
         {
-            return AsBaseUnitVoltsDc().CompareTo(other.AsBaseUnitVoltsDc());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -523,7 +523,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltsDc().Equals(((ElectricPotentialDc) obj).AsBaseUnitVoltsDc());
+            return AsBaseUnit().Equals(((ElectricPotentialDc) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -536,7 +536,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricPotentialDc other, ElectricPotentialDc maxError)
         {
-            return Math.Abs(AsBaseUnitVoltsDc() - other.AsBaseUnitVoltsDc()) <= maxError.AsBaseUnitVoltsDc();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -554,23 +554,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricPotentialDcUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricPotentialDcUnit.KilovoltDc: return (_value) * 1e3d;
+                case ElectricPotentialDcUnit.MegavoltDc: return (_value) * 1e6d;
+                case ElectricPotentialDcUnit.MicrovoltDc: return (_value) * 1e-6d;
+                case ElectricPotentialDcUnit.MillivoltDc: return (_value) * 1e-3d;
+                case ElectricPotentialDcUnit.VoltDc: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltsDc();
+        private double AsBaseNumericType(ElectricPotentialDcUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricPotentialDcUnit.KilovoltDc: return (baseUnitValue) / 1e3d;
                 case ElectricPotentialDcUnit.MegavoltDc: return (baseUnitValue) / 1e6d;
                 case ElectricPotentialDcUnit.MicrovoltDc: return (baseUnitValue) / 1e-6d;
                 case ElectricPotentialDcUnit.MillivoltDc: return (baseUnitValue) / 1e-3d;
                 case ElectricPotentialDcUnit.VoltDc: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -919,30 +944,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricPotentialDc
         /// </summary>
         public static ElectricPotentialDc MinValue => new ElectricPotentialDc(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltsDc()
-        {
-            if (Unit == ElectricPotentialDcUnit.VoltDc) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricPotentialDcUnit.KilovoltDc: return (_value) * 1e3d;
-                case ElectricPotentialDcUnit.MegavoltDc: return (_value) * 1e6d;
-                case ElectricPotentialDcUnit.MicrovoltDc: return (_value) * 1e-6d;
-                case ElectricPotentialDcUnit.MillivoltDc: return (_value) * 1e-3d;
-                case ElectricPotentialDcUnit.VoltDc: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricPotentialDcUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricResistance(double numericValue, ElectricResistanceUnit unit)
+        ElectricResistance(double numericValue, ElectricResistanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricResistance other)
         {
-            return AsBaseUnitOhms().CompareTo(other.AsBaseUnitOhms());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitOhms().Equals(((ElectricResistance) obj).AsBaseUnitOhms());
+            return AsBaseUnit().Equals(((ElectricResistance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricResistance other, ElectricResistance maxError)
         {
-            return Math.Abs(AsBaseUnitOhms() - other.AsBaseUnitOhms()) <= maxError.AsBaseUnitOhms();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricResistanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricResistanceUnit.Kiloohm: return (_value) * 1e3d;
+                case ElectricResistanceUnit.Megaohm: return (_value) * 1e6d;
+                case ElectricResistanceUnit.Milliohm: return (_value) * 1e-3d;
+                case ElectricResistanceUnit.Ohm: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitOhms();
+        private double AsBaseNumericType(ElectricResistanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricResistanceUnit.Kiloohm: return (baseUnitValue) / 1e3d;
                 case ElectricResistanceUnit.Megaohm: return (baseUnitValue) / 1e6d;
                 case ElectricResistanceUnit.Milliohm: return (baseUnitValue) / 1e-3d;
                 case ElectricResistanceUnit.Ohm: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricResistance
         /// </summary>
         public static ElectricResistance MinValue => new ElectricResistance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitOhms()
-        {
-            if (Unit == ElectricResistanceUnit.Ohm) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricResistanceUnit.Kiloohm: return (_value) * 1e3d;
-                case ElectricResistanceUnit.Megaohm: return (_value) * 1e6d;
-                case ElectricResistanceUnit.Milliohm: return (_value) * 1e-3d;
-                case ElectricResistanceUnit.Ohm: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricResistanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ElectricResistivity(double numericValue, ElectricResistivityUnit unit)
+        ElectricResistivity(double numericValue, ElectricResistivityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ElectricResistivity other)
         {
-            return AsBaseUnitOhmMeters().CompareTo(other.AsBaseUnitOhmMeters());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitOhmMeters().Equals(((ElectricResistivity) obj).AsBaseUnitOhmMeters());
+            return AsBaseUnit().Equals(((ElectricResistivity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ElectricResistivity other, ElectricResistivity maxError)
         {
-            return Math.Abs(AsBaseUnitOhmMeters() - other.AsBaseUnitOhmMeters()) <= maxError.AsBaseUnitOhmMeters();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ElectricResistivityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ElectricResistivityUnit.MicroohmMeter: return (_value) * 1e-6d;
+                case ElectricResistivityUnit.MilliohmMeter: return (_value) * 1e-3d;
+                case ElectricResistivityUnit.NanoohmMeter: return (_value) * 1e-9d;
+                case ElectricResistivityUnit.OhmMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitOhmMeters();
+        private double AsBaseNumericType(ElectricResistivityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ElectricResistivityUnit.MicroohmMeter: return (baseUnitValue) / 1e-6d;
                 case ElectricResistivityUnit.MilliohmMeter: return (baseUnitValue) / 1e-3d;
                 case ElectricResistivityUnit.NanoohmMeter: return (baseUnitValue) / 1e-9d;
                 case ElectricResistivityUnit.OhmMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ElectricResistivity
         /// </summary>
         public static ElectricResistivity MinValue => new ElectricResistivity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitOhmMeters()
-        {
-            if (Unit == ElectricResistivityUnit.OhmMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case ElectricResistivityUnit.MicroohmMeter: return (_value) * 1e-6d;
-                case ElectricResistivityUnit.MilliohmMeter: return (_value) * 1e-3d;
-                case ElectricResistivityUnit.NanoohmMeter: return (_value) * 1e-9d;
-                case ElectricResistivityUnit.OhmMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ElectricResistivityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Energy(double numericValue, EnergyUnit unit)
+        Energy(double numericValue, EnergyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1046,7 +1046,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Energy other)
         {
-            return AsBaseUnitJoules().CompareTo(other.AsBaseUnitJoules());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1094,7 +1094,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoules().Equals(((Energy) obj).AsBaseUnitJoules());
+            return AsBaseUnit().Equals(((Energy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1107,7 +1107,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Energy other, Energy maxError)
         {
-            return Math.Abs(AsBaseUnitJoules() - other.AsBaseUnitJoules()) <= maxError.AsBaseUnitJoules();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1125,14 +1125,57 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(EnergyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case EnergyUnit.BritishThermalUnit: return _value*1055.05585262;
+                case EnergyUnit.Calorie: return _value*4.184;
+                case EnergyUnit.DecathermEc: return (_value*105505585.262) * 1e1d;
+                case EnergyUnit.DecathermImperial: return (_value*1.05505585257348e+14) * 1e1d;
+                case EnergyUnit.DecathermUs: return (_value*1.054804e+8) * 1e1d;
+                case EnergyUnit.ElectronVolt: return _value*1.602176565e-19;
+                case EnergyUnit.Erg: return _value*1e-7;
+                case EnergyUnit.FootPound: return _value*1.355817948;
+                case EnergyUnit.GigabritishThermalUnit: return (_value*1055.05585262) * 1e9d;
+                case EnergyUnit.GigawattHour: return (_value*3600d) * 1e9d;
+                case EnergyUnit.Joule: return _value;
+                case EnergyUnit.KilobritishThermalUnit: return (_value*1055.05585262) * 1e3d;
+                case EnergyUnit.Kilocalorie: return (_value*4.184) * 1e3d;
+                case EnergyUnit.Kilojoule: return (_value) * 1e3d;
+                case EnergyUnit.KilowattHour: return (_value*3600d) * 1e3d;
+                case EnergyUnit.MegabritishThermalUnit: return (_value*1055.05585262) * 1e6d;
+                case EnergyUnit.Megajoule: return (_value) * 1e6d;
+                case EnergyUnit.MegawattHour: return (_value*3600d) * 1e6d;
+                case EnergyUnit.ThermEc: return _value*105505585.262;
+                case EnergyUnit.ThermImperial: return _value*1.05505585257348e+14;
+                case EnergyUnit.ThermUs: return _value*1.054804e+8;
+                case EnergyUnit.WattHour: return _value*3600d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoules();
+        private double AsBaseNumericType(EnergyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case EnergyUnit.BritishThermalUnit: return baseUnitValue/1055.05585262;
                 case EnergyUnit.Calorie: return baseUnitValue/4.184;
@@ -1156,9 +1199,8 @@ namespace UnitsNet
                 case EnergyUnit.ThermImperial: return baseUnitValue/1.05505585257348e+14;
                 case EnergyUnit.ThermUs: return baseUnitValue/1.054804e+8;
                 case EnergyUnit.WattHour: return baseUnitValue/3600d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1507,47 +1549,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Energy
         /// </summary>
         public static Energy MinValue => new Energy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoules()
-        {
-            if (Unit == EnergyUnit.Joule) { return _value; }
-
-            switch (Unit)
-            {
-                case EnergyUnit.BritishThermalUnit: return _value*1055.05585262;
-                case EnergyUnit.Calorie: return _value*4.184;
-                case EnergyUnit.DecathermEc: return (_value*105505585.262) * 1e1d;
-                case EnergyUnit.DecathermImperial: return (_value*1.05505585257348e+14) * 1e1d;
-                case EnergyUnit.DecathermUs: return (_value*1.054804e+8) * 1e1d;
-                case EnergyUnit.ElectronVolt: return _value*1.602176565e-19;
-                case EnergyUnit.Erg: return _value*1e-7;
-                case EnergyUnit.FootPound: return _value*1.355817948;
-                case EnergyUnit.GigabritishThermalUnit: return (_value*1055.05585262) * 1e9d;
-                case EnergyUnit.GigawattHour: return (_value*3600d) * 1e9d;
-                case EnergyUnit.Joule: return _value;
-                case EnergyUnit.KilobritishThermalUnit: return (_value*1055.05585262) * 1e3d;
-                case EnergyUnit.Kilocalorie: return (_value*4.184) * 1e3d;
-                case EnergyUnit.Kilojoule: return (_value) * 1e3d;
-                case EnergyUnit.KilowattHour: return (_value*3600d) * 1e3d;
-                case EnergyUnit.MegabritishThermalUnit: return (_value*1055.05585262) * 1e6d;
-                case EnergyUnit.Megajoule: return (_value) * 1e6d;
-                case EnergyUnit.MegawattHour: return (_value*3600d) * 1e6d;
-                case EnergyUnit.ThermEc: return _value*105505585.262;
-                case EnergyUnit.ThermImperial: return _value*1.05505585257348e+14;
-                case EnergyUnit.ThermUs: return _value*1.054804e+8;
-                case EnergyUnit.WattHour: return _value*3600d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(EnergyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Entropy(double numericValue, EntropyUnit unit)
+        Entropy(double numericValue, EntropyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -551,7 +551,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Entropy other)
         {
-            return AsBaseUnitJoulesPerKelvin().CompareTo(other.AsBaseUnitJoulesPerKelvin());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -599,7 +599,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoulesPerKelvin().Equals(((Entropy) obj).AsBaseUnitJoulesPerKelvin());
+            return AsBaseUnit().Equals(((Entropy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -612,7 +612,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Entropy other, Entropy maxError)
         {
-            return Math.Abs(AsBaseUnitJoulesPerKelvin() - other.AsBaseUnitJoulesPerKelvin()) <= maxError.AsBaseUnitJoulesPerKelvin();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -630,14 +630,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(EntropyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case EntropyUnit.CaloriePerKelvin: return _value*4.184;
+                case EntropyUnit.JoulePerDegreeCelsius: return _value;
+                case EntropyUnit.JoulePerKelvin: return _value;
+                case EntropyUnit.KilocaloriePerKelvin: return (_value*4.184) * 1e3d;
+                case EntropyUnit.KilojoulePerDegreeCelsius: return (_value) * 1e3d;
+                case EntropyUnit.KilojoulePerKelvin: return (_value) * 1e3d;
+                case EntropyUnit.MegajoulePerKelvin: return (_value) * 1e6d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoulesPerKelvin();
+        private double AsBaseNumericType(EntropyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case EntropyUnit.CaloriePerKelvin: return baseUnitValue/4.184;
                 case EntropyUnit.JoulePerDegreeCelsius: return baseUnitValue;
@@ -646,9 +674,8 @@ namespace UnitsNet
                 case EntropyUnit.KilojoulePerDegreeCelsius: return (baseUnitValue) / 1e3d;
                 case EntropyUnit.KilojoulePerKelvin: return (baseUnitValue) / 1e3d;
                 case EntropyUnit.MegajoulePerKelvin: return (baseUnitValue) / 1e6d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -997,32 +1024,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Entropy
         /// </summary>
         public static Entropy MinValue => new Entropy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoulesPerKelvin()
-        {
-            if (Unit == EntropyUnit.JoulePerKelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case EntropyUnit.CaloriePerKelvin: return _value*4.184;
-                case EntropyUnit.JoulePerDegreeCelsius: return _value;
-                case EntropyUnit.JoulePerKelvin: return _value;
-                case EntropyUnit.KilocaloriePerKelvin: return (_value*4.184) * 1e3d;
-                case EntropyUnit.KilojoulePerDegreeCelsius: return (_value) * 1e3d;
-                case EntropyUnit.KilojoulePerKelvin: return (_value) * 1e3d;
-                case EntropyUnit.MegajoulePerKelvin: return (_value) * 1e6d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(EntropyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Flow.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Flow(double numericValue, FlowUnit unit)
+        Flow(double numericValue, FlowUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1130,7 +1130,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Flow other)
         {
-            return AsBaseUnitCubicMetersPerSecond().CompareTo(other.AsBaseUnitCubicMetersPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1178,7 +1178,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCubicMetersPerSecond().Equals(((Flow) obj).AsBaseUnitCubicMetersPerSecond());
+            return AsBaseUnit().Equals(((Flow) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1191,7 +1191,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Flow other, Flow maxError)
         {
-            return Math.Abs(AsBaseUnitCubicMetersPerSecond() - other.AsBaseUnitCubicMetersPerSecond()) <= maxError.AsBaseUnitCubicMetersPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1209,14 +1209,59 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(FlowUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case FlowUnit.CentilitersPerMinute: return (_value/60000.00000) * 1e-2d;
+                case FlowUnit.CubicDecimeterPerMinute: return _value/60000.00000;
+                case FlowUnit.CubicFootPerHour: return _value*7.8657907199999087346816086183876e-6;
+                case FlowUnit.CubicFootPerMinute: return _value/2118.88000326;
+                case FlowUnit.CubicFootPerSecond: return _value/35.314666721;
+                case FlowUnit.CubicMeterPerHour: return _value/3600;
+                case FlowUnit.CubicMeterPerMinute: return _value/60;
+                case FlowUnit.CubicMeterPerSecond: return _value;
+                case FlowUnit.CubicYardPerHour: return _value*2.1237634944E-4;
+                case FlowUnit.CubicYardPerMinute: return _value*0.0127425809664;
+                case FlowUnit.CubicYardPerSecond: return _value*0.764554857984;
+                case FlowUnit.DecilitersPerMinute: return (_value/60000.00000) * 1e-1d;
+                case FlowUnit.KilolitersPerMinute: return (_value/60000.00000) * 1e3d;
+                case FlowUnit.LitersPerHour: return _value/3600000.000;
+                case FlowUnit.LitersPerMinute: return _value/60000.00000;
+                case FlowUnit.LitersPerSecond: return _value/1000;
+                case FlowUnit.MicrolitersPerMinute: return (_value/60000.00000) * 1e-6d;
+                case FlowUnit.MillilitersPerMinute: return (_value/60000.00000) * 1e-3d;
+                case FlowUnit.MillionUsGallonsPerDay: return _value/22.824465227;
+                case FlowUnit.NanolitersPerMinute: return (_value/60000.00000) * 1e-9d;
+                case FlowUnit.OilBarrelsPerDay: return _value*1.8401307283333333333333333333333e-6;
+                case FlowUnit.UsGallonsPerHour: return _value/951019.38848933424;
+                case FlowUnit.UsGallonsPerMinute: return _value/15850.323141489;
+                case FlowUnit.UsGallonsPerSecond: return _value/264.1720523581484;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCubicMetersPerSecond();
+        private double AsBaseNumericType(FlowUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case FlowUnit.CentilitersPerMinute: return (baseUnitValue*60000.00000) / 1e-2d;
                 case FlowUnit.CubicDecimeterPerMinute: return baseUnitValue*60000.00000;
@@ -1242,9 +1287,8 @@ namespace UnitsNet
                 case FlowUnit.UsGallonsPerHour: return baseUnitValue*951019.38848933424;
                 case FlowUnit.UsGallonsPerMinute: return baseUnitValue*15850.323141489;
                 case FlowUnit.UsGallonsPerSecond: return baseUnitValue*264.1720523581484;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1593,49 +1637,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Flow
         /// </summary>
         public static Flow MinValue => new Flow(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCubicMetersPerSecond()
-        {
-            if (Unit == FlowUnit.CubicMeterPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case FlowUnit.CentilitersPerMinute: return (_value/60000.00000) * 1e-2d;
-                case FlowUnit.CubicDecimeterPerMinute: return _value/60000.00000;
-                case FlowUnit.CubicFootPerHour: return _value*7.8657907199999087346816086183876e-6;
-                case FlowUnit.CubicFootPerMinute: return _value/2118.88000326;
-                case FlowUnit.CubicFootPerSecond: return _value/35.314666721;
-                case FlowUnit.CubicMeterPerHour: return _value/3600;
-                case FlowUnit.CubicMeterPerMinute: return _value/60;
-                case FlowUnit.CubicMeterPerSecond: return _value;
-                case FlowUnit.CubicYardPerHour: return _value*2.1237634944E-4;
-                case FlowUnit.CubicYardPerMinute: return _value*0.0127425809664;
-                case FlowUnit.CubicYardPerSecond: return _value*0.764554857984;
-                case FlowUnit.DecilitersPerMinute: return (_value/60000.00000) * 1e-1d;
-                case FlowUnit.KilolitersPerMinute: return (_value/60000.00000) * 1e3d;
-                case FlowUnit.LitersPerHour: return _value/3600000.000;
-                case FlowUnit.LitersPerMinute: return _value/60000.00000;
-                case FlowUnit.LitersPerSecond: return _value/1000;
-                case FlowUnit.MicrolitersPerMinute: return (_value/60000.00000) * 1e-6d;
-                case FlowUnit.MillilitersPerMinute: return (_value/60000.00000) * 1e-3d;
-                case FlowUnit.MillionUsGallonsPerDay: return _value/22.824465227;
-                case FlowUnit.NanolitersPerMinute: return (_value/60000.00000) * 1e-9d;
-                case FlowUnit.OilBarrelsPerDay: return _value*1.8401307283333333333333333333333e-6;
-                case FlowUnit.UsGallonsPerHour: return _value/951019.38848933424;
-                case FlowUnit.UsGallonsPerMinute: return _value/15850.323141489;
-                case FlowUnit.UsGallonsPerSecond: return _value/264.1720523581484;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(FlowUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Force(double numericValue, ForceUnit unit)
+        Force(double numericValue, ForceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -650,7 +650,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Force other)
         {
-            return AsBaseUnitNewtons().CompareTo(other.AsBaseUnitNewtons());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -698,7 +698,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtons().Equals(((Force) obj).AsBaseUnitNewtons());
+            return AsBaseUnit().Equals(((Force) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -711,7 +711,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Force other, Force maxError)
         {
-            return Math.Abs(AsBaseUnitNewtons() - other.AsBaseUnitNewtons()) <= maxError.AsBaseUnitNewtons();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -729,14 +729,45 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ForceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ForceUnit.Decanewton: return (_value) * 1e1d;
+                case ForceUnit.Dyn: return _value/1e5;
+                case ForceUnit.KilogramForce: return _value*9.80665002864;
+                case ForceUnit.Kilonewton: return (_value) * 1e3d;
+                case ForceUnit.KiloPond: return _value*9.80665002864;
+                case ForceUnit.Meganewton: return (_value) * 1e6d;
+                case ForceUnit.Newton: return _value;
+                case ForceUnit.Poundal: return _value*0.13825502798973041652092282466083;
+                case ForceUnit.PoundForce: return _value*4.4482216152605095551842641431421;
+                case ForceUnit.TonneForce: return _value*9.80665002864*1000;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtons();
+        private double AsBaseNumericType(ForceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ForceUnit.Decanewton: return (baseUnitValue) / 1e1d;
                 case ForceUnit.Dyn: return baseUnitValue*1e5;
@@ -748,9 +779,8 @@ namespace UnitsNet
                 case ForceUnit.Poundal: return baseUnitValue/0.13825502798973041652092282466083;
                 case ForceUnit.PoundForce: return baseUnitValue/4.4482216152605095551842641431421;
                 case ForceUnit.TonneForce: return baseUnitValue/9.80665002864/1000;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1099,35 +1129,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Force
         /// </summary>
         public static Force MinValue => new Force(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtons()
-        {
-            if (Unit == ForceUnit.Newton) { return _value; }
-
-            switch (Unit)
-            {
-                case ForceUnit.Decanewton: return (_value) * 1e1d;
-                case ForceUnit.Dyn: return _value/1e5;
-                case ForceUnit.KilogramForce: return _value*9.80665002864;
-                case ForceUnit.Kilonewton: return (_value) * 1e3d;
-                case ForceUnit.KiloPond: return _value*9.80665002864;
-                case ForceUnit.Meganewton: return (_value) * 1e6d;
-                case ForceUnit.Newton: return _value;
-                case ForceUnit.Poundal: return _value*0.13825502798973041652092282466083;
-                case ForceUnit.PoundForce: return _value*4.4482216152605095551842641431421;
-                case ForceUnit.TonneForce: return _value*9.80665002864*1000;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ForceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ForceChangeRate(double numericValue, ForceChangeRateUnit unit)
+        ForceChangeRate(double numericValue, ForceChangeRateUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -683,7 +683,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ForceChangeRate other)
         {
-            return AsBaseUnitNewtonsPerSecond().CompareTo(other.AsBaseUnitNewtonsPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -731,7 +731,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonsPerSecond().Equals(((ForceChangeRate) obj).AsBaseUnitNewtonsPerSecond());
+            return AsBaseUnit().Equals(((ForceChangeRate) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -744,7 +744,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ForceChangeRate other, ForceChangeRate maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonsPerSecond() - other.AsBaseUnitNewtonsPerSecond()) <= maxError.AsBaseUnitNewtonsPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -762,14 +762,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ForceChangeRateUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ForceChangeRateUnit.CentinewtonPerSecond: return (_value) * 1e-2d;
+                case ForceChangeRateUnit.DecanewtonPerMinute: return (_value/60) * 1e1d;
+                case ForceChangeRateUnit.DecanewtonPerSecond: return (_value) * 1e1d;
+                case ForceChangeRateUnit.DecinewtonPerSecond: return (_value) * 1e-1d;
+                case ForceChangeRateUnit.KilonewtonPerMinute: return (_value/60) * 1e3d;
+                case ForceChangeRateUnit.KilonewtonPerSecond: return (_value) * 1e3d;
+                case ForceChangeRateUnit.MicronewtonPerSecond: return (_value) * 1e-6d;
+                case ForceChangeRateUnit.MillinewtonPerSecond: return (_value) * 1e-3d;
+                case ForceChangeRateUnit.NanonewtonPerSecond: return (_value) * 1e-9d;
+                case ForceChangeRateUnit.NewtonPerMinute: return _value/60;
+                case ForceChangeRateUnit.NewtonPerSecond: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonsPerSecond();
+        private double AsBaseNumericType(ForceChangeRateUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ForceChangeRateUnit.CentinewtonPerSecond: return (baseUnitValue) / 1e-2d;
                 case ForceChangeRateUnit.DecanewtonPerMinute: return (baseUnitValue*60) / 1e1d;
@@ -782,9 +814,8 @@ namespace UnitsNet
                 case ForceChangeRateUnit.NanonewtonPerSecond: return (baseUnitValue) / 1e-9d;
                 case ForceChangeRateUnit.NewtonPerMinute: return baseUnitValue*60;
                 case ForceChangeRateUnit.NewtonPerSecond: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1133,36 +1164,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ForceChangeRate
         /// </summary>
         public static ForceChangeRate MinValue => new ForceChangeRate(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonsPerSecond()
-        {
-            if (Unit == ForceChangeRateUnit.NewtonPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case ForceChangeRateUnit.CentinewtonPerSecond: return (_value) * 1e-2d;
-                case ForceChangeRateUnit.DecanewtonPerMinute: return (_value/60) * 1e1d;
-                case ForceChangeRateUnit.DecanewtonPerSecond: return (_value) * 1e1d;
-                case ForceChangeRateUnit.DecinewtonPerSecond: return (_value) * 1e-1d;
-                case ForceChangeRateUnit.KilonewtonPerMinute: return (_value/60) * 1e3d;
-                case ForceChangeRateUnit.KilonewtonPerSecond: return (_value) * 1e3d;
-                case ForceChangeRateUnit.MicronewtonPerSecond: return (_value) * 1e-6d;
-                case ForceChangeRateUnit.MillinewtonPerSecond: return (_value) * 1e-3d;
-                case ForceChangeRateUnit.NanonewtonPerSecond: return (_value) * 1e-9d;
-                case ForceChangeRateUnit.NewtonPerMinute: return _value/60;
-                case ForceChangeRateUnit.NewtonPerSecond: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ForceChangeRateUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ForcePerLength(double numericValue, ForcePerLengthUnit unit)
+        ForcePerLength(double numericValue, ForcePerLengthUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -617,7 +617,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ForcePerLength other)
         {
-            return AsBaseUnitNewtonsPerMeter().CompareTo(other.AsBaseUnitNewtonsPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -665,7 +665,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonsPerMeter().Equals(((ForcePerLength) obj).AsBaseUnitNewtonsPerMeter());
+            return AsBaseUnit().Equals(((ForcePerLength) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -678,7 +678,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ForcePerLength other, ForcePerLength maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonsPerMeter() - other.AsBaseUnitNewtonsPerMeter()) <= maxError.AsBaseUnitNewtonsPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -696,14 +696,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ForcePerLengthUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ForcePerLengthUnit.CentinewtonPerMeter: return (_value) * 1e-2d;
+                case ForcePerLengthUnit.DecinewtonPerMeter: return (_value) * 1e-1d;
+                case ForcePerLengthUnit.KilogramForcePerMeter: return _value*9.80665002864;
+                case ForcePerLengthUnit.KilonewtonPerMeter: return (_value) * 1e3d;
+                case ForcePerLengthUnit.MeganewtonPerMeter: return (_value) * 1e6d;
+                case ForcePerLengthUnit.MicronewtonPerMeter: return (_value) * 1e-6d;
+                case ForcePerLengthUnit.MillinewtonPerMeter: return (_value) * 1e-3d;
+                case ForcePerLengthUnit.NanonewtonPerMeter: return (_value) * 1e-9d;
+                case ForcePerLengthUnit.NewtonPerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonsPerMeter();
+        private double AsBaseNumericType(ForcePerLengthUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ForcePerLengthUnit.CentinewtonPerMeter: return (baseUnitValue) / 1e-2d;
                 case ForcePerLengthUnit.DecinewtonPerMeter: return (baseUnitValue) / 1e-1d;
@@ -714,9 +744,8 @@ namespace UnitsNet
                 case ForcePerLengthUnit.MillinewtonPerMeter: return (baseUnitValue) / 1e-3d;
                 case ForcePerLengthUnit.NanonewtonPerMeter: return (baseUnitValue) / 1e-9d;
                 case ForcePerLengthUnit.NewtonPerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1065,34 +1094,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ForcePerLength
         /// </summary>
         public static ForcePerLength MinValue => new ForcePerLength(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonsPerMeter()
-        {
-            if (Unit == ForcePerLengthUnit.NewtonPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case ForcePerLengthUnit.CentinewtonPerMeter: return (_value) * 1e-2d;
-                case ForcePerLengthUnit.DecinewtonPerMeter: return (_value) * 1e-1d;
-                case ForcePerLengthUnit.KilogramForcePerMeter: return _value*9.80665002864;
-                case ForcePerLengthUnit.KilonewtonPerMeter: return (_value) * 1e3d;
-                case ForcePerLengthUnit.MeganewtonPerMeter: return (_value) * 1e6d;
-                case ForcePerLengthUnit.MicronewtonPerMeter: return (_value) * 1e-6d;
-                case ForcePerLengthUnit.MillinewtonPerMeter: return (_value) * 1e-3d;
-                case ForcePerLengthUnit.NanonewtonPerMeter: return (_value) * 1e-9d;
-                case ForcePerLengthUnit.NewtonPerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ForcePerLengthUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Frequency(double numericValue, FrequencyUnit unit)
+        Frequency(double numericValue, FrequencyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -584,7 +584,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Frequency other)
         {
-            return AsBaseUnitHertz().CompareTo(other.AsBaseUnitHertz());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -632,7 +632,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitHertz().Equals(((Frequency) obj).AsBaseUnitHertz());
+            return AsBaseUnit().Equals(((Frequency) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Frequency other, Frequency maxError)
         {
-            return Math.Abs(AsBaseUnitHertz() - other.AsBaseUnitHertz()) <= maxError.AsBaseUnitHertz();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -663,14 +663,43 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(FrequencyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case FrequencyUnit.CyclePerHour: return _value/3600;
+                case FrequencyUnit.CyclePerMinute: return _value/60;
+                case FrequencyUnit.Gigahertz: return (_value) * 1e9d;
+                case FrequencyUnit.Hertz: return _value;
+                case FrequencyUnit.Kilohertz: return (_value) * 1e3d;
+                case FrequencyUnit.Megahertz: return (_value) * 1e6d;
+                case FrequencyUnit.RadianPerSecond: return _value/6.2831853072;
+                case FrequencyUnit.Terahertz: return (_value) * 1e12d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitHertz();
+        private double AsBaseNumericType(FrequencyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case FrequencyUnit.CyclePerHour: return baseUnitValue*3600;
                 case FrequencyUnit.CyclePerMinute: return baseUnitValue*60;
@@ -680,9 +709,8 @@ namespace UnitsNet
                 case FrequencyUnit.Megahertz: return (baseUnitValue) / 1e6d;
                 case FrequencyUnit.RadianPerSecond: return baseUnitValue*6.2831853072;
                 case FrequencyUnit.Terahertz: return (baseUnitValue) / 1e12d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1031,33 +1059,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Frequency
         /// </summary>
         public static Frequency MinValue => new Frequency(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitHertz()
-        {
-            if (Unit == FrequencyUnit.Hertz) { return _value; }
-
-            switch (Unit)
-            {
-                case FrequencyUnit.CyclePerHour: return _value/3600;
-                case FrequencyUnit.CyclePerMinute: return _value/60;
-                case FrequencyUnit.Gigahertz: return (_value) * 1e9d;
-                case FrequencyUnit.Hertz: return _value;
-                case FrequencyUnit.Kilohertz: return (_value) * 1e3d;
-                case FrequencyUnit.Megahertz: return (_value) * 1e6d;
-                case FrequencyUnit.RadianPerSecond: return _value/6.2831853072;
-                case FrequencyUnit.Terahertz: return (_value) * 1e12d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(FrequencyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          HeatFlux(double numericValue, HeatFluxUnit unit)
+        HeatFlux(double numericValue, HeatFluxUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -848,7 +848,7 @@ namespace UnitsNet
 #endif
         int CompareTo(HeatFlux other)
         {
-            return AsBaseUnitWattsPerSquareMeter().CompareTo(other.AsBaseUnitWattsPerSquareMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -896,7 +896,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWattsPerSquareMeter().Equals(((HeatFlux) obj).AsBaseUnitWattsPerSquareMeter());
+            return AsBaseUnit().Equals(((HeatFlux) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -909,7 +909,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(HeatFlux other, HeatFlux maxError)
         {
-            return Math.Abs(AsBaseUnitWattsPerSquareMeter() - other.AsBaseUnitWattsPerSquareMeter()) <= maxError.AsBaseUnitWattsPerSquareMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -927,14 +927,51 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(HeatFluxUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case HeatFluxUnit.BtuPerHourSquareFoot: return _value*3.15459075;
+                case HeatFluxUnit.BtuPerMinuteSquareFoot: return _value*1.89275445e2;
+                case HeatFluxUnit.BtuPerSecondSquareFoot: return _value*1.13565267e4;
+                case HeatFluxUnit.BtuPerSecondSquareInch: return _value*1.63533984e6;
+                case HeatFluxUnit.CaloriePerSecondSquareCentimeter: return _value*4.1868e4;
+                case HeatFluxUnit.CentiwattPerSquareMeter: return (_value) * 1e-2d;
+                case HeatFluxUnit.DeciwattPerSquareMeter: return (_value) * 1e-1d;
+                case HeatFluxUnit.KilocaloriePerHourSquareMeter: return _value*1.163;
+                case HeatFluxUnit.KilocaloriePerSecondSquareCentimeter: return (_value*4.1868e4) * 1e3d;
+                case HeatFluxUnit.KilowattPerSquareMeter: return (_value) * 1e3d;
+                case HeatFluxUnit.MicrowattPerSquareMeter: return (_value) * 1e-6d;
+                case HeatFluxUnit.MilliwattPerSquareMeter: return (_value) * 1e-3d;
+                case HeatFluxUnit.NanowattPerSquareMeter: return (_value) * 1e-9d;
+                case HeatFluxUnit.WattPerSquareFoot: return _value*1.07639e1;
+                case HeatFluxUnit.WattPerSquareInch: return _value*1.5500031e3;
+                case HeatFluxUnit.WattPerSquareMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitWattsPerSquareMeter();
+        private double AsBaseNumericType(HeatFluxUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case HeatFluxUnit.BtuPerHourSquareFoot: return baseUnitValue/3.15459075;
                 case HeatFluxUnit.BtuPerMinuteSquareFoot: return baseUnitValue/1.89275445e2;
@@ -952,9 +989,8 @@ namespace UnitsNet
                 case HeatFluxUnit.WattPerSquareFoot: return baseUnitValue/1.07639e1;
                 case HeatFluxUnit.WattPerSquareInch: return baseUnitValue/1.5500031e3;
                 case HeatFluxUnit.WattPerSquareMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1303,41 +1339,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of HeatFlux
         /// </summary>
         public static HeatFlux MinValue => new HeatFlux(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitWattsPerSquareMeter()
-        {
-            if (Unit == HeatFluxUnit.WattPerSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case HeatFluxUnit.BtuPerHourSquareFoot: return _value*3.15459075;
-                case HeatFluxUnit.BtuPerMinuteSquareFoot: return _value*1.89275445e2;
-                case HeatFluxUnit.BtuPerSecondSquareFoot: return _value*1.13565267e4;
-                case HeatFluxUnit.BtuPerSecondSquareInch: return _value*1.63533984e6;
-                case HeatFluxUnit.CaloriePerSecondSquareCentimeter: return _value*4.1868e4;
-                case HeatFluxUnit.CentiwattPerSquareMeter: return (_value) * 1e-2d;
-                case HeatFluxUnit.DeciwattPerSquareMeter: return (_value) * 1e-1d;
-                case HeatFluxUnit.KilocaloriePerHourSquareMeter: return _value*1.163;
-                case HeatFluxUnit.KilocaloriePerSecondSquareCentimeter: return (_value*4.1868e4) * 1e3d;
-                case HeatFluxUnit.KilowattPerSquareMeter: return (_value) * 1e3d;
-                case HeatFluxUnit.MicrowattPerSquareMeter: return (_value) * 1e-6d;
-                case HeatFluxUnit.MilliwattPerSquareMeter: return (_value) * 1e-3d;
-                case HeatFluxUnit.NanowattPerSquareMeter: return (_value) * 1e-9d;
-                case HeatFluxUnit.WattPerSquareFoot: return _value*1.07639e1;
-                case HeatFluxUnit.WattPerSquareInch: return _value*1.5500031e3;
-                case HeatFluxUnit.WattPerSquareMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(HeatFluxUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          HeatTransferCoefficient(double numericValue, HeatTransferCoefficientUnit unit)
+        HeatTransferCoefficient(double numericValue, HeatTransferCoefficientUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -386,7 +386,7 @@ namespace UnitsNet
 #endif
         int CompareTo(HeatTransferCoefficient other)
         {
-            return AsBaseUnitWattsPerSquareMeterKelvin().CompareTo(other.AsBaseUnitWattsPerSquareMeterKelvin());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -434,7 +434,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWattsPerSquareMeterKelvin().Equals(((HeatTransferCoefficient) obj).AsBaseUnitWattsPerSquareMeterKelvin());
+            return AsBaseUnit().Equals(((HeatTransferCoefficient) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(HeatTransferCoefficient other, HeatTransferCoefficient maxError)
         {
-            return Math.Abs(AsBaseUnitWattsPerSquareMeterKelvin() - other.AsBaseUnitWattsPerSquareMeterKelvin()) <= maxError.AsBaseUnitWattsPerSquareMeterKelvin();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -465,20 +465,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(HeatTransferCoefficientUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case HeatTransferCoefficientUnit.WattPerSquareMeterCelsius: return _value;
+                case HeatTransferCoefficientUnit.WattPerSquareMeterKelvin: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitWattsPerSquareMeterKelvin();
+        private double AsBaseNumericType(HeatTransferCoefficientUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case HeatTransferCoefficientUnit.WattPerSquareMeterCelsius: return baseUnitValue;
                 case HeatTransferCoefficientUnit.WattPerSquareMeterKelvin: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -827,27 +849,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of HeatTransferCoefficient
         /// </summary>
         public static HeatTransferCoefficient MinValue => new HeatTransferCoefficient(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitWattsPerSquareMeterKelvin()
-        {
-            if (Unit == HeatTransferCoefficientUnit.WattPerSquareMeterKelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case HeatTransferCoefficientUnit.WattPerSquareMeterCelsius: return _value;
-                case HeatTransferCoefficientUnit.WattPerSquareMeterKelvin: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(HeatTransferCoefficientUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Illuminance(double numericValue, IlluminanceUnit unit)
+        Illuminance(double numericValue, IlluminanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Illuminance other)
         {
-            return AsBaseUnitLux().CompareTo(other.AsBaseUnitLux());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitLux().Equals(((Illuminance) obj).AsBaseUnitLux());
+            return AsBaseUnit().Equals(((Illuminance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Illuminance other, Illuminance maxError)
         {
-            return Math.Abs(AsBaseUnitLux() - other.AsBaseUnitLux()) <= maxError.AsBaseUnitLux();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(IlluminanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case IlluminanceUnit.Kilolux: return (_value) * 1e3d;
+                case IlluminanceUnit.Lux: return _value;
+                case IlluminanceUnit.Megalux: return (_value) * 1e6d;
+                case IlluminanceUnit.Millilux: return (_value) * 1e-3d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitLux();
+        private double AsBaseNumericType(IlluminanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case IlluminanceUnit.Kilolux: return (baseUnitValue) / 1e3d;
                 case IlluminanceUnit.Lux: return baseUnitValue;
                 case IlluminanceUnit.Megalux: return (baseUnitValue) / 1e6d;
                 case IlluminanceUnit.Millilux: return (baseUnitValue) / 1e-3d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Illuminance
         /// </summary>
         public static Illuminance MinValue => new Illuminance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitLux()
-        {
-            if (Unit == IlluminanceUnit.Lux) { return _value; }
-
-            switch (Unit)
-            {
-                case IlluminanceUnit.Kilolux: return (_value) * 1e3d;
-                case IlluminanceUnit.Lux: return _value;
-                case IlluminanceUnit.Megalux: return (_value) * 1e6d;
-                case IlluminanceUnit.Millilux: return (_value) * 1e-3d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(IlluminanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Information(decimal numericValue, InformationUnit unit)
+        Information(decimal numericValue, InformationUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1168,7 +1168,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Information other)
         {
-            return AsBaseUnitBits().CompareTo(other.AsBaseUnitBits());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1213,7 +1213,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitBits().Equals(((Information) obj).AsBaseUnitBits());
+            return AsBaseUnit().Equals(((Information) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1226,7 +1226,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Information other, Information maxError)
         {
-            return Math.Abs(AsBaseUnitBits() - other.AsBaseUnitBits()) <= maxError.AsBaseUnitBits();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1244,44 +1244,90 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(InformationUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private decimal AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
-            }
-
-            decimal baseUnitValue = AsBaseUnitBits();
-
-            switch (unit)
-            {
-                case InformationUnit.Bit: return Convert.ToDouble(baseUnitValue);
-                case InformationUnit.Byte: return Convert.ToDouble(baseUnitValue/8m);
-                case InformationUnit.Exabit: return Convert.ToDouble((baseUnitValue) / 1e18m);
-                case InformationUnit.Exabyte: return Convert.ToDouble((baseUnitValue/8m) / 1e18m);
-                case InformationUnit.Exbibit: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Exbibyte: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Gibibit: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024));
-                case InformationUnit.Gibibyte: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024));
-                case InformationUnit.Gigabit: return Convert.ToDouble((baseUnitValue) / 1e9m);
-                case InformationUnit.Gigabyte: return Convert.ToDouble((baseUnitValue/8m) / 1e9m);
-                case InformationUnit.Kibibit: return Convert.ToDouble((baseUnitValue) / 1024m);
-                case InformationUnit.Kibibyte: return Convert.ToDouble((baseUnitValue/8m) / 1024m);
-                case InformationUnit.Kilobit: return Convert.ToDouble((baseUnitValue) / 1e3m);
-                case InformationUnit.Kilobyte: return Convert.ToDouble((baseUnitValue/8m) / 1e3m);
-                case InformationUnit.Mebibit: return Convert.ToDouble((baseUnitValue) / (1024m * 1024));
-                case InformationUnit.Mebibyte: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024));
-                case InformationUnit.Megabit: return Convert.ToDouble((baseUnitValue) / 1e6m);
-                case InformationUnit.Megabyte: return Convert.ToDouble((baseUnitValue/8m) / 1e6m);
-                case InformationUnit.Pebibit: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Pebibyte: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Petabit: return Convert.ToDouble((baseUnitValue) / 1e15m);
-                case InformationUnit.Petabyte: return Convert.ToDouble((baseUnitValue/8m) / 1e15m);
-                case InformationUnit.Tebibit: return Convert.ToDouble((baseUnitValue) / (1024m * 1024 * 1024 * 1024));
-                case InformationUnit.Tebibyte: return Convert.ToDouble((baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024));
-                case InformationUnit.Terabit: return Convert.ToDouble((baseUnitValue) / 1e12m);
-                case InformationUnit.Terabyte: return Convert.ToDouble((baseUnitValue/8m) / 1e12m);
-
+                case InformationUnit.Bit: return _value;
+                case InformationUnit.Byte: return _value*8m;
+                case InformationUnit.Exabit: return (_value) * 1e18m;
+                case InformationUnit.Exabyte: return (_value*8m) * 1e18m;
+                case InformationUnit.Exbibit: return (_value) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Exbibyte: return (_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Gibibit: return (_value) * (1024m * 1024 * 1024);
+                case InformationUnit.Gibibyte: return (_value*8m) * (1024m * 1024 * 1024);
+                case InformationUnit.Gigabit: return (_value) * 1e9m;
+                case InformationUnit.Gigabyte: return (_value*8m) * 1e9m;
+                case InformationUnit.Kibibit: return (_value) * 1024m;
+                case InformationUnit.Kibibyte: return (_value*8m) * 1024m;
+                case InformationUnit.Kilobit: return (_value) * 1e3m;
+                case InformationUnit.Kilobyte: return (_value*8m) * 1e3m;
+                case InformationUnit.Mebibit: return (_value) * (1024m * 1024);
+                case InformationUnit.Mebibyte: return (_value*8m) * (1024m * 1024);
+                case InformationUnit.Megabit: return (_value) * 1e6m;
+                case InformationUnit.Megabyte: return (_value*8m) * 1e6m;
+                case InformationUnit.Pebibit: return (_value) * (1024m * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Pebibyte: return (_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Petabit: return (_value) * 1e15m;
+                case InformationUnit.Petabyte: return (_value*8m) * 1e15m;
+                case InformationUnit.Tebibit: return (_value) * (1024m * 1024 * 1024 * 1024);
+                case InformationUnit.Tebibyte: return (_value*8m) * (1024m * 1024 * 1024 * 1024);
+                case InformationUnit.Terabit: return (_value) * 1e12m;
+                case InformationUnit.Terabyte: return (_value*8m) * 1e12m;
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
+            }
+        }
+
+        private decimal AsBaseNumericType(InformationUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
+
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
+            {
+                case InformationUnit.Bit: return baseUnitValue;
+                case InformationUnit.Byte: return baseUnitValue/8m;
+                case InformationUnit.Exabit: return (baseUnitValue) / 1e18m;
+                case InformationUnit.Exabyte: return (baseUnitValue/8m) / 1e18m;
+                case InformationUnit.Exbibit: return (baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Exbibyte: return (baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Gibibit: return (baseUnitValue) / (1024m * 1024 * 1024);
+                case InformationUnit.Gibibyte: return (baseUnitValue/8m) / (1024m * 1024 * 1024);
+                case InformationUnit.Gigabit: return (baseUnitValue) / 1e9m;
+                case InformationUnit.Gigabyte: return (baseUnitValue/8m) / 1e9m;
+                case InformationUnit.Kibibit: return (baseUnitValue) / 1024m;
+                case InformationUnit.Kibibyte: return (baseUnitValue/8m) / 1024m;
+                case InformationUnit.Kilobit: return (baseUnitValue) / 1e3m;
+                case InformationUnit.Kilobyte: return (baseUnitValue/8m) / 1e3m;
+                case InformationUnit.Mebibit: return (baseUnitValue) / (1024m * 1024);
+                case InformationUnit.Mebibyte: return (baseUnitValue/8m) / (1024m * 1024);
+                case InformationUnit.Megabit: return (baseUnitValue) / 1e6m;
+                case InformationUnit.Megabyte: return (baseUnitValue/8m) / 1e6m;
+                case InformationUnit.Pebibit: return (baseUnitValue) / (1024m * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Pebibyte: return (baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024 * 1024);
+                case InformationUnit.Petabit: return (baseUnitValue) / 1e15m;
+                case InformationUnit.Petabyte: return (baseUnitValue/8m) / 1e15m;
+                case InformationUnit.Tebibit: return (baseUnitValue) / (1024m * 1024 * 1024 * 1024);
+                case InformationUnit.Tebibyte: return (baseUnitValue/8m) / (1024m * 1024 * 1024 * 1024);
+                case InformationUnit.Terabit: return (baseUnitValue) / 1e12m;
+                case InformationUnit.Terabyte: return (baseUnitValue/8m) / 1e12m;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1630,51 +1676,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Information
         /// </summary>
         public static Information MinValue => new Information(decimal.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private decimal AsBaseUnitBits()
-        {
-            if (Unit == InformationUnit.Bit) { return _value; }
-
-            switch (Unit)
-            {
-                case InformationUnit.Bit: return Convert.ToDecimal(_value);
-                case InformationUnit.Byte: return Convert.ToDecimal(_value*8m);
-                case InformationUnit.Exabit: return Convert.ToDecimal((_value) * 1e18m);
-                case InformationUnit.Exabyte: return Convert.ToDecimal((_value*8m) * 1e18m);
-                case InformationUnit.Exbibit: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Exbibyte: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Gibibit: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024));
-                case InformationUnit.Gibibyte: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024));
-                case InformationUnit.Gigabit: return Convert.ToDecimal((_value) * 1e9m);
-                case InformationUnit.Gigabyte: return Convert.ToDecimal((_value*8m) * 1e9m);
-                case InformationUnit.Kibibit: return Convert.ToDecimal((_value) * 1024m);
-                case InformationUnit.Kibibyte: return Convert.ToDecimal((_value*8m) * 1024m);
-                case InformationUnit.Kilobit: return Convert.ToDecimal((_value) * 1e3m);
-                case InformationUnit.Kilobyte: return Convert.ToDecimal((_value*8m) * 1e3m);
-                case InformationUnit.Mebibit: return Convert.ToDecimal((_value) * (1024m * 1024));
-                case InformationUnit.Mebibyte: return Convert.ToDecimal((_value*8m) * (1024m * 1024));
-                case InformationUnit.Megabit: return Convert.ToDecimal((_value) * 1e6m);
-                case InformationUnit.Megabyte: return Convert.ToDecimal((_value*8m) * 1e6m);
-                case InformationUnit.Pebibit: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Pebibyte: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024 * 1024 * 1024));
-                case InformationUnit.Petabit: return Convert.ToDecimal((_value) * 1e15m);
-                case InformationUnit.Petabyte: return Convert.ToDecimal((_value*8m) * 1e15m);
-                case InformationUnit.Tebibit: return Convert.ToDecimal((_value) * (1024m * 1024 * 1024 * 1024));
-                case InformationUnit.Tebibyte: return Convert.ToDecimal((_value*8m) * (1024m * 1024 * 1024 * 1024));
-                case InformationUnit.Terabit: return Convert.ToDecimal((_value) * 1e12m);
-                case InformationUnit.Terabyte: return Convert.ToDecimal((_value*8m) * 1e12m);
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private decimal AsBaseNumericType(InformationUnit unit) => Convert.ToDecimal(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Irradiance(double numericValue, IrradianceUnit unit)
+        Irradiance(double numericValue, IrradianceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -386,7 +386,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Irradiance other)
         {
-            return AsBaseUnitWattsPerSquareMeter().CompareTo(other.AsBaseUnitWattsPerSquareMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -434,7 +434,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWattsPerSquareMeter().Equals(((Irradiance) obj).AsBaseUnitWattsPerSquareMeter());
+            return AsBaseUnit().Equals(((Irradiance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Irradiance other, Irradiance maxError)
         {
-            return Math.Abs(AsBaseUnitWattsPerSquareMeter() - other.AsBaseUnitWattsPerSquareMeter()) <= maxError.AsBaseUnitWattsPerSquareMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -465,20 +465,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(IrradianceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case IrradianceUnit.KilowattPerSquareMeter: return (_value) * 1e3d;
+                case IrradianceUnit.WattPerSquareMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitWattsPerSquareMeter();
+        private double AsBaseNumericType(IrradianceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case IrradianceUnit.KilowattPerSquareMeter: return (baseUnitValue) / 1e3d;
                 case IrradianceUnit.WattPerSquareMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -827,27 +849,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Irradiance
         /// </summary>
         public static Irradiance MinValue => new Irradiance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitWattsPerSquareMeter()
-        {
-            if (Unit == IrradianceUnit.WattPerSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case IrradianceUnit.KilowattPerSquareMeter: return (_value) * 1e3d;
-                case IrradianceUnit.WattPerSquareMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(IrradianceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Irradiation(double numericValue, IrradiationUnit unit)
+        Irradiation(double numericValue, IrradiationUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Irradiation other)
         {
-            return AsBaseUnitJoulesPerSquareMeter().CompareTo(other.AsBaseUnitJoulesPerSquareMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoulesPerSquareMeter().Equals(((Irradiation) obj).AsBaseUnitJoulesPerSquareMeter());
+            return AsBaseUnit().Equals(((Irradiation) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Irradiation other, Irradiation maxError)
         {
-            return Math.Abs(AsBaseUnitJoulesPerSquareMeter() - other.AsBaseUnitJoulesPerSquareMeter()) <= maxError.AsBaseUnitJoulesPerSquareMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(IrradiationUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case IrradiationUnit.JoulePerSquareMeter: return _value;
+                case IrradiationUnit.KilowattHourPerSquareMeter: return (_value*3600d) * 1e3d;
+                case IrradiationUnit.WattHourPerSquareMeter: return _value*3600d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoulesPerSquareMeter();
+        private double AsBaseNumericType(IrradiationUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case IrradiationUnit.JoulePerSquareMeter: return baseUnitValue;
                 case IrradiationUnit.KilowattHourPerSquareMeter: return (baseUnitValue/3600d) / 1e3d;
                 case IrradiationUnit.WattHourPerSquareMeter: return baseUnitValue/3600d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Irradiation
         /// </summary>
         public static Irradiation MinValue => new Irradiation(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoulesPerSquareMeter()
-        {
-            if (Unit == IrradiationUnit.JoulePerSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case IrradiationUnit.JoulePerSquareMeter: return _value;
-                case IrradiationUnit.KilowattHourPerSquareMeter: return (_value*3600d) * 1e3d;
-                case IrradiationUnit.WattHourPerSquareMeter: return _value*3600d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(IrradiationUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          KinematicViscosity(double numericValue, KinematicViscosityUnit unit)
+        KinematicViscosity(double numericValue, KinematicViscosityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -584,7 +584,7 @@ namespace UnitsNet
 #endif
         int CompareTo(KinematicViscosity other)
         {
-            return AsBaseUnitSquareMetersPerSecond().CompareTo(other.AsBaseUnitSquareMetersPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -632,7 +632,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSquareMetersPerSecond().Equals(((KinematicViscosity) obj).AsBaseUnitSquareMetersPerSecond());
+            return AsBaseUnit().Equals(((KinematicViscosity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(KinematicViscosity other, KinematicViscosity maxError)
         {
-            return Math.Abs(AsBaseUnitSquareMetersPerSecond() - other.AsBaseUnitSquareMetersPerSecond()) <= maxError.AsBaseUnitSquareMetersPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -663,14 +663,43 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(KinematicViscosityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case KinematicViscosityUnit.Centistokes: return (_value/1e4) * 1e-2d;
+                case KinematicViscosityUnit.Decistokes: return (_value/1e4) * 1e-1d;
+                case KinematicViscosityUnit.Kilostokes: return (_value/1e4) * 1e3d;
+                case KinematicViscosityUnit.Microstokes: return (_value/1e4) * 1e-6d;
+                case KinematicViscosityUnit.Millistokes: return (_value/1e4) * 1e-3d;
+                case KinematicViscosityUnit.Nanostokes: return (_value/1e4) * 1e-9d;
+                case KinematicViscosityUnit.SquareMeterPerSecond: return _value;
+                case KinematicViscosityUnit.Stokes: return _value/1e4;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSquareMetersPerSecond();
+        private double AsBaseNumericType(KinematicViscosityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case KinematicViscosityUnit.Centistokes: return (baseUnitValue*1e4) / 1e-2d;
                 case KinematicViscosityUnit.Decistokes: return (baseUnitValue*1e4) / 1e-1d;
@@ -680,9 +709,8 @@ namespace UnitsNet
                 case KinematicViscosityUnit.Nanostokes: return (baseUnitValue*1e4) / 1e-9d;
                 case KinematicViscosityUnit.SquareMeterPerSecond: return baseUnitValue;
                 case KinematicViscosityUnit.Stokes: return baseUnitValue*1e4;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1031,33 +1059,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of KinematicViscosity
         /// </summary>
         public static KinematicViscosity MinValue => new KinematicViscosity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSquareMetersPerSecond()
-        {
-            if (Unit == KinematicViscosityUnit.SquareMeterPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case KinematicViscosityUnit.Centistokes: return (_value/1e4) * 1e-2d;
-                case KinematicViscosityUnit.Decistokes: return (_value/1e4) * 1e-1d;
-                case KinematicViscosityUnit.Kilostokes: return (_value/1e4) * 1e3d;
-                case KinematicViscosityUnit.Microstokes: return (_value/1e4) * 1e-6d;
-                case KinematicViscosityUnit.Millistokes: return (_value/1e4) * 1e-3d;
-                case KinematicViscosityUnit.Nanostokes: return (_value/1e4) * 1e-9d;
-                case KinematicViscosityUnit.SquareMeterPerSecond: return _value;
-                case KinematicViscosityUnit.Stokes: return _value/1e4;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(KinematicViscosityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          LapseRate(double numericValue, LapseRateUnit unit)
+        LapseRate(double numericValue, LapseRateUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LapseRate other)
         {
-            return AsBaseUnitDegreesCelciusPerKilometer().CompareTo(other.AsBaseUnitDegreesCelciusPerKilometer());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDegreesCelciusPerKilometer().Equals(((LapseRate) obj).AsBaseUnitDegreesCelciusPerKilometer());
+            return AsBaseUnit().Equals(((LapseRate) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(LapseRate other, LapseRate maxError)
         {
-            return Math.Abs(AsBaseUnitDegreesCelciusPerKilometer() - other.AsBaseUnitDegreesCelciusPerKilometer()) <= maxError.AsBaseUnitDegreesCelciusPerKilometer();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(LapseRateUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case LapseRateUnit.DegreeCelsiusPerKilometer: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDegreesCelciusPerKilometer();
+        private double AsBaseNumericType(LapseRateUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case LapseRateUnit.DegreeCelsiusPerKilometer: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of LapseRate
         /// </summary>
         public static LapseRate MinValue => new LapseRate(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDegreesCelciusPerKilometer()
-        {
-            if (Unit == LapseRateUnit.DegreeCelsiusPerKilometer) { return _value; }
-
-            switch (Unit)
-            {
-                case LapseRateUnit.DegreeCelsiusPerKilometer: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(LapseRateUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Length(double numericValue, LengthUnit unit)
+        Length(double numericValue, LengthUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1046,7 +1046,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Length other)
         {
-            return AsBaseUnitMeters().CompareTo(other.AsBaseUnitMeters());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1094,7 +1094,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitMeters().Equals(((Length) obj).AsBaseUnitMeters());
+            return AsBaseUnit().Equals(((Length) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1107,7 +1107,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Length other, Length maxError)
         {
-            return Math.Abs(AsBaseUnitMeters() - other.AsBaseUnitMeters()) <= maxError.AsBaseUnitMeters();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1125,14 +1125,57 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(LengthUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case LengthUnit.Centimeter: return (_value) * 1e-2d;
+                case LengthUnit.Decimeter: return (_value) * 1e-1d;
+                case LengthUnit.DtpPica: return _value/236.220472441;
+                case LengthUnit.DtpPoint: return (_value/72)*2.54e-2;
+                case LengthUnit.Fathom: return _value*1.8288;
+                case LengthUnit.Foot: return _value*0.3048;
+                case LengthUnit.Inch: return _value*2.54e-2;
+                case LengthUnit.Kilometer: return (_value) * 1e3d;
+                case LengthUnit.Meter: return _value;
+                case LengthUnit.Microinch: return _value*2.54e-8;
+                case LengthUnit.Micrometer: return (_value) * 1e-6d;
+                case LengthUnit.Mil: return _value*2.54e-5;
+                case LengthUnit.Mile: return _value*1609.34;
+                case LengthUnit.Millimeter: return (_value) * 1e-3d;
+                case LengthUnit.Nanometer: return (_value) * 1e-9d;
+                case LengthUnit.NauticalMile: return _value*1852;
+                case LengthUnit.PrinterPica: return _value/237.106301584;
+                case LengthUnit.PrinterPoint: return (_value/72.27)*2.54e-2;
+                case LengthUnit.Shackle: return _value*27.432;
+                case LengthUnit.Twip: return _value/56692.913385826;
+                case LengthUnit.UsSurveyFoot: return _value*1200/3937;
+                case LengthUnit.Yard: return _value*0.9144;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitMeters();
+        private double AsBaseNumericType(LengthUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case LengthUnit.Centimeter: return (baseUnitValue) / 1e-2d;
                 case LengthUnit.Decimeter: return (baseUnitValue) / 1e-1d;
@@ -1156,9 +1199,8 @@ namespace UnitsNet
                 case LengthUnit.Twip: return baseUnitValue*56692.913385826;
                 case LengthUnit.UsSurveyFoot: return baseUnitValue*3937/1200;
                 case LengthUnit.Yard: return baseUnitValue/0.9144;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1507,47 +1549,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Length
         /// </summary>
         public static Length MinValue => new Length(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitMeters()
-        {
-            if (Unit == LengthUnit.Meter) { return _value; }
-
-            switch (Unit)
-            {
-                case LengthUnit.Centimeter: return (_value) * 1e-2d;
-                case LengthUnit.Decimeter: return (_value) * 1e-1d;
-                case LengthUnit.DtpPica: return _value/236.220472441;
-                case LengthUnit.DtpPoint: return (_value/72)*2.54e-2;
-                case LengthUnit.Fathom: return _value*1.8288;
-                case LengthUnit.Foot: return _value*0.3048;
-                case LengthUnit.Inch: return _value*2.54e-2;
-                case LengthUnit.Kilometer: return (_value) * 1e3d;
-                case LengthUnit.Meter: return _value;
-                case LengthUnit.Microinch: return _value*2.54e-8;
-                case LengthUnit.Micrometer: return (_value) * 1e-6d;
-                case LengthUnit.Mil: return _value*2.54e-5;
-                case LengthUnit.Mile: return _value*1609.34;
-                case LengthUnit.Millimeter: return (_value) * 1e-3d;
-                case LengthUnit.Nanometer: return (_value) * 1e-9d;
-                case LengthUnit.NauticalMile: return _value*1852;
-                case LengthUnit.PrinterPica: return _value/237.106301584;
-                case LengthUnit.PrinterPoint: return (_value/72.27)*2.54e-2;
-                case LengthUnit.Shackle: return _value*27.432;
-                case LengthUnit.Twip: return _value/56692.913385826;
-                case LengthUnit.UsSurveyFoot: return _value*1200/3937;
-                case LengthUnit.Yard: return _value*0.9144;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(LengthUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Level(double numericValue, LevelUnit unit)
+        Level(double numericValue, LevelUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -384,7 +384,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Level other)
         {
-            return AsBaseUnitDecibels().CompareTo(other.AsBaseUnitDecibels());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -432,7 +432,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDecibels().Equals(((Level) obj).AsBaseUnitDecibels());
+            return AsBaseUnit().Equals(((Level) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Level other, Level maxError)
         {
-            return Math.Abs(AsBaseUnitDecibels() - other.AsBaseUnitDecibels()) <= maxError.AsBaseUnitDecibels();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -463,20 +463,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(LevelUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case LevelUnit.Decibel: return _value;
+                case LevelUnit.Neper: return (1/0.115129254)*_value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDecibels();
+        private double AsBaseNumericType(LevelUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case LevelUnit.Decibel: return baseUnitValue;
                 case LevelUnit.Neper: return 0.115129254*baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -825,27 +847,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Level
         /// </summary>
         public static Level MinValue => new Level(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDecibels()
-        {
-            if (Unit == LevelUnit.Decibel) { return _value; }
-
-            switch (Unit)
-            {
-                case LevelUnit.Decibel: return _value;
-                case LevelUnit.Neper: return (1/0.115129254)*_value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(LevelUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          LinearDensity(double numericValue, LinearDensityUnit unit)
+        LinearDensity(double numericValue, LinearDensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LinearDensity other)
         {
-            return AsBaseUnitKilogramsPerMeter().CompareTo(other.AsBaseUnitKilogramsPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramsPerMeter().Equals(((LinearDensity) obj).AsBaseUnitKilogramsPerMeter());
+            return AsBaseUnit().Equals(((LinearDensity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(LinearDensity other, LinearDensity maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramsPerMeter() - other.AsBaseUnitKilogramsPerMeter()) <= maxError.AsBaseUnitKilogramsPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(LinearDensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case LinearDensityUnit.GramPerMeter: return _value*1e-3;
+                case LinearDensityUnit.KilogramPerMeter: return (_value*1e-3) * 1e3d;
+                case LinearDensityUnit.PoundPerFoot: return _value*1.48816394;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramsPerMeter();
+        private double AsBaseNumericType(LinearDensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case LinearDensityUnit.GramPerMeter: return baseUnitValue/1e-3;
                 case LinearDensityUnit.KilogramPerMeter: return (baseUnitValue/1e-3) / 1e3d;
                 case LinearDensityUnit.PoundPerFoot: return baseUnitValue/1.48816394;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of LinearDensity
         /// </summary>
         public static LinearDensity MinValue => new LinearDensity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramsPerMeter()
-        {
-            if (Unit == LinearDensityUnit.KilogramPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case LinearDensityUnit.GramPerMeter: return _value*1e-3;
-                case LinearDensityUnit.KilogramPerMeter: return (_value*1e-3) * 1e3d;
-                case LinearDensityUnit.PoundPerFoot: return _value*1.48816394;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(LinearDensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          LuminousFlux(double numericValue, LuminousFluxUnit unit)
+        LuminousFlux(double numericValue, LuminousFluxUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LuminousFlux other)
         {
-            return AsBaseUnitLumens().CompareTo(other.AsBaseUnitLumens());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitLumens().Equals(((LuminousFlux) obj).AsBaseUnitLumens());
+            return AsBaseUnit().Equals(((LuminousFlux) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(LuminousFlux other, LuminousFlux maxError)
         {
-            return Math.Abs(AsBaseUnitLumens() - other.AsBaseUnitLumens()) <= maxError.AsBaseUnitLumens();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(LuminousFluxUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case LuminousFluxUnit.Lumen: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitLumens();
+        private double AsBaseNumericType(LuminousFluxUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case LuminousFluxUnit.Lumen: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of LuminousFlux
         /// </summary>
         public static LuminousFlux MinValue => new LuminousFlux(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitLumens()
-        {
-            if (Unit == LuminousFluxUnit.Lumen) { return _value; }
-
-            switch (Unit)
-            {
-                case LuminousFluxUnit.Lumen: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(LuminousFluxUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          LuminousIntensity(double numericValue, LuminousIntensityUnit unit)
+        LuminousIntensity(double numericValue, LuminousIntensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(LuminousIntensity other)
         {
-            return AsBaseUnitCandela().CompareTo(other.AsBaseUnitCandela());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCandela().Equals(((LuminousIntensity) obj).AsBaseUnitCandela());
+            return AsBaseUnit().Equals(((LuminousIntensity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(LuminousIntensity other, LuminousIntensity maxError)
         {
-            return Math.Abs(AsBaseUnitCandela() - other.AsBaseUnitCandela()) <= maxError.AsBaseUnitCandela();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(LuminousIntensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case LuminousIntensityUnit.Candela: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCandela();
+        private double AsBaseNumericType(LuminousIntensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case LuminousIntensityUnit.Candela: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of LuminousIntensity
         /// </summary>
         public static LuminousIntensity MinValue => new LuminousIntensity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCandela()
-        {
-            if (Unit == LuminousIntensityUnit.Candela) { return _value; }
-
-            switch (Unit)
-            {
-                case LuminousIntensityUnit.Candela: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(LuminousIntensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MagneticField(double numericValue, MagneticFieldUnit unit)
+        MagneticField(double numericValue, MagneticFieldUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MagneticField other)
         {
-            return AsBaseUnitTeslas().CompareTo(other.AsBaseUnitTeslas());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitTeslas().Equals(((MagneticField) obj).AsBaseUnitTeslas());
+            return AsBaseUnit().Equals(((MagneticField) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MagneticField other, MagneticField maxError)
         {
-            return Math.Abs(AsBaseUnitTeslas() - other.AsBaseUnitTeslas()) <= maxError.AsBaseUnitTeslas();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MagneticFieldUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MagneticFieldUnit.Tesla: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitTeslas();
+        private double AsBaseNumericType(MagneticFieldUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MagneticFieldUnit.Tesla: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MagneticField
         /// </summary>
         public static MagneticField MinValue => new MagneticField(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitTeslas()
-        {
-            if (Unit == MagneticFieldUnit.Tesla) { return _value; }
-
-            switch (Unit)
-            {
-                case MagneticFieldUnit.Tesla: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MagneticFieldUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MagneticFlux(double numericValue, MagneticFluxUnit unit)
+        MagneticFlux(double numericValue, MagneticFluxUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MagneticFlux other)
         {
-            return AsBaseUnitWebers().CompareTo(other.AsBaseUnitWebers());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWebers().Equals(((MagneticFlux) obj).AsBaseUnitWebers());
+            return AsBaseUnit().Equals(((MagneticFlux) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MagneticFlux other, MagneticFlux maxError)
         {
-            return Math.Abs(AsBaseUnitWebers() - other.AsBaseUnitWebers()) <= maxError.AsBaseUnitWebers();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MagneticFluxUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MagneticFluxUnit.Weber: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitWebers();
+        private double AsBaseNumericType(MagneticFluxUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MagneticFluxUnit.Weber: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MagneticFlux
         /// </summary>
         public static MagneticFlux MinValue => new MagneticFlux(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitWebers()
-        {
-            if (Unit == MagneticFluxUnit.Weber) { return _value; }
-
-            switch (Unit)
-            {
-                case MagneticFluxUnit.Weber: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MagneticFluxUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Magnetization(double numericValue, MagnetizationUnit unit)
+        Magnetization(double numericValue, MagnetizationUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Magnetization other)
         {
-            return AsBaseUnitAmperesPerMeter().CompareTo(other.AsBaseUnitAmperesPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitAmperesPerMeter().Equals(((Magnetization) obj).AsBaseUnitAmperesPerMeter());
+            return AsBaseUnit().Equals(((Magnetization) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Magnetization other, Magnetization maxError)
         {
-            return Math.Abs(AsBaseUnitAmperesPerMeter() - other.AsBaseUnitAmperesPerMeter()) <= maxError.AsBaseUnitAmperesPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MagnetizationUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MagnetizationUnit.AmperePerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitAmperesPerMeter();
+        private double AsBaseNumericType(MagnetizationUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MagnetizationUnit.AmperePerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Magnetization
         /// </summary>
         public static Magnetization MinValue => new Magnetization(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitAmperesPerMeter()
-        {
-            if (Unit == MagnetizationUnit.AmperePerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case MagnetizationUnit.AmperePerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MagnetizationUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Mass(double numericValue, MassUnit unit)
+        Mass(double numericValue, MassUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1013,7 +1013,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Mass other)
         {
-            return AsBaseUnitKilograms().CompareTo(other.AsBaseUnitKilograms());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1061,7 +1061,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilograms().Equals(((Mass) obj).AsBaseUnitKilograms());
+            return AsBaseUnit().Equals(((Mass) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1074,7 +1074,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Mass other, Mass maxError)
         {
-            return Math.Abs(AsBaseUnitKilograms() - other.AsBaseUnitKilograms()) <= maxError.AsBaseUnitKilograms();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1092,14 +1092,56 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MassUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MassUnit.Centigram: return (_value/1e3) * 1e-2d;
+                case MassUnit.Decagram: return (_value/1e3) * 1e1d;
+                case MassUnit.Decigram: return (_value/1e3) * 1e-1d;
+                case MassUnit.Gram: return _value/1e3;
+                case MassUnit.Hectogram: return (_value/1e3) * 1e2d;
+                case MassUnit.Kilogram: return (_value/1e3) * 1e3d;
+                case MassUnit.Kilopound: return (_value*0.45359237) * 1e3d;
+                case MassUnit.Kilotonne: return (_value*1e3) * 1e3d;
+                case MassUnit.LongHundredweight: return _value/0.01968413055222121;
+                case MassUnit.LongTon: return _value*1016.0469088;
+                case MassUnit.Megapound: return (_value*0.45359237) * 1e6d;
+                case MassUnit.Megatonne: return (_value*1e3) * 1e6d;
+                case MassUnit.Microgram: return (_value/1e3) * 1e-6d;
+                case MassUnit.Milligram: return (_value/1e3) * 1e-3d;
+                case MassUnit.Nanogram: return (_value/1e3) * 1e-9d;
+                case MassUnit.Ounce: return _value/35.2739619;
+                case MassUnit.Pound: return _value*0.45359237;
+                case MassUnit.ShortHundredweight: return _value/0.022046226218487758;
+                case MassUnit.ShortTon: return _value*907.18474;
+                case MassUnit.Stone: return _value/0.1574731728702698;
+                case MassUnit.Tonne: return _value*1e3;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilograms();
+        private double AsBaseNumericType(MassUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MassUnit.Centigram: return (baseUnitValue*1e3) / 1e-2d;
                 case MassUnit.Decagram: return (baseUnitValue*1e3) / 1e1d;
@@ -1122,9 +1164,8 @@ namespace UnitsNet
                 case MassUnit.ShortTon: return baseUnitValue/907.18474;
                 case MassUnit.Stone: return baseUnitValue*0.1574731728702698;
                 case MassUnit.Tonne: return baseUnitValue/1e3;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1473,46 +1514,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Mass
         /// </summary>
         public static Mass MinValue => new Mass(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilograms()
-        {
-            if (Unit == MassUnit.Kilogram) { return _value; }
-
-            switch (Unit)
-            {
-                case MassUnit.Centigram: return (_value/1e3) * 1e-2d;
-                case MassUnit.Decagram: return (_value/1e3) * 1e1d;
-                case MassUnit.Decigram: return (_value/1e3) * 1e-1d;
-                case MassUnit.Gram: return _value/1e3;
-                case MassUnit.Hectogram: return (_value/1e3) * 1e2d;
-                case MassUnit.Kilogram: return (_value/1e3) * 1e3d;
-                case MassUnit.Kilopound: return (_value*0.45359237) * 1e3d;
-                case MassUnit.Kilotonne: return (_value*1e3) * 1e3d;
-                case MassUnit.LongHundredweight: return _value/0.01968413055222121;
-                case MassUnit.LongTon: return _value*1016.0469088;
-                case MassUnit.Megapound: return (_value*0.45359237) * 1e6d;
-                case MassUnit.Megatonne: return (_value*1e3) * 1e6d;
-                case MassUnit.Microgram: return (_value/1e3) * 1e-6d;
-                case MassUnit.Milligram: return (_value/1e3) * 1e-3d;
-                case MassUnit.Nanogram: return (_value/1e3) * 1e-9d;
-                case MassUnit.Ounce: return _value/35.2739619;
-                case MassUnit.Pound: return _value*0.45359237;
-                case MassUnit.ShortHundredweight: return _value/0.022046226218487758;
-                case MassUnit.ShortTon: return _value*907.18474;
-                case MassUnit.Stone: return _value/0.1574731728702698;
-                case MassUnit.Tonne: return _value*1e3;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MassUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MassFlow(double numericValue, MassFlowUnit unit)
+        MassFlow(double numericValue, MassFlowUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -815,7 +815,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MassFlow other)
         {
-            return AsBaseUnitGramsPerSecond().CompareTo(other.AsBaseUnitGramsPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -863,7 +863,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitGramsPerSecond().Equals(((MassFlow) obj).AsBaseUnitGramsPerSecond());
+            return AsBaseUnit().Equals(((MassFlow) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -876,7 +876,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MassFlow other, MassFlow maxError)
         {
-            return Math.Abs(AsBaseUnitGramsPerSecond() - other.AsBaseUnitGramsPerSecond()) <= maxError.AsBaseUnitGramsPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -894,14 +894,50 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MassFlowUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MassFlowUnit.CentigramPerSecond: return (_value) * 1e-2d;
+                case MassFlowUnit.DecagramPerSecond: return (_value) * 1e1d;
+                case MassFlowUnit.DecigramPerSecond: return (_value) * 1e-1d;
+                case MassFlowUnit.GramPerSecond: return _value;
+                case MassFlowUnit.HectogramPerSecond: return (_value) * 1e2d;
+                case MassFlowUnit.KilogramPerHour: return _value/3.6;
+                case MassFlowUnit.KilogramPerSecond: return (_value) * 1e3d;
+                case MassFlowUnit.MegapoundPerHour: return (_value/7.93664) * 1e6d;
+                case MassFlowUnit.MicrogramPerSecond: return (_value) * 1e-6d;
+                case MassFlowUnit.MilligramPerSecond: return (_value) * 1e-3d;
+                case MassFlowUnit.NanogramPerSecond: return (_value) * 1e-9d;
+                case MassFlowUnit.PoundPerHour: return _value/7.93664;
+                case MassFlowUnit.ShortTonPerHour: return _value*251.9957611;
+                case MassFlowUnit.TonnePerDay: return _value/0.0864000;
+                case MassFlowUnit.TonnePerHour: return 1000*_value/3.6;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitGramsPerSecond();
+        private double AsBaseNumericType(MassFlowUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MassFlowUnit.CentigramPerSecond: return (baseUnitValue) / 1e-2d;
                 case MassFlowUnit.DecagramPerSecond: return (baseUnitValue) / 1e1d;
@@ -918,9 +954,8 @@ namespace UnitsNet
                 case MassFlowUnit.ShortTonPerHour: return baseUnitValue/251.9957611;
                 case MassFlowUnit.TonnePerDay: return baseUnitValue*0.0864000;
                 case MassFlowUnit.TonnePerHour: return baseUnitValue*3.6/1000;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1269,40 +1304,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MassFlow
         /// </summary>
         public static MassFlow MinValue => new MassFlow(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitGramsPerSecond()
-        {
-            if (Unit == MassFlowUnit.GramPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case MassFlowUnit.CentigramPerSecond: return (_value) * 1e-2d;
-                case MassFlowUnit.DecagramPerSecond: return (_value) * 1e1d;
-                case MassFlowUnit.DecigramPerSecond: return (_value) * 1e-1d;
-                case MassFlowUnit.GramPerSecond: return _value;
-                case MassFlowUnit.HectogramPerSecond: return (_value) * 1e2d;
-                case MassFlowUnit.KilogramPerHour: return _value/3.6;
-                case MassFlowUnit.KilogramPerSecond: return (_value) * 1e3d;
-                case MassFlowUnit.MegapoundPerHour: return (_value/7.93664) * 1e6d;
-                case MassFlowUnit.MicrogramPerSecond: return (_value) * 1e-6d;
-                case MassFlowUnit.MilligramPerSecond: return (_value) * 1e-3d;
-                case MassFlowUnit.NanogramPerSecond: return (_value) * 1e-9d;
-                case MassFlowUnit.PoundPerHour: return _value/7.93664;
-                case MassFlowUnit.ShortTonPerHour: return _value*251.9957611;
-                case MassFlowUnit.TonnePerDay: return _value/0.0864000;
-                case MassFlowUnit.TonnePerHour: return 1000*_value/3.6;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MassFlowUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MassFlux(double numericValue, MassFluxUnit unit)
+        MassFlux(double numericValue, MassFluxUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -386,7 +386,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MassFlux other)
         {
-            return AsBaseUnitKilogramsPerSecondPerSquareMeter().CompareTo(other.AsBaseUnitKilogramsPerSecondPerSquareMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -434,7 +434,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramsPerSecondPerSquareMeter().Equals(((MassFlux) obj).AsBaseUnitKilogramsPerSecondPerSquareMeter());
+            return AsBaseUnit().Equals(((MassFlux) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MassFlux other, MassFlux maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramsPerSecondPerSquareMeter() - other.AsBaseUnitKilogramsPerSecondPerSquareMeter()) <= maxError.AsBaseUnitKilogramsPerSecondPerSquareMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -465,20 +465,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MassFluxUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MassFluxUnit.GramPerSecondPerSquareMeter: return _value/1e3;
+                case MassFluxUnit.KilogramPerSecondPerSquareMeter: return (_value/1e3) * 1e3d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramsPerSecondPerSquareMeter();
+        private double AsBaseNumericType(MassFluxUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MassFluxUnit.GramPerSecondPerSquareMeter: return baseUnitValue*1e3;
                 case MassFluxUnit.KilogramPerSecondPerSquareMeter: return (baseUnitValue*1e3) / 1e3d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -827,27 +849,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MassFlux
         /// </summary>
         public static MassFlux MinValue => new MassFlux(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramsPerSecondPerSquareMeter()
-        {
-            if (Unit == MassFluxUnit.KilogramPerSecondPerSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case MassFluxUnit.GramPerSecondPerSquareMeter: return _value/1e3;
-                case MassFluxUnit.KilogramPerSecondPerSquareMeter: return (_value/1e3) * 1e3d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MassFluxUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MassMomentOfInertia(double numericValue, MassMomentOfInertiaUnit unit)
+        MassMomentOfInertia(double numericValue, MassMomentOfInertiaUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1178,7 +1178,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MassMomentOfInertia other)
         {
-            return AsBaseUnitKilogramSquareMeters().CompareTo(other.AsBaseUnitKilogramSquareMeters());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1226,7 +1226,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramSquareMeters().Equals(((MassMomentOfInertia) obj).AsBaseUnitKilogramSquareMeters());
+            return AsBaseUnit().Equals(((MassMomentOfInertia) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1239,7 +1239,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MassMomentOfInertia other, MassMomentOfInertia maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramSquareMeters() - other.AsBaseUnitKilogramSquareMeters()) <= maxError.AsBaseUnitKilogramSquareMeters();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1257,14 +1257,61 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MassMomentOfInertiaUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MassMomentOfInertiaUnit.GramSquareCentimeter: return _value/1e7;
+                case MassMomentOfInertiaUnit.GramSquareDecimeter: return _value/1e5;
+                case MassMomentOfInertiaUnit.GramSquareMeter: return _value/1e3;
+                case MassMomentOfInertiaUnit.GramSquareMillimeter: return _value/1e9;
+                case MassMomentOfInertiaUnit.KilogramSquareCentimeter: return (_value/1e7) * 1e3d;
+                case MassMomentOfInertiaUnit.KilogramSquareDecimeter: return (_value/1e5) * 1e3d;
+                case MassMomentOfInertiaUnit.KilogramSquareMeter: return (_value/1e3) * 1e3d;
+                case MassMomentOfInertiaUnit.KilogramSquareMillimeter: return (_value/1e9) * 1e3d;
+                case MassMomentOfInertiaUnit.KilotonneSquareCentimeter: return (_value/1e1) * 1e3d;
+                case MassMomentOfInertiaUnit.KilotonneSquareDecimeter: return (_value/1e-1) * 1e3d;
+                case MassMomentOfInertiaUnit.KilotonneSquareMeter: return (_value/1e-3) * 1e3d;
+                case MassMomentOfInertiaUnit.KilotonneSquareMilimeter: return (_value/1e3) * 1e3d;
+                case MassMomentOfInertiaUnit.MegatonneSquareCentimeter: return (_value/1e1) * 1e6d;
+                case MassMomentOfInertiaUnit.MegatonneSquareDecimeter: return (_value/1e-1) * 1e6d;
+                case MassMomentOfInertiaUnit.MegatonneSquareMeter: return (_value/1e-3) * 1e6d;
+                case MassMomentOfInertiaUnit.MegatonneSquareMilimeter: return (_value/1e3) * 1e6d;
+                case MassMomentOfInertiaUnit.MilligramSquareCentimeter: return (_value/1e7) * 1e-3d;
+                case MassMomentOfInertiaUnit.MilligramSquareDecimeter: return (_value/1e5) * 1e-3d;
+                case MassMomentOfInertiaUnit.MilligramSquareMeter: return (_value/1e3) * 1e-3d;
+                case MassMomentOfInertiaUnit.MilligramSquareMillimeter: return (_value/1e9) * 1e-3d;
+                case MassMomentOfInertiaUnit.PoundSquareFoot: return _value*4.21401101e-2;
+                case MassMomentOfInertiaUnit.PoundSquareInch: return _value*2.9263965e-4;
+                case MassMomentOfInertiaUnit.TonneSquareCentimeter: return _value/1e1;
+                case MassMomentOfInertiaUnit.TonneSquareDecimeter: return _value/1e-1;
+                case MassMomentOfInertiaUnit.TonneSquareMeter: return _value/1e-3;
+                case MassMomentOfInertiaUnit.TonneSquareMilimeter: return _value/1e3;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramSquareMeters();
+        private double AsBaseNumericType(MassMomentOfInertiaUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MassMomentOfInertiaUnit.GramSquareCentimeter: return baseUnitValue*1e7;
                 case MassMomentOfInertiaUnit.GramSquareDecimeter: return baseUnitValue*1e5;
@@ -1292,9 +1339,8 @@ namespace UnitsNet
                 case MassMomentOfInertiaUnit.TonneSquareDecimeter: return baseUnitValue*1e-1;
                 case MassMomentOfInertiaUnit.TonneSquareMeter: return baseUnitValue*1e-3;
                 case MassMomentOfInertiaUnit.TonneSquareMilimeter: return baseUnitValue*1e3;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1643,51 +1689,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MassMomentOfInertia
         /// </summary>
         public static MassMomentOfInertia MinValue => new MassMomentOfInertia(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramSquareMeters()
-        {
-            if (Unit == MassMomentOfInertiaUnit.KilogramSquareMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case MassMomentOfInertiaUnit.GramSquareCentimeter: return _value/1e7;
-                case MassMomentOfInertiaUnit.GramSquareDecimeter: return _value/1e5;
-                case MassMomentOfInertiaUnit.GramSquareMeter: return _value/1e3;
-                case MassMomentOfInertiaUnit.GramSquareMillimeter: return _value/1e9;
-                case MassMomentOfInertiaUnit.KilogramSquareCentimeter: return (_value/1e7) * 1e3d;
-                case MassMomentOfInertiaUnit.KilogramSquareDecimeter: return (_value/1e5) * 1e3d;
-                case MassMomentOfInertiaUnit.KilogramSquareMeter: return (_value/1e3) * 1e3d;
-                case MassMomentOfInertiaUnit.KilogramSquareMillimeter: return (_value/1e9) * 1e3d;
-                case MassMomentOfInertiaUnit.KilotonneSquareCentimeter: return (_value/1e1) * 1e3d;
-                case MassMomentOfInertiaUnit.KilotonneSquareDecimeter: return (_value/1e-1) * 1e3d;
-                case MassMomentOfInertiaUnit.KilotonneSquareMeter: return (_value/1e-3) * 1e3d;
-                case MassMomentOfInertiaUnit.KilotonneSquareMilimeter: return (_value/1e3) * 1e3d;
-                case MassMomentOfInertiaUnit.MegatonneSquareCentimeter: return (_value/1e1) * 1e6d;
-                case MassMomentOfInertiaUnit.MegatonneSquareDecimeter: return (_value/1e-1) * 1e6d;
-                case MassMomentOfInertiaUnit.MegatonneSquareMeter: return (_value/1e-3) * 1e6d;
-                case MassMomentOfInertiaUnit.MegatonneSquareMilimeter: return (_value/1e3) * 1e6d;
-                case MassMomentOfInertiaUnit.MilligramSquareCentimeter: return (_value/1e7) * 1e-3d;
-                case MassMomentOfInertiaUnit.MilligramSquareDecimeter: return (_value/1e5) * 1e-3d;
-                case MassMomentOfInertiaUnit.MilligramSquareMeter: return (_value/1e3) * 1e-3d;
-                case MassMomentOfInertiaUnit.MilligramSquareMillimeter: return (_value/1e9) * 1e-3d;
-                case MassMomentOfInertiaUnit.PoundSquareFoot: return _value*4.21401101e-2;
-                case MassMomentOfInertiaUnit.PoundSquareInch: return _value*2.9263965e-4;
-                case MassMomentOfInertiaUnit.TonneSquareCentimeter: return _value/1e1;
-                case MassMomentOfInertiaUnit.TonneSquareDecimeter: return _value/1e-1;
-                case MassMomentOfInertiaUnit.TonneSquareMeter: return _value/1e-3;
-                case MassMomentOfInertiaUnit.TonneSquareMilimeter: return _value/1e3;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MassMomentOfInertiaUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MolarEnergy(double numericValue, MolarEnergyUnit unit)
+        MolarEnergy(double numericValue, MolarEnergyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MolarEnergy other)
         {
-            return AsBaseUnitJoulesPerMole().CompareTo(other.AsBaseUnitJoulesPerMole());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoulesPerMole().Equals(((MolarEnergy) obj).AsBaseUnitJoulesPerMole());
+            return AsBaseUnit().Equals(((MolarEnergy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MolarEnergy other, MolarEnergy maxError)
         {
-            return Math.Abs(AsBaseUnitJoulesPerMole() - other.AsBaseUnitJoulesPerMole()) <= maxError.AsBaseUnitJoulesPerMole();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MolarEnergyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MolarEnergyUnit.JoulePerMole: return _value;
+                case MolarEnergyUnit.KilojoulePerMole: return (_value) * 1e3d;
+                case MolarEnergyUnit.MegajoulePerMole: return (_value) * 1e6d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoulesPerMole();
+        private double AsBaseNumericType(MolarEnergyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MolarEnergyUnit.JoulePerMole: return baseUnitValue;
                 case MolarEnergyUnit.KilojoulePerMole: return (baseUnitValue) / 1e3d;
                 case MolarEnergyUnit.MegajoulePerMole: return (baseUnitValue) / 1e6d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MolarEnergy
         /// </summary>
         public static MolarEnergy MinValue => new MolarEnergy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoulesPerMole()
-        {
-            if (Unit == MolarEnergyUnit.JoulePerMole) { return _value; }
-
-            switch (Unit)
-            {
-                case MolarEnergyUnit.JoulePerMole: return _value;
-                case MolarEnergyUnit.KilojoulePerMole: return (_value) * 1e3d;
-                case MolarEnergyUnit.MegajoulePerMole: return (_value) * 1e6d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MolarEnergyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MolarEntropy(double numericValue, MolarEntropyUnit unit)
+        MolarEntropy(double numericValue, MolarEntropyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MolarEntropy other)
         {
-            return AsBaseUnitJoulesPerMoleKelvin().CompareTo(other.AsBaseUnitJoulesPerMoleKelvin());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoulesPerMoleKelvin().Equals(((MolarEntropy) obj).AsBaseUnitJoulesPerMoleKelvin());
+            return AsBaseUnit().Equals(((MolarEntropy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MolarEntropy other, MolarEntropy maxError)
         {
-            return Math.Abs(AsBaseUnitJoulesPerMoleKelvin() - other.AsBaseUnitJoulesPerMoleKelvin()) <= maxError.AsBaseUnitJoulesPerMoleKelvin();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MolarEntropyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MolarEntropyUnit.JoulePerMoleKelvin: return _value;
+                case MolarEntropyUnit.KilojoulePerMoleKelvin: return (_value) * 1e3d;
+                case MolarEntropyUnit.MegajoulePerMoleKelvin: return (_value) * 1e6d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoulesPerMoleKelvin();
+        private double AsBaseNumericType(MolarEntropyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MolarEntropyUnit.JoulePerMoleKelvin: return baseUnitValue;
                 case MolarEntropyUnit.KilojoulePerMoleKelvin: return (baseUnitValue) / 1e3d;
                 case MolarEntropyUnit.MegajoulePerMoleKelvin: return (baseUnitValue) / 1e6d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MolarEntropy
         /// </summary>
         public static MolarEntropy MinValue => new MolarEntropy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoulesPerMoleKelvin()
-        {
-            if (Unit == MolarEntropyUnit.JoulePerMoleKelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case MolarEntropyUnit.JoulePerMoleKelvin: return _value;
-                case MolarEntropyUnit.KilojoulePerMoleKelvin: return (_value) * 1e3d;
-                case MolarEntropyUnit.MegajoulePerMoleKelvin: return (_value) * 1e6d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MolarEntropyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          MolarMass(double numericValue, MolarMassUnit unit)
+        MolarMass(double numericValue, MolarMassUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -716,7 +716,7 @@ namespace UnitsNet
 #endif
         int CompareTo(MolarMass other)
         {
-            return AsBaseUnitKilogramsPerMole().CompareTo(other.AsBaseUnitKilogramsPerMole());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -764,7 +764,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKilogramsPerMole().Equals(((MolarMass) obj).AsBaseUnitKilogramsPerMole());
+            return AsBaseUnit().Equals(((MolarMass) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -777,7 +777,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(MolarMass other, MolarMass maxError)
         {
-            return Math.Abs(AsBaseUnitKilogramsPerMole() - other.AsBaseUnitKilogramsPerMole()) <= maxError.AsBaseUnitKilogramsPerMole();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -795,14 +795,47 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MolarMassUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MolarMassUnit.CentigramPerMole: return (_value/1e3) * 1e-2d;
+                case MolarMassUnit.DecagramPerMole: return (_value/1e3) * 1e1d;
+                case MolarMassUnit.DecigramPerMole: return (_value/1e3) * 1e-1d;
+                case MolarMassUnit.GramPerMole: return _value/1e3;
+                case MolarMassUnit.HectogramPerMole: return (_value/1e3) * 1e2d;
+                case MolarMassUnit.KilogramPerMole: return (_value/1e3) * 1e3d;
+                case MolarMassUnit.KilopoundPerMole: return (_value*0.45359237) * 1e3d;
+                case MolarMassUnit.MegapoundPerMole: return (_value*0.45359237) * 1e6d;
+                case MolarMassUnit.MicrogramPerMole: return (_value/1e3) * 1e-6d;
+                case MolarMassUnit.MilligramPerMole: return (_value/1e3) * 1e-3d;
+                case MolarMassUnit.NanogramPerMole: return (_value/1e3) * 1e-9d;
+                case MolarMassUnit.PoundPerMole: return _value*0.45359237;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKilogramsPerMole();
+        private double AsBaseNumericType(MolarMassUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MolarMassUnit.CentigramPerMole: return (baseUnitValue*1e3) / 1e-2d;
                 case MolarMassUnit.DecagramPerMole: return (baseUnitValue*1e3) / 1e1d;
@@ -816,9 +849,8 @@ namespace UnitsNet
                 case MolarMassUnit.MilligramPerMole: return (baseUnitValue*1e3) / 1e-3d;
                 case MolarMassUnit.NanogramPerMole: return (baseUnitValue*1e3) / 1e-9d;
                 case MolarMassUnit.PoundPerMole: return baseUnitValue/0.45359237;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1167,37 +1199,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of MolarMass
         /// </summary>
         public static MolarMass MinValue => new MolarMass(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKilogramsPerMole()
-        {
-            if (Unit == MolarMassUnit.KilogramPerMole) { return _value; }
-
-            switch (Unit)
-            {
-                case MolarMassUnit.CentigramPerMole: return (_value/1e3) * 1e-2d;
-                case MolarMassUnit.DecagramPerMole: return (_value/1e3) * 1e1d;
-                case MolarMassUnit.DecigramPerMole: return (_value/1e3) * 1e-1d;
-                case MolarMassUnit.GramPerMole: return _value/1e3;
-                case MolarMassUnit.HectogramPerMole: return (_value/1e3) * 1e2d;
-                case MolarMassUnit.KilogramPerMole: return (_value/1e3) * 1e3d;
-                case MolarMassUnit.KilopoundPerMole: return (_value*0.45359237) * 1e3d;
-                case MolarMassUnit.MegapoundPerMole: return (_value*0.45359237) * 1e6d;
-                case MolarMassUnit.MicrogramPerMole: return (_value/1e3) * 1e-6d;
-                case MolarMassUnit.MilligramPerMole: return (_value/1e3) * 1e-3d;
-                case MolarMassUnit.NanogramPerMole: return (_value/1e3) * 1e-9d;
-                case MolarMassUnit.PoundPerMole: return _value*0.45359237;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MolarMassUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Molarity(double numericValue, MolarityUnit unit)
+        Molarity(double numericValue, MolarityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -584,7 +584,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Molarity other)
         {
-            return AsBaseUnitMolesPerCubicMeter().CompareTo(other.AsBaseUnitMolesPerCubicMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -632,7 +632,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitMolesPerCubicMeter().Equals(((Molarity) obj).AsBaseUnitMolesPerCubicMeter());
+            return AsBaseUnit().Equals(((Molarity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Molarity other, Molarity maxError)
         {
-            return Math.Abs(AsBaseUnitMolesPerCubicMeter() - other.AsBaseUnitMolesPerCubicMeter()) <= maxError.AsBaseUnitMolesPerCubicMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -663,14 +663,43 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(MolarityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case MolarityUnit.CentimolesPerLiter: return (_value/1e-3) * 1e-2d;
+                case MolarityUnit.DecimolesPerLiter: return (_value/1e-3) * 1e-1d;
+                case MolarityUnit.MicromolesPerLiter: return (_value/1e-3) * 1e-6d;
+                case MolarityUnit.MillimolesPerLiter: return (_value/1e-3) * 1e-3d;
+                case MolarityUnit.MolesPerCubicMeter: return _value;
+                case MolarityUnit.MolesPerLiter: return _value/1e-3;
+                case MolarityUnit.NanomolesPerLiter: return (_value/1e-3) * 1e-9d;
+                case MolarityUnit.PicomolesPerLiter: return (_value/1e-3) * 1e-12d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitMolesPerCubicMeter();
+        private double AsBaseNumericType(MolarityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case MolarityUnit.CentimolesPerLiter: return (baseUnitValue*1e-3) / 1e-2d;
                 case MolarityUnit.DecimolesPerLiter: return (baseUnitValue*1e-3) / 1e-1d;
@@ -680,9 +709,8 @@ namespace UnitsNet
                 case MolarityUnit.MolesPerLiter: return baseUnitValue*1e-3;
                 case MolarityUnit.NanomolesPerLiter: return (baseUnitValue*1e-3) / 1e-9d;
                 case MolarityUnit.PicomolesPerLiter: return (baseUnitValue*1e-3) / 1e-12d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1031,33 +1059,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Molarity
         /// </summary>
         public static Molarity MinValue => new Molarity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitMolesPerCubicMeter()
-        {
-            if (Unit == MolarityUnit.MolesPerCubicMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case MolarityUnit.CentimolesPerLiter: return (_value/1e-3) * 1e-2d;
-                case MolarityUnit.DecimolesPerLiter: return (_value/1e-3) * 1e-1d;
-                case MolarityUnit.MicromolesPerLiter: return (_value/1e-3) * 1e-6d;
-                case MolarityUnit.MillimolesPerLiter: return (_value/1e-3) * 1e-3d;
-                case MolarityUnit.MolesPerCubicMeter: return _value;
-                case MolarityUnit.MolesPerLiter: return _value/1e-3;
-                case MolarityUnit.NanomolesPerLiter: return (_value/1e-3) * 1e-9d;
-                case MolarityUnit.PicomolesPerLiter: return (_value/1e-3) * 1e-12d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(MolarityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Permeability(double numericValue, PermeabilityUnit unit)
+        Permeability(double numericValue, PermeabilityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Permeability other)
         {
-            return AsBaseUnitHenriesPerMeter().CompareTo(other.AsBaseUnitHenriesPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitHenriesPerMeter().Equals(((Permeability) obj).AsBaseUnitHenriesPerMeter());
+            return AsBaseUnit().Equals(((Permeability) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Permeability other, Permeability maxError)
         {
-            return Math.Abs(AsBaseUnitHenriesPerMeter() - other.AsBaseUnitHenriesPerMeter()) <= maxError.AsBaseUnitHenriesPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PermeabilityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case PermeabilityUnit.HenryPerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitHenriesPerMeter();
+        private double AsBaseNumericType(PermeabilityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case PermeabilityUnit.HenryPerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Permeability
         /// </summary>
         public static Permeability MinValue => new Permeability(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitHenriesPerMeter()
-        {
-            if (Unit == PermeabilityUnit.HenryPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case PermeabilityUnit.HenryPerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(PermeabilityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Permittivity(double numericValue, PermittivityUnit unit)
+        Permittivity(double numericValue, PermittivityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Permittivity other)
         {
-            return AsBaseUnitFaradsPerMeter().CompareTo(other.AsBaseUnitFaradsPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitFaradsPerMeter().Equals(((Permittivity) obj).AsBaseUnitFaradsPerMeter());
+            return AsBaseUnit().Equals(((Permittivity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Permittivity other, Permittivity maxError)
         {
-            return Math.Abs(AsBaseUnitFaradsPerMeter() - other.AsBaseUnitFaradsPerMeter()) <= maxError.AsBaseUnitFaradsPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PermittivityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case PermittivityUnit.FaradPerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitFaradsPerMeter();
+        private double AsBaseNumericType(PermittivityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case PermittivityUnit.FaradPerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Permittivity
         /// </summary>
         public static Permittivity MinValue => new Permittivity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitFaradsPerMeter()
-        {
-            if (Unit == PermittivityUnit.FaradPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case PermittivityUnit.FaradPerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(PermittivityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Power(decimal numericValue, PowerUnit unit)
+        Power(decimal numericValue, PowerUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -980,7 +980,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Power other)
         {
-            return AsBaseUnitWatts().CompareTo(other.AsBaseUnitWatts());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1025,7 +1025,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWatts().Equals(((Power) obj).AsBaseUnitWatts());
+            return AsBaseUnit().Equals(((Power) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1038,7 +1038,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Power other, Power maxError)
         {
-            return Math.Abs(AsBaseUnitWatts() - other.AsBaseUnitWatts()) <= maxError.AsBaseUnitWatts();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1056,38 +1056,78 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PowerUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private decimal AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
-            }
-
-            decimal baseUnitValue = AsBaseUnitWatts();
-
-            switch (unit)
-            {
-                case PowerUnit.BoilerHorsepower: return Convert.ToDouble(baseUnitValue/9812.5m);
-                case PowerUnit.BritishThermalUnitPerHour: return Convert.ToDouble(baseUnitValue/0.293071m);
-                case PowerUnit.Decawatt: return Convert.ToDouble((baseUnitValue) / 1e1m);
-                case PowerUnit.Deciwatt: return Convert.ToDouble((baseUnitValue) / 1e-1m);
-                case PowerUnit.ElectricalHorsepower: return Convert.ToDouble(baseUnitValue/746m);
-                case PowerUnit.Femtowatt: return Convert.ToDouble((baseUnitValue) / 1e-15m);
-                case PowerUnit.Gigawatt: return Convert.ToDouble((baseUnitValue) / 1e9m);
-                case PowerUnit.HydraulicHorsepower: return Convert.ToDouble(baseUnitValue/745.69988145m);
-                case PowerUnit.KilobritishThermalUnitPerHour: return Convert.ToDouble((baseUnitValue/0.293071m) / 1e3m);
-                case PowerUnit.Kilowatt: return Convert.ToDouble((baseUnitValue) / 1e3m);
-                case PowerUnit.MechanicalHorsepower: return Convert.ToDouble(baseUnitValue/745.69m);
-                case PowerUnit.Megawatt: return Convert.ToDouble((baseUnitValue) / 1e6m);
-                case PowerUnit.MetricHorsepower: return Convert.ToDouble(baseUnitValue/735.49875m);
-                case PowerUnit.Microwatt: return Convert.ToDouble((baseUnitValue) / 1e-6m);
-                case PowerUnit.Milliwatt: return Convert.ToDouble((baseUnitValue) / 1e-3m);
-                case PowerUnit.Nanowatt: return Convert.ToDouble((baseUnitValue) / 1e-9m);
-                case PowerUnit.Petawatt: return Convert.ToDouble((baseUnitValue) / 1e15m);
-                case PowerUnit.Picowatt: return Convert.ToDouble((baseUnitValue) / 1e-12m);
-                case PowerUnit.Terawatt: return Convert.ToDouble((baseUnitValue) / 1e12m);
-                case PowerUnit.Watt: return Convert.ToDouble(baseUnitValue);
-
+                case PowerUnit.BoilerHorsepower: return _value*9812.5m;
+                case PowerUnit.BritishThermalUnitPerHour: return _value*0.293071m;
+                case PowerUnit.Decawatt: return (_value) * 1e1m;
+                case PowerUnit.Deciwatt: return (_value) * 1e-1m;
+                case PowerUnit.ElectricalHorsepower: return _value*746m;
+                case PowerUnit.Femtowatt: return (_value) * 1e-15m;
+                case PowerUnit.Gigawatt: return (_value) * 1e9m;
+                case PowerUnit.HydraulicHorsepower: return _value*745.69988145m;
+                case PowerUnit.KilobritishThermalUnitPerHour: return (_value*0.293071m) * 1e3m;
+                case PowerUnit.Kilowatt: return (_value) * 1e3m;
+                case PowerUnit.MechanicalHorsepower: return _value*745.69m;
+                case PowerUnit.Megawatt: return (_value) * 1e6m;
+                case PowerUnit.MetricHorsepower: return _value*735.49875m;
+                case PowerUnit.Microwatt: return (_value) * 1e-6m;
+                case PowerUnit.Milliwatt: return (_value) * 1e-3m;
+                case PowerUnit.Nanowatt: return (_value) * 1e-9m;
+                case PowerUnit.Petawatt: return (_value) * 1e15m;
+                case PowerUnit.Picowatt: return (_value) * 1e-12m;
+                case PowerUnit.Terawatt: return (_value) * 1e12m;
+                case PowerUnit.Watt: return _value;
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
+            }
+        }
+
+        private decimal AsBaseNumericType(PowerUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
+
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
+            {
+                case PowerUnit.BoilerHorsepower: return baseUnitValue/9812.5m;
+                case PowerUnit.BritishThermalUnitPerHour: return baseUnitValue/0.293071m;
+                case PowerUnit.Decawatt: return (baseUnitValue) / 1e1m;
+                case PowerUnit.Deciwatt: return (baseUnitValue) / 1e-1m;
+                case PowerUnit.ElectricalHorsepower: return baseUnitValue/746m;
+                case PowerUnit.Femtowatt: return (baseUnitValue) / 1e-15m;
+                case PowerUnit.Gigawatt: return (baseUnitValue) / 1e9m;
+                case PowerUnit.HydraulicHorsepower: return baseUnitValue/745.69988145m;
+                case PowerUnit.KilobritishThermalUnitPerHour: return (baseUnitValue/0.293071m) / 1e3m;
+                case PowerUnit.Kilowatt: return (baseUnitValue) / 1e3m;
+                case PowerUnit.MechanicalHorsepower: return baseUnitValue/745.69m;
+                case PowerUnit.Megawatt: return (baseUnitValue) / 1e6m;
+                case PowerUnit.MetricHorsepower: return baseUnitValue/735.49875m;
+                case PowerUnit.Microwatt: return (baseUnitValue) / 1e-6m;
+                case PowerUnit.Milliwatt: return (baseUnitValue) / 1e-3m;
+                case PowerUnit.Nanowatt: return (baseUnitValue) / 1e-9m;
+                case PowerUnit.Petawatt: return (baseUnitValue) / 1e15m;
+                case PowerUnit.Picowatt: return (baseUnitValue) / 1e-12m;
+                case PowerUnit.Terawatt: return (baseUnitValue) / 1e12m;
+                case PowerUnit.Watt: return baseUnitValue;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1436,45 +1476,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Power
         /// </summary>
         public static Power MinValue => new Power(decimal.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private decimal AsBaseUnitWatts()
-        {
-            if (Unit == PowerUnit.Watt) { return _value; }
-
-            switch (Unit)
-            {
-                case PowerUnit.BoilerHorsepower: return Convert.ToDecimal(_value*9812.5m);
-                case PowerUnit.BritishThermalUnitPerHour: return Convert.ToDecimal(_value*0.293071m);
-                case PowerUnit.Decawatt: return Convert.ToDecimal((_value) * 1e1m);
-                case PowerUnit.Deciwatt: return Convert.ToDecimal((_value) * 1e-1m);
-                case PowerUnit.ElectricalHorsepower: return Convert.ToDecimal(_value*746m);
-                case PowerUnit.Femtowatt: return Convert.ToDecimal((_value) * 1e-15m);
-                case PowerUnit.Gigawatt: return Convert.ToDecimal((_value) * 1e9m);
-                case PowerUnit.HydraulicHorsepower: return Convert.ToDecimal(_value*745.69988145m);
-                case PowerUnit.KilobritishThermalUnitPerHour: return Convert.ToDecimal((_value*0.293071m) * 1e3m);
-                case PowerUnit.Kilowatt: return Convert.ToDecimal((_value) * 1e3m);
-                case PowerUnit.MechanicalHorsepower: return Convert.ToDecimal(_value*745.69m);
-                case PowerUnit.Megawatt: return Convert.ToDecimal((_value) * 1e6m);
-                case PowerUnit.MetricHorsepower: return Convert.ToDecimal(_value*735.49875m);
-                case PowerUnit.Microwatt: return Convert.ToDecimal((_value) * 1e-6m);
-                case PowerUnit.Milliwatt: return Convert.ToDecimal((_value) * 1e-3m);
-                case PowerUnit.Nanowatt: return Convert.ToDecimal((_value) * 1e-9m);
-                case PowerUnit.Petawatt: return Convert.ToDecimal((_value) * 1e15m);
-                case PowerUnit.Picowatt: return Convert.ToDecimal((_value) * 1e-12m);
-                case PowerUnit.Terawatt: return Convert.ToDecimal((_value) * 1e12m);
-                case PowerUnit.Watt: return Convert.ToDecimal(_value);
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private decimal AsBaseNumericType(PowerUnit unit) => Convert.ToDecimal(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          PowerDensity(double numericValue, PowerDensityUnit unit)
+        PowerDensity(double numericValue, PowerDensityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1772,7 +1772,7 @@ namespace UnitsNet
 #endif
         int CompareTo(PowerDensity other)
         {
-            return AsBaseUnitWattsPerCubicMeter().CompareTo(other.AsBaseUnitWattsPerCubicMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1820,7 +1820,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWattsPerCubicMeter().Equals(((PowerDensity) obj).AsBaseUnitWattsPerCubicMeter());
+            return AsBaseUnit().Equals(((PowerDensity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1833,7 +1833,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(PowerDensity other, PowerDensity maxError)
         {
-            return Math.Abs(AsBaseUnitWattsPerCubicMeter() - other.AsBaseUnitWattsPerCubicMeter()) <= maxError.AsBaseUnitWattsPerCubicMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1851,14 +1851,79 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PowerDensityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case PowerDensityUnit.DecawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e1d;
+                case PowerDensityUnit.DecawattPerCubicInch: return (_value*6.102374409473228e4) * 1e1d;
+                case PowerDensityUnit.DecawattPerCubicMeter: return (_value) * 1e1d;
+                case PowerDensityUnit.DecawattPerLiter: return (_value*1.0e3) * 1e1d;
+                case PowerDensityUnit.DeciwattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-1d;
+                case PowerDensityUnit.DeciwattPerCubicInch: return (_value*6.102374409473228e4) * 1e-1d;
+                case PowerDensityUnit.DeciwattPerCubicMeter: return (_value) * 1e-1d;
+                case PowerDensityUnit.DeciwattPerLiter: return (_value*1.0e3) * 1e-1d;
+                case PowerDensityUnit.GigawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e9d;
+                case PowerDensityUnit.GigawattPerCubicInch: return (_value*6.102374409473228e4) * 1e9d;
+                case PowerDensityUnit.GigawattPerCubicMeter: return (_value) * 1e9d;
+                case PowerDensityUnit.GigawattPerLiter: return (_value*1.0e3) * 1e9d;
+                case PowerDensityUnit.KilowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e3d;
+                case PowerDensityUnit.KilowattPerCubicInch: return (_value*6.102374409473228e4) * 1e3d;
+                case PowerDensityUnit.KilowattPerCubicMeter: return (_value) * 1e3d;
+                case PowerDensityUnit.KilowattPerLiter: return (_value*1.0e3) * 1e3d;
+                case PowerDensityUnit.MegawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e6d;
+                case PowerDensityUnit.MegawattPerCubicInch: return (_value*6.102374409473228e4) * 1e6d;
+                case PowerDensityUnit.MegawattPerCubicMeter: return (_value) * 1e6d;
+                case PowerDensityUnit.MegawattPerLiter: return (_value*1.0e3) * 1e6d;
+                case PowerDensityUnit.MicrowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-6d;
+                case PowerDensityUnit.MicrowattPerCubicInch: return (_value*6.102374409473228e4) * 1e-6d;
+                case PowerDensityUnit.MicrowattPerCubicMeter: return (_value) * 1e-6d;
+                case PowerDensityUnit.MicrowattPerLiter: return (_value*1.0e3) * 1e-6d;
+                case PowerDensityUnit.MilliwattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-3d;
+                case PowerDensityUnit.MilliwattPerCubicInch: return (_value*6.102374409473228e4) * 1e-3d;
+                case PowerDensityUnit.MilliwattPerCubicMeter: return (_value) * 1e-3d;
+                case PowerDensityUnit.MilliwattPerLiter: return (_value*1.0e3) * 1e-3d;
+                case PowerDensityUnit.NanowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-9d;
+                case PowerDensityUnit.NanowattPerCubicInch: return (_value*6.102374409473228e4) * 1e-9d;
+                case PowerDensityUnit.NanowattPerCubicMeter: return (_value) * 1e-9d;
+                case PowerDensityUnit.NanowattPerLiter: return (_value*1.0e3) * 1e-9d;
+                case PowerDensityUnit.PicowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-12d;
+                case PowerDensityUnit.PicowattPerCubicInch: return (_value*6.102374409473228e4) * 1e-12d;
+                case PowerDensityUnit.PicowattPerCubicMeter: return (_value) * 1e-12d;
+                case PowerDensityUnit.PicowattPerLiter: return (_value*1.0e3) * 1e-12d;
+                case PowerDensityUnit.TerawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e12d;
+                case PowerDensityUnit.TerawattPerCubicInch: return (_value*6.102374409473228e4) * 1e12d;
+                case PowerDensityUnit.TerawattPerCubicMeter: return (_value) * 1e12d;
+                case PowerDensityUnit.TerawattPerLiter: return (_value*1.0e3) * 1e12d;
+                case PowerDensityUnit.WattPerCubicFoot: return _value*3.531466672148859e1;
+                case PowerDensityUnit.WattPerCubicInch: return _value*6.102374409473228e4;
+                case PowerDensityUnit.WattPerCubicMeter: return _value;
+                case PowerDensityUnit.WattPerLiter: return _value*1.0e3;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitWattsPerCubicMeter();
+        private double AsBaseNumericType(PowerDensityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case PowerDensityUnit.DecawattPerCubicFoot: return (baseUnitValue/3.531466672148859e1) / 1e1d;
                 case PowerDensityUnit.DecawattPerCubicInch: return (baseUnitValue/6.102374409473228e4) / 1e1d;
@@ -1904,9 +1969,8 @@ namespace UnitsNet
                 case PowerDensityUnit.WattPerCubicInch: return baseUnitValue/6.102374409473228e4;
                 case PowerDensityUnit.WattPerCubicMeter: return baseUnitValue;
                 case PowerDensityUnit.WattPerLiter: return baseUnitValue/1.0e3;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -2255,69 +2319,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of PowerDensity
         /// </summary>
         public static PowerDensity MinValue => new PowerDensity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitWattsPerCubicMeter()
-        {
-            if (Unit == PowerDensityUnit.WattPerCubicMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case PowerDensityUnit.DecawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e1d;
-                case PowerDensityUnit.DecawattPerCubicInch: return (_value*6.102374409473228e4) * 1e1d;
-                case PowerDensityUnit.DecawattPerCubicMeter: return (_value) * 1e1d;
-                case PowerDensityUnit.DecawattPerLiter: return (_value*1.0e3) * 1e1d;
-                case PowerDensityUnit.DeciwattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-1d;
-                case PowerDensityUnit.DeciwattPerCubicInch: return (_value*6.102374409473228e4) * 1e-1d;
-                case PowerDensityUnit.DeciwattPerCubicMeter: return (_value) * 1e-1d;
-                case PowerDensityUnit.DeciwattPerLiter: return (_value*1.0e3) * 1e-1d;
-                case PowerDensityUnit.GigawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e9d;
-                case PowerDensityUnit.GigawattPerCubicInch: return (_value*6.102374409473228e4) * 1e9d;
-                case PowerDensityUnit.GigawattPerCubicMeter: return (_value) * 1e9d;
-                case PowerDensityUnit.GigawattPerLiter: return (_value*1.0e3) * 1e9d;
-                case PowerDensityUnit.KilowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e3d;
-                case PowerDensityUnit.KilowattPerCubicInch: return (_value*6.102374409473228e4) * 1e3d;
-                case PowerDensityUnit.KilowattPerCubicMeter: return (_value) * 1e3d;
-                case PowerDensityUnit.KilowattPerLiter: return (_value*1.0e3) * 1e3d;
-                case PowerDensityUnit.MegawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e6d;
-                case PowerDensityUnit.MegawattPerCubicInch: return (_value*6.102374409473228e4) * 1e6d;
-                case PowerDensityUnit.MegawattPerCubicMeter: return (_value) * 1e6d;
-                case PowerDensityUnit.MegawattPerLiter: return (_value*1.0e3) * 1e6d;
-                case PowerDensityUnit.MicrowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-6d;
-                case PowerDensityUnit.MicrowattPerCubicInch: return (_value*6.102374409473228e4) * 1e-6d;
-                case PowerDensityUnit.MicrowattPerCubicMeter: return (_value) * 1e-6d;
-                case PowerDensityUnit.MicrowattPerLiter: return (_value*1.0e3) * 1e-6d;
-                case PowerDensityUnit.MilliwattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-3d;
-                case PowerDensityUnit.MilliwattPerCubicInch: return (_value*6.102374409473228e4) * 1e-3d;
-                case PowerDensityUnit.MilliwattPerCubicMeter: return (_value) * 1e-3d;
-                case PowerDensityUnit.MilliwattPerLiter: return (_value*1.0e3) * 1e-3d;
-                case PowerDensityUnit.NanowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-9d;
-                case PowerDensityUnit.NanowattPerCubicInch: return (_value*6.102374409473228e4) * 1e-9d;
-                case PowerDensityUnit.NanowattPerCubicMeter: return (_value) * 1e-9d;
-                case PowerDensityUnit.NanowattPerLiter: return (_value*1.0e3) * 1e-9d;
-                case PowerDensityUnit.PicowattPerCubicFoot: return (_value*3.531466672148859e1) * 1e-12d;
-                case PowerDensityUnit.PicowattPerCubicInch: return (_value*6.102374409473228e4) * 1e-12d;
-                case PowerDensityUnit.PicowattPerCubicMeter: return (_value) * 1e-12d;
-                case PowerDensityUnit.PicowattPerLiter: return (_value*1.0e3) * 1e-12d;
-                case PowerDensityUnit.TerawattPerCubicFoot: return (_value*3.531466672148859e1) * 1e12d;
-                case PowerDensityUnit.TerawattPerCubicInch: return (_value*6.102374409473228e4) * 1e12d;
-                case PowerDensityUnit.TerawattPerCubicMeter: return (_value) * 1e12d;
-                case PowerDensityUnit.TerawattPerLiter: return (_value*1.0e3) * 1e12d;
-                case PowerDensityUnit.WattPerCubicFoot: return _value*3.531466672148859e1;
-                case PowerDensityUnit.WattPerCubicInch: return _value*6.102374409473228e4;
-                case PowerDensityUnit.WattPerCubicMeter: return _value;
-                case PowerDensityUnit.WattPerLiter: return _value*1.0e3;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(PowerDensityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          PowerRatio(double numericValue, PowerRatioUnit unit)
+        PowerRatio(double numericValue, PowerRatioUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -384,7 +384,7 @@ namespace UnitsNet
 #endif
         int CompareTo(PowerRatio other)
         {
-            return AsBaseUnitDecibelWatts().CompareTo(other.AsBaseUnitDecibelWatts());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -432,7 +432,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDecibelWatts().Equals(((PowerRatio) obj).AsBaseUnitDecibelWatts());
+            return AsBaseUnit().Equals(((PowerRatio) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(PowerRatio other, PowerRatio maxError)
         {
-            return Math.Abs(AsBaseUnitDecibelWatts() - other.AsBaseUnitDecibelWatts()) <= maxError.AsBaseUnitDecibelWatts();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -463,20 +463,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PowerRatioUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case PowerRatioUnit.DecibelMilliwatt: return _value - 30;
+                case PowerRatioUnit.DecibelWatt: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDecibelWatts();
+        private double AsBaseNumericType(PowerRatioUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case PowerRatioUnit.DecibelMilliwatt: return baseUnitValue + 30;
                 case PowerRatioUnit.DecibelWatt: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -825,27 +847,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of PowerRatio
         /// </summary>
         public static PowerRatio MinValue => new PowerRatio(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDecibelWatts()
-        {
-            if (Unit == PowerRatioUnit.DecibelWatt) { return _value; }
-
-            switch (Unit)
-            {
-                case PowerRatioUnit.DecibelMilliwatt: return _value - 30;
-                case PowerRatioUnit.DecibelWatt: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(PowerRatioUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Pressure(double numericValue, PressureUnit unit)
+        Pressure(double numericValue, PressureUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1575,7 +1575,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Pressure other)
         {
-            return AsBaseUnitPascals().CompareTo(other.AsBaseUnitPascals());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1623,7 +1623,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitPascals().Equals(((Pressure) obj).AsBaseUnitPascals());
+            return AsBaseUnit().Equals(((Pressure) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1636,7 +1636,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Pressure other, Pressure maxError)
         {
-            return Math.Abs(AsBaseUnitPascals() - other.AsBaseUnitPascals()) <= maxError.AsBaseUnitPascals();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1654,14 +1654,73 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PressureUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case PressureUnit.Atmosphere: return _value*1.01325*1e5;
+                case PressureUnit.Bar: return _value*1e5;
+                case PressureUnit.Centibar: return (_value*1e5) * 1e-2d;
+                case PressureUnit.Decapascal: return (_value) * 1e1d;
+                case PressureUnit.Decibar: return (_value*1e5) * 1e-1d;
+                case PressureUnit.FootOfHead: return _value*2989.0669;
+                case PressureUnit.Gigapascal: return (_value) * 1e9d;
+                case PressureUnit.Hectopascal: return (_value) * 1e2d;
+                case PressureUnit.InchOfMercury: return _value/2.95299830714159e-4;
+                case PressureUnit.Kilobar: return (_value*1e5) * 1e3d;
+                case PressureUnit.KilogramForcePerSquareCentimeter: return _value*9.80665*1e4;
+                case PressureUnit.KilogramForcePerSquareMeter: return _value*9.80665019960652;
+                case PressureUnit.KilogramForcePerSquareMillimeter: return _value*9806650.19960652;
+                case PressureUnit.KilonewtonPerSquareCentimeter: return (_value*1e4) * 1e3d;
+                case PressureUnit.KilonewtonPerSquareMeter: return (_value) * 1e3d;
+                case PressureUnit.KilonewtonPerSquareMillimeter: return (_value*1e6) * 1e3d;
+                case PressureUnit.Kilopascal: return (_value) * 1e3d;
+                case PressureUnit.KilopoundForcePerSquareFoot: return (_value*47.8802631216372) * 1e3d;
+                case PressureUnit.KilopoundForcePerSquareInch: return (_value*6894.75729316836) * 1e3d;
+                case PressureUnit.Megabar: return (_value*1e5) * 1e6d;
+                case PressureUnit.MeganewtonPerSquareMeter: return (_value) * 1e6d;
+                case PressureUnit.Megapascal: return (_value) * 1e6d;
+                case PressureUnit.MeterOfHead: return _value*9804.139432;
+                case PressureUnit.Micropascal: return (_value) * 1e-6d;
+                case PressureUnit.Millibar: return (_value*1e5) * 1e-3d;
+                case PressureUnit.MillimeterOfMercury: return _value/7.50061561302643e-3;
+                case PressureUnit.NewtonPerSquareCentimeter: return _value*1e4;
+                case PressureUnit.NewtonPerSquareMeter: return _value;
+                case PressureUnit.NewtonPerSquareMillimeter: return _value*1e6;
+                case PressureUnit.Pascal: return _value;
+                case PressureUnit.PoundForcePerSquareFoot: return _value*47.8802631216372;
+                case PressureUnit.PoundForcePerSquareInch: return _value*6894.75729316836;
+                case PressureUnit.Psi: return _value*6.89464975179*1e3;
+                case PressureUnit.TechnicalAtmosphere: return _value*9.80680592331*1e4;
+                case PressureUnit.TonneForcePerSquareCentimeter: return _value*98066501.9960652;
+                case PressureUnit.TonneForcePerSquareMeter: return _value*9806.65019960653;
+                case PressureUnit.TonneForcePerSquareMillimeter: return _value*9806650199.60653;
+                case PressureUnit.Torr: return _value*1.3332266752*1e2;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitPascals();
+        private double AsBaseNumericType(PressureUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case PressureUnit.Atmosphere: return baseUnitValue/(1.01325*1e5);
                 case PressureUnit.Bar: return baseUnitValue/1e5;
@@ -1701,9 +1760,8 @@ namespace UnitsNet
                 case PressureUnit.TonneForcePerSquareMeter: return baseUnitValue*0.000101971619222242;
                 case PressureUnit.TonneForcePerSquareMillimeter: return baseUnitValue*1.01971619222242E-10;
                 case PressureUnit.Torr: return baseUnitValue/(1.3332266752*1e2);
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -2052,63 +2110,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Pressure
         /// </summary>
         public static Pressure MinValue => new Pressure(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitPascals()
-        {
-            if (Unit == PressureUnit.Pascal) { return _value; }
-
-            switch (Unit)
-            {
-                case PressureUnit.Atmosphere: return _value*1.01325*1e5;
-                case PressureUnit.Bar: return _value*1e5;
-                case PressureUnit.Centibar: return (_value*1e5) * 1e-2d;
-                case PressureUnit.Decapascal: return (_value) * 1e1d;
-                case PressureUnit.Decibar: return (_value*1e5) * 1e-1d;
-                case PressureUnit.FootOfHead: return _value*2989.0669;
-                case PressureUnit.Gigapascal: return (_value) * 1e9d;
-                case PressureUnit.Hectopascal: return (_value) * 1e2d;
-                case PressureUnit.InchOfMercury: return _value/2.95299830714159e-4;
-                case PressureUnit.Kilobar: return (_value*1e5) * 1e3d;
-                case PressureUnit.KilogramForcePerSquareCentimeter: return _value*9.80665*1e4;
-                case PressureUnit.KilogramForcePerSquareMeter: return _value*9.80665019960652;
-                case PressureUnit.KilogramForcePerSquareMillimeter: return _value*9806650.19960652;
-                case PressureUnit.KilonewtonPerSquareCentimeter: return (_value*1e4) * 1e3d;
-                case PressureUnit.KilonewtonPerSquareMeter: return (_value) * 1e3d;
-                case PressureUnit.KilonewtonPerSquareMillimeter: return (_value*1e6) * 1e3d;
-                case PressureUnit.Kilopascal: return (_value) * 1e3d;
-                case PressureUnit.KilopoundForcePerSquareFoot: return (_value*47.8802631216372) * 1e3d;
-                case PressureUnit.KilopoundForcePerSquareInch: return (_value*6894.75729316836) * 1e3d;
-                case PressureUnit.Megabar: return (_value*1e5) * 1e6d;
-                case PressureUnit.MeganewtonPerSquareMeter: return (_value) * 1e6d;
-                case PressureUnit.Megapascal: return (_value) * 1e6d;
-                case PressureUnit.MeterOfHead: return _value*9804.139432;
-                case PressureUnit.Micropascal: return (_value) * 1e-6d;
-                case PressureUnit.Millibar: return (_value*1e5) * 1e-3d;
-                case PressureUnit.MillimeterOfMercury: return _value/7.50061561302643e-3;
-                case PressureUnit.NewtonPerSquareCentimeter: return _value*1e4;
-                case PressureUnit.NewtonPerSquareMeter: return _value;
-                case PressureUnit.NewtonPerSquareMillimeter: return _value*1e6;
-                case PressureUnit.Pascal: return _value;
-                case PressureUnit.PoundForcePerSquareFoot: return _value*47.8802631216372;
-                case PressureUnit.PoundForcePerSquareInch: return _value*6894.75729316836;
-                case PressureUnit.Psi: return _value*6.89464975179*1e3;
-                case PressureUnit.TechnicalAtmosphere: return _value*9.80680592331*1e4;
-                case PressureUnit.TonneForcePerSquareCentimeter: return _value*98066501.9960652;
-                case PressureUnit.TonneForcePerSquareMeter: return _value*9806.65019960653;
-                case PressureUnit.TonneForcePerSquareMillimeter: return _value*9806650199.60653;
-                case PressureUnit.Torr: return _value*1.3332266752*1e2;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(PressureUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          PressureChangeRate(double numericValue, PressureChangeRateUnit unit)
+        PressureChangeRate(double numericValue, PressureChangeRateUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(PressureChangeRate other)
         {
-            return AsBaseUnitPascalsPerSecond().CompareTo(other.AsBaseUnitPascalsPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitPascalsPerSecond().Equals(((PressureChangeRate) obj).AsBaseUnitPascalsPerSecond());
+            return AsBaseUnit().Equals(((PressureChangeRate) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(PressureChangeRate other, PressureChangeRate maxError)
         {
-            return Math.Abs(AsBaseUnitPascalsPerSecond() - other.AsBaseUnitPascalsPerSecond()) <= maxError.AsBaseUnitPascalsPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(PressureChangeRateUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case PressureChangeRateUnit.AtmospherePerSecond: return _value * 1.01325*1e5;
+                case PressureChangeRateUnit.KilopascalPerSecond: return (_value) * 1e3d;
+                case PressureChangeRateUnit.MegapascalPerSecond: return (_value) * 1e6d;
+                case PressureChangeRateUnit.PascalPerSecond: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitPascalsPerSecond();
+        private double AsBaseNumericType(PressureChangeRateUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case PressureChangeRateUnit.AtmospherePerSecond: return baseUnitValue / (1.01325*1e5);
                 case PressureChangeRateUnit.KilopascalPerSecond: return (baseUnitValue) / 1e3d;
                 case PressureChangeRateUnit.MegapascalPerSecond: return (baseUnitValue) / 1e6d;
                 case PressureChangeRateUnit.PascalPerSecond: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of PressureChangeRate
         /// </summary>
         public static PressureChangeRate MinValue => new PressureChangeRate(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitPascalsPerSecond()
-        {
-            if (Unit == PressureChangeRateUnit.PascalPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case PressureChangeRateUnit.AtmospherePerSecond: return _value * 1.01325*1e5;
-                case PressureChangeRateUnit.KilopascalPerSecond: return (_value) * 1e3d;
-                case PressureChangeRateUnit.MegapascalPerSecond: return (_value) * 1e6d;
-                case PressureChangeRateUnit.PascalPerSecond: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(PressureChangeRateUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Ratio(double numericValue, RatioUnit unit)
+        Ratio(double numericValue, RatioUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -508,7 +508,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Ratio other)
         {
-            return AsBaseUnitDecimalFractions().CompareTo(other.AsBaseUnitDecimalFractions());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -556,7 +556,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDecimalFractions().Equals(((Ratio) obj).AsBaseUnitDecimalFractions());
+            return AsBaseUnit().Equals(((Ratio) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -569,7 +569,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Ratio other, Ratio maxError)
         {
-            return Math.Abs(AsBaseUnitDecimalFractions() - other.AsBaseUnitDecimalFractions()) <= maxError.AsBaseUnitDecimalFractions();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -587,14 +587,41 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(RatioUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case RatioUnit.DecimalFraction: return _value;
+                case RatioUnit.PartPerBillion: return _value/1e9;
+                case RatioUnit.PartPerMillion: return _value/1e6;
+                case RatioUnit.PartPerThousand: return _value/1e3;
+                case RatioUnit.PartPerTrillion: return _value/1e12;
+                case RatioUnit.Percent: return _value/1e2;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDecimalFractions();
+        private double AsBaseNumericType(RatioUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case RatioUnit.DecimalFraction: return baseUnitValue;
                 case RatioUnit.PartPerBillion: return baseUnitValue*1e9;
@@ -602,9 +629,8 @@ namespace UnitsNet
                 case RatioUnit.PartPerThousand: return baseUnitValue*1e3;
                 case RatioUnit.PartPerTrillion: return baseUnitValue*1e12;
                 case RatioUnit.Percent: return baseUnitValue*1e2;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -953,31 +979,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Ratio
         /// </summary>
         public static Ratio MinValue => new Ratio(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDecimalFractions()
-        {
-            if (Unit == RatioUnit.DecimalFraction) { return _value; }
-
-            switch (Unit)
-            {
-                case RatioUnit.DecimalFraction: return _value;
-                case RatioUnit.PartPerBillion: return _value/1e9;
-                case RatioUnit.PartPerMillion: return _value/1e6;
-                case RatioUnit.PartPerThousand: return _value/1e3;
-                case RatioUnit.PartPerTrillion: return _value/1e12;
-                case RatioUnit.Percent: return _value/1e2;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(RatioUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ReactiveEnergy(double numericValue, ReactiveEnergyUnit unit)
+        ReactiveEnergy(double numericValue, ReactiveEnergyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ReactiveEnergy other)
         {
-            return AsBaseUnitVoltampereReactiveHours().CompareTo(other.AsBaseUnitVoltampereReactiveHours());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltampereReactiveHours().Equals(((ReactiveEnergy) obj).AsBaseUnitVoltampereReactiveHours());
+            return AsBaseUnit().Equals(((ReactiveEnergy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ReactiveEnergy other, ReactiveEnergy maxError)
         {
-            return Math.Abs(AsBaseUnitVoltampereReactiveHours() - other.AsBaseUnitVoltampereReactiveHours()) <= maxError.AsBaseUnitVoltampereReactiveHours();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ReactiveEnergyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ReactiveEnergyUnit.KilovoltampereReactiveHour: return (_value) * 1e3d;
+                case ReactiveEnergyUnit.MegavoltampereReactiveHour: return (_value) * 1e6d;
+                case ReactiveEnergyUnit.VoltampereReactiveHour: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltampereReactiveHours();
+        private double AsBaseNumericType(ReactiveEnergyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ReactiveEnergyUnit.KilovoltampereReactiveHour: return (baseUnitValue) / 1e3d;
                 case ReactiveEnergyUnit.MegavoltampereReactiveHour: return (baseUnitValue) / 1e6d;
                 case ReactiveEnergyUnit.VoltampereReactiveHour: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ReactiveEnergy
         /// </summary>
         public static ReactiveEnergy MinValue => new ReactiveEnergy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltampereReactiveHours()
-        {
-            if (Unit == ReactiveEnergyUnit.VoltampereReactiveHour) { return _value; }
-
-            switch (Unit)
-            {
-                case ReactiveEnergyUnit.KilovoltampereReactiveHour: return (_value) * 1e3d;
-                case ReactiveEnergyUnit.MegavoltampereReactiveHour: return (_value) * 1e6d;
-                case ReactiveEnergyUnit.VoltampereReactiveHour: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ReactiveEnergyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ReactivePower(double numericValue, ReactivePowerUnit unit)
+        ReactivePower(double numericValue, ReactivePowerUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -452,7 +452,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ReactivePower other)
         {
-            return AsBaseUnitVoltamperesReactive().CompareTo(other.AsBaseUnitVoltamperesReactive());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -500,7 +500,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitVoltamperesReactive().Equals(((ReactivePower) obj).AsBaseUnitVoltamperesReactive());
+            return AsBaseUnit().Equals(((ReactivePower) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ReactivePower other, ReactivePower maxError)
         {
-            return Math.Abs(AsBaseUnitVoltamperesReactive() - other.AsBaseUnitVoltamperesReactive()) <= maxError.AsBaseUnitVoltamperesReactive();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -531,22 +531,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ReactivePowerUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ReactivePowerUnit.GigavoltampereReactive: return (_value) * 1e9d;
+                case ReactivePowerUnit.KilovoltampereReactive: return (_value) * 1e3d;
+                case ReactivePowerUnit.MegavoltampereReactive: return (_value) * 1e6d;
+                case ReactivePowerUnit.VoltampereReactive: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitVoltamperesReactive();
+        private double AsBaseNumericType(ReactivePowerUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ReactivePowerUnit.GigavoltampereReactive: return (baseUnitValue) / 1e9d;
                 case ReactivePowerUnit.KilovoltampereReactive: return (baseUnitValue) / 1e3d;
                 case ReactivePowerUnit.MegavoltampereReactive: return (baseUnitValue) / 1e6d;
                 case ReactivePowerUnit.VoltampereReactive: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -895,29 +919,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ReactivePower
         /// </summary>
         public static ReactivePower MinValue => new ReactivePower(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitVoltamperesReactive()
-        {
-            if (Unit == ReactivePowerUnit.VoltampereReactive) { return _value; }
-
-            switch (Unit)
-            {
-                case ReactivePowerUnit.GigavoltampereReactive: return (_value) * 1e9d;
-                case ReactivePowerUnit.KilovoltampereReactive: return (_value) * 1e3d;
-                case ReactivePowerUnit.MegavoltampereReactive: return (_value) * 1e6d;
-                case ReactivePowerUnit.VoltampereReactive: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ReactivePowerUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          RotationalAcceleration(double numericValue, RotationalAccelerationUnit unit)
+        RotationalAcceleration(double numericValue, RotationalAccelerationUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalAcceleration other)
         {
-            return AsBaseUnitRadiansPerSecondSquared().CompareTo(other.AsBaseUnitRadiansPerSecondSquared());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitRadiansPerSecondSquared().Equals(((RotationalAcceleration) obj).AsBaseUnitRadiansPerSecondSquared());
+            return AsBaseUnit().Equals(((RotationalAcceleration) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(RotationalAcceleration other, RotationalAcceleration maxError)
         {
-            return Math.Abs(AsBaseUnitRadiansPerSecondSquared() - other.AsBaseUnitRadiansPerSecondSquared()) <= maxError.AsBaseUnitRadiansPerSecondSquared();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(RotationalAccelerationUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case RotationalAccelerationUnit.DegreePerSecondSquared: return (Math.PI/180)*_value;
+                case RotationalAccelerationUnit.RadianPerSecondSquared: return _value;
+                case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return ((2*Math.PI)/60)*_value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitRadiansPerSecondSquared();
+        private double AsBaseNumericType(RotationalAccelerationUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (180/Math.PI)*baseUnitValue;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return baseUnitValue;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return (60/(2*Math.PI))*baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of RotationalAcceleration
         /// </summary>
         public static RotationalAcceleration MinValue => new RotationalAcceleration(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitRadiansPerSecondSquared()
-        {
-            if (Unit == RotationalAccelerationUnit.RadianPerSecondSquared) { return _value; }
-
-            switch (Unit)
-            {
-                case RotationalAccelerationUnit.DegreePerSecondSquared: return (Math.PI/180)*_value;
-                case RotationalAccelerationUnit.RadianPerSecondSquared: return _value;
-                case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return ((2*Math.PI)/60)*_value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(RotationalAccelerationUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          RotationalSpeed(double numericValue, RotationalSpeedUnit unit)
+        RotationalSpeed(double numericValue, RotationalSpeedUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -749,7 +749,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalSpeed other)
         {
-            return AsBaseUnitRadiansPerSecond().CompareTo(other.AsBaseUnitRadiansPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -797,7 +797,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitRadiansPerSecond().Equals(((RotationalSpeed) obj).AsBaseUnitRadiansPerSecond());
+            return AsBaseUnit().Equals(((RotationalSpeed) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -810,7 +810,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(RotationalSpeed other, RotationalSpeed maxError)
         {
-            return Math.Abs(AsBaseUnitRadiansPerSecond() - other.AsBaseUnitRadiansPerSecond()) <= maxError.AsBaseUnitRadiansPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -828,14 +828,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(RotationalSpeedUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case RotationalSpeedUnit.CentiradianPerSecond: return (_value) * 1e-2d;
+                case RotationalSpeedUnit.DeciradianPerSecond: return (_value) * 1e-1d;
+                case RotationalSpeedUnit.DegreePerMinute: return (Math.PI/(180*60))*_value;
+                case RotationalSpeedUnit.DegreePerSecond: return (Math.PI/180)*_value;
+                case RotationalSpeedUnit.MicrodegreePerSecond: return ((Math.PI/180)*_value) * 1e-6d;
+                case RotationalSpeedUnit.MicroradianPerSecond: return (_value) * 1e-6d;
+                case RotationalSpeedUnit.MillidegreePerSecond: return ((Math.PI/180)*_value) * 1e-3d;
+                case RotationalSpeedUnit.MilliradianPerSecond: return (_value) * 1e-3d;
+                case RotationalSpeedUnit.NanodegreePerSecond: return ((Math.PI/180)*_value) * 1e-9d;
+                case RotationalSpeedUnit.NanoradianPerSecond: return (_value) * 1e-9d;
+                case RotationalSpeedUnit.RadianPerSecond: return _value;
+                case RotationalSpeedUnit.RevolutionPerMinute: return (_value*6.2831853072)/60;
+                case RotationalSpeedUnit.RevolutionPerSecond: return _value*6.2831853072;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitRadiansPerSecond();
+        private double AsBaseNumericType(RotationalSpeedUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case RotationalSpeedUnit.CentiradianPerSecond: return (baseUnitValue) / 1e-2d;
                 case RotationalSpeedUnit.DeciradianPerSecond: return (baseUnitValue) / 1e-1d;
@@ -850,9 +884,8 @@ namespace UnitsNet
                 case RotationalSpeedUnit.RadianPerSecond: return baseUnitValue;
                 case RotationalSpeedUnit.RevolutionPerMinute: return (baseUnitValue/6.2831853072)*60;
                 case RotationalSpeedUnit.RevolutionPerSecond: return baseUnitValue/6.2831853072;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1201,38 +1234,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of RotationalSpeed
         /// </summary>
         public static RotationalSpeed MinValue => new RotationalSpeed(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitRadiansPerSecond()
-        {
-            if (Unit == RotationalSpeedUnit.RadianPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case RotationalSpeedUnit.CentiradianPerSecond: return (_value) * 1e-2d;
-                case RotationalSpeedUnit.DeciradianPerSecond: return (_value) * 1e-1d;
-                case RotationalSpeedUnit.DegreePerMinute: return (Math.PI/(180*60))*_value;
-                case RotationalSpeedUnit.DegreePerSecond: return (Math.PI/180)*_value;
-                case RotationalSpeedUnit.MicrodegreePerSecond: return ((Math.PI/180)*_value) * 1e-6d;
-                case RotationalSpeedUnit.MicroradianPerSecond: return (_value) * 1e-6d;
-                case RotationalSpeedUnit.MillidegreePerSecond: return ((Math.PI/180)*_value) * 1e-3d;
-                case RotationalSpeedUnit.MilliradianPerSecond: return (_value) * 1e-3d;
-                case RotationalSpeedUnit.NanodegreePerSecond: return ((Math.PI/180)*_value) * 1e-9d;
-                case RotationalSpeedUnit.NanoradianPerSecond: return (_value) * 1e-9d;
-                case RotationalSpeedUnit.RadianPerSecond: return _value;
-                case RotationalSpeedUnit.RevolutionPerMinute: return (_value*6.2831853072)/60;
-                case RotationalSpeedUnit.RevolutionPerSecond: return _value*6.2831853072;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(RotationalSpeedUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          RotationalStiffness(double numericValue, RotationalStiffnessUnit unit)
+        RotationalStiffness(double numericValue, RotationalStiffnessUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalStiffness other)
         {
-            return AsBaseUnitNewtonMetersPerRadian().CompareTo(other.AsBaseUnitNewtonMetersPerRadian());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonMetersPerRadian().Equals(((RotationalStiffness) obj).AsBaseUnitNewtonMetersPerRadian());
+            return AsBaseUnit().Equals(((RotationalStiffness) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(RotationalStiffness other, RotationalStiffness maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonMetersPerRadian() - other.AsBaseUnitNewtonMetersPerRadian()) <= maxError.AsBaseUnitNewtonMetersPerRadian();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(RotationalStiffnessUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case RotationalStiffnessUnit.KilonewtonMeterPerRadian: return (_value) * 1e3d;
+                case RotationalStiffnessUnit.MeganewtonMeterPerRadian: return (_value) * 1e6d;
+                case RotationalStiffnessUnit.NewtonMeterPerRadian: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonMetersPerRadian();
+        private double AsBaseNumericType(RotationalStiffnessUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case RotationalStiffnessUnit.KilonewtonMeterPerRadian: return (baseUnitValue) / 1e3d;
                 case RotationalStiffnessUnit.MeganewtonMeterPerRadian: return (baseUnitValue) / 1e6d;
                 case RotationalStiffnessUnit.NewtonMeterPerRadian: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of RotationalStiffness
         /// </summary>
         public static RotationalStiffness MinValue => new RotationalStiffness(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonMetersPerRadian()
-        {
-            if (Unit == RotationalStiffnessUnit.NewtonMeterPerRadian) { return _value; }
-
-            switch (Unit)
-            {
-                case RotationalStiffnessUnit.KilonewtonMeterPerRadian: return (_value) * 1e3d;
-                case RotationalStiffnessUnit.MeganewtonMeterPerRadian: return (_value) * 1e6d;
-                case RotationalStiffnessUnit.NewtonMeterPerRadian: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(RotationalStiffnessUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          RotationalStiffnessPerLength(double numericValue, RotationalStiffnessPerLengthUnit unit)
+        RotationalStiffnessPerLength(double numericValue, RotationalStiffnessPerLengthUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -419,7 +419,7 @@ namespace UnitsNet
 #endif
         int CompareTo(RotationalStiffnessPerLength other)
         {
-            return AsBaseUnitNewtonMetersPerRadianPerMeter().CompareTo(other.AsBaseUnitNewtonMetersPerRadianPerMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -467,7 +467,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonMetersPerRadianPerMeter().Equals(((RotationalStiffnessPerLength) obj).AsBaseUnitNewtonMetersPerRadianPerMeter());
+            return AsBaseUnit().Equals(((RotationalStiffnessPerLength) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(RotationalStiffnessPerLength other, RotationalStiffnessPerLength maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonMetersPerRadianPerMeter() - other.AsBaseUnitNewtonMetersPerRadianPerMeter()) <= maxError.AsBaseUnitNewtonMetersPerRadianPerMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -498,21 +498,44 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(RotationalStiffnessPerLengthUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case RotationalStiffnessPerLengthUnit.KilonewtonMeterPerRadianPerMeter: return (_value) * 1e3d;
+                case RotationalStiffnessPerLengthUnit.MeganewtonMeterPerRadianPerMeter: return (_value) * 1e6d;
+                case RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonMetersPerRadianPerMeter();
+        private double AsBaseNumericType(RotationalStiffnessPerLengthUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case RotationalStiffnessPerLengthUnit.KilonewtonMeterPerRadianPerMeter: return (baseUnitValue) / 1e3d;
                 case RotationalStiffnessPerLengthUnit.MeganewtonMeterPerRadianPerMeter: return (baseUnitValue) / 1e6d;
                 case RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -861,28 +884,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of RotationalStiffnessPerLength
         /// </summary>
         public static RotationalStiffnessPerLength MinValue => new RotationalStiffnessPerLength(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonMetersPerRadianPerMeter()
-        {
-            if (Unit == RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case RotationalStiffnessPerLengthUnit.KilonewtonMeterPerRadianPerMeter: return (_value) * 1e3d;
-                case RotationalStiffnessPerLengthUnit.MeganewtonMeterPerRadianPerMeter: return (_value) * 1e6d;
-                case RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(RotationalStiffnessPerLengthUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          SolidAngle(double numericValue, SolidAngleUnit unit)
+        SolidAngle(double numericValue, SolidAngleUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -343,7 +343,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SolidAngle other)
         {
-            return AsBaseUnitSteradians().CompareTo(other.AsBaseUnitSteradians());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -391,7 +391,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSteradians().Equals(((SolidAngle) obj).AsBaseUnitSteradians());
+            return AsBaseUnit().Equals(((SolidAngle) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(SolidAngle other, SolidAngle maxError)
         {
-            return Math.Abs(AsBaseUnitSteradians() - other.AsBaseUnitSteradians()) <= maxError.AsBaseUnitSteradians();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -422,19 +422,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(SolidAngleUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case SolidAngleUnit.Steradian: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSteradians();
+        private double AsBaseNumericType(SolidAngleUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case SolidAngleUnit.Steradian: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -783,26 +804,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of SolidAngle
         /// </summary>
         public static SolidAngle MinValue => new SolidAngle(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSteradians()
-        {
-            if (Unit == SolidAngleUnit.Steradian) { return _value; }
-
-            switch (Unit)
-            {
-                case SolidAngleUnit.Steradian: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(SolidAngleUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          SpecificEnergy(double numericValue, SpecificEnergyUnit unit)
+        SpecificEnergy(double numericValue, SpecificEnergyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -584,7 +584,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificEnergy other)
         {
-            return AsBaseUnitJoulesPerKilogram().CompareTo(other.AsBaseUnitJoulesPerKilogram());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -632,7 +632,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoulesPerKilogram().Equals(((SpecificEnergy) obj).AsBaseUnitJoulesPerKilogram());
+            return AsBaseUnit().Equals(((SpecificEnergy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(SpecificEnergy other, SpecificEnergy maxError)
         {
-            return Math.Abs(AsBaseUnitJoulesPerKilogram() - other.AsBaseUnitJoulesPerKilogram()) <= maxError.AsBaseUnitJoulesPerKilogram();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -663,14 +663,43 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(SpecificEnergyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case SpecificEnergyUnit.CaloriePerGram: return _value*4.184e3;
+                case SpecificEnergyUnit.JoulePerKilogram: return _value;
+                case SpecificEnergyUnit.KilocaloriePerGram: return (_value*4.184e3) * 1e3d;
+                case SpecificEnergyUnit.KilojoulePerKilogram: return (_value) * 1e3d;
+                case SpecificEnergyUnit.KilowattHourPerKilogram: return (_value*3.6e3) * 1e3d;
+                case SpecificEnergyUnit.MegajoulePerKilogram: return (_value) * 1e6d;
+                case SpecificEnergyUnit.MegawattHourPerKilogram: return (_value*3.6e3) * 1e6d;
+                case SpecificEnergyUnit.WattHourPerKilogram: return _value*3.6e3;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoulesPerKilogram();
+        private double AsBaseNumericType(SpecificEnergyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case SpecificEnergyUnit.CaloriePerGram: return baseUnitValue/4.184e3;
                 case SpecificEnergyUnit.JoulePerKilogram: return baseUnitValue;
@@ -680,9 +709,8 @@ namespace UnitsNet
                 case SpecificEnergyUnit.MegajoulePerKilogram: return (baseUnitValue) / 1e6d;
                 case SpecificEnergyUnit.MegawattHourPerKilogram: return (baseUnitValue/3.6e3) / 1e6d;
                 case SpecificEnergyUnit.WattHourPerKilogram: return baseUnitValue/3.6e3;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1031,33 +1059,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of SpecificEnergy
         /// </summary>
         public static SpecificEnergy MinValue => new SpecificEnergy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoulesPerKilogram()
-        {
-            if (Unit == SpecificEnergyUnit.JoulePerKilogram) { return _value; }
-
-            switch (Unit)
-            {
-                case SpecificEnergyUnit.CaloriePerGram: return _value*4.184e3;
-                case SpecificEnergyUnit.JoulePerKilogram: return _value;
-                case SpecificEnergyUnit.KilocaloriePerGram: return (_value*4.184e3) * 1e3d;
-                case SpecificEnergyUnit.KilojoulePerKilogram: return (_value) * 1e3d;
-                case SpecificEnergyUnit.KilowattHourPerKilogram: return (_value*3.6e3) * 1e3d;
-                case SpecificEnergyUnit.MegajoulePerKilogram: return (_value) * 1e6d;
-                case SpecificEnergyUnit.MegawattHourPerKilogram: return (_value*3.6e3) * 1e6d;
-                case SpecificEnergyUnit.WattHourPerKilogram: return _value*3.6e3;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(SpecificEnergyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          SpecificEntropy(double numericValue, SpecificEntropyUnit unit)
+        SpecificEntropy(double numericValue, SpecificEntropyUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -584,7 +584,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificEntropy other)
         {
-            return AsBaseUnitJoulesPerKilogramKelvin().CompareTo(other.AsBaseUnitJoulesPerKilogramKelvin());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -632,7 +632,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitJoulesPerKilogramKelvin().Equals(((SpecificEntropy) obj).AsBaseUnitJoulesPerKilogramKelvin());
+            return AsBaseUnit().Equals(((SpecificEntropy) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(SpecificEntropy other, SpecificEntropy maxError)
         {
-            return Math.Abs(AsBaseUnitJoulesPerKilogramKelvin() - other.AsBaseUnitJoulesPerKilogramKelvin()) <= maxError.AsBaseUnitJoulesPerKilogramKelvin();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -663,14 +663,43 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(SpecificEntropyUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case SpecificEntropyUnit.CaloriePerGramKelvin: return _value*4.184e3;
+                case SpecificEntropyUnit.JoulePerKilogramDegreeCelsius: return _value;
+                case SpecificEntropyUnit.JoulePerKilogramKelvin: return _value;
+                case SpecificEntropyUnit.KilocaloriePerGramKelvin: return (_value*4.184e3) * 1e3d;
+                case SpecificEntropyUnit.KilojoulePerKilogramDegreeCelsius: return (_value) * 1e3d;
+                case SpecificEntropyUnit.KilojoulePerKilogramKelvin: return (_value) * 1e3d;
+                case SpecificEntropyUnit.MegajoulePerKilogramDegreeCelsius: return (_value) * 1e6d;
+                case SpecificEntropyUnit.MegajoulePerKilogramKelvin: return (_value) * 1e6d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitJoulesPerKilogramKelvin();
+        private double AsBaseNumericType(SpecificEntropyUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case SpecificEntropyUnit.CaloriePerGramKelvin: return baseUnitValue/4.184e3;
                 case SpecificEntropyUnit.JoulePerKilogramDegreeCelsius: return baseUnitValue;
@@ -680,9 +709,8 @@ namespace UnitsNet
                 case SpecificEntropyUnit.KilojoulePerKilogramKelvin: return (baseUnitValue) / 1e3d;
                 case SpecificEntropyUnit.MegajoulePerKilogramDegreeCelsius: return (baseUnitValue) / 1e6d;
                 case SpecificEntropyUnit.MegajoulePerKilogramKelvin: return (baseUnitValue) / 1e6d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1031,33 +1059,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of SpecificEntropy
         /// </summary>
         public static SpecificEntropy MinValue => new SpecificEntropy(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitJoulesPerKilogramKelvin()
-        {
-            if (Unit == SpecificEntropyUnit.JoulePerKilogramKelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case SpecificEntropyUnit.CaloriePerGramKelvin: return _value*4.184e3;
-                case SpecificEntropyUnit.JoulePerKilogramDegreeCelsius: return _value;
-                case SpecificEntropyUnit.JoulePerKilogramKelvin: return _value;
-                case SpecificEntropyUnit.KilocaloriePerGramKelvin: return (_value*4.184e3) * 1e3d;
-                case SpecificEntropyUnit.KilojoulePerKilogramDegreeCelsius: return (_value) * 1e3d;
-                case SpecificEntropyUnit.KilojoulePerKilogramKelvin: return (_value) * 1e3d;
-                case SpecificEntropyUnit.MegajoulePerKilogramDegreeCelsius: return (_value) * 1e6d;
-                case SpecificEntropyUnit.MegajoulePerKilogramKelvin: return (_value) * 1e6d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(SpecificEntropyUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          SpecificVolume(double numericValue, SpecificVolumeUnit unit)
+        SpecificVolume(double numericValue, SpecificVolumeUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -353,7 +353,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificVolume other)
         {
-            return AsBaseUnitCubicMetersPerKilogram().CompareTo(other.AsBaseUnitCubicMetersPerKilogram());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -401,7 +401,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCubicMetersPerKilogram().Equals(((SpecificVolume) obj).AsBaseUnitCubicMetersPerKilogram());
+            return AsBaseUnit().Equals(((SpecificVolume) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(SpecificVolume other, SpecificVolume maxError)
         {
-            return Math.Abs(AsBaseUnitCubicMetersPerKilogram() - other.AsBaseUnitCubicMetersPerKilogram()) <= maxError.AsBaseUnitCubicMetersPerKilogram();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -432,19 +432,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(SpecificVolumeUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case SpecificVolumeUnit.CubicMeterPerKilogram: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCubicMetersPerKilogram();
+        private double AsBaseNumericType(SpecificVolumeUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case SpecificVolumeUnit.CubicMeterPerKilogram: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -793,26 +814,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of SpecificVolume
         /// </summary>
         public static SpecificVolume MinValue => new SpecificVolume(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCubicMetersPerKilogram()
-        {
-            if (Unit == SpecificVolumeUnit.CubicMeterPerKilogram) { return _value; }
-
-            switch (Unit)
-            {
-                case SpecificVolumeUnit.CubicMeterPerKilogram: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(SpecificVolumeUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          SpecificWeight(double numericValue, SpecificWeightUnit unit)
+        SpecificWeight(double numericValue, SpecificWeightUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -881,7 +881,7 @@ namespace UnitsNet
 #endif
         int CompareTo(SpecificWeight other)
         {
-            return AsBaseUnitNewtonsPerCubicMeter().CompareTo(other.AsBaseUnitNewtonsPerCubicMeter());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -929,7 +929,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonsPerCubicMeter().Equals(((SpecificWeight) obj).AsBaseUnitNewtonsPerCubicMeter());
+            return AsBaseUnit().Equals(((SpecificWeight) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -942,7 +942,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(SpecificWeight other, SpecificWeight maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonsPerCubicMeter() - other.AsBaseUnitNewtonsPerCubicMeter()) <= maxError.AsBaseUnitNewtonsPerCubicMeter();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -960,14 +960,52 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(SpecificWeightUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case SpecificWeightUnit.KilogramForcePerCubicCentimeter: return _value*9806650.19960652;
+                case SpecificWeightUnit.KilogramForcePerCubicMeter: return _value*9.80665019960652;
+                case SpecificWeightUnit.KilogramForcePerCubicMillimeter: return _value*9806650199.60653;
+                case SpecificWeightUnit.KilonewtonPerCubicCentimeter: return (_value*1000000) * 1e3d;
+                case SpecificWeightUnit.KilonewtonPerCubicMeter: return (_value) * 1e3d;
+                case SpecificWeightUnit.KilonewtonPerCubicMillimeter: return (_value*1000000000) * 1e3d;
+                case SpecificWeightUnit.KilopoundForcePerCubicFoot: return (_value*157.087477433193) * 1e3d;
+                case SpecificWeightUnit.KilopoundForcePerCubicInch: return (_value*271447.161004558) * 1e3d;
+                case SpecificWeightUnit.MeganewtonPerCubicMeter: return (_value) * 1e6d;
+                case SpecificWeightUnit.NewtonPerCubicCentimeter: return _value*1000000;
+                case SpecificWeightUnit.NewtonPerCubicMeter: return _value;
+                case SpecificWeightUnit.NewtonPerCubicMillimeter: return _value*1000000000;
+                case SpecificWeightUnit.PoundForcePerCubicFoot: return _value*157.087477433193;
+                case SpecificWeightUnit.PoundForcePerCubicInch: return _value*271447.161004558;
+                case SpecificWeightUnit.TonneForcePerCubicCentimeter: return _value*9806650199.60653;
+                case SpecificWeightUnit.TonneForcePerCubicMeter: return _value*9806.65019960653;
+                case SpecificWeightUnit.TonneForcePerCubicMillimeter: return _value*9806650199606.53;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonsPerCubicMeter();
+        private double AsBaseNumericType(SpecificWeightUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case SpecificWeightUnit.KilogramForcePerCubicCentimeter: return baseUnitValue*1.01971619222242E-07;
                 case SpecificWeightUnit.KilogramForcePerCubicMeter: return baseUnitValue*0.101971619222242;
@@ -986,9 +1024,8 @@ namespace UnitsNet
                 case SpecificWeightUnit.TonneForcePerCubicCentimeter: return baseUnitValue*1.01971619222242E-10;
                 case SpecificWeightUnit.TonneForcePerCubicMeter: return baseUnitValue*0.000101971619222242;
                 case SpecificWeightUnit.TonneForcePerCubicMillimeter: return baseUnitValue*1.01971619222242E-13;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1337,42 +1374,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of SpecificWeight
         /// </summary>
         public static SpecificWeight MinValue => new SpecificWeight(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonsPerCubicMeter()
-        {
-            if (Unit == SpecificWeightUnit.NewtonPerCubicMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case SpecificWeightUnit.KilogramForcePerCubicCentimeter: return _value*9806650.19960652;
-                case SpecificWeightUnit.KilogramForcePerCubicMeter: return _value*9.80665019960652;
-                case SpecificWeightUnit.KilogramForcePerCubicMillimeter: return _value*9806650199.60653;
-                case SpecificWeightUnit.KilonewtonPerCubicCentimeter: return (_value*1000000) * 1e3d;
-                case SpecificWeightUnit.KilonewtonPerCubicMeter: return (_value) * 1e3d;
-                case SpecificWeightUnit.KilonewtonPerCubicMillimeter: return (_value*1000000000) * 1e3d;
-                case SpecificWeightUnit.KilopoundForcePerCubicFoot: return (_value*157.087477433193) * 1e3d;
-                case SpecificWeightUnit.KilopoundForcePerCubicInch: return (_value*271447.161004558) * 1e3d;
-                case SpecificWeightUnit.MeganewtonPerCubicMeter: return (_value) * 1e6d;
-                case SpecificWeightUnit.NewtonPerCubicCentimeter: return _value*1000000;
-                case SpecificWeightUnit.NewtonPerCubicMeter: return _value;
-                case SpecificWeightUnit.NewtonPerCubicMillimeter: return _value*1000000000;
-                case SpecificWeightUnit.PoundForcePerCubicFoot: return _value*157.087477433193;
-                case SpecificWeightUnit.PoundForcePerCubicInch: return _value*271447.161004558;
-                case SpecificWeightUnit.TonneForcePerCubicCentimeter: return _value*9806650199.60653;
-                case SpecificWeightUnit.TonneForcePerCubicMeter: return _value*9806.65019960653;
-                case SpecificWeightUnit.TonneForcePerCubicMillimeter: return _value*9806650199606.53;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(SpecificWeightUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Speed(double numericValue, SpeedUnit unit)
+        Speed(double numericValue, SpeedUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1376,7 +1376,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Speed other)
         {
-            return AsBaseUnitMetersPerSecond().CompareTo(other.AsBaseUnitMetersPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1424,7 +1424,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitMetersPerSecond().Equals(((Speed) obj).AsBaseUnitMetersPerSecond());
+            return AsBaseUnit().Equals(((Speed) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1437,7 +1437,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Speed other, Speed maxError)
         {
-            return Math.Abs(AsBaseUnitMetersPerSecond() - other.AsBaseUnitMetersPerSecond()) <= maxError.AsBaseUnitMetersPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1455,14 +1455,67 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(SpeedUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case SpeedUnit.CentimeterPerHour: return (_value/3600) * 1e-2d;
+                case SpeedUnit.CentimeterPerMinute: return (_value/60) * 1e-2d;
+                case SpeedUnit.CentimeterPerSecond: return (_value) * 1e-2d;
+                case SpeedUnit.DecimeterPerMinute: return (_value/60) * 1e-1d;
+                case SpeedUnit.DecimeterPerSecond: return (_value) * 1e-1d;
+                case SpeedUnit.FootPerHour: return _value*0.3048/3600;
+                case SpeedUnit.FootPerMinute: return _value*0.3048/60;
+                case SpeedUnit.FootPerSecond: return _value*0.3048;
+                case SpeedUnit.InchPerHour: return (_value/3600)*2.54e-2;
+                case SpeedUnit.InchPerMinute: return (_value/60)*2.54e-2;
+                case SpeedUnit.InchPerSecond: return _value*2.54e-2;
+                case SpeedUnit.KilometerPerHour: return (_value/3600) * 1e3d;
+                case SpeedUnit.KilometerPerMinute: return (_value/60) * 1e3d;
+                case SpeedUnit.KilometerPerSecond: return (_value) * 1e3d;
+                case SpeedUnit.Knot: return _value*0.514444;
+                case SpeedUnit.MeterPerHour: return _value/3600;
+                case SpeedUnit.MeterPerMinute: return _value/60;
+                case SpeedUnit.MeterPerSecond: return _value;
+                case SpeedUnit.MicrometerPerMinute: return (_value/60) * 1e-6d;
+                case SpeedUnit.MicrometerPerSecond: return (_value) * 1e-6d;
+                case SpeedUnit.MilePerHour: return _value*0.44704;
+                case SpeedUnit.MillimeterPerHour: return (_value/3600) * 1e-3d;
+                case SpeedUnit.MillimeterPerMinute: return (_value/60) * 1e-3d;
+                case SpeedUnit.MillimeterPerSecond: return (_value) * 1e-3d;
+                case SpeedUnit.NanometerPerMinute: return (_value/60) * 1e-9d;
+                case SpeedUnit.NanometerPerSecond: return (_value) * 1e-9d;
+                case SpeedUnit.UsSurveyFootPerHour: return (_value*1200/3937)/3600;
+                case SpeedUnit.UsSurveyFootPerMinute: return (_value*1200/3937)/60;
+                case SpeedUnit.UsSurveyFootPerSecond: return _value*1200/3937;
+                case SpeedUnit.YardPerHour: return _value*0.9144/3600;
+                case SpeedUnit.YardPerMinute: return _value*0.9144/60;
+                case SpeedUnit.YardPerSecond: return _value*0.9144;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitMetersPerSecond();
+        private double AsBaseNumericType(SpeedUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case SpeedUnit.CentimeterPerHour: return (baseUnitValue*3600) / 1e-2d;
                 case SpeedUnit.CentimeterPerMinute: return (baseUnitValue*60) / 1e-2d;
@@ -1496,9 +1549,8 @@ namespace UnitsNet
                 case SpeedUnit.YardPerHour: return baseUnitValue/0.9144*3600;
                 case SpeedUnit.YardPerMinute: return baseUnitValue/0.9144*60;
                 case SpeedUnit.YardPerSecond: return baseUnitValue/0.9144;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1847,57 +1899,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Speed
         /// </summary>
         public static Speed MinValue => new Speed(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitMetersPerSecond()
-        {
-            if (Unit == SpeedUnit.MeterPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case SpeedUnit.CentimeterPerHour: return (_value/3600) * 1e-2d;
-                case SpeedUnit.CentimeterPerMinute: return (_value/60) * 1e-2d;
-                case SpeedUnit.CentimeterPerSecond: return (_value) * 1e-2d;
-                case SpeedUnit.DecimeterPerMinute: return (_value/60) * 1e-1d;
-                case SpeedUnit.DecimeterPerSecond: return (_value) * 1e-1d;
-                case SpeedUnit.FootPerHour: return _value*0.3048/3600;
-                case SpeedUnit.FootPerMinute: return _value*0.3048/60;
-                case SpeedUnit.FootPerSecond: return _value*0.3048;
-                case SpeedUnit.InchPerHour: return (_value/3600)*2.54e-2;
-                case SpeedUnit.InchPerMinute: return (_value/60)*2.54e-2;
-                case SpeedUnit.InchPerSecond: return _value*2.54e-2;
-                case SpeedUnit.KilometerPerHour: return (_value/3600) * 1e3d;
-                case SpeedUnit.KilometerPerMinute: return (_value/60) * 1e3d;
-                case SpeedUnit.KilometerPerSecond: return (_value) * 1e3d;
-                case SpeedUnit.Knot: return _value*0.514444;
-                case SpeedUnit.MeterPerHour: return _value/3600;
-                case SpeedUnit.MeterPerMinute: return _value/60;
-                case SpeedUnit.MeterPerSecond: return _value;
-                case SpeedUnit.MicrometerPerMinute: return (_value/60) * 1e-6d;
-                case SpeedUnit.MicrometerPerSecond: return (_value) * 1e-6d;
-                case SpeedUnit.MilePerHour: return _value*0.44704;
-                case SpeedUnit.MillimeterPerHour: return (_value/3600) * 1e-3d;
-                case SpeedUnit.MillimeterPerMinute: return (_value/60) * 1e-3d;
-                case SpeedUnit.MillimeterPerSecond: return (_value) * 1e-3d;
-                case SpeedUnit.NanometerPerMinute: return (_value/60) * 1e-9d;
-                case SpeedUnit.NanometerPerSecond: return (_value) * 1e-9d;
-                case SpeedUnit.UsSurveyFootPerHour: return (_value*1200/3937)/3600;
-                case SpeedUnit.UsSurveyFootPerMinute: return (_value*1200/3937)/60;
-                case SpeedUnit.UsSurveyFootPerSecond: return _value*1200/3937;
-                case SpeedUnit.YardPerHour: return _value*0.9144/3600;
-                case SpeedUnit.YardPerMinute: return _value*0.9144/60;
-                case SpeedUnit.YardPerSecond: return _value*0.9144;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(SpeedUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Temperature(double numericValue, TemperatureUnit unit)
+        Temperature(double numericValue, TemperatureUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -542,7 +542,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Temperature other)
         {
-            return AsBaseUnitKelvins().CompareTo(other.AsBaseUnitKelvins());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -590,7 +590,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKelvins().Equals(((Temperature) obj).AsBaseUnitKelvins());
+            return AsBaseUnit().Equals(((Temperature) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -603,7 +603,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Temperature other, Temperature maxError)
         {
-            return Math.Abs(AsBaseUnitKelvins() - other.AsBaseUnitKelvins()) <= maxError.AsBaseUnitKelvins();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -621,14 +621,43 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(TemperatureUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case TemperatureUnit.DegreeCelsius: return _value + 273.15;
+                case TemperatureUnit.DegreeDelisle: return _value*-2/3 + 373.15;
+                case TemperatureUnit.DegreeFahrenheit: return _value*5/9 + 459.67*5/9;
+                case TemperatureUnit.DegreeNewton: return _value*100/33 + 273.15;
+                case TemperatureUnit.DegreeRankine: return _value*5/9;
+                case TemperatureUnit.DegreeReaumur: return _value*5/4 + 273.15;
+                case TemperatureUnit.DegreeRoemer: return _value*40/21 + 273.15 - 7.5*40d/21;
+                case TemperatureUnit.Kelvin: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKelvins();
+        private double AsBaseNumericType(TemperatureUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case TemperatureUnit.DegreeCelsius: return baseUnitValue - 273.15;
                 case TemperatureUnit.DegreeDelisle: return (baseUnitValue - 373.15)*-3/2;
@@ -638,9 +667,8 @@ namespace UnitsNet
                 case TemperatureUnit.DegreeReaumur: return (baseUnitValue - 273.15)*4/5;
                 case TemperatureUnit.DegreeRoemer: return (baseUnitValue - (273.15 - 7.5*40d/21))*21/40;
                 case TemperatureUnit.Kelvin: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -989,33 +1017,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Temperature
         /// </summary>
         public static Temperature MinValue => new Temperature(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKelvins()
-        {
-            if (Unit == TemperatureUnit.Kelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case TemperatureUnit.DegreeCelsius: return _value + 273.15;
-                case TemperatureUnit.DegreeDelisle: return _value*-2/3 + 373.15;
-                case TemperatureUnit.DegreeFahrenheit: return _value*5/9 + 459.67*5/9;
-                case TemperatureUnit.DegreeNewton: return _value*100/33 + 273.15;
-                case TemperatureUnit.DegreeRankine: return _value*5/9;
-                case TemperatureUnit.DegreeReaumur: return _value*5/4 + 273.15;
-                case TemperatureUnit.DegreeRoemer: return _value*40/21 + 273.15 - 7.5*40d/21;
-                case TemperatureUnit.Kelvin: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(TemperatureUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          TemperatureChangeRate(double numericValue, TemperatureChangeRateUnit unit)
+        TemperatureChangeRate(double numericValue, TemperatureChangeRateUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -650,7 +650,7 @@ namespace UnitsNet
 #endif
         int CompareTo(TemperatureChangeRate other)
         {
-            return AsBaseUnitDegreesCelsiusPerSecond().CompareTo(other.AsBaseUnitDegreesCelsiusPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -698,7 +698,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitDegreesCelsiusPerSecond().Equals(((TemperatureChangeRate) obj).AsBaseUnitDegreesCelsiusPerSecond());
+            return AsBaseUnit().Equals(((TemperatureChangeRate) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -711,7 +711,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(TemperatureChangeRate other, TemperatureChangeRate maxError)
         {
-            return Math.Abs(AsBaseUnitDegreesCelsiusPerSecond() - other.AsBaseUnitDegreesCelsiusPerSecond()) <= maxError.AsBaseUnitDegreesCelsiusPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -729,14 +729,45 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(TemperatureChangeRateUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case TemperatureChangeRateUnit.CentidegreeCelsiusPerSecond: return (_value) * 1e-2d;
+                case TemperatureChangeRateUnit.DecadegreeCelsiusPerSecond: return (_value) * 1e1d;
+                case TemperatureChangeRateUnit.DecidegreeCelsiusPerSecond: return (_value) * 1e-1d;
+                case TemperatureChangeRateUnit.DegreeCelsiusPerMinute: return _value/60;
+                case TemperatureChangeRateUnit.DegreeCelsiusPerSecond: return _value;
+                case TemperatureChangeRateUnit.HectodegreeCelsiusPerSecond: return (_value) * 1e2d;
+                case TemperatureChangeRateUnit.KilodegreeCelsiusPerSecond: return (_value) * 1e3d;
+                case TemperatureChangeRateUnit.MicrodegreeCelsiusPerSecond: return (_value) * 1e-6d;
+                case TemperatureChangeRateUnit.MillidegreeCelsiusPerSecond: return (_value) * 1e-3d;
+                case TemperatureChangeRateUnit.NanodegreeCelsiusPerSecond: return (_value) * 1e-9d;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitDegreesCelsiusPerSecond();
+        private double AsBaseNumericType(TemperatureChangeRateUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case TemperatureChangeRateUnit.CentidegreeCelsiusPerSecond: return (baseUnitValue) / 1e-2d;
                 case TemperatureChangeRateUnit.DecadegreeCelsiusPerSecond: return (baseUnitValue) / 1e1d;
@@ -748,9 +779,8 @@ namespace UnitsNet
                 case TemperatureChangeRateUnit.MicrodegreeCelsiusPerSecond: return (baseUnitValue) / 1e-6d;
                 case TemperatureChangeRateUnit.MillidegreeCelsiusPerSecond: return (baseUnitValue) / 1e-3d;
                 case TemperatureChangeRateUnit.NanodegreeCelsiusPerSecond: return (baseUnitValue) / 1e-9d;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1099,35 +1129,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of TemperatureChangeRate
         /// </summary>
         public static TemperatureChangeRate MinValue => new TemperatureChangeRate(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitDegreesCelsiusPerSecond()
-        {
-            if (Unit == TemperatureChangeRateUnit.DegreeCelsiusPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case TemperatureChangeRateUnit.CentidegreeCelsiusPerSecond: return (_value) * 1e-2d;
-                case TemperatureChangeRateUnit.DecadegreeCelsiusPerSecond: return (_value) * 1e1d;
-                case TemperatureChangeRateUnit.DecidegreeCelsiusPerSecond: return (_value) * 1e-1d;
-                case TemperatureChangeRateUnit.DegreeCelsiusPerMinute: return _value/60;
-                case TemperatureChangeRateUnit.DegreeCelsiusPerSecond: return _value;
-                case TemperatureChangeRateUnit.HectodegreeCelsiusPerSecond: return (_value) * 1e2d;
-                case TemperatureChangeRateUnit.KilodegreeCelsiusPerSecond: return (_value) * 1e3d;
-                case TemperatureChangeRateUnit.MicrodegreeCelsiusPerSecond: return (_value) * 1e-6d;
-                case TemperatureChangeRateUnit.MillidegreeCelsiusPerSecond: return (_value) * 1e-3d;
-                case TemperatureChangeRateUnit.NanodegreeCelsiusPerSecond: return (_value) * 1e-9d;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(TemperatureChangeRateUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          TemperatureDelta(double numericValue, TemperatureDeltaUnit unit)
+        TemperatureDelta(double numericValue, TemperatureDeltaUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -846,7 +846,7 @@ namespace UnitsNet
 #endif
         int CompareTo(TemperatureDelta other)
         {
-            return AsBaseUnitKelvins().CompareTo(other.AsBaseUnitKelvins());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -894,7 +894,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitKelvins().Equals(((TemperatureDelta) obj).AsBaseUnitKelvins());
+            return AsBaseUnit().Equals(((TemperatureDelta) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -907,7 +907,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(TemperatureDelta other, TemperatureDelta maxError)
         {
-            return Math.Abs(AsBaseUnitKelvins() - other.AsBaseUnitKelvins()) <= maxError.AsBaseUnitKelvins();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -925,14 +925,51 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(TemperatureDeltaUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case TemperatureDeltaUnit.DegreeCelsius: return _value;
+                case TemperatureDeltaUnit.DegreeCelsiusDelta: return _value;
+                case TemperatureDeltaUnit.DegreeDelisle: return _value*-2/3;
+                case TemperatureDeltaUnit.DegreeDelisleDelta: return _value*-2/3;
+                case TemperatureDeltaUnit.DegreeFahrenheit: return _value*5/9;
+                case TemperatureDeltaUnit.DegreeFahrenheitDelta: return _value*5/9;
+                case TemperatureDeltaUnit.DegreeNewton: return _value*100/33;
+                case TemperatureDeltaUnit.DegreeNewtonDelta: return _value*100/33;
+                case TemperatureDeltaUnit.DegreeRankine: return _value*5/9;
+                case TemperatureDeltaUnit.DegreeRankineDelta: return _value*5/9;
+                case TemperatureDeltaUnit.DegreeReaumur: return _value*5/4;
+                case TemperatureDeltaUnit.DegreeReaumurDelta: return _value*5/4;
+                case TemperatureDeltaUnit.DegreeRoemer: return _value*40/21;
+                case TemperatureDeltaUnit.DegreeRoemerDelta: return _value*40/21;
+                case TemperatureDeltaUnit.Kelvin: return _value;
+                case TemperatureDeltaUnit.KelvinDelta: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitKelvins();
+        private double AsBaseNumericType(TemperatureDeltaUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case TemperatureDeltaUnit.DegreeCelsius: return baseUnitValue;
                 case TemperatureDeltaUnit.DegreeCelsiusDelta: return baseUnitValue;
@@ -950,9 +987,8 @@ namespace UnitsNet
                 case TemperatureDeltaUnit.DegreeRoemerDelta: return baseUnitValue*21/40;
                 case TemperatureDeltaUnit.Kelvin: return baseUnitValue;
                 case TemperatureDeltaUnit.KelvinDelta: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1301,41 +1337,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of TemperatureDelta
         /// </summary>
         public static TemperatureDelta MinValue => new TemperatureDelta(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitKelvins()
-        {
-            if (Unit == TemperatureDeltaUnit.Kelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case TemperatureDeltaUnit.DegreeCelsius: return _value;
-                case TemperatureDeltaUnit.DegreeCelsiusDelta: return _value;
-                case TemperatureDeltaUnit.DegreeDelisle: return _value*-2/3;
-                case TemperatureDeltaUnit.DegreeDelisleDelta: return _value*-2/3;
-                case TemperatureDeltaUnit.DegreeFahrenheit: return _value*5/9;
-                case TemperatureDeltaUnit.DegreeFahrenheitDelta: return _value*5/9;
-                case TemperatureDeltaUnit.DegreeNewton: return _value*100/33;
-                case TemperatureDeltaUnit.DegreeNewtonDelta: return _value*100/33;
-                case TemperatureDeltaUnit.DegreeRankine: return _value*5/9;
-                case TemperatureDeltaUnit.DegreeRankineDelta: return _value*5/9;
-                case TemperatureDeltaUnit.DegreeReaumur: return _value*5/4;
-                case TemperatureDeltaUnit.DegreeReaumurDelta: return _value*5/4;
-                case TemperatureDeltaUnit.DegreeRoemer: return _value*40/21;
-                case TemperatureDeltaUnit.DegreeRoemerDelta: return _value*40/21;
-                case TemperatureDeltaUnit.Kelvin: return _value;
-                case TemperatureDeltaUnit.KelvinDelta: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(TemperatureDeltaUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ThermalConductivity(double numericValue, ThermalConductivityUnit unit)
+        ThermalConductivity(double numericValue, ThermalConductivityUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -386,7 +386,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ThermalConductivity other)
         {
-            return AsBaseUnitWattsPerMeterKelvin().CompareTo(other.AsBaseUnitWattsPerMeterKelvin());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -434,7 +434,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitWattsPerMeterKelvin().Equals(((ThermalConductivity) obj).AsBaseUnitWattsPerMeterKelvin());
+            return AsBaseUnit().Equals(((ThermalConductivity) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ThermalConductivity other, ThermalConductivity maxError)
         {
-            return Math.Abs(AsBaseUnitWattsPerMeterKelvin() - other.AsBaseUnitWattsPerMeterKelvin()) <= maxError.AsBaseUnitWattsPerMeterKelvin();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -465,20 +465,42 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ThermalConductivityUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ThermalConductivityUnit.BtuPerHourFootFahrenheit: return _value*1.73073467;
+                case ThermalConductivityUnit.WattPerMeterKelvin: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitWattsPerMeterKelvin();
+        private double AsBaseNumericType(ThermalConductivityUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ThermalConductivityUnit.BtuPerHourFootFahrenheit: return baseUnitValue/1.73073467;
                 case ThermalConductivityUnit.WattPerMeterKelvin: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -827,27 +849,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ThermalConductivity
         /// </summary>
         public static ThermalConductivity MinValue => new ThermalConductivity(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitWattsPerMeterKelvin()
-        {
-            if (Unit == ThermalConductivityUnit.WattPerMeterKelvin) { return _value; }
-
-            switch (Unit)
-            {
-                case ThermalConductivityUnit.BtuPerHourFootFahrenheit: return _value*1.73073467;
-                case ThermalConductivityUnit.WattPerMeterKelvin: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ThermalConductivityUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          ThermalResistance(double numericValue, ThermalResistanceUnit unit)
+        ThermalResistance(double numericValue, ThermalResistanceUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -485,7 +485,7 @@ namespace UnitsNet
 #endif
         int CompareTo(ThermalResistance other)
         {
-            return AsBaseUnitSquareMeterKelvinsPerKilowatt().CompareTo(other.AsBaseUnitSquareMeterKelvinsPerKilowatt());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -533,7 +533,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitSquareMeterKelvinsPerKilowatt().Equals(((ThermalResistance) obj).AsBaseUnitSquareMeterKelvinsPerKilowatt());
+            return AsBaseUnit().Equals(((ThermalResistance) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(ThermalResistance other, ThermalResistance maxError)
         {
-            return Math.Abs(AsBaseUnitSquareMeterKelvinsPerKilowatt() - other.AsBaseUnitSquareMeterKelvinsPerKilowatt()) <= maxError.AsBaseUnitSquareMeterKelvinsPerKilowatt();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -564,23 +564,48 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(ThermalResistanceUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case ThermalResistanceUnit.HourSquareFeetDegreeFahrenheitPerBtu: return _value*176.1121482159839;
+                case ThermalResistanceUnit.SquareCentimeterHourDegreeCelsiusPerKilocalorie: return _value*0.0859779507590433;
+                case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return _value*0.0999964777570357;
+                case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return _value*1000.088056074108;
+                case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitSquareMeterKelvinsPerKilowatt();
+        private double AsBaseNumericType(ThermalResistanceUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case ThermalResistanceUnit.HourSquareFeetDegreeFahrenheitPerBtu: return baseUnitValue/176.1121482159839;
                 case ThermalResistanceUnit.SquareCentimeterHourDegreeCelsiusPerKilocalorie: return baseUnitValue/0.0859779507590433;
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return baseUnitValue/0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return baseUnitValue/1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -929,30 +954,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of ThermalResistance
         /// </summary>
         public static ThermalResistance MinValue => new ThermalResistance(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitSquareMeterKelvinsPerKilowatt()
-        {
-            if (Unit == ThermalResistanceUnit.SquareMeterKelvinPerKilowatt) { return _value; }
-
-            switch (Unit)
-            {
-                case ThermalResistanceUnit.HourSquareFeetDegreeFahrenheitPerBtu: return _value*176.1121482159839;
-                case ThermalResistanceUnit.SquareCentimeterHourDegreeCelsiusPerKilocalorie: return _value*0.0859779507590433;
-                case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return _value*0.0999964777570357;
-                case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return _value*1000.088056074108;
-                case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(ThermalResistanceUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Torque(double numericValue, TorqueUnit unit)
+        Torque(double numericValue, TorqueUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1013,7 +1013,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Torque other)
         {
-            return AsBaseUnitNewtonMeters().CompareTo(other.AsBaseUnitNewtonMeters());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1061,7 +1061,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitNewtonMeters().Equals(((Torque) obj).AsBaseUnitNewtonMeters());
+            return AsBaseUnit().Equals(((Torque) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1074,7 +1074,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Torque other, Torque maxError)
         {
-            return Math.Abs(AsBaseUnitNewtonMeters() - other.AsBaseUnitNewtonMeters()) <= maxError.AsBaseUnitNewtonMeters();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1092,14 +1092,56 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(TorqueUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case TorqueUnit.KilogramForceCentimeter: return _value*0.0980665019960652;
+                case TorqueUnit.KilogramForceMeter: return _value*9.80665019960652;
+                case TorqueUnit.KilogramForceMillimeter: return _value*0.00980665019960652;
+                case TorqueUnit.KilonewtonCentimeter: return (_value*0.01) * 1e3d;
+                case TorqueUnit.KilonewtonMeter: return (_value) * 1e3d;
+                case TorqueUnit.KilonewtonMillimeter: return (_value*0.001) * 1e3d;
+                case TorqueUnit.KilopoundForceFoot: return (_value*1.3558180656) * 1e3d;
+                case TorqueUnit.KilopoundForceInch: return (_value*0.1129848388) * 1e3d;
+                case TorqueUnit.MeganewtonCentimeter: return (_value*0.01) * 1e6d;
+                case TorqueUnit.MeganewtonMeter: return (_value) * 1e6d;
+                case TorqueUnit.MeganewtonMillimeter: return (_value*0.001) * 1e6d;
+                case TorqueUnit.MegapoundForceFoot: return (_value*1.3558180656) * 1e6d;
+                case TorqueUnit.MegapoundForceInch: return (_value*0.1129848388) * 1e6d;
+                case TorqueUnit.NewtonCentimeter: return _value*0.01;
+                case TorqueUnit.NewtonMeter: return _value;
+                case TorqueUnit.NewtonMillimeter: return _value*0.001;
+                case TorqueUnit.PoundForceFoot: return _value*1.3558180656;
+                case TorqueUnit.PoundForceInch: return _value*0.1129848388;
+                case TorqueUnit.TonneForceCentimeter: return _value*98.0665019960652;
+                case TorqueUnit.TonneForceMeter: return _value*9806.65019960653;
+                case TorqueUnit.TonneForceMillimeter: return _value*9.80665019960652;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitNewtonMeters();
+        private double AsBaseNumericType(TorqueUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case TorqueUnit.KilogramForceCentimeter: return baseUnitValue*10.1971619222242;
                 case TorqueUnit.KilogramForceMeter: return baseUnitValue*0.101971619222242;
@@ -1122,9 +1164,8 @@ namespace UnitsNet
                 case TorqueUnit.TonneForceCentimeter: return baseUnitValue*0.0101971619222242;
                 case TorqueUnit.TonneForceMeter: return baseUnitValue*0.000101971619222242;
                 case TorqueUnit.TonneForceMillimeter: return baseUnitValue*0.101971619222242;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1473,46 +1514,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Torque
         /// </summary>
         public static Torque MinValue => new Torque(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitNewtonMeters()
-        {
-            if (Unit == TorqueUnit.NewtonMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case TorqueUnit.KilogramForceCentimeter: return _value*0.0980665019960652;
-                case TorqueUnit.KilogramForceMeter: return _value*9.80665019960652;
-                case TorqueUnit.KilogramForceMillimeter: return _value*0.00980665019960652;
-                case TorqueUnit.KilonewtonCentimeter: return (_value*0.01) * 1e3d;
-                case TorqueUnit.KilonewtonMeter: return (_value) * 1e3d;
-                case TorqueUnit.KilonewtonMillimeter: return (_value*0.001) * 1e3d;
-                case TorqueUnit.KilopoundForceFoot: return (_value*1.3558180656) * 1e3d;
-                case TorqueUnit.KilopoundForceInch: return (_value*0.1129848388) * 1e3d;
-                case TorqueUnit.MeganewtonCentimeter: return (_value*0.01) * 1e6d;
-                case TorqueUnit.MeganewtonMeter: return (_value) * 1e6d;
-                case TorqueUnit.MeganewtonMillimeter: return (_value*0.001) * 1e6d;
-                case TorqueUnit.MegapoundForceFoot: return (_value*1.3558180656) * 1e6d;
-                case TorqueUnit.MegapoundForceInch: return (_value*0.1129848388) * 1e6d;
-                case TorqueUnit.NewtonCentimeter: return _value*0.01;
-                case TorqueUnit.NewtonMeter: return _value;
-                case TorqueUnit.NewtonMillimeter: return _value*0.001;
-                case TorqueUnit.PoundForceFoot: return _value*1.3558180656;
-                case TorqueUnit.PoundForceInch: return _value*0.1129848388;
-                case TorqueUnit.TonneForceCentimeter: return _value*98.0665019960652;
-                case TorqueUnit.TonneForceMeter: return _value*9806.65019960653;
-                case TorqueUnit.TonneForceMillimeter: return _value*9.80665019960652;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(TorqueUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          VitaminA(double numericValue, VitaminAUnit unit)
+        VitaminA(double numericValue, VitaminAUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -343,7 +343,7 @@ namespace UnitsNet
 #endif
         int CompareTo(VitaminA other)
         {
-            return AsBaseUnitInternationalUnits().CompareTo(other.AsBaseUnitInternationalUnits());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -391,7 +391,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitInternationalUnits().Equals(((VitaminA) obj).AsBaseUnitInternationalUnits());
+            return AsBaseUnit().Equals(((VitaminA) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(VitaminA other, VitaminA maxError)
         {
-            return Math.Abs(AsBaseUnitInternationalUnits() - other.AsBaseUnitInternationalUnits()) <= maxError.AsBaseUnitInternationalUnits();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -422,19 +422,40 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(VitaminAUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case VitaminAUnit.InternationalUnit: return _value;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitInternationalUnits();
+        private double AsBaseNumericType(VitaminAUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case VitaminAUnit.InternationalUnit: return baseUnitValue;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -783,26 +804,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of VitaminA
         /// </summary>
         public static VitaminA MinValue => new VitaminA(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitInternationalUnits()
-        {
-            if (Unit == VitaminAUnit.InternationalUnit) { return _value; }
-
-            switch (Unit)
-            {
-                case VitaminAUnit.InternationalUnit: return _value;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(VitaminAUnit unit) => Convert.ToDouble(As(unit));
 
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          Volume(double numericValue, VolumeUnit unit)
+        Volume(double numericValue, VolumeUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1774,7 +1774,7 @@ namespace UnitsNet
 #endif
         int CompareTo(Volume other)
         {
-            return AsBaseUnitCubicMeters().CompareTo(other.AsBaseUnitCubicMeters());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1822,7 +1822,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCubicMeters().Equals(((Volume) obj).AsBaseUnitCubicMeters());
+            return AsBaseUnit().Equals(((Volume) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1835,7 +1835,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(Volume other, Volume maxError)
         {
-            return Math.Abs(AsBaseUnitCubicMeters() - other.AsBaseUnitCubicMeters()) <= maxError.AsBaseUnitCubicMeters();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1853,14 +1853,79 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(VolumeUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case VolumeUnit.AuTablespoon: return _value*2e-5;
+                case VolumeUnit.Centiliter: return (_value/1e3) * 1e-2d;
+                case VolumeUnit.CubicCentimeter: return _value/1e6;
+                case VolumeUnit.CubicDecimeter: return _value/1e3;
+                case VolumeUnit.CubicFoot: return _value*0.0283168;
+                case VolumeUnit.CubicInch: return _value*1.6387*1e-5;
+                case VolumeUnit.CubicKilometer: return _value*1e9;
+                case VolumeUnit.CubicMeter: return _value;
+                case VolumeUnit.CubicMicrometer: return _value/1e18;
+                case VolumeUnit.CubicMile: return _value*4.16818183*1e9;
+                case VolumeUnit.CubicMillimeter: return _value/1e9;
+                case VolumeUnit.CubicYard: return _value*0.764554858;
+                case VolumeUnit.Deciliter: return (_value/1e3) * 1e-1d;
+                case VolumeUnit.HectocubicFoot: return (_value*0.0283168) * 1e2d;
+                case VolumeUnit.HectocubicMeter: return (_value) * 1e2d;
+                case VolumeUnit.Hectoliter: return (_value/1e3) * 1e2d;
+                case VolumeUnit.ImperialBeerBarrel: return _value*0.16365924;
+                case VolumeUnit.ImperialGallon: return _value*0.00454609000000181429905810072407;
+                case VolumeUnit.ImperialOunce: return _value*2.8413062499962901241875439064617e-5;
+                case VolumeUnit.KilocubicFoot: return (_value*0.0283168) * 1e3d;
+                case VolumeUnit.KilocubicMeter: return (_value) * 1e3d;
+                case VolumeUnit.KiloimperialGallon: return (_value*0.00454609000000181429905810072407) * 1e3d;
+                case VolumeUnit.KilousGallon: return (_value*0.00378541) * 1e3d;
+                case VolumeUnit.Liter: return _value/1e3;
+                case VolumeUnit.MegacubicFoot: return (_value*0.0283168) * 1e6d;
+                case VolumeUnit.MegaimperialGallon: return (_value*0.00454609000000181429905810072407) * 1e6d;
+                case VolumeUnit.MegausGallon: return (_value*0.00378541) * 1e6d;
+                case VolumeUnit.MetricCup: return _value*0.00025;
+                case VolumeUnit.MetricTeaspoon: return _value*0.5e-5;
+                case VolumeUnit.Microliter: return (_value/1e3) * 1e-6d;
+                case VolumeUnit.Milliliter: return (_value/1e3) * 1e-3d;
+                case VolumeUnit.OilBarrel: return _value*0.158987294928;
+                case VolumeUnit.Tablespoon: return _value*1.478676478125e-5;
+                case VolumeUnit.Teaspoon: return _value*4.92892159375e-6;
+                case VolumeUnit.UkTablespoon: return _value*1.5e-5;
+                case VolumeUnit.UsBeerBarrel: return _value*0.1173477658;
+                case VolumeUnit.UsCustomaryCup: return _value*0.0002365882365;
+                case VolumeUnit.UsGallon: return _value*0.00378541;
+                case VolumeUnit.UsLegalCup: return _value*0.00024;
+                case VolumeUnit.UsOunce: return _value*2.957352956253760505068307980135e-5;
+                case VolumeUnit.UsPint: return _value*4.73176473e-4;
+                case VolumeUnit.UsQuart: return _value*9.46352946e-4;
+                case VolumeUnit.UsTablespoon: return _value*1.478676478125e-5;
+                case VolumeUnit.UsTeaspoon: return _value*4.92892159375e-6;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCubicMeters();
+        private double AsBaseNumericType(VolumeUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case VolumeUnit.AuTablespoon: return baseUnitValue/2e-5;
                 case VolumeUnit.Centiliter: return (baseUnitValue*1e3) / 1e-2d;
@@ -1906,9 +1971,8 @@ namespace UnitsNet
                 case VolumeUnit.UsQuart: return baseUnitValue/9.46352946e-4;
                 case VolumeUnit.UsTablespoon: return baseUnitValue/1.478676478125e-5;
                 case VolumeUnit.UsTeaspoon: return baseUnitValue/4.92892159375e-6;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -2257,69 +2321,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of Volume
         /// </summary>
         public static Volume MinValue => new Volume(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCubicMeters()
-        {
-            if (Unit == VolumeUnit.CubicMeter) { return _value; }
-
-            switch (Unit)
-            {
-                case VolumeUnit.AuTablespoon: return _value*2e-5;
-                case VolumeUnit.Centiliter: return (_value/1e3) * 1e-2d;
-                case VolumeUnit.CubicCentimeter: return _value/1e6;
-                case VolumeUnit.CubicDecimeter: return _value/1e3;
-                case VolumeUnit.CubicFoot: return _value*0.0283168;
-                case VolumeUnit.CubicInch: return _value*1.6387*1e-5;
-                case VolumeUnit.CubicKilometer: return _value*1e9;
-                case VolumeUnit.CubicMeter: return _value;
-                case VolumeUnit.CubicMicrometer: return _value/1e18;
-                case VolumeUnit.CubicMile: return _value*4.16818183*1e9;
-                case VolumeUnit.CubicMillimeter: return _value/1e9;
-                case VolumeUnit.CubicYard: return _value*0.764554858;
-                case VolumeUnit.Deciliter: return (_value/1e3) * 1e-1d;
-                case VolumeUnit.HectocubicFoot: return (_value*0.0283168) * 1e2d;
-                case VolumeUnit.HectocubicMeter: return (_value) * 1e2d;
-                case VolumeUnit.Hectoliter: return (_value/1e3) * 1e2d;
-                case VolumeUnit.ImperialBeerBarrel: return _value*0.16365924;
-                case VolumeUnit.ImperialGallon: return _value*0.00454609000000181429905810072407;
-                case VolumeUnit.ImperialOunce: return _value*2.8413062499962901241875439064617e-5;
-                case VolumeUnit.KilocubicFoot: return (_value*0.0283168) * 1e3d;
-                case VolumeUnit.KilocubicMeter: return (_value) * 1e3d;
-                case VolumeUnit.KiloimperialGallon: return (_value*0.00454609000000181429905810072407) * 1e3d;
-                case VolumeUnit.KilousGallon: return (_value*0.00378541) * 1e3d;
-                case VolumeUnit.Liter: return _value/1e3;
-                case VolumeUnit.MegacubicFoot: return (_value*0.0283168) * 1e6d;
-                case VolumeUnit.MegaimperialGallon: return (_value*0.00454609000000181429905810072407) * 1e6d;
-                case VolumeUnit.MegausGallon: return (_value*0.00378541) * 1e6d;
-                case VolumeUnit.MetricCup: return _value*0.00025;
-                case VolumeUnit.MetricTeaspoon: return _value*0.5e-5;
-                case VolumeUnit.Microliter: return (_value/1e3) * 1e-6d;
-                case VolumeUnit.Milliliter: return (_value/1e3) * 1e-3d;
-                case VolumeUnit.OilBarrel: return _value*0.158987294928;
-                case VolumeUnit.Tablespoon: return _value*1.478676478125e-5;
-                case VolumeUnit.Teaspoon: return _value*4.92892159375e-6;
-                case VolumeUnit.UkTablespoon: return _value*1.5e-5;
-                case VolumeUnit.UsBeerBarrel: return _value*0.1173477658;
-                case VolumeUnit.UsCustomaryCup: return _value*0.0002365882365;
-                case VolumeUnit.UsGallon: return _value*0.00378541;
-                case VolumeUnit.UsLegalCup: return _value*0.00024;
-                case VolumeUnit.UsOunce: return _value*2.957352956253760505068307980135e-5;
-                case VolumeUnit.UsPint: return _value*4.73176473e-4;
-                case VolumeUnit.UsQuart: return _value*9.46352946e-4;
-                case VolumeUnit.UsTablespoon: return _value*1.478676478125e-5;
-                case VolumeUnit.UsTeaspoon: return _value*4.92892159375e-6;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(VolumeUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -113,11 +113,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          VolumeFlow(double numericValue, VolumeFlowUnit unit)
+        VolumeFlow(double numericValue, VolumeFlowUnit unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -1112,7 +1112,7 @@ namespace UnitsNet
 #endif
         int CompareTo(VolumeFlow other)
         {
-            return AsBaseUnitCubicMetersPerSecond().CompareTo(other.AsBaseUnitCubicMetersPerSecond());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -1160,7 +1160,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnitCubicMetersPerSecond().Equals(((VolumeFlow) obj).AsBaseUnitCubicMetersPerSecond());
+            return AsBaseUnit().Equals(((VolumeFlow) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -1173,7 +1173,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals(VolumeFlow other, VolumeFlow maxError)
         {
-            return Math.Abs(AsBaseUnitCubicMetersPerSecond() - other.AsBaseUnitCubicMetersPerSecond()) <= maxError.AsBaseUnitCubicMetersPerSecond();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -1191,14 +1191,59 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As(VolumeFlowUnit unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private double AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+                case VolumeFlowUnit.CentilitersPerMinute: return (_value/60000.00000) * 1e-2d;
+                case VolumeFlowUnit.CubicDecimeterPerMinute: return _value/60000.00000;
+                case VolumeFlowUnit.CubicFootPerHour: return _value*7.8657907199999087346816086183876e-6;
+                case VolumeFlowUnit.CubicFootPerMinute: return _value/2118.88000326;
+                case VolumeFlowUnit.CubicFootPerSecond: return _value/35.314666721;
+                case VolumeFlowUnit.CubicMeterPerHour: return _value/3600;
+                case VolumeFlowUnit.CubicMeterPerMinute: return _value/60;
+                case VolumeFlowUnit.CubicMeterPerSecond: return _value;
+                case VolumeFlowUnit.CubicYardPerHour: return _value*2.1237634944E-4;
+                case VolumeFlowUnit.CubicYardPerMinute: return _value*0.0127425809664;
+                case VolumeFlowUnit.CubicYardPerSecond: return _value*0.764554857984;
+                case VolumeFlowUnit.DecilitersPerMinute: return (_value/60000.00000) * 1e-1d;
+                case VolumeFlowUnit.KilolitersPerMinute: return (_value/60000.00000) * 1e3d;
+                case VolumeFlowUnit.LitersPerHour: return _value/3600000.000;
+                case VolumeFlowUnit.LitersPerMinute: return _value/60000.00000;
+                case VolumeFlowUnit.LitersPerSecond: return _value/1000;
+                case VolumeFlowUnit.MicrolitersPerMinute: return (_value/60000.00000) * 1e-6d;
+                case VolumeFlowUnit.MillilitersPerMinute: return (_value/60000.00000) * 1e-3d;
+                case VolumeFlowUnit.MillionUsGallonsPerDay: return _value/22.824465227;
+                case VolumeFlowUnit.NanolitersPerMinute: return (_value/60000.00000) * 1e-9d;
+                case VolumeFlowUnit.OilBarrelsPerDay: return _value*1.8401307283333333333333333333333e-6;
+                case VolumeFlowUnit.UsGallonsPerHour: return _value/951019.38848933424;
+                case VolumeFlowUnit.UsGallonsPerMinute: return _value/15850.323141489;
+                case VolumeFlowUnit.UsGallonsPerSecond: return _value/264.1720523581484;
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            double baseUnitValue = AsBaseUnitCubicMetersPerSecond();
+        private double AsBaseNumericType(VolumeFlowUnit unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
                 case VolumeFlowUnit.CentilitersPerMinute: return (baseUnitValue*60000.00000) / 1e-2d;
                 case VolumeFlowUnit.CubicDecimeterPerMinute: return baseUnitValue*60000.00000;
@@ -1224,9 +1269,8 @@ namespace UnitsNet
                 case VolumeFlowUnit.UsGallonsPerHour: return baseUnitValue*951019.38848933424;
                 case VolumeFlowUnit.UsGallonsPerMinute: return baseUnitValue*15850.323141489;
                 case VolumeFlowUnit.UsGallonsPerSecond: return baseUnitValue*264.1720523581484;
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -1575,49 +1619,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of VolumeFlow
         /// </summary>
         public static VolumeFlow MinValue => new VolumeFlow(double.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private double AsBaseUnitCubicMetersPerSecond()
-        {
-            if (Unit == VolumeFlowUnit.CubicMeterPerSecond) { return _value; }
-
-            switch (Unit)
-            {
-                case VolumeFlowUnit.CentilitersPerMinute: return (_value/60000.00000) * 1e-2d;
-                case VolumeFlowUnit.CubicDecimeterPerMinute: return _value/60000.00000;
-                case VolumeFlowUnit.CubicFootPerHour: return _value*7.8657907199999087346816086183876e-6;
-                case VolumeFlowUnit.CubicFootPerMinute: return _value/2118.88000326;
-                case VolumeFlowUnit.CubicFootPerSecond: return _value/35.314666721;
-                case VolumeFlowUnit.CubicMeterPerHour: return _value/3600;
-                case VolumeFlowUnit.CubicMeterPerMinute: return _value/60;
-                case VolumeFlowUnit.CubicMeterPerSecond: return _value;
-                case VolumeFlowUnit.CubicYardPerHour: return _value*2.1237634944E-4;
-                case VolumeFlowUnit.CubicYardPerMinute: return _value*0.0127425809664;
-                case VolumeFlowUnit.CubicYardPerSecond: return _value*0.764554857984;
-                case VolumeFlowUnit.DecilitersPerMinute: return (_value/60000.00000) * 1e-1d;
-                case VolumeFlowUnit.KilolitersPerMinute: return (_value/60000.00000) * 1e3d;
-                case VolumeFlowUnit.LitersPerHour: return _value/3600000.000;
-                case VolumeFlowUnit.LitersPerMinute: return _value/60000.00000;
-                case VolumeFlowUnit.LitersPerSecond: return _value/1000;
-                case VolumeFlowUnit.MicrolitersPerMinute: return (_value/60000.00000) * 1e-6d;
-                case VolumeFlowUnit.MillilitersPerMinute: return (_value/60000.00000) * 1e-3d;
-                case VolumeFlowUnit.MillionUsGallonsPerDay: return _value/22.824465227;
-                case VolumeFlowUnit.NanolitersPerMinute: return (_value/60000.00000) * 1e-9d;
-                case VolumeFlowUnit.OilBarrelsPerDay: return _value*1.8401307283333333333333333333333e-6;
-                case VolumeFlowUnit.UsGallonsPerHour: return _value/951019.38848933424;
-                case VolumeFlowUnit.UsGallonsPerMinute: return _value/15850.323141489;
-                case VolumeFlowUnit.UsGallonsPerSecond: return _value/264.1720523581484;
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private double AsBaseNumericType(VolumeFlowUnit unit) => Convert.ToDouble(As(unit));
 
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.

--- a/UnitsNet/Scripts/GenerateUnits.ps1
+++ b/UnitsNet/Scripts/GenerateUnits.ps1
@@ -141,15 +141,8 @@ function Set-ConversionFunctions
             }
 
             # Convert to/from double for other base types
-            if ($quantity.BaseType -eq "decimal") {
-                $u.FromUnitToBaseFunc = "Convert.ToDecimal($($u.FromUnitToBaseFunc))"
-                $u.FromBaseToUnitFunc = "Convert.ToDouble($($u.FromBaseToUnitFunc))"
-            } else {
-                if ($quantity.BaseType -eq "long") {
-                  $u.FromUnitToBaseFunc = "Convert.ToInt64($($u.FromUnitToBaseFunc))"
-                  $u.FromBaseToUnitFunc = "Convert.ToDouble($($u.FromBaseToUnitFunc))"
-                }
-            }
+            $u.FromUnitToBaseFunc = "$($u.FromUnitToBaseFunc)"
+            $u.FromBaseToUnitFunc = "$($u.FromBaseToUnitFunc)"
         }
         return $quantity
     }

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -154,11 +154,11 @@ namespace UnitsNet
 #else
         public 
 #endif
-          $quantityName($baseType numericValue, $unitEnumName unit)
+        $quantityName($baseType numericValue, $unitEnumName unit)
         {
             _value = numericValue;
             _unit = unit;
-         }
+        }
 
         // Windows Runtime Component does not allow public methods/ctors with same number of parameters: https://msdn.microsoft.com/en-us/library/br230301.aspx#Overloaded methods
         /// <summary>
@@ -423,7 +423,7 @@ namespace UnitsNet
 #endif
         int CompareTo($quantityName other)
         {
-            return AsBaseUnit$baseUnitPluralName().CompareTo(other.AsBaseUnit$baseUnitPluralName());
+            return AsBaseUnit().CompareTo(other.AsBaseUnit());
         }
 
         // Windows Runtime Component does not allow operator overloads: https://msdn.microsoft.com/en-us/library/br230301.aspx
@@ -468,7 +468,7 @@ namespace UnitsNet
                 return false;
             }
 
-            return AsBaseUnit$baseUnitPluralName().Equals((($quantityName) obj).AsBaseUnit$baseUnitPluralName());
+            return AsBaseUnit().Equals((($quantityName) obj).AsBaseUnit());
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <returns>True if the difference between the two values is not greater than the specified max.</returns>
         public bool Equals($quantityName other, $quantityName maxError)
         {
-            return Math.Abs(AsBaseUnit$baseUnitPluralName() - other.AsBaseUnit$baseUnitPluralName()) <= maxError.AsBaseUnit$baseUnitPluralName();
+            return Math.Abs(AsBaseUnit() - other.AsBaseUnit()) <= maxError.AsBaseUnit();
         }
 
         public override int GetHashCode()
@@ -499,22 +499,46 @@ namespace UnitsNet
         /// <returns>Value converted to the specified unit.</returns>
         public double As($unitEnumName unit)
         {
-            if (Unit == unit)
+            if(Unit == unit)
+                return Convert.ToDouble(Value);
+
+            var converted = AsBaseNumericType(unit);
+            return Convert.ToDouble(converted);
+        }
+
+        /// <summary>
+        ///     Converts the current value + unit to the base unit.
+        ///     This is typically the first step in converting from one unit to another.
+        /// </summary>
+        /// <returns>The value in the base unit representation.</returns>
+        private $baseType AsBaseUnit()
+        {
+            switch(Unit)
             {
-                return (double)Value;
+"@; foreach ($unit in $units) {
+        $func = $unit.FromUnitToBaseFunc.Replace("x", "_value");@"
+                case $unitEnumName.$($unit.SingularName): return $func;
+"@; }@"
+                default:
+                    throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
+        }
 
-            $baseType baseUnitValue = AsBaseUnit$($baseUnitPluralName)();
+        private $baseType AsBaseNumericType($unitEnumName unit)
+        {
+            if(Unit == unit)
+                return _value;
 
-            switch (unit)
+            var baseUnitValue = AsBaseUnit();
+
+            switch(unit)
             {
 "@; foreach ($unit in $units) {
         $func = $unit.FromBaseToUnitFunc.Replace("x", "baseUnitValue");@"
                 case $unitEnumName.$($unit.SingularName): return $func;
 "@; }@"
-
                 default:
-                    throw new NotImplementedException("unit: " + unit);
+                    throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }
         }
 
@@ -863,29 +887,6 @@ namespace UnitsNet
         /// Represents the smallest possible value of $quantityName
         /// </summary>
         public static $quantityName MinValue => new $quantityName($baseType.MinValue, BaseUnit);
-
-        /// <summary>
-        ///     Converts the current value + unit to the base unit.
-        ///     This is typically the first step in converting from one unit to another.
-        /// </summary>
-        /// <returns>The value in the base unit representation.</returns>
-        private $baseType AsBaseUnit$baseUnitPluralName()
-        {
-            if (Unit == $unitEnumName.$baseUnitSingularName) { return _value; }
-
-            switch (Unit)
-            {
-"@; foreach ($unit in $units) {
-        $func = $unit.FromUnitToBaseFunc.Replace("x", "_value");@"
-                case $unitEnumName.$($unit.SingularName): return $func;
-"@; }@"
-                default:
-                    throw new NotImplementedException("Unit not implemented: " + Unit);
-            }
-        }
-
-        /// <summary>Convenience method for working with internal numeric type.</summary>
-        private $baseType AsBaseNumericType($unitEnumName unit) => $convertToBaseType(As(unit));
 
 "@;
 if($baseDimensions)


### PR DESCRIPTION
Doing As conversions in base type for accuracy sake. Only doing double conversion for As method.

Moving AsXXX methods to all be together in "Conversion" region.

I also renamed the method to convert to base units to make it consistent across all quantities. Potentially useful for future interface method. It also means the method signature won't change if a quantity's base unit is changed.