### PR TITLE
Fixing ~1200 warnings by disabling XML comment warnings for generated…

### DIFF
--- a/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 0, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit MeterPerSecondSquared.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Acceleration(double meterspersecondsquared)
         {
@@ -227,6 +230,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit MeterPerSecondSquared.
+        /// </summary>
         public static Acceleration Zero => new Acceleration(0, BaseUnit);
 
         /// <summary>
@@ -567,6 +573,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Acceleration.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
@@ -729,10 +729,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is MeterPerSecondSquared
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AccelerationUnit ToStringDefaultUnit { get; set; } = AccelerationUnit.MeterPerSecondSquared;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
@@ -750,10 +750,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Mole
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AmountOfSubstanceUnit ToStringDefaultUnit { get; set; } = AmountOfSubstanceUnit.Mole;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 1, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Mole.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public AmountOfSubstance(double moles)
         {
@@ -232,6 +235,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Mole.
+        /// </summary>
         public static AmountOfSubstance Zero => new AmountOfSubstance(0, BaseUnit);
 
         /// <summary>
@@ -586,6 +592,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current AmountOfSubstance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit DecibelVolt.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public AmplitudeRatio(double decibelvolts)
         {
@@ -181,6 +184,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit DecibelVolt.
+        /// </summary>
         public static AmplitudeRatio Zero => new AmplitudeRatio(0, BaseUnit);
 
         /// <summary>
@@ -395,6 +401,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current AmplitudeRatio.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
@@ -539,10 +539,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is DecibelVolt
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AmplitudeRatioUnit ToStringDefaultUnit { get; set; } = AmplitudeRatioUnit.DecibelVolt;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Angle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Angle.Common.g.cs
@@ -749,10 +749,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Degree
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AngleUnit ToStringDefaultUnit { get; set; } = AngleUnit.Degree;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Angle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Angle.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Degree.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Angle(double degrees)
         {
@@ -231,6 +234,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Degree.
+        /// </summary>
         public static Angle Zero => new Angle(0, BaseUnit);
 
         /// <summary>
@@ -585,6 +591,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Angle.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is VoltampereHour
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ApparentEnergyUnit ToStringDefaultUnit { get; set; } = ApparentEnergyUnit.VoltampereHour;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit VoltampereHour.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ApparentEnergy(double voltamperehours)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereHour.
+        /// </summary>
         public static ApparentEnergy Zero => new ApparentEnergy(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ApparentEnergy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Voltampere.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ApparentPower(double voltamperes)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Voltampere.
+        /// </summary>
         public static ApparentPower Zero => new ApparentPower(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ApparentPower.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Voltampere
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ApparentPowerUnit ToStringDefaultUnit { get; set; } = ApparentPowerUnit.Voltampere;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Area.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Area.Common.g.cs
@@ -729,10 +729,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is SquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AreaUnit ToStringDefaultUnit { get; set; } = AreaUnit.SquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Area.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Area.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit SquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Area(double squaremeters)
         {
@@ -227,6 +230,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeter.
+        /// </summary>
         public static Area Zero => new Area(0, BaseUnit);
 
         /// <summary>
@@ -567,6 +573,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Area.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramPerSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AreaDensityUnit ToStringDefaultUnit { get; set; } = AreaDensityUnit.KilogramPerSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramPerSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public AreaDensity(double kilogramspersquaremeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerSquareMeter.
+        /// </summary>
         public static AreaDensity Zero => new AreaDensity(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current AreaDensity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
@@ -582,10 +582,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is MeterToTheFourth
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static AreaMomentOfInertiaUnit ToStringDefaultUnit { get; set; } = AreaMomentOfInertiaUnit.MeterToTheFourth;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(4, 0, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit MeterToTheFourth.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public AreaMomentOfInertia(double meterstothefourth)
         {
@@ -192,6 +195,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit MeterToTheFourth.
+        /// </summary>
         public static AreaMomentOfInertia Zero => new AreaMomentOfInertia(0, BaseUnit);
 
         /// <summary>
@@ -434,6 +440,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current AreaMomentOfInertia.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
@@ -1000,10 +1000,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is BitPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static BitRateUnit ToStringDefaultUnit { get; set; } = BitRateUnit.BitPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit BitPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public BitRate(double bitspersecond)
         {
@@ -291,6 +294,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit BitPerSecond.
+        /// </summary>
         public static BitRate Zero => new BitRate(0, BaseUnit);
 
         /// <summary>
@@ -812,6 +818,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current BitRate.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramPerJoule
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static BrakeSpecificFuelConsumptionUnit ToStringDefaultUnit { get; set; } = BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramPerJoule.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public BrakeSpecificFuelConsumption(double kilogramsperjoule)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerJoule.
+        /// </summary>
         public static BrakeSpecificFuelConsumption Zero => new BrakeSpecificFuelConsumption(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current BrakeSpecificFuelConsumption.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Farad.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Capacitance(double farads)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Farad.
+        /// </summary>
         public static Capacitance Zero => new Capacitance(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Capacitance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Farad
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static CapacitanceUnit ToStringDefaultUnit { get; set; } = CapacitanceUnit.Farad;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Density.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Density.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramPerCubicMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Density(double kilogramspercubicmeter)
         {
@@ -352,6 +355,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerCubicMeter.
+        /// </summary>
         public static Density Zero => new Density(0, BaseUnit);
 
         /// <summary>
@@ -1042,6 +1048,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Density.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Density.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Density.Common.g.cs
@@ -1254,10 +1254,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramPerCubicMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static DensityUnit ToStringDefaultUnit { get; set; } = DensityUnit.KilogramPerCubicMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Duration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Duration.Common.g.cs
@@ -710,10 +710,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Second
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static DurationUnit ToStringDefaultUnit { get; set; } = DurationUnit.Second;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Duration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Duration.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Second.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Duration(double seconds)
         {
@@ -224,6 +227,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Second.
+        /// </summary>
         public static Duration Zero => new Duration(0, BaseUnit);
 
         /// <summary>
@@ -550,6 +556,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Duration.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
@@ -582,10 +582,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonSecondPerMeterSquared
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static DynamicViscosityUnit ToStringDefaultUnit { get; set; } = DynamicViscosityUnit.NewtonSecondPerMeterSquared;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonSecondPerMeterSquared.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public DynamicViscosity(double newtonsecondspermetersquared)
         {
@@ -192,6 +195,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonSecondPerMeterSquared.
+        /// </summary>
         public static DynamicViscosity Zero => new DynamicViscosity(0, BaseUnit);
 
         /// <summary>
@@ -434,6 +440,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current DynamicViscosity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Siemens
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricAdmittanceUnit ToStringDefaultUnit { get; set; } = ElectricAdmittanceUnit.Siemens;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Siemens.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricAdmittance(double siemens)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Siemens.
+        /// </summary>
         public static ElectricAdmittance Zero => new ElectricAdmittance(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricAdmittance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 1, 1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Coulomb.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricCharge(double coulombs)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Coulomb.
+        /// </summary>
         public static ElectricCharge Zero => new ElectricCharge(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricCharge.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Coulomb
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricChargeUnit ToStringDefaultUnit { get; set; } = ElectricChargeUnit.Coulomb;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is CoulombPerCubicMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricChargeDensityUnit ToStringDefaultUnit { get; set; } = ElectricChargeDensityUnit.CoulombPerCubicMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit CoulombPerCubicMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricChargeDensity(double coulombspercubicmeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit CoulombPerCubicMeter.
+        /// </summary>
         public static ElectricChargeDensity Zero => new ElectricChargeDensity(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricChargeDensity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Siemens
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricConductanceUnit ToStringDefaultUnit { get; set; } = ElectricConductanceUnit.Siemens;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Siemens.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricConductance(double siemens)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Siemens.
+        /// </summary>
         public static ElectricConductance Zero => new ElectricConductance(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricConductance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit SiemensPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricConductivity(double siemenspermeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit SiemensPerMeter.
+        /// </summary>
         public static ElectricConductivity Zero => new ElectricConductivity(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricConductivity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is SiemensPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricConductivityUnit ToStringDefaultUnit { get; set; } = ElectricConductivityUnit.SiemensPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 0, 1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Ampere.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricCurrent(double amperes)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Ampere.
+        /// </summary>
         public static ElectricCurrent Zero => new ElectricCurrent(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricCurrent.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Ampere
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricCurrentUnit ToStringDefaultUnit { get; set; } = ElectricCurrentUnit.Ampere;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit AmperePerSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricCurrentDensity(double amperespersquaremeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerSquareMeter.
+        /// </summary>
         public static ElectricCurrentDensity Zero => new ElectricCurrentDensity(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricCurrentDensity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is AmperePerSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricCurrentDensityUnit ToStringDefaultUnit { get; set; } = ElectricCurrentDensityUnit.AmperePerSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, -1, 1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit AmperePerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricCurrentGradient(double amperespersecond)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerSecond.
+        /// </summary>
         public static ElectricCurrentGradient Zero => new ElectricCurrentGradient(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricCurrentGradient.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is AmperePerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricCurrentGradientUnit ToStringDefaultUnit { get; set; } = ElectricCurrentGradientUnit.AmperePerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is VoltPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricFieldUnit ToStringDefaultUnit { get; set; } = ElectricFieldUnit.VoltPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 1, -3, -1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit VoltPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricField(double voltspermeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit VoltPerMeter.
+        /// </summary>
         public static ElectricField Zero => new ElectricField(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricField.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Henry
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricInductanceUnit ToStringDefaultUnit { get; set; } = ElectricInductanceUnit.Henry;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, -2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Henry.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricInductance(double henries)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Henry.
+        /// </summary>
         public static ElectricInductance Zero => new ElectricInductance(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricInductance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -3, -1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Volt.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricPotential(double volts)
         {
@@ -187,6 +190,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Volt.
+        /// </summary>
         public static ElectricPotential Zero => new ElectricPotential(0, BaseUnit);
 
         /// <summary>
@@ -415,6 +421,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricPotential.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
@@ -561,10 +561,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Volt
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricPotentialUnit ToStringDefaultUnit { get; set; } = ElectricPotentialUnit.Volt;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit VoltAc.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricPotentialAc(double voltsac)
         {
@@ -186,6 +189,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit VoltAc.
+        /// </summary>
         public static ElectricPotentialAc Zero => new ElectricPotentialAc(0, BaseUnit);
 
         /// <summary>
@@ -414,6 +420,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricPotentialAc.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
@@ -560,10 +560,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is VoltAc
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricPotentialAcUnit ToStringDefaultUnit { get; set; } = ElectricPotentialAcUnit.VoltAc;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit VoltDc.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricPotentialDc(double voltsdc)
         {
@@ -186,6 +189,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit VoltDc.
+        /// </summary>
         public static ElectricPotentialDc Zero => new ElectricPotentialDc(0, BaseUnit);
 
         /// <summary>
@@ -414,6 +420,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricPotentialDc.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
@@ -560,10 +560,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is VoltDc
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricPotentialDcUnit ToStringDefaultUnit { get; set; } = ElectricPotentialDcUnit.VoltDc;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Ohm.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricResistance(double ohms)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Ohm.
+        /// </summary>
         public static ElectricResistance Zero => new ElectricResistance(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricResistance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Ohm
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricResistanceUnit ToStringDefaultUnit { get; set; } = ElectricResistanceUnit.Ohm;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(3, 1, -3, -2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit OhmMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ElectricResistivity(double ohmmeters)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit OhmMeter.
+        /// </summary>
         public static ElectricResistivity Zero => new ElectricResistivity(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ElectricResistivity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is OhmMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ElectricResistivityUnit ToStringDefaultUnit { get; set; } = ElectricResistivityUnit.OhmMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Energy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Energy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Joule.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Energy(double joules)
         {
@@ -272,6 +275,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Joule.
+        /// </summary>
         public static Energy Zero => new Energy(0, BaseUnit);
 
         /// <summary>
@@ -738,6 +744,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Energy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Energy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Energy.Common.g.cs
@@ -918,10 +918,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Joule
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static EnergyUnit ToStringDefaultUnit { get; set; } = EnergyUnit.Joule;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit JoulePerKelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Entropy(double joulesperkelvin)
         {
@@ -197,6 +200,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKelvin.
+        /// </summary>
         public static Entropy Zero => new Entropy(0, BaseUnit);
 
         /// <summary>
@@ -453,6 +459,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Entropy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
@@ -603,10 +603,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is JoulePerKelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static EntropyUnit ToStringDefaultUnit { get; set; } = EntropyUnit.JoulePerKelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Flow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Flow.Common.g.cs
@@ -978,10 +978,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is CubicMeterPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static FlowUnit ToStringDefaultUnit { get; set; } = FlowUnit.CubicMeterPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Flow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Flow.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(3, 0, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit CubicMeterPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Flow(double cubicmeterspersecond)
         {
@@ -300,6 +303,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerSecond.
+        /// </summary>
         public static Flow Zero => new Flow(0, BaseUnit);
 
         /// <summary>
@@ -794,6 +800,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Flow.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Force.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Force.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Newton.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Force(double newtons)
         {
@@ -212,6 +215,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Newton.
+        /// </summary>
         public static Force Zero => new Force(0, BaseUnit);
 
         /// <summary>
@@ -510,6 +516,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Force.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Force.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Force.Common.g.cs
@@ -666,10 +666,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Newton
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ForceUnit ToStringDefaultUnit { get; set; } = ForceUnit.Newton;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
@@ -687,10 +687,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ForceChangeRateUnit ToStringDefaultUnit { get; set; } = ForceChangeRateUnit.NewtonPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ForceChangeRate(double newtonspersecond)
         {
@@ -217,6 +220,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerSecond.
+        /// </summary>
         public static ForceChangeRate Zero => new ForceChangeRate(0, BaseUnit);
 
         /// <summary>
@@ -529,6 +535,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ForceChangeRate.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
@@ -645,10 +645,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ForcePerLengthUnit ToStringDefaultUnit { get; set; } = ForcePerLengthUnit.NewtonPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ForcePerLength(double newtonspermeter)
         {
@@ -207,6 +210,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerMeter.
+        /// </summary>
         public static ForcePerLength Zero => new ForcePerLength(0, BaseUnit);
 
         /// <summary>
@@ -491,6 +497,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ForcePerLength.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Hertz.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Frequency(double hertz)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Hertz.
+        /// </summary>
         public static Frequency Zero => new Frequency(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Frequency.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Hertz
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static FrequencyUnit ToStringDefaultUnit { get; set; } = FrequencyUnit.Hertz;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
@@ -792,10 +792,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is WattPerSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static HeatFluxUnit ToStringDefaultUnit { get; set; } = HeatFluxUnit.WattPerSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit WattPerSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public HeatFlux(double wattspersquaremeter)
         {
@@ -242,6 +245,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeter.
+        /// </summary>
         public static HeatFlux Zero => new HeatFlux(0, BaseUnit);
 
         /// <summary>
@@ -624,6 +630,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current HeatFlux.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
@@ -498,10 +498,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is WattPerSquareMeterKelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static HeatTransferCoefficientUnit ToStringDefaultUnit { get; set; } = HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -3, 0, -1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit WattPerSquareMeterKelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public HeatTransferCoefficient(double wattspersquaremeterkelvin)
         {
@@ -172,6 +175,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeterKelvin.
+        /// </summary>
         public static HeatTransferCoefficient Zero => new HeatTransferCoefficient(0, BaseUnit);
 
         /// <summary>
@@ -358,6 +364,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current HeatTransferCoefficient.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Lux
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static IlluminanceUnit ToStringDefaultUnit { get; set; } = IlluminanceUnit.Lux;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Lux.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Illuminance(double lux)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Lux.
+        /// </summary>
         public static Illuminance Zero => new Illuminance(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Illuminance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Information.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Information.Common.g.cs
@@ -1000,10 +1000,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Bit
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static InformationUnit ToStringDefaultUnit { get; set; } = InformationUnit.Bit;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Information.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Information.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Bit.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Information(double bits)
         {
@@ -291,6 +294,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Bit.
+        /// </summary>
         public static Information Zero => new Information(0, BaseUnit);
 
         /// <summary>
@@ -812,6 +818,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Information.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit WattPerSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Irradiance(double wattspersquaremeter)
         {
@@ -172,6 +175,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeter.
+        /// </summary>
         public static Irradiance Zero => new Irradiance(0, BaseUnit);
 
         /// <summary>
@@ -358,6 +364,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Irradiance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
@@ -498,10 +498,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is WattPerSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static IrradianceUnit ToStringDefaultUnit { get; set; } = IrradianceUnit.WattPerSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit JoulePerSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Irradiation(double joulespersquaremeter)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerSquareMeter.
+        /// </summary>
         public static Irradiation Zero => new Irradiation(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Irradiation.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is JoulePerSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static IrradiationUnit ToStringDefaultUnit { get; set; } = IrradiationUnit.JoulePerSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is SquareMeterPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static KinematicViscosityUnit ToStringDefaultUnit { get; set; } = KinematicViscosityUnit.SquareMeterPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 0, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit SquareMeterPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public KinematicViscosity(double squaremeterspersecond)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeterPerSecond.
+        /// </summary>
         public static KinematicViscosity Zero => new KinematicViscosity(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current KinematicViscosity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is DegreeCelsiusPerKilometer
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static LapseRateUnit ToStringDefaultUnit { get; set; } = LapseRateUnit.DegreeCelsiusPerKilometer;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit DegreeCelsiusPerKilometer.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public LapseRate(double degreescelciusperkilometer)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit DegreeCelsiusPerKilometer.
+        /// </summary>
         public static LapseRate Zero => new LapseRate(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current LapseRate.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Length.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Length.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Meter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Length(double meters)
         {
@@ -272,6 +275,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Meter.
+        /// </summary>
         public static Length Zero => new Length(0, BaseUnit);
 
         /// <summary>
@@ -738,6 +744,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Length.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Length.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Length.Common.g.cs
@@ -918,10 +918,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Meter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static LengthUnit ToStringDefaultUnit { get; set; } = LengthUnit.Meter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Level.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Level.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Decibel.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Level(double decibels)
         {
@@ -171,6 +174,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Decibel.
+        /// </summary>
         public static Level Zero => new Level(0, BaseUnit);
 
         /// <summary>
@@ -357,6 +363,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Level.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Level.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Level.Common.g.cs
@@ -497,10 +497,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Decibel
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static LevelUnit ToStringDefaultUnit { get; set; } = LevelUnit.Decibel;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static LinearDensityUnit ToStringDefaultUnit { get; set; } = LinearDensityUnit.KilogramPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public LinearDensity(double kilogramspermeter)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerMeter.
+        /// </summary>
         public static LinearDensity Zero => new LinearDensity(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current LinearDensity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Lumen
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static LuminousFluxUnit ToStringDefaultUnit { get; set; } = LuminousFluxUnit.Lumen;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Lumen.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public LuminousFlux(double lumens)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Lumen.
+        /// </summary>
         public static LuminousFlux Zero => new LuminousFlux(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current LuminousFlux.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Candela
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static LuminousIntensityUnit ToStringDefaultUnit { get; set; } = LuminousIntensityUnit.Candela;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Candela.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public LuminousIntensity(double candela)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Candela.
+        /// </summary>
         public static LuminousIntensity Zero => new LuminousIntensity(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current LuminousIntensity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -2, -1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Tesla.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MagneticField(double teslas)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Tesla.
+        /// </summary>
         public static MagneticField Zero => new MagneticField(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MagneticField.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Tesla
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MagneticFieldUnit ToStringDefaultUnit { get; set; } = MagneticFieldUnit.Tesla;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, -1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Weber.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MagneticFlux(double webers)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Weber.
+        /// </summary>
         public static MagneticFlux Zero => new MagneticFlux(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MagneticFlux.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Weber
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MagneticFluxUnit ToStringDefaultUnit { get; set; } = MagneticFluxUnit.Weber;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is AmperePerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MagnetizationUnit ToStringDefaultUnit { get; set; } = MagnetizationUnit.AmperePerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit AmperePerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Magnetization(double amperespermeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerMeter.
+        /// </summary>
         public static Magnetization Zero => new Magnetization(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Magnetization.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Mass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Mass.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Kilogram.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Mass(double kilograms)
         {
@@ -267,6 +270,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Kilogram.
+        /// </summary>
         public static Mass Zero => new Mass(0, BaseUnit);
 
         /// <summary>
@@ -719,6 +725,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Mass.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Mass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Mass.Common.g.cs
@@ -897,10 +897,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Kilogram
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MassUnit ToStringDefaultUnit { get; set; } = MassUnit.Kilogram;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit GramPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MassFlow(double gramspersecond)
         {
@@ -237,6 +240,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit GramPerSecond.
+        /// </summary>
         public static MassFlow Zero => new MassFlow(0, BaseUnit);
 
         /// <summary>
@@ -605,6 +611,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MassFlow.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
@@ -771,10 +771,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is GramPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MassFlowUnit ToStringDefaultUnit { get; set; } = MassFlowUnit.GramPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
@@ -498,10 +498,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramPerSecondPerSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MassFluxUnit ToStringDefaultUnit { get; set; } = MassFluxUnit.KilogramPerSecondPerSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramPerSecondPerSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MassFlux(double kilogramspersecondpersquaremeter)
         {
@@ -172,6 +175,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerSecondPerSquareMeter.
+        /// </summary>
         public static MassFlux Zero => new MassFlux(0, BaseUnit);
 
         /// <summary>
@@ -358,6 +364,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MassFlux.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramSquareMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MassMomentOfInertia(double kilogramsquaremeters)
         {
@@ -292,6 +295,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramSquareMeter.
+        /// </summary>
         public static MassMomentOfInertia Zero => new MassMomentOfInertia(0, BaseUnit);
 
         /// <summary>
@@ -814,6 +820,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MassMomentOfInertia.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
@@ -1002,10 +1002,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramSquareMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MassMomentOfInertiaUnit ToStringDefaultUnit { get; set; } = MassMomentOfInertiaUnit.KilogramSquareMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is JoulePerMole
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MolarEnergyUnit ToStringDefaultUnit { get; set; } = MolarEnergyUnit.JoulePerMole;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, -1, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit JoulePerMole.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MolarEnergy(double joulespermole)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerMole.
+        /// </summary>
         public static MolarEnergy Zero => new MolarEnergy(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MolarEnergy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, -1, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit JoulePerMoleKelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MolarEntropy(double joulespermolekelvin)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerMoleKelvin.
+        /// </summary>
         public static MolarEntropy Zero => new MolarEntropy(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MolarEntropy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is JoulePerMoleKelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MolarEntropyUnit ToStringDefaultUnit { get; set; } = MolarEntropyUnit.JoulePerMoleKelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
@@ -708,10 +708,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is KilogramPerMole
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MolarMassUnit ToStringDefaultUnit { get; set; } = MolarMassUnit.KilogramPerMole;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, -1, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit KilogramPerMole.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public MolarMass(double kilogramspermole)
         {
@@ -222,6 +225,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerMole.
+        /// </summary>
         public static MolarMass Zero => new MolarMass(0, BaseUnit);
 
         /// <summary>
@@ -548,6 +554,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current MolarMass.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is MolesPerCubicMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static MolarityUnit ToStringDefaultUnit { get; set; } = MolarityUnit.MolesPerCubicMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit MolesPerCubicMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Molarity(double molespercubicmeter)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit MolesPerCubicMeter.
+        /// </summary>
         public static Molarity Zero => new Molarity(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Molarity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is HenryPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PermeabilityUnit ToStringDefaultUnit { get; set; } = PermeabilityUnit.HenryPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 1, -2, -2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit HenryPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Permeability(double henriespermeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit HenryPerMeter.
+        /// </summary>
         public static Permeability Zero => new Permeability(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Permeability.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
@@ -477,10 +477,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is FaradPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PermittivityUnit ToStringDefaultUnit { get; set; } = PermittivityUnit.FaradPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit FaradPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Permittivity(double faradspermeter)
         {
@@ -167,6 +170,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit FaradPerMeter.
+        /// </summary>
         public static Permittivity Zero => new Permittivity(0, BaseUnit);
 
         /// <summary>
@@ -339,6 +345,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Permittivity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Power.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Power.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Watt.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Power(double watts)
         {
@@ -262,6 +265,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Watt.
+        /// </summary>
         public static Power Zero => new Power(0, BaseUnit);
 
         /// <summary>
@@ -699,6 +705,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Power.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Power.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Power.Common.g.cs
@@ -875,10 +875,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Watt
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PowerUnit ToStringDefaultUnit { get; set; } = PowerUnit.Watt;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit WattPerCubicMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public PowerDensity(double wattspercubicmeter)
         {
@@ -382,6 +385,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerCubicMeter.
+        /// </summary>
         public static PowerDensity Zero => new PowerDensity(0, BaseUnit);
 
         /// <summary>
@@ -1156,6 +1162,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current PowerDensity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
@@ -1380,10 +1380,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is WattPerCubicMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PowerDensityUnit ToStringDefaultUnit { get; set; } = PowerDensityUnit.WattPerCubicMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit DecibelWatt.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public PowerRatio(double decibelwatts)
         {
@@ -171,6 +174,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit DecibelWatt.
+        /// </summary>
         public static PowerRatio Zero => new PowerRatio(0, BaseUnit);
 
         /// <summary>
@@ -357,6 +363,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current PowerRatio.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
@@ -497,10 +497,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is DecibelWatt
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PowerRatioUnit ToStringDefaultUnit { get; set; } = PowerRatioUnit.DecibelWatt;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
@@ -1255,10 +1255,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Pascal
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PressureUnit ToStringDefaultUnit { get; set; } = PressureUnit.Pascal;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Pascal.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Pressure(double pascals)
         {
@@ -353,6 +356,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Pascal.
+        /// </summary>
         public static Pressure Zero => new Pressure(0, BaseUnit);
 
         /// <summary>
@@ -1043,6 +1049,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Pressure.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is PascalPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static PressureChangeRateUnit ToStringDefaultUnit { get; set; } = PressureChangeRateUnit.PascalPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit PascalPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public PressureChangeRate(double pascalspersecond)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit PascalPerSecond.
+        /// </summary>
         public static PressureChangeRate Zero => new PressureChangeRate(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current PressureChangeRate.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
@@ -581,10 +581,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is DecimalFraction
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static RatioUnit ToStringDefaultUnit { get; set; } = RatioUnit.DecimalFraction;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit DecimalFraction.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Ratio(double decimalfractions)
         {
@@ -191,6 +194,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit DecimalFraction.
+        /// </summary>
         public static Ratio Zero => new Ratio(0, BaseUnit);
 
         /// <summary>
@@ -433,6 +439,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Ratio.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is VoltampereReactiveHour
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ReactiveEnergyUnit ToStringDefaultUnit { get; set; } = ReactiveEnergyUnit.VoltampereReactiveHour;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit VoltampereReactiveHour.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ReactiveEnergy(double voltamperereactivehours)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereReactiveHour.
+        /// </summary>
         public static ReactiveEnergy Zero => new ReactiveEnergy(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ReactiveEnergy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
@@ -540,10 +540,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is VoltampereReactive
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ReactivePowerUnit ToStringDefaultUnit { get; set; } = ReactivePowerUnit.VoltampereReactive;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit VoltampereReactive.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ReactivePower(double voltamperesreactive)
         {
@@ -182,6 +185,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereReactive.
+        /// </summary>
         public static ReactivePower Zero => new ReactivePower(0, BaseUnit);
 
         /// <summary>
@@ -396,6 +402,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ReactivePower.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is RadianPerSecondSquared
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static RotationalAccelerationUnit ToStringDefaultUnit { get; set; } = RotationalAccelerationUnit.RadianPerSecondSquared;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit RadianPerSecondSquared.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public RotationalAcceleration(double radianspersecondsquared)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit RadianPerSecondSquared.
+        /// </summary>
         public static RotationalAcceleration Zero => new RotationalAcceleration(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current RotationalAcceleration.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
@@ -729,10 +729,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is RadianPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static RotationalSpeedUnit ToStringDefaultUnit { get; set; } = RotationalSpeedUnit.RadianPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit RadianPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public RotationalSpeed(double radianspersecond)
         {
@@ -227,6 +230,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit RadianPerSecond.
+        /// </summary>
         public static RotationalSpeed Zero => new RotationalSpeed(0, BaseUnit);
 
         /// <summary>
@@ -567,6 +573,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current RotationalSpeed.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonMeterPerRadian.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public RotationalStiffness(double newtonmetersperradian)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeterPerRadian.
+        /// </summary>
         public static RotationalStiffness Zero => new RotationalStiffness(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current RotationalStiffness.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonMeterPerRadian
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static RotationalStiffnessUnit ToStringDefaultUnit { get; set; } = RotationalStiffnessUnit.NewtonMeterPerRadian;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonMeterPerRadianPerMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public RotationalStiffnessPerLength(double newtonmetersperradianpermeter)
         {
@@ -177,6 +180,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeterPerRadianPerMeter.
+        /// </summary>
         public static RotationalStiffnessPerLength Zero => new RotationalStiffnessPerLength(0, BaseUnit);
 
         /// <summary>
@@ -377,6 +383,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current RotationalStiffnessPerLength.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
@@ -519,10 +519,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonMeterPerRadianPerMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static RotationalStiffnessPerLengthUnit ToStringDefaultUnit { get; set; } = RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
@@ -476,10 +476,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Steradian
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static SolidAngleUnit ToStringDefaultUnit { get; set; } = SolidAngleUnit.Steradian;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Steradian.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public SolidAngle(double steradians)
         {
@@ -166,6 +169,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Steradian.
+        /// </summary>
         public static SolidAngle Zero => new SolidAngle(0, BaseUnit);
 
         /// <summary>
@@ -338,6 +344,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current SolidAngle.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is JoulePerKilogram
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static SpecificEnergyUnit ToStringDefaultUnit { get; set; } = SpecificEnergyUnit.JoulePerKilogram;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit JoulePerKilogram.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public SpecificEnergy(double joulesperkilogram)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKilogram.
+        /// </summary>
         public static SpecificEnergy Zero => new SpecificEnergy(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current SpecificEnergy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 0, -2, 0, -1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit JoulePerKilogramKelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public SpecificEntropy(double joulesperkilogramkelvin)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKilogramKelvin.
+        /// </summary>
         public static SpecificEntropy Zero => new SpecificEntropy(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current SpecificEntropy.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is JoulePerKilogramKelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static SpecificEntropyUnit ToStringDefaultUnit { get; set; } = SpecificEntropyUnit.JoulePerKilogramKelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(3, -1, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit CubicMeterPerKilogram.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public SpecificVolume(double cubicmetersperkilogram)
         {
@@ -172,6 +175,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerKilogram.
+        /// </summary>
         public static SpecificVolume Zero => new SpecificVolume(0, BaseUnit);
 
         /// <summary>
@@ -358,6 +364,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current SpecificVolume.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
@@ -498,10 +498,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is CubicMeterPerKilogram
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static SpecificVolumeUnit ToStringDefaultUnit { get; set; } = SpecificVolumeUnit.CubicMeterPerKilogram;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
@@ -813,10 +813,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonPerCubicMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static SpecificWeightUnit ToStringDefaultUnit { get; set; } = SpecificWeightUnit.NewtonPerCubicMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonPerCubicMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public SpecificWeight(double newtonspercubicmeter)
         {
@@ -247,6 +250,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerCubicMeter.
+        /// </summary>
         public static SpecificWeight Zero => new SpecificWeight(0, BaseUnit);
 
         /// <summary>
@@ -643,6 +649,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current SpecificWeight.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Speed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Speed.Common.g.cs
@@ -1128,10 +1128,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is MeterPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static SpeedUnit ToStringDefaultUnit { get; set; } = SpeedUnit.MeterPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Speed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Speed.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit MeterPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Speed(double meterspersecond)
         {
@@ -322,6 +325,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit MeterPerSecond.
+        /// </summary>
         public static Speed Zero => new Speed(0, BaseUnit);
 
         /// <summary>
@@ -928,6 +934,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Speed.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Kelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Temperature(double kelvins)
         {
@@ -202,6 +205,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Kelvin.
+        /// </summary>
         public static Temperature Zero => new Temperature(0, BaseUnit);
 
         /// <summary>
@@ -472,6 +478,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Temperature.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
@@ -624,10 +624,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Kelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static TemperatureUnit ToStringDefaultUnit { get; set; } = TemperatureUnit.Kelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, 0, -1, 0, 1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit DegreeCelsiusPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public TemperatureChangeRate(double degreescelsiuspersecond)
         {
@@ -212,6 +215,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit DegreeCelsiusPerSecond.
+        /// </summary>
         public static TemperatureChangeRate Zero => new TemperatureChangeRate(0, BaseUnit);
 
         /// <summary>
@@ -510,6 +516,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current TemperatureChangeRate.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
@@ -666,10 +666,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is DegreeCelsiusPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static TemperatureChangeRateUnit ToStringDefaultUnit { get; set; } = TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit Kelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public TemperatureDelta(double kelvins)
         {
@@ -249,6 +252,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit Kelvin.
+        /// </summary>
         public static TemperatureDelta Zero => new TemperatureDelta(0, BaseUnit);
 
         /// <summary>
@@ -631,6 +637,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current TemperatureDelta.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
@@ -799,10 +799,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is Kelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static TemperatureDeltaUnit ToStringDefaultUnit { get; set; } = TemperatureDeltaUnit.Kelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
@@ -498,10 +498,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is WattPerMeterKelvin
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ThermalConductivityUnit ToStringDefaultUnit { get; set; } = ThermalConductivityUnit.WattPerMeterKelvin;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(1, 1, -3, 0, -1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit WattPerMeterKelvin.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ThermalConductivity(double wattspermeterkelvin)
         {
@@ -172,6 +175,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerMeterKelvin.
+        /// </summary>
         public static ThermalConductivity Zero => new ThermalConductivity(0, BaseUnit);
 
         /// <summary>
@@ -358,6 +364,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ThermalConductivity.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
@@ -561,10 +561,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is SquareMeterKelvinPerKilowatt
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static ThermalResistanceUnit ToStringDefaultUnit { get; set; } = ThermalResistanceUnit.SquareMeterKelvinPerKilowatt;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(0, -1, 3, 0, 1, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit SquareMeterKelvinPerKilowatt.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public ThermalResistance(double squaremeterkelvinsperkilowatt)
         {
@@ -187,6 +190,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeterKelvinPerKilowatt.
+        /// </summary>
         public static ThermalResistance Zero => new ThermalResistance(0, BaseUnit);
 
         /// <summary>
@@ -415,6 +421,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current ThermalResistance.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Torque.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Torque.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit NewtonMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Torque(double newtonmeters)
         {
@@ -267,6 +270,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeter.
+        /// </summary>
         public static Torque Zero => new Torque(0, BaseUnit);
 
         /// <summary>
@@ -719,6 +725,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Torque.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/Torque.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Torque.Common.g.cs
@@ -897,10 +897,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is NewtonMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static TorqueUnit ToStringDefaultUnit { get; set; } = TorqueUnit.NewtonMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
@@ -81,6 +81,9 @@ namespace UnitsNet
         {
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit InternationalUnit.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public VitaminA(double internationalunits)
         {
@@ -166,6 +169,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit InternationalUnit.
+        /// </summary>
         public static VitaminA Zero => new VitaminA(0, BaseUnit);
 
         /// <summary>
@@ -338,6 +344,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current VitaminA.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
@@ -476,10 +476,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is InternationalUnit
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static VitaminAUnit ToStringDefaultUnit { get; set; } = VitaminAUnit.InternationalUnit;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Volume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Volume.Common.g.cs
@@ -1382,10 +1382,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is CubicMeter
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static VolumeUnit ToStringDefaultUnit { get; set; } = VolumeUnit.CubicMeter;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/Volume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Volume.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(3, 0, 0, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit CubicMeter.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public Volume(double cubicmeters)
         {
@@ -384,6 +387,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeter.
+        /// </summary>
         public static Volume Zero => new Volume(0, BaseUnit);
 
         /// <summary>
@@ -1158,6 +1164,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current Volume.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
@@ -877,7 +877,7 @@ namespace UnitsNet
                 case VolumeFlowUnit.NanolitersPerMinute: return (_value/60000.00000) * 1e-9d;
                 case VolumeFlowUnit.OilBarrelsPerDay: return _value*1.8401307283333333333333333333333e-6;
                 case VolumeFlowUnit.OilBarrelsPerHour: return _value*4.41631375e-5;
-                case VolumeFlowUnit.OilBarrelsPerMinute: return _value*02.64978825e-3;
+                case VolumeFlowUnit.OilBarrelsPerMinute: return _value*2.64978825e-3;
                 case VolumeFlowUnit.UsGallonsPerHour: return _value/951019.38848933424;
                 case VolumeFlowUnit.UsGallonsPerMinute: return _value/15850.323141489;
                 case VolumeFlowUnit.UsGallonsPerSecond: return _value/264.1720523581484;
@@ -917,7 +917,7 @@ namespace UnitsNet
                 case VolumeFlowUnit.NanolitersPerMinute: return (baseUnitValue*60000.00000) / 1e-9d;
                 case VolumeFlowUnit.OilBarrelsPerDay: return baseUnitValue/1.8401307283333333333333333333333e-6;
                 case VolumeFlowUnit.OilBarrelsPerHour: return baseUnitValue/4.41631375e-5;
-                case VolumeFlowUnit.OilBarrelsPerMinute: return baseUnitValue/02.64978825e-3;
+                case VolumeFlowUnit.OilBarrelsPerMinute: return baseUnitValue/2.64978825e-3;
                 case VolumeFlowUnit.UsGallonsPerHour: return baseUnitValue*951019.38848933424;
                 case VolumeFlowUnit.UsGallonsPerMinute: return baseUnitValue*15850.323141489;
                 case VolumeFlowUnit.UsGallonsPerSecond: return baseUnitValue*264.1720523581484;
@@ -1002,10 +1002,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is CubicMeterPerSecond
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static VolumeFlowUnit ToStringDefaultUnit { get; set; } = VolumeFlowUnit.CubicMeterPerSecond;
 
         /// <summary>

--- a/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
@@ -82,6 +82,9 @@ namespace UnitsNet
             BaseDimensions = new BaseDimensions(3, 0, -1, 0, 0, 0, 0);
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit CubicMeterPerSecond.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public VolumeFlow(double cubicmeterspersecond)
         {
@@ -292,6 +295,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerSecond.
+        /// </summary>
         public static VolumeFlow Zero => new VolumeFlow(0, BaseUnit);
 
         /// <summary>
@@ -814,6 +820,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current VolumeFlow.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Acceleration.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Acceleration.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit MeterPerSecondSquared.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Acceleration()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmountOfSubstance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmountOfSubstance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Mole.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public AmountOfSubstance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmplitudeRatio.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmplitudeRatio.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit DecibelVolt.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public AmplitudeRatio()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Angle.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Angle.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Degree.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Angle()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentEnergy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit VoltampereHour.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ApparentEnergy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentPower.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentPower.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Voltampere.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ApparentPower()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit SquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Area()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaDensity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramPerSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public AreaDensity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaMomentOfInertia.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaMomentOfInertia.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit MeterToTheFourth.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public AreaMomentOfInertia()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BitRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BitRate.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit BitPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public BitRate()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramPerJoule.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public BrakeSpecificFuelConsumption()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Capacitance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Capacitance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Farad.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Capacitance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Density.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Density.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramPerCubicMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Density()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Duration.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Duration.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Second.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Duration()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonSecondPerMeterSquared.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public DynamicViscosity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricAdmittance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricAdmittance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Siemens.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricAdmittance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCharge.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCharge.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Coulomb.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricCharge()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricChargeDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricChargeDensity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit CoulombPerCubicMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricChargeDensity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Siemens.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricConductance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit SiemensPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricConductivity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrent.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrent.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Ampere.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricCurrent()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentDensity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit AmperePerSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricCurrentDensity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentGradient.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentGradient.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit AmperePerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricCurrentGradient()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricField.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricField.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit VoltPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricField()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricInductance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricInductance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Henry.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricInductance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotential.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotential.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Volt.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricPotential()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialAc.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialAc.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit VoltAc.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricPotentialAc()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialDc.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialDc.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit VoltDc.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricPotentialDc()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Ohm.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricResistance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistivity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit OhmMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ElectricResistivity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Energy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Energy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Joule.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Energy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Entropy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Entropy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit JoulePerKelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Entropy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Flow.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Flow.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit CubicMeterPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Flow()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Newton.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Force()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForceChangeRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForceChangeRate.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ForceChangeRate()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForcePerLength.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForcePerLength.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ForcePerLength()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Hertz.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Frequency()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatFlux.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit WattPerSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public HeatFlux()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatTransferCoefficient.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatTransferCoefficient.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit WattPerSquareMeterKelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public HeatTransferCoefficient()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Illuminance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Illuminance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Lux.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Illuminance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Bit.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Information()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit WattPerSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Irradiance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiation.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiation.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit JoulePerSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Irradiation()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/KinematicViscosity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/KinematicViscosity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit SquareMeterPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public KinematicViscosity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LapseRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LapseRate.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit DegreeCelsiusPerKilometer.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public LapseRate()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Meter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Length()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Decibel.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Level()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearDensity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public LinearDensity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousFlux.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Lumen.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public LuminousFlux()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousIntensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousIntensity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Candela.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public LuminousIntensity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticField.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticField.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Tesla.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MagneticField()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticFlux.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Weber.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MagneticFlux()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Magnetization.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Magnetization.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit AmperePerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Magnetization()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Mass.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Mass.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Kilogram.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Mass()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlow.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlow.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit GramPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MassFlow()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlux.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramPerSecondPerSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MassFlux()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassMomentOfInertia.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassMomentOfInertia.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramSquareMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MassMomentOfInertia()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEnergy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit JoulePerMole.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MolarEnergy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEntropy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEntropy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit JoulePerMoleKelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MolarEntropy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarMass.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarMass.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit KilogramPerMole.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public MolarMass()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit MolesPerCubicMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Molarity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permeability.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permeability.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit HenryPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Permeability()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permittivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permittivity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit FaradPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Permittivity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Power.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Power.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Watt.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Power()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerDensity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit WattPerCubicMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public PowerDensity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerRatio.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerRatio.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit DecibelWatt.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public PowerRatio()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Pressure.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Pressure.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Pascal.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Pressure()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PressureChangeRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PressureChangeRate.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit PascalPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public PressureChangeRate()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Ratio.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Ratio.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit DecimalFraction.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Ratio()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactiveEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactiveEnergy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit VoltampereReactiveHour.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ReactiveEnergy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactivePower.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactivePower.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit VoltampereReactive.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ReactivePower()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit RadianPerSecondSquared.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public RotationalAcceleration()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalSpeed.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalSpeed.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit RadianPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public RotationalSpeed()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffness.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffness.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonMeterPerRadian.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public RotationalStiffness()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffnessPerLength.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffnessPerLength.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonMeterPerRadianPerMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public RotationalStiffnessPerLength()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SolidAngle.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SolidAngle.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Steradian.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public SolidAngle()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEnergy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit JoulePerKilogram.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public SpecificEnergy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEntropy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEntropy.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit JoulePerKilogramKelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public SpecificEntropy()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificVolume.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificVolume.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit CubicMeterPerKilogram.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public SpecificVolume()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificWeight.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificWeight.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonPerCubicMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public SpecificWeight()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Speed.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Speed.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit MeterPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Speed()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Temperature.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Temperature.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Kelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Temperature()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureChangeRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureChangeRate.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit DegreeCelsiusPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public TemperatureChangeRate()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureDelta.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureDelta.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit Kelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public TemperatureDelta()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalConductivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalConductivity.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit WattPerMeterKelvin.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ThermalConductivity()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit SquareMeterKelvinPerKilowatt.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public ThermalResistance()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Torque.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Torque.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit NewtonMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Torque()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VitaminA.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VitaminA.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit InternationalUnit.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public VitaminA()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Volume.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Volume.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit CubicMeter.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public Volume()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumeFlow.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumeFlow.WindowsRuntimeComponent.g.cs
@@ -63,7 +63,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit CubicMeterPerSecond.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public VolumeFlow()
         {
             _value = 0;

--- a/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.csproj
+++ b/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.csproj
@@ -104,7 +104,7 @@
     <Compile Include="..\Common\**\*.cs;" Exclude="**\obj\**">
       <Link>Common\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
-    <None Include="..\Common\**\*" Exclude="**\obj\**">
+    <None Include="..\Common\**\*" Exclude="**\obj\**;**\*.cs">
       <Link>Common\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
     <Compile Include="..\UnitsNet\**\*.cs;" Exclude="**\AssemblyInfo.cs;**\*NetFramework*.cs;**\obj\**">

--- a/UnitsNet/GeneratedCode/Units/AccelerationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AccelerationUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AccelerationUnit
     {
         Undefined = 0,
@@ -56,4 +59,6 @@ namespace UnitsNet.Units
         NanometerPerSecondSquared,
         StandardGravity,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/AmountOfSubstanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AmountOfSubstanceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AmountOfSubstanceUnit
     {
         Undefined = 0,
@@ -57,4 +60,6 @@ namespace UnitsNet.Units
         NanopoundMole,
         PoundMole,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/AmplitudeRatioUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AmplitudeRatioUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AmplitudeRatioUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         DecibelUnloaded,
         DecibelVolt,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/AngleUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AngleUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AngleUnit
     {
         Undefined = 0,
@@ -57,4 +60,6 @@ namespace UnitsNet.Units
         Radian,
         Revolution,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ApparentEnergyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ApparentEnergyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ApparentEnergyUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         MegavoltampereHour,
         VoltampereHour,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ApparentPowerUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ApparentPowerUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ApparentPowerUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         Megavoltampere,
         Voltampere,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/AreaDensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AreaDensityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AreaDensityUnit
     {
         Undefined = 0,
         KilogramPerSquareMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/AreaMomentOfInertiaUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AreaMomentOfInertiaUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AreaMomentOfInertiaUnit
     {
         Undefined = 0,
@@ -49,4 +52,6 @@ namespace UnitsNet.Units
         MeterToTheFourth,
         MillimeterToTheFourth,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/AreaUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AreaUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum AreaUnit
     {
         Undefined = 0,
@@ -56,4 +59,6 @@ namespace UnitsNet.Units
         SquareYard,
         UsSurveySquareFoot,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/BitRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/BitRateUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum BitRateUnit
     {
         Undefined = 0,
@@ -69,4 +72,6 @@ namespace UnitsNet.Units
         TerabitPerSecond,
         TerabytePerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/BrakeSpecificFuelConsumptionUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/BrakeSpecificFuelConsumptionUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum BrakeSpecificFuelConsumptionUnit
     {
         Undefined = 0,
@@ -50,4 +53,6 @@ namespace UnitsNet.Units
         /// </summary>
         PoundPerMechanicalHorsepowerHour,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/CapacitanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/CapacitanceUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum CapacitanceUnit
     {
         Undefined = 0,
         Farad,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/DensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/DensityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum DensityUnit
     {
         Undefined = 0,
@@ -81,4 +84,6 @@ namespace UnitsNet.Units
         TonnePerCubicMeter,
         TonnePerCubicMillimeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/DurationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/DurationUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum DurationUnit
     {
         Undefined = 0,
@@ -57,4 +60,6 @@ namespace UnitsNet.Units
         Year,
         Year365,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/DynamicViscosityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/DynamicViscosityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum DynamicViscosityUnit
     {
         Undefined = 0,
@@ -49,4 +52,6 @@ namespace UnitsNet.Units
         PascalSecond,
         Poise,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricAdmittanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricAdmittanceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricAdmittanceUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         Nanosiemens,
         Siemens,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricChargeDensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricChargeDensityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricChargeDensityUnit
     {
         Undefined = 0,
         CoulombPerCubicMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricChargeUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricChargeUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricChargeUnit
     {
         Undefined = 0,
         Coulomb,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricConductanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricConductanceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricConductanceUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         Millisiemens,
         Siemens,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricConductivityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricConductivityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricConductivityUnit
     {
         Undefined = 0,
         SiemensPerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricCurrentDensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricCurrentDensityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricCurrentDensityUnit
     {
         Undefined = 0,
         AmperePerSquareMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricCurrentGradientUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricCurrentGradientUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricCurrentGradientUnit
     {
         Undefined = 0,
         AmperePerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricCurrentUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricCurrentUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricCurrentUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         Nanoampere,
         Picoampere,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricFieldUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricFieldUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricFieldUnit
     {
         Undefined = 0,
         VoltPerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricInductanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricInductanceUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricInductanceUnit
     {
         Undefined = 0,
         Henry,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricPotentialAcUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricPotentialAcUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricPotentialAcUnit
     {
         Undefined = 0,
@@ -48,4 +51,6 @@ namespace UnitsNet.Units
         MillivoltAc,
         VoltAc,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricPotentialDcUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricPotentialDcUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricPotentialDcUnit
     {
         Undefined = 0,
@@ -48,4 +51,6 @@ namespace UnitsNet.Units
         MillivoltDc,
         VoltDc,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricPotentialUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricPotentialUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricPotentialUnit
     {
         Undefined = 0,
@@ -48,4 +51,6 @@ namespace UnitsNet.Units
         Millivolt,
         Volt,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricResistanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricResistanceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricResistanceUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         Milliohm,
         Ohm,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ElectricResistivityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricResistivityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ElectricResistivityUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         NanoohmMeter,
         OhmMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/EnergyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/EnergyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum EnergyUnit
     {
         Undefined = 0,
@@ -65,4 +68,6 @@ namespace UnitsNet.Units
         ThermUs,
         WattHour,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/EntropyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/EntropyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum EntropyUnit
     {
         Undefined = 0,
@@ -50,4 +53,6 @@ namespace UnitsNet.Units
         KilojoulePerKelvin,
         MegajoulePerKelvin,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/FlowUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/FlowUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum FlowUnit
     {
         Undefined = 0,
@@ -85,4 +88,6 @@ namespace UnitsNet.Units
         [System.Obsolete("Deprecated due to github issue #363, please use VolumeFlow instead")]
         UsGallonsPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ForceChangeRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ForceChangeRateUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ForceChangeRateUnit
     {
         Undefined = 0,
@@ -54,4 +57,6 @@ namespace UnitsNet.Units
         NewtonPerMinute,
         NewtonPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ForcePerLengthUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ForcePerLengthUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ForcePerLengthUnit
     {
         Undefined = 0,
@@ -52,4 +55,6 @@ namespace UnitsNet.Units
         NanonewtonPerMeter,
         NewtonPerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ForceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ForceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ForceUnit
     {
         Undefined = 0,
@@ -53,4 +56,6 @@ namespace UnitsNet.Units
         PoundForce,
         TonneForce,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum FrequencyUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         RadianPerSecond,
         Terahertz,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/HeatFluxUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/HeatFluxUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum HeatFluxUnit
     {
         Undefined = 0,
@@ -59,4 +62,6 @@ namespace UnitsNet.Units
         WattPerSquareInch,
         WattPerSquareMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/HeatTransferCoefficientUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/HeatTransferCoefficientUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum HeatTransferCoefficientUnit
     {
         Undefined = 0,
         WattPerSquareMeterCelsius,
         WattPerSquareMeterKelvin,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/IlluminanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/IlluminanceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum IlluminanceUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         Megalux,
         Millilux,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/InformationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/InformationUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum InformationUnit
     {
         Undefined = 0,
@@ -69,4 +72,6 @@ namespace UnitsNet.Units
         Terabit,
         Terabyte,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/IrradianceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/IrradianceUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum IrradianceUnit
     {
         Undefined = 0,
         KilowattPerSquareMeter,
         WattPerSquareMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/IrradiationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/IrradiationUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum IrradiationUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         KilowattHourPerSquareMeter,
         WattHourPerSquareMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/KinematicViscosityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/KinematicViscosityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum KinematicViscosityUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         SquareMeterPerSecond,
         Stokes,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/LapseRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LapseRateUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum LapseRateUnit
     {
         Undefined = 0,
         DegreeCelsiusPerKilometer,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/LengthUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LengthUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum LengthUnit
     {
         Undefined = 0,
@@ -65,4 +68,6 @@ namespace UnitsNet.Units
         UsSurveyFoot,
         Yard,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/LevelUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LevelUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum LevelUnit
     {
         Undefined = 0,
         Decibel,
         Neper,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/LinearDensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LinearDensityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum LinearDensityUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         KilogramPerMeter,
         PoundPerFoot,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/LuminousFluxUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LuminousFluxUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum LuminousFluxUnit
     {
         Undefined = 0,
         Lumen,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/LuminousIntensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LuminousIntensityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum LuminousIntensityUnit
     {
         Undefined = 0,
         Candela,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MagneticFieldUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MagneticFieldUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MagneticFieldUnit
     {
         Undefined = 0,
         Tesla,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MagneticFluxUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MagneticFluxUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MagneticFluxUnit
     {
         Undefined = 0,
         Weber,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MagnetizationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MagnetizationUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MagnetizationUnit
     {
         Undefined = 0,
         AmperePerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MassFlowUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MassFlowUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MassFlowUnit
     {
         Undefined = 0,
@@ -58,4 +61,6 @@ namespace UnitsNet.Units
         TonnePerDay,
         TonnePerHour,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MassFluxUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MassFluxUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MassFluxUnit
     {
         Undefined = 0,
         GramPerSecondPerSquareMeter,
         KilogramPerSecondPerSquareMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MassMomentOfInertiaUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MassMomentOfInertiaUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MassMomentOfInertiaUnit
     {
         Undefined = 0,
@@ -69,4 +72,6 @@ namespace UnitsNet.Units
         TonneSquareMeter,
         TonneSquareMilimeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MassUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MassUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MassUnit
     {
         Undefined = 0,
@@ -98,4 +101,6 @@ namespace UnitsNet.Units
         Stone,
         Tonne,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MolarEnergyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MolarEnergyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MolarEnergyUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         KilojoulePerMole,
         MegajoulePerMole,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MolarEntropyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MolarEntropyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MolarEntropyUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         KilojoulePerMoleKelvin,
         MegajoulePerMoleKelvin,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MolarMassUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MolarMassUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MolarMassUnit
     {
         Undefined = 0,
@@ -55,4 +58,6 @@ namespace UnitsNet.Units
         NanogramPerMole,
         PoundPerMole,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/MolarityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MolarityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum MolarityUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         NanomolesPerLiter,
         PicomolesPerLiter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PermeabilityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PermeabilityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PermeabilityUnit
     {
         Undefined = 0,
         HenryPerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PermittivityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PermittivityUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PermittivityUnit
     {
         Undefined = 0,
         FaradPerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PowerDensityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PowerDensityUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PowerDensityUnit
     {
         Undefined = 0,
@@ -87,4 +90,6 @@ namespace UnitsNet.Units
         WattPerCubicMeter,
         WattPerLiter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PowerRatioUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PowerRatioUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PowerRatioUnit
     {
         Undefined = 0,
         DecibelMilliwatt,
         DecibelWatt,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PowerUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PowerUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PowerUnit
     {
         Undefined = 0,
@@ -63,4 +66,6 @@ namespace UnitsNet.Units
         Terawatt,
         Watt,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PressureChangeRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PressureChangeRateUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PressureChangeRateUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         MegapascalPerSecond,
         PascalPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/PressureUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PressureUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum PressureUnit
     {
         Undefined = 0,
@@ -82,4 +85,6 @@ namespace UnitsNet.Units
         TonneForcePerSquareMillimeter,
         Torr,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/RatioUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RatioUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum RatioUnit
     {
         Undefined = 0,
@@ -49,4 +52,6 @@ namespace UnitsNet.Units
         PartPerTrillion,
         Percent,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ReactiveEnergyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ReactiveEnergyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ReactiveEnergyUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         MegavoltampereReactiveHour,
         VoltampereReactiveHour,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ReactivePowerUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ReactivePowerUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ReactivePowerUnit
     {
         Undefined = 0,
@@ -47,4 +50,6 @@ namespace UnitsNet.Units
         MegavoltampereReactive,
         VoltampereReactive,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum RotationalAccelerationUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         RadianPerSecondSquared,
         RevolutionPerMinutePerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/RotationalSpeedUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RotationalSpeedUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum RotationalSpeedUnit
     {
         Undefined = 0,
@@ -56,4 +59,6 @@ namespace UnitsNet.Units
         RevolutionPerMinute,
         RevolutionPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/RotationalStiffnessPerLengthUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RotationalStiffnessPerLengthUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum RotationalStiffnessPerLengthUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         MeganewtonMeterPerRadianPerMeter,
         NewtonMeterPerRadianPerMeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/RotationalStiffnessUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RotationalStiffnessUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum RotationalStiffnessUnit
     {
         Undefined = 0,
@@ -46,4 +49,6 @@ namespace UnitsNet.Units
         MeganewtonMeterPerRadian,
         NewtonMeterPerRadian,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/SolidAngleUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/SolidAngleUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum SolidAngleUnit
     {
         Undefined = 0,
         Steradian,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/SpecificEnergyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/SpecificEnergyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum SpecificEnergyUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         MegawattHourPerKilogram,
         WattHourPerKilogram,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/SpecificEntropyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/SpecificEntropyUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum SpecificEntropyUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         MegajoulePerKilogramDegreeCelsius,
         MegajoulePerKilogramKelvin,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/SpecificVolumeUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/SpecificVolumeUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum SpecificVolumeUnit
     {
         Undefined = 0,
         CubicFootPerPound,
         CubicMeterPerKilogram,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/SpecificWeightUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/SpecificWeightUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum SpecificWeightUnit
     {
         Undefined = 0,
@@ -60,4 +63,6 @@ namespace UnitsNet.Units
         TonneForcePerCubicMeter,
         TonneForcePerCubicMillimeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/SpeedUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/SpeedUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum SpeedUnit
     {
         Undefined = 0,
@@ -75,4 +78,6 @@ namespace UnitsNet.Units
         YardPerMinute,
         YardPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/TemperatureChangeRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/TemperatureChangeRateUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum TemperatureChangeRateUnit
     {
         Undefined = 0,
@@ -53,4 +56,6 @@ namespace UnitsNet.Units
         MillidegreeCelsiusPerSecond,
         NanodegreeCelsiusPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/TemperatureDeltaUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/TemperatureDeltaUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum TemperatureDeltaUnit
     {
         Undefined = 0,
@@ -67,4 +70,6 @@ namespace UnitsNet.Units
         [System.Obsolete("Deprecated due to github issue #180, please use Kelvin instead")]
         KelvinDelta,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/TemperatureUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/TemperatureUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum TemperatureUnit
     {
         Undefined = 0,
@@ -51,4 +54,6 @@ namespace UnitsNet.Units
         DegreeRoemer,
         Kelvin,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ThermalConductivityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ThermalConductivityUnit.g.cs
@@ -39,10 +39,15 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ThermalConductivityUnit
     {
         Undefined = 0,
         BtuPerHourFootFahrenheit,
         WattPerMeterKelvin,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/ThermalResistanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ThermalResistanceUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum ThermalResistanceUnit
     {
         Undefined = 0,
@@ -48,4 +51,6 @@ namespace UnitsNet.Units
         SquareMeterDegreeCelsiusPerWatt,
         SquareMeterKelvinPerKilowatt,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/TorqueUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/TorqueUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum TorqueUnit
     {
         Undefined = 0,
@@ -64,4 +67,6 @@ namespace UnitsNet.Units
         TonneForceMeter,
         TonneForceMillimeter,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/VitaminAUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/VitaminAUnit.g.cs
@@ -39,9 +39,14 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum VitaminAUnit
     {
         Undefined = 0,
         InternationalUnit,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/VolumeFlowUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/VolumeFlowUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum VolumeFlowUnit
     {
         Undefined = 0,
@@ -69,4 +72,6 @@ namespace UnitsNet.Units
         UsGallonsPerMinute,
         UsGallonsPerSecond,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/GeneratedCode/Units/VolumeUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/VolumeUnit.g.cs
@@ -39,6 +39,9 @@
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum VolumeUnit
     {
         Undefined = 0,
@@ -89,4 +92,6 @@ namespace UnitsNet.Units
         UsTablespoon,
         UsTeaspoon,
     }
+
+    #pragma warning restore 1591
 }

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
@@ -130,6 +130,9 @@ namespace UnitsNet
 @"
         }
 
+        /// <summary>
+        ///     Creates the quantity with the given value in the base unit $baseUnitSingularName.
+        /// </summary>
         [Obsolete("Use the constructor that takes a unit parameter. This constructor will be removed in a future version.")]
         public $quantityName(double $baseUnitPluralNameLower)
         {
@@ -225,6 +228,9 @@ namespace UnitsNet
 
         #region Static
 
+        /// <summary>
+        ///     Gets an instance of this quantity with a value of 0 in the base unit $baseUnitSingularName.
+        /// </summary>
         public static $quantityName Zero => new $quantityName(0, BaseUnit);
 
 "@; foreach ($unit in $units) {
@@ -399,6 +405,10 @@ namespace UnitsNet
             return Math.Abs(_value - other.AsBaseNumericType(this.Unit)) <= maxError.AsBaseNumericType(this.Unit);
         }
 
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current $quantityName.</returns>
         public override int GetHashCode()
         {
             return new { Value, Unit }.GetHashCode();

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
@@ -543,10 +543,10 @@ namespace UnitsNet
 
         #endregion
 
-        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         /// <summary>
         ///     Set the default unit used by ToString(). Default is $baseUnitSingularName
         /// </summary>
+        [Obsolete("This is no longer used since we will instead use the quantity's Unit value as default.")]
         public static $unitEnumName ToStringDefaultUnit { get; set; } = $unitEnumName.$baseUnitSingularName;
 
         /// <summary>

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeWindowsRuntimeComponent.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeWindowsRuntimeComponent.ps1
@@ -104,7 +104,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => Convert.ToDouble(_value);
 
-        // Windows Runtime Component requires a default constructor
+        /// <summary>
+        ///     Creates the quantity with a value of 0 in the base unit $baseUnitSingularName.
+        /// </summary>
+        /// <remarks>
+        ///     Windows Runtime Component requires a default constructor.
+        /// </remarks>
         public $quantityName()
         {
             _value = 0;

--- a/UnitsNet/Scripts/Include-GenerateUnitTypeSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitTypeSourceCode.ps1
@@ -1,4 +1,4 @@
-function GenerateUnitTypeSourceCode($quantity) {
+﻿function GenerateUnitTypeSourceCode($quantity) {
     $quantityName = $quantity.Name;
     $units = $quantity.Units;
     $unitEnumName = "$($quantityName)Unit";
@@ -44,6 +44,9 @@ function GenerateUnitTypeSourceCode($quantity) {
 // ReSharper disable once CheckNamespace
 namespace UnitsNet.Units
 {
+    // Disable missing XML comment warnings for the generated unit enums.
+    #pragma warning disable 1591
+
     public enum $unitEnumName
     {
         Undefined = 0,
@@ -65,6 +68,8 @@ namespace UnitsNet.Units
         $($unit.SingularName),
 "@; }@"
     }
+
+    #pragma warning restore 1591
 }
 "@;
 }


### PR DESCRIPTION
Fixing ~1200 warnings by disabling XML comment warnings for generated unit enums. Move obsolete tag for ToStringDefaultUnit to make XML comment valid.