### PR TITLE
No Undefined enum value for Units property

### DIFF
--- a/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Acceleration(double numericValue, AccelerationUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Acceleration quantity.
         /// </summary>
-        public static AccelerationUnit[] Units { get; } = Enum.GetValues(typeof(AccelerationUnit)).Cast<AccelerationUnit>().ToArray();
+        public static AccelerationUnit[] Units { get; } = Enum.GetValues(typeof(AccelerationUnit)).Cast<AccelerationUnit>().Except(new AccelerationUnit[]{ AccelerationUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Acceleration in CentimetersPerSecondSquared.

--- a/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         AmountOfSubstance(double numericValue, AmountOfSubstanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the AmountOfSubstance quantity.
         /// </summary>
-        public static AmountOfSubstanceUnit[] Units { get; } = Enum.GetValues(typeof(AmountOfSubstanceUnit)).Cast<AmountOfSubstanceUnit>().ToArray();
+        public static AmountOfSubstanceUnit[] Units { get; } = Enum.GetValues(typeof(AmountOfSubstanceUnit)).Cast<AmountOfSubstanceUnit>().Except(new AmountOfSubstanceUnit[]{ AmountOfSubstanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get AmountOfSubstance in Centimoles.

--- a/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         AmplitudeRatio(double numericValue, AmplitudeRatioUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the AmplitudeRatio quantity.
         /// </summary>
-        public static AmplitudeRatioUnit[] Units { get; } = Enum.GetValues(typeof(AmplitudeRatioUnit)).Cast<AmplitudeRatioUnit>().ToArray();
+        public static AmplitudeRatioUnit[] Units { get; } = Enum.GetValues(typeof(AmplitudeRatioUnit)).Cast<AmplitudeRatioUnit>().Except(new AmplitudeRatioUnit[]{ AmplitudeRatioUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get AmplitudeRatio in DecibelMicrovolts.

--- a/Common/GeneratedCode/Quantities/Angle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Angle.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Angle(double numericValue, AngleUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Angle quantity.
         /// </summary>
-        public static AngleUnit[] Units { get; } = Enum.GetValues(typeof(AngleUnit)).Cast<AngleUnit>().ToArray();
+        public static AngleUnit[] Units { get; } = Enum.GetValues(typeof(AngleUnit)).Cast<AngleUnit>().Except(new AngleUnit[]{ AngleUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Angle in Arcminutes.

--- a/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ApparentEnergy(double numericValue, ApparentEnergyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ApparentEnergy quantity.
         /// </summary>
-        public static ApparentEnergyUnit[] Units { get; } = Enum.GetValues(typeof(ApparentEnergyUnit)).Cast<ApparentEnergyUnit>().ToArray();
+        public static ApparentEnergyUnit[] Units { get; } = Enum.GetValues(typeof(ApparentEnergyUnit)).Cast<ApparentEnergyUnit>().Except(new ApparentEnergyUnit[]{ ApparentEnergyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ApparentEnergy in KilovoltampereHours.

--- a/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ApparentPower(double numericValue, ApparentPowerUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ApparentPower quantity.
         /// </summary>
-        public static ApparentPowerUnit[] Units { get; } = Enum.GetValues(typeof(ApparentPowerUnit)).Cast<ApparentPowerUnit>().ToArray();
+        public static ApparentPowerUnit[] Units { get; } = Enum.GetValues(typeof(ApparentPowerUnit)).Cast<ApparentPowerUnit>().Except(new ApparentPowerUnit[]{ ApparentPowerUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ApparentPower in Gigavoltamperes.

--- a/Common/GeneratedCode/Quantities/Area.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Area.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Area(double numericValue, AreaUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Area quantity.
         /// </summary>
-        public static AreaUnit[] Units { get; } = Enum.GetValues(typeof(AreaUnit)).Cast<AreaUnit>().ToArray();
+        public static AreaUnit[] Units { get; } = Enum.GetValues(typeof(AreaUnit)).Cast<AreaUnit>().Except(new AreaUnit[]{ AreaUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Area in Acres.

--- a/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         AreaDensity(double numericValue, AreaDensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the AreaDensity quantity.
         /// </summary>
-        public static AreaDensityUnit[] Units { get; } = Enum.GetValues(typeof(AreaDensityUnit)).Cast<AreaDensityUnit>().ToArray();
+        public static AreaDensityUnit[] Units { get; } = Enum.GetValues(typeof(AreaDensityUnit)).Cast<AreaDensityUnit>().Except(new AreaDensityUnit[]{ AreaDensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get AreaDensity in KilogramsPerSquareMeter.

--- a/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         AreaMomentOfInertia(double numericValue, AreaMomentOfInertiaUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the AreaMomentOfInertia quantity.
         /// </summary>
-        public static AreaMomentOfInertiaUnit[] Units { get; } = Enum.GetValues(typeof(AreaMomentOfInertiaUnit)).Cast<AreaMomentOfInertiaUnit>().ToArray();
+        public static AreaMomentOfInertiaUnit[] Units { get; } = Enum.GetValues(typeof(AreaMomentOfInertiaUnit)).Cast<AreaMomentOfInertiaUnit>().Except(new AreaMomentOfInertiaUnit[]{ AreaMomentOfInertiaUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get AreaMomentOfInertia in CentimetersToTheFourth.

--- a/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         BitRate(decimal numericValue, BitRateUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the BitRate quantity.
         /// </summary>
-        public static BitRateUnit[] Units { get; } = Enum.GetValues(typeof(BitRateUnit)).Cast<BitRateUnit>().ToArray();
+        public static BitRateUnit[] Units { get; } = Enum.GetValues(typeof(BitRateUnit)).Cast<BitRateUnit>().Except(new BitRateUnit[]{ BitRateUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get BitRate in BitsPerSecond.

--- a/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         BrakeSpecificFuelConsumption(double numericValue, BrakeSpecificFuelConsumptionUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the BrakeSpecificFuelConsumption quantity.
         /// </summary>
-        public static BrakeSpecificFuelConsumptionUnit[] Units { get; } = Enum.GetValues(typeof(BrakeSpecificFuelConsumptionUnit)).Cast<BrakeSpecificFuelConsumptionUnit>().ToArray();
+        public static BrakeSpecificFuelConsumptionUnit[] Units { get; } = Enum.GetValues(typeof(BrakeSpecificFuelConsumptionUnit)).Cast<BrakeSpecificFuelConsumptionUnit>().Except(new BrakeSpecificFuelConsumptionUnit[]{ BrakeSpecificFuelConsumptionUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption in GramsPerKiloWattHour.

--- a/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Capacitance(double numericValue, CapacitanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Capacitance quantity.
         /// </summary>
-        public static CapacitanceUnit[] Units { get; } = Enum.GetValues(typeof(CapacitanceUnit)).Cast<CapacitanceUnit>().ToArray();
+        public static CapacitanceUnit[] Units { get; } = Enum.GetValues(typeof(CapacitanceUnit)).Cast<CapacitanceUnit>().Except(new CapacitanceUnit[]{ CapacitanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Capacitance in Farads.

--- a/Common/GeneratedCode/Quantities/Density.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Density.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Density(double numericValue, DensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Density quantity.
         /// </summary>
-        public static DensityUnit[] Units { get; } = Enum.GetValues(typeof(DensityUnit)).Cast<DensityUnit>().ToArray();
+        public static DensityUnit[] Units { get; } = Enum.GetValues(typeof(DensityUnit)).Cast<DensityUnit>().Except(new DensityUnit[]{ DensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Density in CentigramsPerDeciLiter.

--- a/Common/GeneratedCode/Quantities/Duration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Duration.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Duration(double numericValue, DurationUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Duration quantity.
         /// </summary>
-        public static DurationUnit[] Units { get; } = Enum.GetValues(typeof(DurationUnit)).Cast<DurationUnit>().ToArray();
+        public static DurationUnit[] Units { get; } = Enum.GetValues(typeof(DurationUnit)).Cast<DurationUnit>().Except(new DurationUnit[]{ DurationUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Duration in Days.

--- a/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         DynamicViscosity(double numericValue, DynamicViscosityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the DynamicViscosity quantity.
         /// </summary>
-        public static DynamicViscosityUnit[] Units { get; } = Enum.GetValues(typeof(DynamicViscosityUnit)).Cast<DynamicViscosityUnit>().ToArray();
+        public static DynamicViscosityUnit[] Units { get; } = Enum.GetValues(typeof(DynamicViscosityUnit)).Cast<DynamicViscosityUnit>().Except(new DynamicViscosityUnit[]{ DynamicViscosityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get DynamicViscosity in Centipoise.

--- a/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricAdmittance(double numericValue, ElectricAdmittanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricAdmittance quantity.
         /// </summary>
-        public static ElectricAdmittanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricAdmittanceUnit)).Cast<ElectricAdmittanceUnit>().ToArray();
+        public static ElectricAdmittanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricAdmittanceUnit)).Cast<ElectricAdmittanceUnit>().Except(new ElectricAdmittanceUnit[]{ ElectricAdmittanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricAdmittance in Microsiemens.

--- a/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricCharge(double numericValue, ElectricChargeUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricCharge quantity.
         /// </summary>
-        public static ElectricChargeUnit[] Units { get; } = Enum.GetValues(typeof(ElectricChargeUnit)).Cast<ElectricChargeUnit>().ToArray();
+        public static ElectricChargeUnit[] Units { get; } = Enum.GetValues(typeof(ElectricChargeUnit)).Cast<ElectricChargeUnit>().Except(new ElectricChargeUnit[]{ ElectricChargeUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricCharge in Coulombs.

--- a/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricChargeDensity(double numericValue, ElectricChargeDensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricChargeDensity quantity.
         /// </summary>
-        public static ElectricChargeDensityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricChargeDensityUnit)).Cast<ElectricChargeDensityUnit>().ToArray();
+        public static ElectricChargeDensityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricChargeDensityUnit)).Cast<ElectricChargeDensityUnit>().Except(new ElectricChargeDensityUnit[]{ ElectricChargeDensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricChargeDensity in CoulombsPerCubicMeter.

--- a/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricConductance(double numericValue, ElectricConductanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricConductance quantity.
         /// </summary>
-        public static ElectricConductanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricConductanceUnit)).Cast<ElectricConductanceUnit>().ToArray();
+        public static ElectricConductanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricConductanceUnit)).Cast<ElectricConductanceUnit>().Except(new ElectricConductanceUnit[]{ ElectricConductanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricConductance in Microsiemens.

--- a/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricConductivity(double numericValue, ElectricConductivityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricConductivity quantity.
         /// </summary>
-        public static ElectricConductivityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricConductivityUnit)).Cast<ElectricConductivityUnit>().ToArray();
+        public static ElectricConductivityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricConductivityUnit)).Cast<ElectricConductivityUnit>().Except(new ElectricConductivityUnit[]{ ElectricConductivityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricConductivity in SiemensPerMeter.

--- a/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricCurrent(double numericValue, ElectricCurrentUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricCurrent quantity.
         /// </summary>
-        public static ElectricCurrentUnit[] Units { get; } = Enum.GetValues(typeof(ElectricCurrentUnit)).Cast<ElectricCurrentUnit>().ToArray();
+        public static ElectricCurrentUnit[] Units { get; } = Enum.GetValues(typeof(ElectricCurrentUnit)).Cast<ElectricCurrentUnit>().Except(new ElectricCurrentUnit[]{ ElectricCurrentUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricCurrent in Amperes.

--- a/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricCurrentDensity(double numericValue, ElectricCurrentDensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricCurrentDensity quantity.
         /// </summary>
-        public static ElectricCurrentDensityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricCurrentDensityUnit)).Cast<ElectricCurrentDensityUnit>().ToArray();
+        public static ElectricCurrentDensityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricCurrentDensityUnit)).Cast<ElectricCurrentDensityUnit>().Except(new ElectricCurrentDensityUnit[]{ ElectricCurrentDensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricCurrentDensity in AmperesPerSquareMeter.

--- a/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricCurrentGradient(double numericValue, ElectricCurrentGradientUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricCurrentGradient quantity.
         /// </summary>
-        public static ElectricCurrentGradientUnit[] Units { get; } = Enum.GetValues(typeof(ElectricCurrentGradientUnit)).Cast<ElectricCurrentGradientUnit>().ToArray();
+        public static ElectricCurrentGradientUnit[] Units { get; } = Enum.GetValues(typeof(ElectricCurrentGradientUnit)).Cast<ElectricCurrentGradientUnit>().Except(new ElectricCurrentGradientUnit[]{ ElectricCurrentGradientUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricCurrentGradient in AmperesPerSecond.

--- a/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricField(double numericValue, ElectricFieldUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricField quantity.
         /// </summary>
-        public static ElectricFieldUnit[] Units { get; } = Enum.GetValues(typeof(ElectricFieldUnit)).Cast<ElectricFieldUnit>().ToArray();
+        public static ElectricFieldUnit[] Units { get; } = Enum.GetValues(typeof(ElectricFieldUnit)).Cast<ElectricFieldUnit>().Except(new ElectricFieldUnit[]{ ElectricFieldUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricField in VoltsPerMeter.

--- a/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricInductance(double numericValue, ElectricInductanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricInductance quantity.
         /// </summary>
-        public static ElectricInductanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricInductanceUnit)).Cast<ElectricInductanceUnit>().ToArray();
+        public static ElectricInductanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricInductanceUnit)).Cast<ElectricInductanceUnit>().Except(new ElectricInductanceUnit[]{ ElectricInductanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricInductance in Henries.

--- a/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricPotential(double numericValue, ElectricPotentialUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricPotential quantity.
         /// </summary>
-        public static ElectricPotentialUnit[] Units { get; } = Enum.GetValues(typeof(ElectricPotentialUnit)).Cast<ElectricPotentialUnit>().ToArray();
+        public static ElectricPotentialUnit[] Units { get; } = Enum.GetValues(typeof(ElectricPotentialUnit)).Cast<ElectricPotentialUnit>().Except(new ElectricPotentialUnit[]{ ElectricPotentialUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricPotential in Kilovolts.

--- a/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricPotentialAc(double numericValue, ElectricPotentialAcUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricPotentialAc quantity.
         /// </summary>
-        public static ElectricPotentialAcUnit[] Units { get; } = Enum.GetValues(typeof(ElectricPotentialAcUnit)).Cast<ElectricPotentialAcUnit>().ToArray();
+        public static ElectricPotentialAcUnit[] Units { get; } = Enum.GetValues(typeof(ElectricPotentialAcUnit)).Cast<ElectricPotentialAcUnit>().Except(new ElectricPotentialAcUnit[]{ ElectricPotentialAcUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricPotentialAc in KilovoltsAc.

--- a/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricPotentialDc(double numericValue, ElectricPotentialDcUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricPotentialDc quantity.
         /// </summary>
-        public static ElectricPotentialDcUnit[] Units { get; } = Enum.GetValues(typeof(ElectricPotentialDcUnit)).Cast<ElectricPotentialDcUnit>().ToArray();
+        public static ElectricPotentialDcUnit[] Units { get; } = Enum.GetValues(typeof(ElectricPotentialDcUnit)).Cast<ElectricPotentialDcUnit>().Except(new ElectricPotentialDcUnit[]{ ElectricPotentialDcUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricPotentialDc in KilovoltsDc.

--- a/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricResistance(double numericValue, ElectricResistanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricResistance quantity.
         /// </summary>
-        public static ElectricResistanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricResistanceUnit)).Cast<ElectricResistanceUnit>().ToArray();
+        public static ElectricResistanceUnit[] Units { get; } = Enum.GetValues(typeof(ElectricResistanceUnit)).Cast<ElectricResistanceUnit>().Except(new ElectricResistanceUnit[]{ ElectricResistanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricResistance in Kiloohms.

--- a/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ElectricResistivity(double numericValue, ElectricResistivityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ElectricResistivity quantity.
         /// </summary>
-        public static ElectricResistivityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricResistivityUnit)).Cast<ElectricResistivityUnit>().ToArray();
+        public static ElectricResistivityUnit[] Units { get; } = Enum.GetValues(typeof(ElectricResistivityUnit)).Cast<ElectricResistivityUnit>().Except(new ElectricResistivityUnit[]{ ElectricResistivityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ElectricResistivity in MicroohmMeters.

--- a/Common/GeneratedCode/Quantities/Energy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Energy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Energy(double numericValue, EnergyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Energy quantity.
         /// </summary>
-        public static EnergyUnit[] Units { get; } = Enum.GetValues(typeof(EnergyUnit)).Cast<EnergyUnit>().ToArray();
+        public static EnergyUnit[] Units { get; } = Enum.GetValues(typeof(EnergyUnit)).Cast<EnergyUnit>().Except(new EnergyUnit[]{ EnergyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Energy in BritishThermalUnits.

--- a/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Entropy(double numericValue, EntropyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Entropy quantity.
         /// </summary>
-        public static EntropyUnit[] Units { get; } = Enum.GetValues(typeof(EntropyUnit)).Cast<EntropyUnit>().ToArray();
+        public static EntropyUnit[] Units { get; } = Enum.GetValues(typeof(EntropyUnit)).Cast<EntropyUnit>().Except(new EntropyUnit[]{ EntropyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Entropy in CaloriesPerKelvin.

--- a/Common/GeneratedCode/Quantities/Flow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Flow.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Flow(double numericValue, FlowUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Flow quantity.
         /// </summary>
-        public static FlowUnit[] Units { get; } = Enum.GetValues(typeof(FlowUnit)).Cast<FlowUnit>().ToArray();
+        public static FlowUnit[] Units { get; } = Enum.GetValues(typeof(FlowUnit)).Cast<FlowUnit>().Except(new FlowUnit[]{ FlowUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Flow in CentilitersPerMinute.

--- a/Common/GeneratedCode/Quantities/Force.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Force.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Force(double numericValue, ForceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Force quantity.
         /// </summary>
-        public static ForceUnit[] Units { get; } = Enum.GetValues(typeof(ForceUnit)).Cast<ForceUnit>().ToArray();
+        public static ForceUnit[] Units { get; } = Enum.GetValues(typeof(ForceUnit)).Cast<ForceUnit>().Except(new ForceUnit[]{ ForceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Force in Decanewtons.

--- a/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ForceChangeRate(double numericValue, ForceChangeRateUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ForceChangeRate quantity.
         /// </summary>
-        public static ForceChangeRateUnit[] Units { get; } = Enum.GetValues(typeof(ForceChangeRateUnit)).Cast<ForceChangeRateUnit>().ToArray();
+        public static ForceChangeRateUnit[] Units { get; } = Enum.GetValues(typeof(ForceChangeRateUnit)).Cast<ForceChangeRateUnit>().Except(new ForceChangeRateUnit[]{ ForceChangeRateUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ForceChangeRate in CentinewtonsPerSecond.

--- a/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ForcePerLength(double numericValue, ForcePerLengthUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ForcePerLength quantity.
         /// </summary>
-        public static ForcePerLengthUnit[] Units { get; } = Enum.GetValues(typeof(ForcePerLengthUnit)).Cast<ForcePerLengthUnit>().ToArray();
+        public static ForcePerLengthUnit[] Units { get; } = Enum.GetValues(typeof(ForcePerLengthUnit)).Cast<ForcePerLengthUnit>().Except(new ForcePerLengthUnit[]{ ForcePerLengthUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ForcePerLength in CentinewtonsPerMeter.

--- a/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Frequency(double numericValue, FrequencyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Frequency quantity.
         /// </summary>
-        public static FrequencyUnit[] Units { get; } = Enum.GetValues(typeof(FrequencyUnit)).Cast<FrequencyUnit>().ToArray();
+        public static FrequencyUnit[] Units { get; } = Enum.GetValues(typeof(FrequencyUnit)).Cast<FrequencyUnit>().Except(new FrequencyUnit[]{ FrequencyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Frequency in CyclesPerHour.

--- a/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         HeatFlux(double numericValue, HeatFluxUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the HeatFlux quantity.
         /// </summary>
-        public static HeatFluxUnit[] Units { get; } = Enum.GetValues(typeof(HeatFluxUnit)).Cast<HeatFluxUnit>().ToArray();
+        public static HeatFluxUnit[] Units { get; } = Enum.GetValues(typeof(HeatFluxUnit)).Cast<HeatFluxUnit>().Except(new HeatFluxUnit[]{ HeatFluxUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get HeatFlux in BtusPerHourSquareFoot.

--- a/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         HeatTransferCoefficient(double numericValue, HeatTransferCoefficientUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the HeatTransferCoefficient quantity.
         /// </summary>
-        public static HeatTransferCoefficientUnit[] Units { get; } = Enum.GetValues(typeof(HeatTransferCoefficientUnit)).Cast<HeatTransferCoefficientUnit>().ToArray();
+        public static HeatTransferCoefficientUnit[] Units { get; } = Enum.GetValues(typeof(HeatTransferCoefficientUnit)).Cast<HeatTransferCoefficientUnit>().Except(new HeatTransferCoefficientUnit[]{ HeatTransferCoefficientUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get HeatTransferCoefficient in WattsPerSquareMeterCelsius.

--- a/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Illuminance(double numericValue, IlluminanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Illuminance quantity.
         /// </summary>
-        public static IlluminanceUnit[] Units { get; } = Enum.GetValues(typeof(IlluminanceUnit)).Cast<IlluminanceUnit>().ToArray();
+        public static IlluminanceUnit[] Units { get; } = Enum.GetValues(typeof(IlluminanceUnit)).Cast<IlluminanceUnit>().Except(new IlluminanceUnit[]{ IlluminanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Illuminance in Kilolux.

--- a/Common/GeneratedCode/Quantities/Information.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Information.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Information(decimal numericValue, InformationUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Information quantity.
         /// </summary>
-        public static InformationUnit[] Units { get; } = Enum.GetValues(typeof(InformationUnit)).Cast<InformationUnit>().ToArray();
+        public static InformationUnit[] Units { get; } = Enum.GetValues(typeof(InformationUnit)).Cast<InformationUnit>().Except(new InformationUnit[]{ InformationUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Information in Bits.

--- a/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Irradiance(double numericValue, IrradianceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Irradiance quantity.
         /// </summary>
-        public static IrradianceUnit[] Units { get; } = Enum.GetValues(typeof(IrradianceUnit)).Cast<IrradianceUnit>().ToArray();
+        public static IrradianceUnit[] Units { get; } = Enum.GetValues(typeof(IrradianceUnit)).Cast<IrradianceUnit>().Except(new IrradianceUnit[]{ IrradianceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Irradiance in KilowattsPerSquareMeter.

--- a/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Irradiation(double numericValue, IrradiationUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Irradiation quantity.
         /// </summary>
-        public static IrradiationUnit[] Units { get; } = Enum.GetValues(typeof(IrradiationUnit)).Cast<IrradiationUnit>().ToArray();
+        public static IrradiationUnit[] Units { get; } = Enum.GetValues(typeof(IrradiationUnit)).Cast<IrradiationUnit>().Except(new IrradiationUnit[]{ IrradiationUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Irradiation in JoulesPerSquareMeter.

--- a/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         KinematicViscosity(double numericValue, KinematicViscosityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the KinematicViscosity quantity.
         /// </summary>
-        public static KinematicViscosityUnit[] Units { get; } = Enum.GetValues(typeof(KinematicViscosityUnit)).Cast<KinematicViscosityUnit>().ToArray();
+        public static KinematicViscosityUnit[] Units { get; } = Enum.GetValues(typeof(KinematicViscosityUnit)).Cast<KinematicViscosityUnit>().Except(new KinematicViscosityUnit[]{ KinematicViscosityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get KinematicViscosity in Centistokes.

--- a/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         LapseRate(double numericValue, LapseRateUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the LapseRate quantity.
         /// </summary>
-        public static LapseRateUnit[] Units { get; } = Enum.GetValues(typeof(LapseRateUnit)).Cast<LapseRateUnit>().ToArray();
+        public static LapseRateUnit[] Units { get; } = Enum.GetValues(typeof(LapseRateUnit)).Cast<LapseRateUnit>().Except(new LapseRateUnit[]{ LapseRateUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get LapseRate in DegreesCelciusPerKilometer.

--- a/Common/GeneratedCode/Quantities/Length.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Length.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Length(double numericValue, LengthUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Length quantity.
         /// </summary>
-        public static LengthUnit[] Units { get; } = Enum.GetValues(typeof(LengthUnit)).Cast<LengthUnit>().ToArray();
+        public static LengthUnit[] Units { get; } = Enum.GetValues(typeof(LengthUnit)).Cast<LengthUnit>().Except(new LengthUnit[]{ LengthUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Length in Centimeters.

--- a/Common/GeneratedCode/Quantities/Level.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Level.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Level(double numericValue, LevelUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Level quantity.
         /// </summary>
-        public static LevelUnit[] Units { get; } = Enum.GetValues(typeof(LevelUnit)).Cast<LevelUnit>().ToArray();
+        public static LevelUnit[] Units { get; } = Enum.GetValues(typeof(LevelUnit)).Cast<LevelUnit>().Except(new LevelUnit[]{ LevelUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Level in Decibels.

--- a/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         LinearDensity(double numericValue, LinearDensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the LinearDensity quantity.
         /// </summary>
-        public static LinearDensityUnit[] Units { get; } = Enum.GetValues(typeof(LinearDensityUnit)).Cast<LinearDensityUnit>().ToArray();
+        public static LinearDensityUnit[] Units { get; } = Enum.GetValues(typeof(LinearDensityUnit)).Cast<LinearDensityUnit>().Except(new LinearDensityUnit[]{ LinearDensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get LinearDensity in GramsPerMeter.

--- a/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         LuminousFlux(double numericValue, LuminousFluxUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the LuminousFlux quantity.
         /// </summary>
-        public static LuminousFluxUnit[] Units { get; } = Enum.GetValues(typeof(LuminousFluxUnit)).Cast<LuminousFluxUnit>().ToArray();
+        public static LuminousFluxUnit[] Units { get; } = Enum.GetValues(typeof(LuminousFluxUnit)).Cast<LuminousFluxUnit>().Except(new LuminousFluxUnit[]{ LuminousFluxUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get LuminousFlux in Lumens.

--- a/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         LuminousIntensity(double numericValue, LuminousIntensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the LuminousIntensity quantity.
         /// </summary>
-        public static LuminousIntensityUnit[] Units { get; } = Enum.GetValues(typeof(LuminousIntensityUnit)).Cast<LuminousIntensityUnit>().ToArray();
+        public static LuminousIntensityUnit[] Units { get; } = Enum.GetValues(typeof(LuminousIntensityUnit)).Cast<LuminousIntensityUnit>().Except(new LuminousIntensityUnit[]{ LuminousIntensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get LuminousIntensity in Candela.

--- a/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MagneticField(double numericValue, MagneticFieldUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MagneticField quantity.
         /// </summary>
-        public static MagneticFieldUnit[] Units { get; } = Enum.GetValues(typeof(MagneticFieldUnit)).Cast<MagneticFieldUnit>().ToArray();
+        public static MagneticFieldUnit[] Units { get; } = Enum.GetValues(typeof(MagneticFieldUnit)).Cast<MagneticFieldUnit>().Except(new MagneticFieldUnit[]{ MagneticFieldUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MagneticField in Teslas.

--- a/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MagneticFlux(double numericValue, MagneticFluxUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MagneticFlux quantity.
         /// </summary>
-        public static MagneticFluxUnit[] Units { get; } = Enum.GetValues(typeof(MagneticFluxUnit)).Cast<MagneticFluxUnit>().ToArray();
+        public static MagneticFluxUnit[] Units { get; } = Enum.GetValues(typeof(MagneticFluxUnit)).Cast<MagneticFluxUnit>().Except(new MagneticFluxUnit[]{ MagneticFluxUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MagneticFlux in Webers.

--- a/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Magnetization(double numericValue, MagnetizationUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Magnetization quantity.
         /// </summary>
-        public static MagnetizationUnit[] Units { get; } = Enum.GetValues(typeof(MagnetizationUnit)).Cast<MagnetizationUnit>().ToArray();
+        public static MagnetizationUnit[] Units { get; } = Enum.GetValues(typeof(MagnetizationUnit)).Cast<MagnetizationUnit>().Except(new MagnetizationUnit[]{ MagnetizationUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Magnetization in AmperesPerMeter.

--- a/Common/GeneratedCode/Quantities/Mass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Mass.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Mass(double numericValue, MassUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Mass quantity.
         /// </summary>
-        public static MassUnit[] Units { get; } = Enum.GetValues(typeof(MassUnit)).Cast<MassUnit>().ToArray();
+        public static MassUnit[] Units { get; } = Enum.GetValues(typeof(MassUnit)).Cast<MassUnit>().Except(new MassUnit[]{ MassUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Mass in Centigrams.

--- a/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MassFlow(double numericValue, MassFlowUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MassFlow quantity.
         /// </summary>
-        public static MassFlowUnit[] Units { get; } = Enum.GetValues(typeof(MassFlowUnit)).Cast<MassFlowUnit>().ToArray();
+        public static MassFlowUnit[] Units { get; } = Enum.GetValues(typeof(MassFlowUnit)).Cast<MassFlowUnit>().Except(new MassFlowUnit[]{ MassFlowUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MassFlow in CentigramsPerSecond.

--- a/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MassFlux(double numericValue, MassFluxUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MassFlux quantity.
         /// </summary>
-        public static MassFluxUnit[] Units { get; } = Enum.GetValues(typeof(MassFluxUnit)).Cast<MassFluxUnit>().ToArray();
+        public static MassFluxUnit[] Units { get; } = Enum.GetValues(typeof(MassFluxUnit)).Cast<MassFluxUnit>().Except(new MassFluxUnit[]{ MassFluxUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MassFlux in GramsPerSecondPerSquareMeter.

--- a/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MassMomentOfInertia(double numericValue, MassMomentOfInertiaUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MassMomentOfInertia quantity.
         /// </summary>
-        public static MassMomentOfInertiaUnit[] Units { get; } = Enum.GetValues(typeof(MassMomentOfInertiaUnit)).Cast<MassMomentOfInertiaUnit>().ToArray();
+        public static MassMomentOfInertiaUnit[] Units { get; } = Enum.GetValues(typeof(MassMomentOfInertiaUnit)).Cast<MassMomentOfInertiaUnit>().Except(new MassMomentOfInertiaUnit[]{ MassMomentOfInertiaUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MassMomentOfInertia in GramSquareCentimeters.

--- a/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MolarEnergy(double numericValue, MolarEnergyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MolarEnergy quantity.
         /// </summary>
-        public static MolarEnergyUnit[] Units { get; } = Enum.GetValues(typeof(MolarEnergyUnit)).Cast<MolarEnergyUnit>().ToArray();
+        public static MolarEnergyUnit[] Units { get; } = Enum.GetValues(typeof(MolarEnergyUnit)).Cast<MolarEnergyUnit>().Except(new MolarEnergyUnit[]{ MolarEnergyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MolarEnergy in JoulesPerMole.

--- a/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MolarEntropy(double numericValue, MolarEntropyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MolarEntropy quantity.
         /// </summary>
-        public static MolarEntropyUnit[] Units { get; } = Enum.GetValues(typeof(MolarEntropyUnit)).Cast<MolarEntropyUnit>().ToArray();
+        public static MolarEntropyUnit[] Units { get; } = Enum.GetValues(typeof(MolarEntropyUnit)).Cast<MolarEntropyUnit>().Except(new MolarEntropyUnit[]{ MolarEntropyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MolarEntropy in JoulesPerMoleKelvin.

--- a/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         MolarMass(double numericValue, MolarMassUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the MolarMass quantity.
         /// </summary>
-        public static MolarMassUnit[] Units { get; } = Enum.GetValues(typeof(MolarMassUnit)).Cast<MolarMassUnit>().ToArray();
+        public static MolarMassUnit[] Units { get; } = Enum.GetValues(typeof(MolarMassUnit)).Cast<MolarMassUnit>().Except(new MolarMassUnit[]{ MolarMassUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get MolarMass in CentigramsPerMole.

--- a/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Molarity(double numericValue, MolarityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Molarity quantity.
         /// </summary>
-        public static MolarityUnit[] Units { get; } = Enum.GetValues(typeof(MolarityUnit)).Cast<MolarityUnit>().ToArray();
+        public static MolarityUnit[] Units { get; } = Enum.GetValues(typeof(MolarityUnit)).Cast<MolarityUnit>().Except(new MolarityUnit[]{ MolarityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Molarity in CentimolesPerLiter.

--- a/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Permeability(double numericValue, PermeabilityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Permeability quantity.
         /// </summary>
-        public static PermeabilityUnit[] Units { get; } = Enum.GetValues(typeof(PermeabilityUnit)).Cast<PermeabilityUnit>().ToArray();
+        public static PermeabilityUnit[] Units { get; } = Enum.GetValues(typeof(PermeabilityUnit)).Cast<PermeabilityUnit>().Except(new PermeabilityUnit[]{ PermeabilityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Permeability in HenriesPerMeter.

--- a/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Permittivity(double numericValue, PermittivityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Permittivity quantity.
         /// </summary>
-        public static PermittivityUnit[] Units { get; } = Enum.GetValues(typeof(PermittivityUnit)).Cast<PermittivityUnit>().ToArray();
+        public static PermittivityUnit[] Units { get; } = Enum.GetValues(typeof(PermittivityUnit)).Cast<PermittivityUnit>().Except(new PermittivityUnit[]{ PermittivityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Permittivity in FaradsPerMeter.

--- a/Common/GeneratedCode/Quantities/Power.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Power.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Power(decimal numericValue, PowerUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Power quantity.
         /// </summary>
-        public static PowerUnit[] Units { get; } = Enum.GetValues(typeof(PowerUnit)).Cast<PowerUnit>().ToArray();
+        public static PowerUnit[] Units { get; } = Enum.GetValues(typeof(PowerUnit)).Cast<PowerUnit>().Except(new PowerUnit[]{ PowerUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Power in BoilerHorsepower.

--- a/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         PowerDensity(double numericValue, PowerDensityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the PowerDensity quantity.
         /// </summary>
-        public static PowerDensityUnit[] Units { get; } = Enum.GetValues(typeof(PowerDensityUnit)).Cast<PowerDensityUnit>().ToArray();
+        public static PowerDensityUnit[] Units { get; } = Enum.GetValues(typeof(PowerDensityUnit)).Cast<PowerDensityUnit>().Except(new PowerDensityUnit[]{ PowerDensityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get PowerDensity in DecawattsPerCubicFoot.

--- a/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         PowerRatio(double numericValue, PowerRatioUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the PowerRatio quantity.
         /// </summary>
-        public static PowerRatioUnit[] Units { get; } = Enum.GetValues(typeof(PowerRatioUnit)).Cast<PowerRatioUnit>().ToArray();
+        public static PowerRatioUnit[] Units { get; } = Enum.GetValues(typeof(PowerRatioUnit)).Cast<PowerRatioUnit>().Except(new PowerRatioUnit[]{ PowerRatioUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get PowerRatio in DecibelMilliwatts.

--- a/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Pressure(double numericValue, PressureUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Pressure quantity.
         /// </summary>
-        public static PressureUnit[] Units { get; } = Enum.GetValues(typeof(PressureUnit)).Cast<PressureUnit>().ToArray();
+        public static PressureUnit[] Units { get; } = Enum.GetValues(typeof(PressureUnit)).Cast<PressureUnit>().Except(new PressureUnit[]{ PressureUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Pressure in Atmospheres.

--- a/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         PressureChangeRate(double numericValue, PressureChangeRateUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the PressureChangeRate quantity.
         /// </summary>
-        public static PressureChangeRateUnit[] Units { get; } = Enum.GetValues(typeof(PressureChangeRateUnit)).Cast<PressureChangeRateUnit>().ToArray();
+        public static PressureChangeRateUnit[] Units { get; } = Enum.GetValues(typeof(PressureChangeRateUnit)).Cast<PressureChangeRateUnit>().Except(new PressureChangeRateUnit[]{ PressureChangeRateUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get PressureChangeRate in AtmospheresPerSecond.

--- a/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Ratio(double numericValue, RatioUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Ratio quantity.
         /// </summary>
-        public static RatioUnit[] Units { get; } = Enum.GetValues(typeof(RatioUnit)).Cast<RatioUnit>().ToArray();
+        public static RatioUnit[] Units { get; } = Enum.GetValues(typeof(RatioUnit)).Cast<RatioUnit>().Except(new RatioUnit[]{ RatioUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Ratio in DecimalFractions.

--- a/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ReactiveEnergy(double numericValue, ReactiveEnergyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ReactiveEnergy quantity.
         /// </summary>
-        public static ReactiveEnergyUnit[] Units { get; } = Enum.GetValues(typeof(ReactiveEnergyUnit)).Cast<ReactiveEnergyUnit>().ToArray();
+        public static ReactiveEnergyUnit[] Units { get; } = Enum.GetValues(typeof(ReactiveEnergyUnit)).Cast<ReactiveEnergyUnit>().Except(new ReactiveEnergyUnit[]{ ReactiveEnergyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ReactiveEnergy in KilovoltampereReactiveHours.

--- a/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ReactivePower(double numericValue, ReactivePowerUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ReactivePower quantity.
         /// </summary>
-        public static ReactivePowerUnit[] Units { get; } = Enum.GetValues(typeof(ReactivePowerUnit)).Cast<ReactivePowerUnit>().ToArray();
+        public static ReactivePowerUnit[] Units { get; } = Enum.GetValues(typeof(ReactivePowerUnit)).Cast<ReactivePowerUnit>().Except(new ReactivePowerUnit[]{ ReactivePowerUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ReactivePower in GigavoltamperesReactive.

--- a/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         RotationalAcceleration(double numericValue, RotationalAccelerationUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the RotationalAcceleration quantity.
         /// </summary>
-        public static RotationalAccelerationUnit[] Units { get; } = Enum.GetValues(typeof(RotationalAccelerationUnit)).Cast<RotationalAccelerationUnit>().ToArray();
+        public static RotationalAccelerationUnit[] Units { get; } = Enum.GetValues(typeof(RotationalAccelerationUnit)).Cast<RotationalAccelerationUnit>().Except(new RotationalAccelerationUnit[]{ RotationalAccelerationUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get RotationalAcceleration in DegreesPerSecondSquared.

--- a/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         RotationalSpeed(double numericValue, RotationalSpeedUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the RotationalSpeed quantity.
         /// </summary>
-        public static RotationalSpeedUnit[] Units { get; } = Enum.GetValues(typeof(RotationalSpeedUnit)).Cast<RotationalSpeedUnit>().ToArray();
+        public static RotationalSpeedUnit[] Units { get; } = Enum.GetValues(typeof(RotationalSpeedUnit)).Cast<RotationalSpeedUnit>().Except(new RotationalSpeedUnit[]{ RotationalSpeedUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get RotationalSpeed in CentiradiansPerSecond.

--- a/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         RotationalStiffness(double numericValue, RotationalStiffnessUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the RotationalStiffness quantity.
         /// </summary>
-        public static RotationalStiffnessUnit[] Units { get; } = Enum.GetValues(typeof(RotationalStiffnessUnit)).Cast<RotationalStiffnessUnit>().ToArray();
+        public static RotationalStiffnessUnit[] Units { get; } = Enum.GetValues(typeof(RotationalStiffnessUnit)).Cast<RotationalStiffnessUnit>().Except(new RotationalStiffnessUnit[]{ RotationalStiffnessUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get RotationalStiffness in KilonewtonMetersPerRadian.

--- a/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         RotationalStiffnessPerLength(double numericValue, RotationalStiffnessPerLengthUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the RotationalStiffnessPerLength quantity.
         /// </summary>
-        public static RotationalStiffnessPerLengthUnit[] Units { get; } = Enum.GetValues(typeof(RotationalStiffnessPerLengthUnit)).Cast<RotationalStiffnessPerLengthUnit>().ToArray();
+        public static RotationalStiffnessPerLengthUnit[] Units { get; } = Enum.GetValues(typeof(RotationalStiffnessPerLengthUnit)).Cast<RotationalStiffnessPerLengthUnit>().Except(new RotationalStiffnessPerLengthUnit[]{ RotationalStiffnessPerLengthUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get RotationalStiffnessPerLength in KilonewtonMetersPerRadianPerMeter.

--- a/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         SolidAngle(double numericValue, SolidAngleUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the SolidAngle quantity.
         /// </summary>
-        public static SolidAngleUnit[] Units { get; } = Enum.GetValues(typeof(SolidAngleUnit)).Cast<SolidAngleUnit>().ToArray();
+        public static SolidAngleUnit[] Units { get; } = Enum.GetValues(typeof(SolidAngleUnit)).Cast<SolidAngleUnit>().Except(new SolidAngleUnit[]{ SolidAngleUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get SolidAngle in Steradians.

--- a/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         SpecificEnergy(double numericValue, SpecificEnergyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the SpecificEnergy quantity.
         /// </summary>
-        public static SpecificEnergyUnit[] Units { get; } = Enum.GetValues(typeof(SpecificEnergyUnit)).Cast<SpecificEnergyUnit>().ToArray();
+        public static SpecificEnergyUnit[] Units { get; } = Enum.GetValues(typeof(SpecificEnergyUnit)).Cast<SpecificEnergyUnit>().Except(new SpecificEnergyUnit[]{ SpecificEnergyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get SpecificEnergy in CaloriesPerGram.

--- a/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         SpecificEntropy(double numericValue, SpecificEntropyUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the SpecificEntropy quantity.
         /// </summary>
-        public static SpecificEntropyUnit[] Units { get; } = Enum.GetValues(typeof(SpecificEntropyUnit)).Cast<SpecificEntropyUnit>().ToArray();
+        public static SpecificEntropyUnit[] Units { get; } = Enum.GetValues(typeof(SpecificEntropyUnit)).Cast<SpecificEntropyUnit>().Except(new SpecificEntropyUnit[]{ SpecificEntropyUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get SpecificEntropy in CaloriesPerGramKelvin.

--- a/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         SpecificVolume(double numericValue, SpecificVolumeUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the SpecificVolume quantity.
         /// </summary>
-        public static SpecificVolumeUnit[] Units { get; } = Enum.GetValues(typeof(SpecificVolumeUnit)).Cast<SpecificVolumeUnit>().ToArray();
+        public static SpecificVolumeUnit[] Units { get; } = Enum.GetValues(typeof(SpecificVolumeUnit)).Cast<SpecificVolumeUnit>().Except(new SpecificVolumeUnit[]{ SpecificVolumeUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get SpecificVolume in CubicFeetPerPound.

--- a/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         SpecificWeight(double numericValue, SpecificWeightUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the SpecificWeight quantity.
         /// </summary>
-        public static SpecificWeightUnit[] Units { get; } = Enum.GetValues(typeof(SpecificWeightUnit)).Cast<SpecificWeightUnit>().ToArray();
+        public static SpecificWeightUnit[] Units { get; } = Enum.GetValues(typeof(SpecificWeightUnit)).Cast<SpecificWeightUnit>().Except(new SpecificWeightUnit[]{ SpecificWeightUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get SpecificWeight in KilogramsForcePerCubicCentimeter.

--- a/Common/GeneratedCode/Quantities/Speed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Speed.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Speed(double numericValue, SpeedUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Speed quantity.
         /// </summary>
-        public static SpeedUnit[] Units { get; } = Enum.GetValues(typeof(SpeedUnit)).Cast<SpeedUnit>().ToArray();
+        public static SpeedUnit[] Units { get; } = Enum.GetValues(typeof(SpeedUnit)).Cast<SpeedUnit>().Except(new SpeedUnit[]{ SpeedUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Speed in CentimetersPerHour.

--- a/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Temperature(double numericValue, TemperatureUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Temperature quantity.
         /// </summary>
-        public static TemperatureUnit[] Units { get; } = Enum.GetValues(typeof(TemperatureUnit)).Cast<TemperatureUnit>().ToArray();
+        public static TemperatureUnit[] Units { get; } = Enum.GetValues(typeof(TemperatureUnit)).Cast<TemperatureUnit>().Except(new TemperatureUnit[]{ TemperatureUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Temperature in DegreesCelsius.

--- a/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         TemperatureChangeRate(double numericValue, TemperatureChangeRateUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the TemperatureChangeRate quantity.
         /// </summary>
-        public static TemperatureChangeRateUnit[] Units { get; } = Enum.GetValues(typeof(TemperatureChangeRateUnit)).Cast<TemperatureChangeRateUnit>().ToArray();
+        public static TemperatureChangeRateUnit[] Units { get; } = Enum.GetValues(typeof(TemperatureChangeRateUnit)).Cast<TemperatureChangeRateUnit>().Except(new TemperatureChangeRateUnit[]{ TemperatureChangeRateUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get TemperatureChangeRate in CentidegreesCelsiusPerSecond.

--- a/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         TemperatureDelta(double numericValue, TemperatureDeltaUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the TemperatureDelta quantity.
         /// </summary>
-        public static TemperatureDeltaUnit[] Units { get; } = Enum.GetValues(typeof(TemperatureDeltaUnit)).Cast<TemperatureDeltaUnit>().ToArray();
+        public static TemperatureDeltaUnit[] Units { get; } = Enum.GetValues(typeof(TemperatureDeltaUnit)).Cast<TemperatureDeltaUnit>().Except(new TemperatureDeltaUnit[]{ TemperatureDeltaUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get TemperatureDelta in DegreesCelsius.

--- a/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ThermalConductivity(double numericValue, ThermalConductivityUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ThermalConductivity quantity.
         /// </summary>
-        public static ThermalConductivityUnit[] Units { get; } = Enum.GetValues(typeof(ThermalConductivityUnit)).Cast<ThermalConductivityUnit>().ToArray();
+        public static ThermalConductivityUnit[] Units { get; } = Enum.GetValues(typeof(ThermalConductivityUnit)).Cast<ThermalConductivityUnit>().Except(new ThermalConductivityUnit[]{ ThermalConductivityUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ThermalConductivity in BtusPerHourFootFahrenheit.

--- a/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         ThermalResistance(double numericValue, ThermalResistanceUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the ThermalResistance quantity.
         /// </summary>
-        public static ThermalResistanceUnit[] Units { get; } = Enum.GetValues(typeof(ThermalResistanceUnit)).Cast<ThermalResistanceUnit>().ToArray();
+        public static ThermalResistanceUnit[] Units { get; } = Enum.GetValues(typeof(ThermalResistanceUnit)).Cast<ThermalResistanceUnit>().Except(new ThermalResistanceUnit[]{ ThermalResistanceUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get ThermalResistance in HourSquareFeetDegreesFahrenheitPerBtu.

--- a/Common/GeneratedCode/Quantities/Torque.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Torque.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Torque(double numericValue, TorqueUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Torque quantity.
         /// </summary>
-        public static TorqueUnit[] Units { get; } = Enum.GetValues(typeof(TorqueUnit)).Cast<TorqueUnit>().ToArray();
+        public static TorqueUnit[] Units { get; } = Enum.GetValues(typeof(TorqueUnit)).Cast<TorqueUnit>().Except(new TorqueUnit[]{ TorqueUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Torque in KilogramForceCentimeters.

--- a/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
@@ -100,7 +100,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         VitaminA(double numericValue, VitaminAUnit unit)
         {
@@ -158,7 +158,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the VitaminA quantity.
         /// </summary>
-        public static VitaminAUnit[] Units { get; } = Enum.GetValues(typeof(VitaminAUnit)).Cast<VitaminAUnit>().ToArray();
+        public static VitaminAUnit[] Units { get; } = Enum.GetValues(typeof(VitaminAUnit)).Cast<VitaminAUnit>().Except(new VitaminAUnit[]{ VitaminAUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get VitaminA in InternationalUnits.

--- a/Common/GeneratedCode/Quantities/Volume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Volume.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         Volume(double numericValue, VolumeUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the Volume quantity.
         /// </summary>
-        public static VolumeUnit[] Units { get; } = Enum.GetValues(typeof(VolumeUnit)).Cast<VolumeUnit>().ToArray();
+        public static VolumeUnit[] Units { get; } = Enum.GetValues(typeof(VolumeUnit)).Cast<VolumeUnit>().Except(new VolumeUnit[]{ VolumeUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get Volume in AuTablespoons.

--- a/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
@@ -101,7 +101,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         VolumeFlow(double numericValue, VolumeFlowUnit unit)
         {
@@ -159,7 +159,7 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the VolumeFlow quantity.
         /// </summary>
-        public static VolumeFlowUnit[] Units { get; } = Enum.GetValues(typeof(VolumeFlowUnit)).Cast<VolumeFlowUnit>().ToArray();
+        public static VolumeFlowUnit[] Units { get; } = Enum.GetValues(typeof(VolumeFlowUnit)).Cast<VolumeFlowUnit>().Except(new VolumeFlowUnit[]{ VolumeFlowUnit.Undefined }).ToArray();
 
         /// <summary>
         ///     Get VolumeFlow in CentilitersPerMinute.

--- a/UnitsNet.Tests/GeneratedCode/AccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AccelerationTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -305,5 +306,12 @@ namespace UnitsNet.Tests
             Acceleration meterpersecondsquared = Acceleration.FromMetersPerSecondSquared(1);
             Assert.False(meterpersecondsquared.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AccelerationUnit.Undefined, Acceleration.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/AmountOfSubstanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AmountOfSubstanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -315,5 +316,12 @@ namespace UnitsNet.Tests
             AmountOfSubstance mole = AmountOfSubstance.FromMoles(1);
             Assert.False(mole.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AmountOfSubstanceUnit.Undefined, AmountOfSubstance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -220,5 +221,12 @@ namespace UnitsNet.Tests
             AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
             Assert.False(decibelvolt.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AmplitudeRatioUnit.Undefined, AmplitudeRatio.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/AngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AngleTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -315,5 +316,12 @@ namespace UnitsNet.Tests
             Angle degree = Angle.FromDegrees(1);
             Assert.False(degree.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AngleUnit.Undefined, Angle.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ApparentEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ApparentEnergyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             ApparentEnergy voltamperehour = ApparentEnergy.FromVoltampereHours(1);
             Assert.False(voltamperehour.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ApparentEnergyUnit.Undefined, ApparentEnergy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ApparentPowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ApparentPowerTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             ApparentPower voltampere = ApparentPower.FromVoltamperes(1);
             Assert.False(voltampere.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ApparentPowerUnit.Undefined, ApparentPower.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/AreaDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaDensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             AreaDensity kilogrampersquaremeter = AreaDensity.FromKilogramsPerSquareMeter(1);
             Assert.False(kilogrampersquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AreaDensityUnit.Undefined, AreaDensity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/AreaMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaMomentOfInertiaTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -235,5 +236,12 @@ namespace UnitsNet.Tests
             AreaMomentOfInertia metertothefourth = AreaMomentOfInertia.FromMetersToTheFourth(1);
             Assert.False(metertothefourth.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AreaMomentOfInertiaUnit.Undefined, AreaMomentOfInertia.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/AreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -305,5 +306,12 @@ namespace UnitsNet.Tests
             Area squaremeter = Area.FromSquareMeters(1);
             Assert.False(squaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(AreaUnit.Undefined, Area.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/BitRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/BitRateTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -435,5 +436,12 @@ namespace UnitsNet.Tests
             BitRate bitpersecond = BitRate.FromBitsPerSecond(1);
             Assert.False(bitpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(BitRateUnit.Undefined, BitRate.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/BrakeSpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/BrakeSpecificFuelConsumptionTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             BrakeSpecificFuelConsumption kilogramperjoule = BrakeSpecificFuelConsumption.FromKilogramsPerJoule(1);
             Assert.False(kilogramperjoule.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(BrakeSpecificFuelConsumptionUnit.Undefined, BrakeSpecificFuelConsumption.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/CapacitanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/CapacitanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             Capacitance farad = Capacitance.FromFarads(1);
             Assert.False(farad.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(CapacitanceUnit.Undefined, Capacitance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/DensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/DensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -555,5 +556,12 @@ namespace UnitsNet.Tests
             Density kilogrampercubicmeter = Density.FromKilogramsPerCubicMeter(1);
             Assert.False(kilogrampercubicmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(DensityUnit.Undefined, Density.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/DurationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/DurationTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -295,5 +296,12 @@ namespace UnitsNet.Tests
             Duration second = Duration.FromSeconds(1);
             Assert.False(second.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(DurationUnit.Undefined, Duration.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/DynamicViscosityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -235,5 +236,12 @@ namespace UnitsNet.Tests
             DynamicViscosity newtonsecondpermetersquared = DynamicViscosity.FromNewtonSecondsPerMeterSquared(1);
             Assert.False(newtonsecondpermetersquared.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(DynamicViscosityUnit.Undefined, DynamicViscosity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricAdmittanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricAdmittanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             ElectricAdmittance siemens = ElectricAdmittance.FromSiemens(1);
             Assert.False(siemens.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricAdmittanceUnit.Undefined, ElectricAdmittance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricChargeDensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricChargeDensity coulombpercubicmeter = ElectricChargeDensity.FromCoulombsPerCubicMeter(1);
             Assert.False(coulombpercubicmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricChargeDensityUnit.Undefined, ElectricChargeDensity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricChargeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricChargeTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricCharge coulomb = ElectricCharge.FromCoulombs(1);
             Assert.False(coulomb.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricChargeUnit.Undefined, ElectricCharge.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricConductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricConductanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             ElectricConductance siemens = ElectricConductance.FromSiemens(1);
             Assert.False(siemens.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricConductanceUnit.Undefined, ElectricConductance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricConductivityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricConductivity siemenspermeter = ElectricConductivity.FromSiemensPerMeter(1);
             Assert.False(siemenspermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricConductivityUnit.Undefined, ElectricConductivity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricCurrentDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricCurrentDensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricCurrentDensity amperepersquaremeter = ElectricCurrentDensity.FromAmperesPerSquareMeter(1);
             Assert.False(amperepersquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricCurrentDensityUnit.Undefined, ElectricCurrentDensity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricCurrentGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricCurrentGradientTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricCurrentGradient amperepersecond = ElectricCurrentGradient.FromAmperesPerSecond(1);
             Assert.False(amperepersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricCurrentGradientUnit.Undefined, ElectricCurrentGradient.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricCurrentTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricCurrentTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -255,5 +256,12 @@ namespace UnitsNet.Tests
             ElectricCurrent ampere = ElectricCurrent.FromAmperes(1);
             Assert.False(ampere.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricCurrentUnit.Undefined, ElectricCurrent.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricFieldTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricField voltpermeter = ElectricField.FromVoltsPerMeter(1);
             Assert.False(voltpermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricFieldUnit.Undefined, ElectricField.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricInductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricInductanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             ElectricInductance henry = ElectricInductance.FromHenries(1);
             Assert.False(henry.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricInductanceUnit.Undefined, ElectricInductance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricPotentialAcTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricPotentialAcTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -225,5 +226,12 @@ namespace UnitsNet.Tests
             ElectricPotentialAc voltac = ElectricPotentialAc.FromVoltsAc(1);
             Assert.False(voltac.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricPotentialAcUnit.Undefined, ElectricPotentialAc.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricPotentialDcTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricPotentialDcTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -225,5 +226,12 @@ namespace UnitsNet.Tests
             ElectricPotentialDc voltdc = ElectricPotentialDc.FromVoltsDc(1);
             Assert.False(voltdc.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricPotentialDcUnit.Undefined, ElectricPotentialDc.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricPotentialTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricPotentialTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -225,5 +226,12 @@ namespace UnitsNet.Tests
             ElectricPotential volt = ElectricPotential.FromVolts(1);
             Assert.False(volt.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricPotentialUnit.Undefined, ElectricPotential.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricResistanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             ElectricResistance ohm = ElectricResistance.FromOhms(1);
             Assert.False(ohm.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricResistanceUnit.Undefined, ElectricResistance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ElectricResistivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricResistivityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             ElectricResistivity ohmmeter = ElectricResistivity.FromOhmMeters(1);
             Assert.False(ohmmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ElectricResistivityUnit.Undefined, ElectricResistivity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/EnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/EnergyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -395,5 +396,12 @@ namespace UnitsNet.Tests
             Energy joule = Energy.FromJoules(1);
             Assert.False(joule.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(EnergyUnit.Undefined, Energy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/EntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/EntropyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -245,5 +246,12 @@ namespace UnitsNet.Tests
             Entropy jouleperkelvin = Entropy.FromJoulesPerKelvin(1);
             Assert.False(jouleperkelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(EntropyUnit.Undefined, Entropy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/FlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/FlowTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -415,5 +416,12 @@ namespace UnitsNet.Tests
             Flow cubicmeterpersecond = Flow.FromCubicMetersPerSecond(1);
             Assert.False(cubicmeterpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(FlowUnit.Undefined, Flow.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ForceChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForceChangeRateTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -285,5 +286,12 @@ namespace UnitsNet.Tests
             ForceChangeRate newtonpersecond = ForceChangeRate.FromNewtonsPerSecond(1);
             Assert.False(newtonpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ForceChangeRateUnit.Undefined, ForceChangeRate.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ForcePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForcePerLengthTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -265,5 +266,12 @@ namespace UnitsNet.Tests
             ForcePerLength newtonpermeter = ForcePerLength.FromNewtonsPerMeter(1);
             Assert.False(newtonpermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ForcePerLengthUnit.Undefined, ForcePerLength.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ForceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -275,5 +276,12 @@ namespace UnitsNet.Tests
             Force newton = Force.FromNewtons(1);
             Assert.False(newton.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ForceUnit.Undefined, Force.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/FrequencyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -255,5 +256,12 @@ namespace UnitsNet.Tests
             Frequency hertz = Frequency.FromHertz(1);
             Assert.False(hertz.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(FrequencyUnit.Undefined, Frequency.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/HeatFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/HeatFluxTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -335,5 +336,12 @@ namespace UnitsNet.Tests
             HeatFlux wattpersquaremeter = HeatFlux.FromWattsPerSquareMeter(1);
             Assert.False(wattpersquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(HeatFluxUnit.Undefined, HeatFlux.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/HeatTransferCoefficientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/HeatTransferCoefficientTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -195,5 +196,12 @@ namespace UnitsNet.Tests
             HeatTransferCoefficient wattpersquaremeterkelvin = HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(1);
             Assert.False(wattpersquaremeterkelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(HeatTransferCoefficientUnit.Undefined, HeatTransferCoefficient.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/IlluminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IlluminanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             Illuminance lux = Illuminance.FromLux(1);
             Assert.False(lux.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(IlluminanceUnit.Undefined, Illuminance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/InformationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/InformationTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -435,5 +436,12 @@ namespace UnitsNet.Tests
             Information bit = Information.FromBits(1);
             Assert.False(bit.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(InformationUnit.Undefined, Information.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/IrradianceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IrradianceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -195,5 +196,12 @@ namespace UnitsNet.Tests
             Irradiance wattpersquaremeter = Irradiance.FromWattsPerSquareMeter(1);
             Assert.False(wattpersquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(IrradianceUnit.Undefined, Irradiance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/IrradiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IrradiationTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             Irradiation joulepersquaremeter = Irradiation.FromJoulesPerSquareMeter(1);
             Assert.False(joulepersquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(IrradiationUnit.Undefined, Irradiation.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/KinematicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/KinematicViscosityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -255,5 +256,12 @@ namespace UnitsNet.Tests
             KinematicViscosity squaremeterpersecond = KinematicViscosity.FromSquareMetersPerSecond(1);
             Assert.False(squaremeterpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(KinematicViscosityUnit.Undefined, KinematicViscosity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/LapseRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LapseRateTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             LapseRate degreecelsiusperkilometer = LapseRate.FromDegreesCelciusPerKilometer(1);
             Assert.False(degreecelsiusperkilometer.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(LapseRateUnit.Undefined, LapseRate.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/LengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LengthTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -395,5 +396,12 @@ namespace UnitsNet.Tests
             Length meter = Length.FromMeters(1);
             Assert.False(meter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(LengthUnit.Undefined, Length.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/LevelTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LevelTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -200,5 +201,12 @@ namespace UnitsNet.Tests
             Level decibel = Level.FromDecibels(1);
             Assert.False(decibel.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(LevelUnit.Undefined, Level.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/LinearDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LinearDensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             LinearDensity kilogrampermeter = LinearDensity.FromKilogramsPerMeter(1);
             Assert.False(kilogrampermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(LinearDensityUnit.Undefined, LinearDensity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/LuminousFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LuminousFluxTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             LuminousFlux lumen = LuminousFlux.FromLumens(1);
             Assert.False(lumen.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(LuminousFluxUnit.Undefined, LuminousFlux.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/LuminousIntensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LuminousIntensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             LuminousIntensity candela = LuminousIntensity.FromCandela(1);
             Assert.False(candela.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(LuminousIntensityUnit.Undefined, LuminousIntensity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MagneticFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MagneticFieldTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             MagneticField tesla = MagneticField.FromTeslas(1);
             Assert.False(tesla.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MagneticFieldUnit.Undefined, MagneticField.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MagneticFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MagneticFluxTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             MagneticFlux weber = MagneticFlux.FromWebers(1);
             Assert.False(weber.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MagneticFluxUnit.Undefined, MagneticFlux.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MagnetizationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MagnetizationTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             Magnetization amperepermeter = Magnetization.FromAmperesPerMeter(1);
             Assert.False(amperepermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MagnetizationUnit.Undefined, Magnetization.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MassFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassFlowTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -325,5 +326,12 @@ namespace UnitsNet.Tests
             MassFlow grampersecond = MassFlow.FromGramsPerSecond(1);
             Assert.False(grampersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MassFlowUnit.Undefined, MassFlow.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MassFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassFluxTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -195,5 +196,12 @@ namespace UnitsNet.Tests
             MassFlux kilogrampersecondpersquaremeter = MassFlux.FromKilogramsPerSecondPerSquareMeter(1);
             Assert.False(kilogrampersecondpersquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MassFluxUnit.Undefined, MassFlux.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MassMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassMomentOfInertiaTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -435,5 +436,12 @@ namespace UnitsNet.Tests
             MassMomentOfInertia kilogramsquaremeter = MassMomentOfInertia.FromKilogramSquareMeters(1);
             Assert.False(kilogramsquaremeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MassMomentOfInertiaUnit.Undefined, MassMomentOfInertia.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -385,5 +386,12 @@ namespace UnitsNet.Tests
             Mass kilogram = Mass.FromKilograms(1);
             Assert.False(kilogram.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MassUnit.Undefined, Mass.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MolarEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarEnergyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             MolarEnergy joulepermole = MolarEnergy.FromJoulesPerMole(1);
             Assert.False(joulepermole.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MolarEnergyUnit.Undefined, MolarEnergy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MolarEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarEntropyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             MolarEntropy joulepermolekelvin = MolarEntropy.FromJoulesPerMoleKelvin(1);
             Assert.False(joulepermolekelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MolarEntropyUnit.Undefined, MolarEntropy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MolarMassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarMassTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -295,5 +296,12 @@ namespace UnitsNet.Tests
             MolarMass kilogrampermole = MolarMass.FromKilogramsPerMole(1);
             Assert.False(kilogrampermole.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MolarMassUnit.Undefined, MolarMass.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/MolarityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -255,5 +256,12 @@ namespace UnitsNet.Tests
             Molarity molespercubicmeter = Molarity.FromMolesPerCubicMeter(1);
             Assert.False(molespercubicmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(MolarityUnit.Undefined, Molarity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PermeabilityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             Permeability henrypermeter = Permeability.FromHenriesPerMeter(1);
             Assert.False(henrypermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PermeabilityUnit.Undefined, Permeability.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PermittivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PermittivityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             Permittivity faradpermeter = Permittivity.FromFaradsPerMeter(1);
             Assert.False(faradpermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PermittivityUnit.Undefined, Permittivity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PowerDensityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -615,5 +616,12 @@ namespace UnitsNet.Tests
             PowerDensity wattpercubicmeter = PowerDensity.FromWattsPerCubicMeter(1);
             Assert.False(wattpercubicmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PowerDensityUnit.Undefined, PowerDensity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PowerRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PowerRatioTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -200,5 +201,12 @@ namespace UnitsNet.Tests
             PowerRatio decibelwatt = PowerRatio.FromDecibelWatts(1);
             Assert.False(decibelwatt.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PowerRatioUnit.Undefined, PowerRatio.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PowerTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -375,5 +376,12 @@ namespace UnitsNet.Tests
             Power watt = Power.FromWatts(1);
             Assert.False(watt.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PowerUnit.Undefined, Power.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PressureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PressureChangeRateTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             PressureChangeRate pascalpersecond = PressureChangeRate.FromPascalsPerSecond(1);
             Assert.False(pascalpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PressureChangeRateUnit.Undefined, PressureChangeRate.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/PressureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PressureTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -555,5 +556,12 @@ namespace UnitsNet.Tests
             Pressure pascal = Pressure.FromPascals(1);
             Assert.False(pascal.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(PressureUnit.Undefined, Pressure.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/RatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RatioTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -235,5 +236,12 @@ namespace UnitsNet.Tests
             Ratio decimalfraction = Ratio.FromDecimalFractions(1);
             Assert.False(decimalfraction.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(RatioUnit.Undefined, Ratio.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ReactiveEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ReactiveEnergyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             ReactiveEnergy voltamperereactivehour = ReactiveEnergy.FromVoltampereReactiveHours(1);
             Assert.False(voltamperereactivehour.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ReactiveEnergyUnit.Undefined, ReactiveEnergy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ReactivePowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ReactivePowerTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -215,5 +216,12 @@ namespace UnitsNet.Tests
             ReactivePower voltamperereactive = ReactivePower.FromVoltamperesReactive(1);
             Assert.False(voltamperereactive.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ReactivePowerUnit.Undefined, ReactivePower.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             RotationalAcceleration radianpersecondsquared = RotationalAcceleration.FromRadiansPerSecondSquared(1);
             Assert.False(radianpersecondsquared.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(RotationalAccelerationUnit.Undefined, RotationalAcceleration.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/RotationalSpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalSpeedTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -305,5 +306,12 @@ namespace UnitsNet.Tests
             RotationalSpeed radianpersecond = RotationalSpeed.FromRadiansPerSecond(1);
             Assert.False(radianpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(RotationalSpeedUnit.Undefined, RotationalSpeed.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/RotationalStiffnessPerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalStiffnessPerLengthTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             RotationalStiffnessPerLength newtonmeterperradianpermeter = RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(1);
             Assert.False(newtonmeterperradianpermeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(RotationalStiffnessPerLengthUnit.Undefined, RotationalStiffnessPerLength.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/RotationalStiffnessTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalStiffnessTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -205,5 +206,12 @@ namespace UnitsNet.Tests
             RotationalStiffness newtonmeterperradian = RotationalStiffness.FromNewtonMetersPerRadian(1);
             Assert.False(newtonmeterperradian.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(RotationalStiffnessUnit.Undefined, RotationalStiffness.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/SolidAngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SolidAngleTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             SolidAngle steradian = SolidAngle.FromSteradians(1);
             Assert.False(steradian.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(SolidAngleUnit.Undefined, SolidAngle.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/SpecificEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificEnergyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -255,5 +256,12 @@ namespace UnitsNet.Tests
             SpecificEnergy jouleperkilogram = SpecificEnergy.FromJoulesPerKilogram(1);
             Assert.False(jouleperkilogram.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(SpecificEnergyUnit.Undefined, SpecificEnergy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/SpecificEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificEntropyTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -255,5 +256,12 @@ namespace UnitsNet.Tests
             SpecificEntropy jouleperkilogramkelvin = SpecificEntropy.FromJoulesPerKilogramKelvin(1);
             Assert.False(jouleperkilogramkelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(SpecificEntropyUnit.Undefined, SpecificEntropy.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/SpecificVolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificVolumeTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -195,5 +196,12 @@ namespace UnitsNet.Tests
             SpecificVolume cubicmeterperkilogram = SpecificVolume.FromCubicMetersPerKilogram(1);
             Assert.False(cubicmeterperkilogram.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(SpecificVolumeUnit.Undefined, SpecificVolume.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/SpecificWeightTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificWeightTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -345,5 +346,12 @@ namespace UnitsNet.Tests
             SpecificWeight newtonpercubicmeter = SpecificWeight.FromNewtonsPerCubicMeter(1);
             Assert.False(newtonpercubicmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(SpecificWeightUnit.Undefined, SpecificWeight.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/SpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpeedTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -495,5 +496,12 @@ namespace UnitsNet.Tests
             Speed meterpersecond = Speed.FromMetersPerSecond(1);
             Assert.False(meterpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(SpeedUnit.Undefined, Speed.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TemperatureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TemperatureChangeRateTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -275,5 +276,12 @@ namespace UnitsNet.Tests
             TemperatureChangeRate degreecelsiuspersecond = TemperatureChangeRate.FromDegreesCelsiusPerSecond(1);
             Assert.False(degreecelsiuspersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(TemperatureChangeRateUnit.Undefined, TemperatureChangeRate.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TemperatureDeltaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TemperatureDeltaTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -335,5 +336,12 @@ namespace UnitsNet.Tests
             TemperatureDelta kelvin = TemperatureDelta.FromKelvins(1);
             Assert.False(kelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(TemperatureDeltaUnit.Undefined, TemperatureDelta.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TemperatureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TemperatureTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -243,5 +244,12 @@ namespace UnitsNet.Tests
             Temperature kelvin = Temperature.FromKelvins(1);
             Assert.False(kelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(TemperatureUnit.Undefined, Temperature.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ThermalConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ThermalConductivityTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -195,5 +196,12 @@ namespace UnitsNet.Tests
             ThermalConductivity wattpermeterkelvin = ThermalConductivity.FromWattsPerMeterKelvin(1);
             Assert.False(wattpermeterkelvin.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ThermalConductivityUnit.Undefined, ThermalConductivity.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/ThermalResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ThermalResistanceTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -225,5 +226,12 @@ namespace UnitsNet.Tests
             ThermalResistance squaremeterkelvinperkilowatt = ThermalResistance.FromSquareMeterKelvinsPerKilowatt(1);
             Assert.False(squaremeterkelvinperkilowatt.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(ThermalResistanceUnit.Undefined, ThermalResistance.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TorqueTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TorqueTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -385,5 +386,12 @@ namespace UnitsNet.Tests
             Torque newtonmeter = Torque.FromNewtonMeters(1);
             Assert.False(newtonmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(TorqueUnit.Undefined, Torque.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/VitaminATestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VitaminATestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -185,5 +186,12 @@ namespace UnitsNet.Tests
             VitaminA internationalunit = VitaminA.FromInternationalUnits(1);
             Assert.False(internationalunit.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(VitaminAUnit.Undefined, VitaminA.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/VolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeFlowTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -435,5 +436,12 @@ namespace UnitsNet.Tests
             VolumeFlow cubicmeterpersecond = VolumeFlow.FromCubicMetersPerSecond(1);
             Assert.False(cubicmeterpersecond.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(VolumeFlowUnit.Undefined, VolumeFlow.Units);
+        }
+
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
@@ -37,6 +37,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -615,5 +616,12 @@ namespace UnitsNet.Tests
             Volume cubicmeter = Volume.FromCubicMeters(1);
             Assert.False(cubicmeter.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain(VolumeUnit.Undefined, Volume.Units);
+        }
+
     }
 }

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
@@ -125,7 +125,7 @@ namespace UnitsNet
     {
 @"
             BaseDimensions = new BaseDimensions($baseDimensionLength, $baseDimensionMass, $baseDimensionTime, $baseDimensionElectricCurrent, $baseDimensionTemperature, $baseDimensionAmountOfSubstance, $baseDimensionLuminousIntensity);
-"@; 
+"@;
     }
 @"
         }
@@ -149,7 +149,7 @@ namespace UnitsNet
 #if WINDOWS_UWP
         private
 #else
-        public 
+        public
 #endif
         $quantityName($baseType numericValue, $unitEnumName unit)
         {
@@ -207,8 +207,8 @@ namespace UnitsNet
         /// <summary>
         ///     All units of measurement for the $quantityName quantity.
         /// </summary>
-        public static $unitEnumName[] Units { get; } = Enum.GetValues(typeof($unitEnumName)).Cast<$unitEnumName>().ToArray();
-"@; 
+        public static $unitEnumName[] Units { get; } = Enum.GetValues(typeof($unitEnumName)).Cast<$unitEnumName>().Except(new $unitEnumName[]{ $unitEnumName.Undefined }).ToArray();
+"@;
     foreach ($unit in $units) {
         $propertyName = $unit.PluralName;
         $obsoleteAttribute = GetObsoleteAttribute($unit);

--- a/UnitsNet/Scripts/Include-GenerateUnitTestBaseClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitTestBaseClassSourceCode.ps1
@@ -48,6 +48,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using UnitsNet.Units;
 using Xunit;
 
@@ -234,6 +235,13 @@ namespace UnitsNet.Tests
             $quantityName $baseUnitVariableName = $quantityName.From$baseUnitPluralName(1);
             Assert.False($baseUnitVariableName.Equals(null));
         }
+
+        [Fact]
+        public void UnitsDoesNotContainUndefined()
+        {
+            Assert.DoesNotContain($unitEnumName.Undefined, $quantityName.Units);
+        }
+
     }
 }
 "@;


### PR DESCRIPTION
See notes in the related issue (#437). Worth noting that this does not remove the Undefined value, but just does not expose it from each quantity classes Units property.

Resolves #437.