### PR TITLE
Add xmldoc to nugets

### DIFF
--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Common.props
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Common.props
@@ -9,6 +9,7 @@
     <Copyright>Copyright (c) 2015 Andreas Gullberg Larsen</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>

--- a/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.csproj
+++ b/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.csproj
@@ -37,6 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <DocumentationFile>..\Artifacts\UnitsNet.WindowsRuntimeComponent\UnitsNet.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/UnitsNet/UnitsNet.Common.props
+++ b/UnitsNet/UnitsNet.Common.props
@@ -9,6 +9,7 @@
     <Copyright>Copyright (c) 2013 Andreas Gullberg Larsen</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>


### PR DESCRIPTION
I verified that, with these changes, all nugets now have an .XML file included and they did not before.. What is the use of all our lovely xmldoc if no one is actually able to read it? :-D

Weird no one has caught this before, oh well !