### PR TITLE
Changing extension methods to use generics. Allows for broader use wh…

### DIFF
--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAccelerationExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAccelerationExtensions.g.cs
@@ -47,442 +47,130 @@ namespace UnitsNet.Extensions.NumberToAcceleration
         #region CentimeterPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration CentimetersPerSecondSquared(this int value) => Acceleration.FromCentimetersPerSecondSquared(value);
+        public static Acceleration CentimetersPerSecondSquared<T>(this T value) => Acceleration.FromCentimetersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? CentimetersPerSecondSquared(this int? value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration CentimetersPerSecondSquared(this long value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? CentimetersPerSecondSquared(this long? value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration CentimetersPerSecondSquared(this double value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? CentimetersPerSecondSquared(this double? value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration CentimetersPerSecondSquared(this float value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? CentimetersPerSecondSquared(this float? value) => Acceleration.FromCentimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration CentimetersPerSecondSquared(this decimal value) => Acceleration.FromCentimetersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromCentimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? CentimetersPerSecondSquared(this decimal? value) => Acceleration.FromCentimetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? CentimetersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromCentimetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecimeterPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration DecimetersPerSecondSquared(this int value) => Acceleration.FromDecimetersPerSecondSquared(value);
+        public static Acceleration DecimetersPerSecondSquared<T>(this T value) => Acceleration.FromDecimetersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? DecimetersPerSecondSquared(this int? value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration DecimetersPerSecondSquared(this long value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? DecimetersPerSecondSquared(this long? value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration DecimetersPerSecondSquared(this double value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? DecimetersPerSecondSquared(this double? value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration DecimetersPerSecondSquared(this float value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? DecimetersPerSecondSquared(this float? value) => Acceleration.FromDecimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration DecimetersPerSecondSquared(this decimal value) => Acceleration.FromDecimetersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromDecimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? DecimetersPerSecondSquared(this decimal? value) => Acceleration.FromDecimetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? DecimetersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromDecimetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration FeetPerSecondSquared(this int value) => Acceleration.FromFeetPerSecondSquared(value);
+        public static Acceleration FeetPerSecondSquared<T>(this T value) => Acceleration.FromFeetPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? FeetPerSecondSquared(this int? value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration FeetPerSecondSquared(this long value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? FeetPerSecondSquared(this long? value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration FeetPerSecondSquared(this double value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? FeetPerSecondSquared(this double? value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration FeetPerSecondSquared(this float value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? FeetPerSecondSquared(this float? value) => Acceleration.FromFeetPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration FeetPerSecondSquared(this decimal value) => Acceleration.FromFeetPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromFeetPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? FeetPerSecondSquared(this decimal? value) => Acceleration.FromFeetPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? FeetPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromFeetPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region InchPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration InchesPerSecondSquared(this int value) => Acceleration.FromInchesPerSecondSquared(value);
+        public static Acceleration InchesPerSecondSquared<T>(this T value) => Acceleration.FromInchesPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? InchesPerSecondSquared(this int? value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration InchesPerSecondSquared(this long value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? InchesPerSecondSquared(this long? value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration InchesPerSecondSquared(this double value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? InchesPerSecondSquared(this double? value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration InchesPerSecondSquared(this float value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? InchesPerSecondSquared(this float? value) => Acceleration.FromInchesPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration InchesPerSecondSquared(this decimal value) => Acceleration.FromInchesPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromInchesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? InchesPerSecondSquared(this decimal? value) => Acceleration.FromInchesPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? InchesPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromInchesPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilometerPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration KilometersPerSecondSquared(this int value) => Acceleration.FromKilometersPerSecondSquared(value);
+        public static Acceleration KilometersPerSecondSquared<T>(this T value) => Acceleration.FromKilometersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? KilometersPerSecondSquared(this int? value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration KilometersPerSecondSquared(this long value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? KilometersPerSecondSquared(this long? value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration KilometersPerSecondSquared(this double value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? KilometersPerSecondSquared(this double? value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration KilometersPerSecondSquared(this float value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? KilometersPerSecondSquared(this float? value) => Acceleration.FromKilometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration KilometersPerSecondSquared(this decimal value) => Acceleration.FromKilometersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromKilometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? KilometersPerSecondSquared(this decimal? value) => Acceleration.FromKilometersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? KilometersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromKilometersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KnotPerHour
 
         /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerHour(this int value) => Acceleration.FromKnotsPerHour(value);
+        public static Acceleration KnotsPerHour<T>(this T value) => Acceleration.FromKnotsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerHour(this int? value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerHour(this long value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerHour(this long? value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerHour(this double value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerHour(this double? value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerHour(this float value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerHour(this float? value) => Acceleration.FromKnotsPerHour(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerHour(this decimal value) => Acceleration.FromKnotsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerHour(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerHour(this decimal? value) => Acceleration.FromKnotsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? KnotsPerHour<T>(this T? value) where T : struct => Acceleration.FromKnotsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KnotPerMinute
 
         /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerMinute(this int value) => Acceleration.FromKnotsPerMinute(value);
+        public static Acceleration KnotsPerMinute<T>(this T value) => Acceleration.FromKnotsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerMinute(this int? value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerMinute(this long value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerMinute(this long? value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerMinute(this double value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerMinute(this double? value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerMinute(this float value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerMinute(this float? value) => Acceleration.FromKnotsPerMinute(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerMinute(this decimal value) => Acceleration.FromKnotsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerMinute(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerMinute(this decimal? value) => Acceleration.FromKnotsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? KnotsPerMinute<T>(this T? value) where T : struct => Acceleration.FromKnotsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KnotPerSecond
 
         /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerSecond(this int value) => Acceleration.FromKnotsPerSecond(value);
+        public static Acceleration KnotsPerSecond<T>(this T value) => Acceleration.FromKnotsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerSecond(this int? value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerSecond(this long value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerSecond(this long? value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerSecond(this double value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerSecond(this double? value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerSecond(this float value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerSecond(this float? value) => Acceleration.FromKnotsPerSecond(value);
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration KnotsPerSecond(this decimal value) => Acceleration.FromKnotsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromKnotsPerSecond(UnitsNet.QuantityValue)" />
-        public static Acceleration? KnotsPerSecond(this decimal? value) => Acceleration.FromKnotsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? KnotsPerSecond<T>(this T? value) where T : struct => Acceleration.FromKnotsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeterPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MetersPerSecondSquared(this int value) => Acceleration.FromMetersPerSecondSquared(value);
+        public static Acceleration MetersPerSecondSquared<T>(this T value) => Acceleration.FromMetersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MetersPerSecondSquared(this int? value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MetersPerSecondSquared(this long value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MetersPerSecondSquared(this long? value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MetersPerSecondSquared(this double value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MetersPerSecondSquared(this double? value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MetersPerSecondSquared(this float value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MetersPerSecondSquared(this float? value) => Acceleration.FromMetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MetersPerSecondSquared(this decimal value) => Acceleration.FromMetersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromMetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MetersPerSecondSquared(this decimal? value) => Acceleration.FromMetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? MetersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromMetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrometerPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MicrometersPerSecondSquared(this int value) => Acceleration.FromMicrometersPerSecondSquared(value);
+        public static Acceleration MicrometersPerSecondSquared<T>(this T value) => Acceleration.FromMicrometersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MicrometersPerSecondSquared(this int? value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MicrometersPerSecondSquared(this long value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MicrometersPerSecondSquared(this long? value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MicrometersPerSecondSquared(this double value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MicrometersPerSecondSquared(this double? value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MicrometersPerSecondSquared(this float value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MicrometersPerSecondSquared(this float? value) => Acceleration.FromMicrometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MicrometersPerSecondSquared(this decimal value) => Acceleration.FromMicrometersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromMicrometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MicrometersPerSecondSquared(this decimal? value) => Acceleration.FromMicrometersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? MicrometersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromMicrometersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimeterPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MillimetersPerSecondSquared(this int value) => Acceleration.FromMillimetersPerSecondSquared(value);
+        public static Acceleration MillimetersPerSecondSquared<T>(this T value) => Acceleration.FromMillimetersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MillimetersPerSecondSquared(this int? value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MillimetersPerSecondSquared(this long value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MillimetersPerSecondSquared(this long? value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MillimetersPerSecondSquared(this double value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MillimetersPerSecondSquared(this double? value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MillimetersPerSecondSquared(this float value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MillimetersPerSecondSquared(this float? value) => Acceleration.FromMillimetersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration MillimetersPerSecondSquared(this decimal value) => Acceleration.FromMillimetersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromMillimetersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? MillimetersPerSecondSquared(this decimal? value) => Acceleration.FromMillimetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? MillimetersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromMillimetersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanometerPerSecondSquared
 
         /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration NanometersPerSecondSquared(this int value) => Acceleration.FromNanometersPerSecondSquared(value);
+        public static Acceleration NanometersPerSecondSquared<T>(this T value) => Acceleration.FromNanometersPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? NanometersPerSecondSquared(this int? value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration NanometersPerSecondSquared(this long value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? NanometersPerSecondSquared(this long? value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration NanometersPerSecondSquared(this double value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? NanometersPerSecondSquared(this double? value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration NanometersPerSecondSquared(this float value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? NanometersPerSecondSquared(this float? value) => Acceleration.FromNanometersPerSecondSquared(value);
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration NanometersPerSecondSquared(this decimal value) => Acceleration.FromNanometersPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromNanometersPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static Acceleration? NanometersPerSecondSquared(this decimal? value) => Acceleration.FromNanometersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? NanometersPerSecondSquared<T>(this T? value) where T : struct => Acceleration.FromNanometersPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region StandardGravity
 
         /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration StandardGravity(this int value) => Acceleration.FromStandardGravity(value);
+        public static Acceleration StandardGravity<T>(this T value) => Acceleration.FromStandardGravity(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration? StandardGravity(this int? value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration StandardGravity(this long value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration? StandardGravity(this long? value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration StandardGravity(this double value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration? StandardGravity(this double? value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration StandardGravity(this float value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration? StandardGravity(this float? value) => Acceleration.FromStandardGravity(value);
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration StandardGravity(this decimal value) => Acceleration.FromStandardGravity(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Acceleration.FromStandardGravity(UnitsNet.QuantityValue)" />
-        public static Acceleration? StandardGravity(this decimal? value) => Acceleration.FromStandardGravity(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Acceleration? StandardGravity<T>(this T? value) where T : struct => Acceleration.FromStandardGravity(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAmountOfSubstanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAmountOfSubstanceExtensions.g.cs
@@ -47,476 +47,140 @@ namespace UnitsNet.Extensions.NumberToAmountOfSubstance
         #region Centimole
 
         /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Centimoles(this int value) => AmountOfSubstance.FromCentimoles(value);
+        public static AmountOfSubstance Centimoles<T>(this T value) => AmountOfSubstance.FromCentimoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Centimoles(this int? value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Centimoles(this long value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Centimoles(this long? value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Centimoles(this double value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Centimoles(this double? value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Centimoles(this float value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Centimoles(this float? value) => AmountOfSubstance.FromCentimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Centimoles(this decimal value) => AmountOfSubstance.FromCentimoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Centimoles(this decimal? value) => AmountOfSubstance.FromCentimoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Centimoles<T>(this T? value) where T : struct => AmountOfSubstance.FromCentimoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CentipoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance CentipoundMoles(this int value) => AmountOfSubstance.FromCentipoundMoles(value);
+        public static AmountOfSubstance CentipoundMoles<T>(this T value) => AmountOfSubstance.FromCentipoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? CentipoundMoles(this int? value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance CentipoundMoles(this long value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? CentipoundMoles(this long? value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance CentipoundMoles(this double value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? CentipoundMoles(this double? value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance CentipoundMoles(this float value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? CentipoundMoles(this float? value) => AmountOfSubstance.FromCentipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance CentipoundMoles(this decimal value) => AmountOfSubstance.FromCentipoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromCentipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? CentipoundMoles(this decimal? value) => AmountOfSubstance.FromCentipoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? CentipoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromCentipoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decimole
 
         /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Decimoles(this int value) => AmountOfSubstance.FromDecimoles(value);
+        public static AmountOfSubstance Decimoles<T>(this T value) => AmountOfSubstance.FromDecimoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Decimoles(this int? value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Decimoles(this long value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Decimoles(this long? value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Decimoles(this double value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Decimoles(this double? value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Decimoles(this float value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Decimoles(this float? value) => AmountOfSubstance.FromDecimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Decimoles(this decimal value) => AmountOfSubstance.FromDecimoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Decimoles(this decimal? value) => AmountOfSubstance.FromDecimoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Decimoles<T>(this T? value) where T : struct => AmountOfSubstance.FromDecimoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecipoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance DecipoundMoles(this int value) => AmountOfSubstance.FromDecipoundMoles(value);
+        public static AmountOfSubstance DecipoundMoles<T>(this T value) => AmountOfSubstance.FromDecipoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? DecipoundMoles(this int? value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance DecipoundMoles(this long value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? DecipoundMoles(this long? value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance DecipoundMoles(this double value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? DecipoundMoles(this double? value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance DecipoundMoles(this float value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? DecipoundMoles(this float? value) => AmountOfSubstance.FromDecipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance DecipoundMoles(this decimal value) => AmountOfSubstance.FromDecipoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromDecipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? DecipoundMoles(this decimal? value) => AmountOfSubstance.FromDecipoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? DecipoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromDecipoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilomole
 
         /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Kilomoles(this int value) => AmountOfSubstance.FromKilomoles(value);
+        public static AmountOfSubstance Kilomoles<T>(this T value) => AmountOfSubstance.FromKilomoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Kilomoles(this int? value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Kilomoles(this long value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Kilomoles(this long? value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Kilomoles(this double value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Kilomoles(this double? value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Kilomoles(this float value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Kilomoles(this float? value) => AmountOfSubstance.FromKilomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Kilomoles(this decimal value) => AmountOfSubstance.FromKilomoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Kilomoles(this decimal? value) => AmountOfSubstance.FromKilomoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Kilomoles<T>(this T? value) where T : struct => AmountOfSubstance.FromKilomoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance KilopoundMoles(this int value) => AmountOfSubstance.FromKilopoundMoles(value);
+        public static AmountOfSubstance KilopoundMoles<T>(this T value) => AmountOfSubstance.FromKilopoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? KilopoundMoles(this int? value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance KilopoundMoles(this long value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? KilopoundMoles(this long? value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance KilopoundMoles(this double value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? KilopoundMoles(this double? value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance KilopoundMoles(this float value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? KilopoundMoles(this float? value) => AmountOfSubstance.FromKilopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance KilopoundMoles(this decimal value) => AmountOfSubstance.FromKilopoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromKilopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? KilopoundMoles(this decimal? value) => AmountOfSubstance.FromKilopoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? KilopoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromKilopoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Micromole
 
         /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Micromoles(this int value) => AmountOfSubstance.FromMicromoles(value);
+        public static AmountOfSubstance Micromoles<T>(this T value) => AmountOfSubstance.FromMicromoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Micromoles(this int? value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Micromoles(this long value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Micromoles(this long? value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Micromoles(this double value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Micromoles(this double? value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Micromoles(this float value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Micromoles(this float? value) => AmountOfSubstance.FromMicromoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Micromoles(this decimal value) => AmountOfSubstance.FromMicromoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicromoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Micromoles(this decimal? value) => AmountOfSubstance.FromMicromoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Micromoles<T>(this T? value) where T : struct => AmountOfSubstance.FromMicromoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicropoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MicropoundMoles(this int value) => AmountOfSubstance.FromMicropoundMoles(value);
+        public static AmountOfSubstance MicropoundMoles<T>(this T value) => AmountOfSubstance.FromMicropoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MicropoundMoles(this int? value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MicropoundMoles(this long value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MicropoundMoles(this long? value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MicropoundMoles(this double value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MicropoundMoles(this double? value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MicropoundMoles(this float value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MicropoundMoles(this float? value) => AmountOfSubstance.FromMicropoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MicropoundMoles(this decimal value) => AmountOfSubstance.FromMicropoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMicropoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MicropoundMoles(this decimal? value) => AmountOfSubstance.FromMicropoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? MicropoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromMicropoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millimole
 
         /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Millimoles(this int value) => AmountOfSubstance.FromMillimoles(value);
+        public static AmountOfSubstance Millimoles<T>(this T value) => AmountOfSubstance.FromMillimoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Millimoles(this int? value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Millimoles(this long value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Millimoles(this long? value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Millimoles(this double value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Millimoles(this double? value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Millimoles(this float value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Millimoles(this float? value) => AmountOfSubstance.FromMillimoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Millimoles(this decimal value) => AmountOfSubstance.FromMillimoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillimoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Millimoles(this decimal? value) => AmountOfSubstance.FromMillimoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Millimoles<T>(this T? value) where T : struct => AmountOfSubstance.FromMillimoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillipoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MillipoundMoles(this int value) => AmountOfSubstance.FromMillipoundMoles(value);
+        public static AmountOfSubstance MillipoundMoles<T>(this T value) => AmountOfSubstance.FromMillipoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MillipoundMoles(this int? value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MillipoundMoles(this long value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MillipoundMoles(this long? value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MillipoundMoles(this double value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MillipoundMoles(this double? value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MillipoundMoles(this float value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MillipoundMoles(this float? value) => AmountOfSubstance.FromMillipoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance MillipoundMoles(this decimal value) => AmountOfSubstance.FromMillipoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMillipoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? MillipoundMoles(this decimal? value) => AmountOfSubstance.FromMillipoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? MillipoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromMillipoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Mole
 
         /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Moles(this int value) => AmountOfSubstance.FromMoles(value);
+        public static AmountOfSubstance Moles<T>(this T value) => AmountOfSubstance.FromMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Moles(this int? value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Moles(this long value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Moles(this long? value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Moles(this double value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Moles(this double? value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Moles(this float value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Moles(this float? value) => AmountOfSubstance.FromMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Moles(this decimal value) => AmountOfSubstance.FromMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Moles(this decimal? value) => AmountOfSubstance.FromMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Moles<T>(this T? value) where T : struct => AmountOfSubstance.FromMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanomole
 
         /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Nanomoles(this int value) => AmountOfSubstance.FromNanomoles(value);
+        public static AmountOfSubstance Nanomoles<T>(this T value) => AmountOfSubstance.FromNanomoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Nanomoles(this int? value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Nanomoles(this long value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Nanomoles(this long? value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Nanomoles(this double value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Nanomoles(this double? value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Nanomoles(this float value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Nanomoles(this float? value) => AmountOfSubstance.FromNanomoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance Nanomoles(this decimal value) => AmountOfSubstance.FromNanomoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanomoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? Nanomoles(this decimal? value) => AmountOfSubstance.FromNanomoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? Nanomoles<T>(this T? value) where T : struct => AmountOfSubstance.FromNanomoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanopoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance NanopoundMoles(this int value) => AmountOfSubstance.FromNanopoundMoles(value);
+        public static AmountOfSubstance NanopoundMoles<T>(this T value) => AmountOfSubstance.FromNanopoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? NanopoundMoles(this int? value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance NanopoundMoles(this long value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? NanopoundMoles(this long? value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance NanopoundMoles(this double value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? NanopoundMoles(this double? value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance NanopoundMoles(this float value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? NanopoundMoles(this float? value) => AmountOfSubstance.FromNanopoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance NanopoundMoles(this decimal value) => AmountOfSubstance.FromNanopoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromNanopoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? NanopoundMoles(this decimal? value) => AmountOfSubstance.FromNanopoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? NanopoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromNanopoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundMole
 
         /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance PoundMoles(this int value) => AmountOfSubstance.FromPoundMoles(value);
+        public static AmountOfSubstance PoundMoles<T>(this T value) => AmountOfSubstance.FromPoundMoles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? PoundMoles(this int? value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance PoundMoles(this long value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? PoundMoles(this long? value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance PoundMoles(this double value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? PoundMoles(this double? value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance PoundMoles(this float value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? PoundMoles(this float? value) => AmountOfSubstance.FromPoundMoles(value);
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance PoundMoles(this decimal value) => AmountOfSubstance.FromPoundMoles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmountOfSubstance.FromPoundMoles(UnitsNet.QuantityValue)" />
-        public static AmountOfSubstance? PoundMoles(this decimal? value) => AmountOfSubstance.FromPoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmountOfSubstance? PoundMoles<T>(this T? value) where T : struct => AmountOfSubstance.FromPoundMoles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAmplitudeRatioExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAmplitudeRatioExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToAmplitudeRatio
         #region DecibelMicrovolt
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMicrovolts(this int value) => AmplitudeRatio.FromDecibelMicrovolts(value);
+        public static AmplitudeRatio DecibelMicrovolts<T>(this T value) => AmplitudeRatio.FromDecibelMicrovolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMicrovolts(this int? value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMicrovolts(this long value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMicrovolts(this long? value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMicrovolts(this double value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMicrovolts(this double? value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMicrovolts(this float value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMicrovolts(this float? value) => AmplitudeRatio.FromDecibelMicrovolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMicrovolts(this decimal value) => AmplitudeRatio.FromDecibelMicrovolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMicrovolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMicrovolts(this decimal? value) => AmplitudeRatio.FromDecibelMicrovolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmplitudeRatio? DecibelMicrovolts<T>(this T? value) where T : struct => AmplitudeRatio.FromDecibelMicrovolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecibelMillivolt
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMillivolts(this int value) => AmplitudeRatio.FromDecibelMillivolts(value);
+        public static AmplitudeRatio DecibelMillivolts<T>(this T value) => AmplitudeRatio.FromDecibelMillivolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMillivolts(this int? value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMillivolts(this long value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMillivolts(this long? value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMillivolts(this double value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMillivolts(this double? value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMillivolts(this float value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMillivolts(this float? value) => AmplitudeRatio.FromDecibelMillivolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelMillivolts(this decimal value) => AmplitudeRatio.FromDecibelMillivolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelMillivolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelMillivolts(this decimal? value) => AmplitudeRatio.FromDecibelMillivolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmplitudeRatio? DecibelMillivolts<T>(this T? value) where T : struct => AmplitudeRatio.FromDecibelMillivolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecibelUnloaded
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelsUnloaded(this int value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+        public static AmplitudeRatio DecibelsUnloaded<T>(this T value) => AmplitudeRatio.FromDecibelsUnloaded(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelsUnloaded(this int? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelsUnloaded(this long value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelsUnloaded(this long? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelsUnloaded(this double value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelsUnloaded(this double? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelsUnloaded(this float value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelsUnloaded(this float? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelsUnloaded(this decimal value) => AmplitudeRatio.FromDecibelsUnloaded(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelsUnloaded(this decimal? value) => AmplitudeRatio.FromDecibelsUnloaded(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmplitudeRatio? DecibelsUnloaded<T>(this T? value) where T : struct => AmplitudeRatio.FromDecibelsUnloaded(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecibelVolt
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelVolts(this int value) => AmplitudeRatio.FromDecibelVolts(value);
+        public static AmplitudeRatio DecibelVolts<T>(this T value) => AmplitudeRatio.FromDecibelVolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelVolts(this int? value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelVolts(this long value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelVolts(this long? value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelVolts(this double value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelVolts(this double? value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelVolts(this float value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelVolts(this float? value) => AmplitudeRatio.FromDecibelVolts(value);
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio DecibelVolts(this decimal value) => AmplitudeRatio.FromDecibelVolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(UnitsNet.QuantityValue)" />
-        public static AmplitudeRatio? DecibelVolts(this decimal? value) => AmplitudeRatio.FromDecibelVolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AmplitudeRatio? DecibelVolts<T>(this T? value) where T : struct => AmplitudeRatio.FromDecibelVolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAngleExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAngleExtensions.g.cs
@@ -47,476 +47,140 @@ namespace UnitsNet.Extensions.NumberToAngle
         #region Arcminute
 
         /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle Arcminutes(this int value) => Angle.FromArcminutes(value);
+        public static Angle Arcminutes<T>(this T value) => Angle.FromArcminutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle? Arcminutes(this int? value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle Arcminutes(this long value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle? Arcminutes(this long? value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle Arcminutes(this double value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle? Arcminutes(this double? value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle Arcminutes(this float value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle? Arcminutes(this float? value) => Angle.FromArcminutes(value);
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle Arcminutes(this decimal value) => Angle.FromArcminutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromArcminutes(UnitsNet.QuantityValue)" />
-        public static Angle? Arcminutes(this decimal? value) => Angle.FromArcminutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Arcminutes<T>(this T? value) where T : struct => Angle.FromArcminutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Arcsecond
 
         /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle Arcseconds(this int value) => Angle.FromArcseconds(value);
+        public static Angle Arcseconds<T>(this T value) => Angle.FromArcseconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle? Arcseconds(this int? value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle Arcseconds(this long value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle? Arcseconds(this long? value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle Arcseconds(this double value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle? Arcseconds(this double? value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle Arcseconds(this float value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle? Arcseconds(this float? value) => Angle.FromArcseconds(value);
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle Arcseconds(this decimal value) => Angle.FromArcseconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromArcseconds(UnitsNet.QuantityValue)" />
-        public static Angle? Arcseconds(this decimal? value) => Angle.FromArcseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Arcseconds<T>(this T? value) where T : struct => Angle.FromArcseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Centiradian
 
         /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle Centiradians(this int value) => Angle.FromCentiradians(value);
+        public static Angle Centiradians<T>(this T value) => Angle.FromCentiradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle? Centiradians(this int? value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle Centiradians(this long value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle? Centiradians(this long? value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle Centiradians(this double value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle? Centiradians(this double? value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle Centiradians(this float value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle? Centiradians(this float? value) => Angle.FromCentiradians(value);
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle Centiradians(this decimal value) => Angle.FromCentiradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromCentiradians(UnitsNet.QuantityValue)" />
-        public static Angle? Centiradians(this decimal? value) => Angle.FromCentiradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Centiradians<T>(this T? value) where T : struct => Angle.FromCentiradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Deciradian
 
         /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle Deciradians(this int value) => Angle.FromDeciradians(value);
+        public static Angle Deciradians<T>(this T value) => Angle.FromDeciradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle? Deciradians(this int? value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle Deciradians(this long value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle? Deciradians(this long? value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle Deciradians(this double value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle? Deciradians(this double? value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle Deciradians(this float value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle? Deciradians(this float? value) => Angle.FromDeciradians(value);
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle Deciradians(this decimal value) => Angle.FromDeciradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromDeciradians(UnitsNet.QuantityValue)" />
-        public static Angle? Deciradians(this decimal? value) => Angle.FromDeciradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Deciradians<T>(this T? value) where T : struct => Angle.FromDeciradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Degree
 
         /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle Degrees(this int value) => Angle.FromDegrees(value);
+        public static Angle Degrees<T>(this T value) => Angle.FromDegrees(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Degrees(this int? value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle Degrees(this long value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Degrees(this long? value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle Degrees(this double value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Degrees(this double? value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle Degrees(this float value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Degrees(this float? value) => Angle.FromDegrees(value);
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle Degrees(this decimal value) => Angle.FromDegrees(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromDegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Degrees(this decimal? value) => Angle.FromDegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Degrees<T>(this T? value) where T : struct => Angle.FromDegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gradian
 
         /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle Gradians(this int value) => Angle.FromGradians(value);
+        public static Angle Gradians<T>(this T value) => Angle.FromGradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle? Gradians(this int? value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle Gradians(this long value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle? Gradians(this long? value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle Gradians(this double value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle? Gradians(this double? value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle Gradians(this float value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle? Gradians(this float? value) => Angle.FromGradians(value);
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle Gradians(this decimal value) => Angle.FromGradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromGradians(UnitsNet.QuantityValue)" />
-        public static Angle? Gradians(this decimal? value) => Angle.FromGradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Gradians<T>(this T? value) where T : struct => Angle.FromGradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microdegree
 
         /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Microdegrees(this int value) => Angle.FromMicrodegrees(value);
+        public static Angle Microdegrees<T>(this T value) => Angle.FromMicrodegrees(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Microdegrees(this int? value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Microdegrees(this long value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Microdegrees(this long? value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Microdegrees(this double value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Microdegrees(this double? value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Microdegrees(this float value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Microdegrees(this float? value) => Angle.FromMicrodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Microdegrees(this decimal value) => Angle.FromMicrodegrees(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromMicrodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Microdegrees(this decimal? value) => Angle.FromMicrodegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Microdegrees<T>(this T? value) where T : struct => Angle.FromMicrodegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microradian
 
         /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle Microradians(this int value) => Angle.FromMicroradians(value);
+        public static Angle Microradians<T>(this T value) => Angle.FromMicroradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle? Microradians(this int? value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle Microradians(this long value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle? Microradians(this long? value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle Microradians(this double value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle? Microradians(this double? value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle Microradians(this float value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle? Microradians(this float? value) => Angle.FromMicroradians(value);
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle Microradians(this decimal value) => Angle.FromMicroradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromMicroradians(UnitsNet.QuantityValue)" />
-        public static Angle? Microradians(this decimal? value) => Angle.FromMicroradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Microradians<T>(this T? value) where T : struct => Angle.FromMicroradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millidegree
 
         /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle Millidegrees(this int value) => Angle.FromMillidegrees(value);
+        public static Angle Millidegrees<T>(this T value) => Angle.FromMillidegrees(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Millidegrees(this int? value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle Millidegrees(this long value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Millidegrees(this long? value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle Millidegrees(this double value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Millidegrees(this double? value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle Millidegrees(this float value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Millidegrees(this float? value) => Angle.FromMillidegrees(value);
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle Millidegrees(this decimal value) => Angle.FromMillidegrees(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromMillidegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Millidegrees(this decimal? value) => Angle.FromMillidegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Millidegrees<T>(this T? value) where T : struct => Angle.FromMillidegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Milliradian
 
         /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle Milliradians(this int value) => Angle.FromMilliradians(value);
+        public static Angle Milliradians<T>(this T value) => Angle.FromMilliradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle? Milliradians(this int? value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle Milliradians(this long value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle? Milliradians(this long? value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle Milliradians(this double value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle? Milliradians(this double? value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle Milliradians(this float value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle? Milliradians(this float? value) => Angle.FromMilliradians(value);
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle Milliradians(this decimal value) => Angle.FromMilliradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromMilliradians(UnitsNet.QuantityValue)" />
-        public static Angle? Milliradians(this decimal? value) => Angle.FromMilliradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Milliradians<T>(this T? value) where T : struct => Angle.FromMilliradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanodegree
 
         /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Nanodegrees(this int value) => Angle.FromNanodegrees(value);
+        public static Angle Nanodegrees<T>(this T value) => Angle.FromNanodegrees(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Nanodegrees(this int? value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Nanodegrees(this long value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Nanodegrees(this long? value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Nanodegrees(this double value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Nanodegrees(this double? value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Nanodegrees(this float value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Nanodegrees(this float? value) => Angle.FromNanodegrees(value);
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle Nanodegrees(this decimal value) => Angle.FromNanodegrees(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromNanodegrees(UnitsNet.QuantityValue)" />
-        public static Angle? Nanodegrees(this decimal? value) => Angle.FromNanodegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Nanodegrees<T>(this T? value) where T : struct => Angle.FromNanodegrees(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanoradian
 
         /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle Nanoradians(this int value) => Angle.FromNanoradians(value);
+        public static Angle Nanoradians<T>(this T value) => Angle.FromNanoradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle? Nanoradians(this int? value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle Nanoradians(this long value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle? Nanoradians(this long? value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle Nanoradians(this double value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle? Nanoradians(this double? value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle Nanoradians(this float value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle? Nanoradians(this float? value) => Angle.FromNanoradians(value);
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle Nanoradians(this decimal value) => Angle.FromNanoradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromNanoradians(UnitsNet.QuantityValue)" />
-        public static Angle? Nanoradians(this decimal? value) => Angle.FromNanoradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Nanoradians<T>(this T? value) where T : struct => Angle.FromNanoradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Radian
 
         /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle Radians(this int value) => Angle.FromRadians(value);
+        public static Angle Radians<T>(this T value) => Angle.FromRadians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle? Radians(this int? value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle Radians(this long value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle? Radians(this long? value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle Radians(this double value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle? Radians(this double? value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle Radians(this float value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle? Radians(this float? value) => Angle.FromRadians(value);
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle Radians(this decimal value) => Angle.FromRadians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromRadians(UnitsNet.QuantityValue)" />
-        public static Angle? Radians(this decimal? value) => Angle.FromRadians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Radians<T>(this T? value) where T : struct => Angle.FromRadians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Revolution
 
         /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle Revolutions(this int value) => Angle.FromRevolutions(value);
+        public static Angle Revolutions<T>(this T value) => Angle.FromRevolutions(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle? Revolutions(this int? value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle Revolutions(this long value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle? Revolutions(this long? value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle Revolutions(this double value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle? Revolutions(this double? value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle Revolutions(this float value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle? Revolutions(this float? value) => Angle.FromRevolutions(value);
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle Revolutions(this decimal value) => Angle.FromRevolutions(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Angle.FromRevolutions(UnitsNet.QuantityValue)" />
-        public static Angle? Revolutions(this decimal? value) => Angle.FromRevolutions(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Angle? Revolutions<T>(this T? value) where T : struct => Angle.FromRevolutions(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToApparentEnergyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToApparentEnergyExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToApparentEnergy
         #region KilovoltampereHour
 
         /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy KilovoltampereHours(this int value) => ApparentEnergy.FromKilovoltampereHours(value);
+        public static ApparentEnergy KilovoltampereHours<T>(this T value) => ApparentEnergy.FromKilovoltampereHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? KilovoltampereHours(this int? value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy KilovoltampereHours(this long value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? KilovoltampereHours(this long? value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy KilovoltampereHours(this double value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? KilovoltampereHours(this double? value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy KilovoltampereHours(this float value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? KilovoltampereHours(this float? value) => ApparentEnergy.FromKilovoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy KilovoltampereHours(this decimal value) => ApparentEnergy.FromKilovoltampereHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentEnergy.FromKilovoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? KilovoltampereHours(this decimal? value) => ApparentEnergy.FromKilovoltampereHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentEnergy? KilovoltampereHours<T>(this T? value) where T : struct => ApparentEnergy.FromKilovoltampereHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegavoltampereHour
 
         /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy MegavoltampereHours(this int value) => ApparentEnergy.FromMegavoltampereHours(value);
+        public static ApparentEnergy MegavoltampereHours<T>(this T value) => ApparentEnergy.FromMegavoltampereHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? MegavoltampereHours(this int? value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy MegavoltampereHours(this long value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? MegavoltampereHours(this long? value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy MegavoltampereHours(this double value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? MegavoltampereHours(this double? value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy MegavoltampereHours(this float value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? MegavoltampereHours(this float? value) => ApparentEnergy.FromMegavoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy MegavoltampereHours(this decimal value) => ApparentEnergy.FromMegavoltampereHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentEnergy.FromMegavoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? MegavoltampereHours(this decimal? value) => ApparentEnergy.FromMegavoltampereHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentEnergy? MegavoltampereHours<T>(this T? value) where T : struct => ApparentEnergy.FromMegavoltampereHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region VoltampereHour
 
         /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy VoltampereHours(this int value) => ApparentEnergy.FromVoltampereHours(value);
+        public static ApparentEnergy VoltampereHours<T>(this T value) => ApparentEnergy.FromVoltampereHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? VoltampereHours(this int? value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy VoltampereHours(this long value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? VoltampereHours(this long? value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy VoltampereHours(this double value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? VoltampereHours(this double? value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy VoltampereHours(this float value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? VoltampereHours(this float? value) => ApparentEnergy.FromVoltampereHours(value);
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy VoltampereHours(this decimal value) => ApparentEnergy.FromVoltampereHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentEnergy.FromVoltampereHours(UnitsNet.QuantityValue)" />
-        public static ApparentEnergy? VoltampereHours(this decimal? value) => ApparentEnergy.FromVoltampereHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentEnergy? VoltampereHours<T>(this T? value) where T : struct => ApparentEnergy.FromVoltampereHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToApparentPowerExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToApparentPowerExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToApparentPower
         #region Gigavoltampere
 
         /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Gigavoltamperes(this int value) => ApparentPower.FromGigavoltamperes(value);
+        public static ApparentPower Gigavoltamperes<T>(this T value) => ApparentPower.FromGigavoltamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Gigavoltamperes(this int? value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Gigavoltamperes(this long value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Gigavoltamperes(this long? value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Gigavoltamperes(this double value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Gigavoltamperes(this double? value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Gigavoltamperes(this float value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Gigavoltamperes(this float? value) => ApparentPower.FromGigavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Gigavoltamperes(this decimal value) => ApparentPower.FromGigavoltamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentPower.FromGigavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Gigavoltamperes(this decimal? value) => ApparentPower.FromGigavoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentPower? Gigavoltamperes<T>(this T? value) where T : struct => ApparentPower.FromGigavoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilovoltampere
 
         /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Kilovoltamperes(this int value) => ApparentPower.FromKilovoltamperes(value);
+        public static ApparentPower Kilovoltamperes<T>(this T value) => ApparentPower.FromKilovoltamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Kilovoltamperes(this int? value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Kilovoltamperes(this long value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Kilovoltamperes(this long? value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Kilovoltamperes(this double value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Kilovoltamperes(this double? value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Kilovoltamperes(this float value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Kilovoltamperes(this float? value) => ApparentPower.FromKilovoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Kilovoltamperes(this decimal value) => ApparentPower.FromKilovoltamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentPower.FromKilovoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Kilovoltamperes(this decimal? value) => ApparentPower.FromKilovoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentPower? Kilovoltamperes<T>(this T? value) where T : struct => ApparentPower.FromKilovoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megavoltampere
 
         /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Megavoltamperes(this int value) => ApparentPower.FromMegavoltamperes(value);
+        public static ApparentPower Megavoltamperes<T>(this T value) => ApparentPower.FromMegavoltamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Megavoltamperes(this int? value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Megavoltamperes(this long value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Megavoltamperes(this long? value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Megavoltamperes(this double value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Megavoltamperes(this double? value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Megavoltamperes(this float value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Megavoltamperes(this float? value) => ApparentPower.FromMegavoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Megavoltamperes(this decimal value) => ApparentPower.FromMegavoltamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentPower.FromMegavoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Megavoltamperes(this decimal? value) => ApparentPower.FromMegavoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentPower? Megavoltamperes<T>(this T? value) where T : struct => ApparentPower.FromMegavoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Voltampere
 
         /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Voltamperes(this int value) => ApparentPower.FromVoltamperes(value);
+        public static ApparentPower Voltamperes<T>(this T value) => ApparentPower.FromVoltamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Voltamperes(this int? value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Voltamperes(this long value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Voltamperes(this long? value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Voltamperes(this double value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Voltamperes(this double? value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Voltamperes(this float value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Voltamperes(this float? value) => ApparentPower.FromVoltamperes(value);
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower Voltamperes(this decimal value) => ApparentPower.FromVoltamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ApparentPower.FromVoltamperes(UnitsNet.QuantityValue)" />
-        public static ApparentPower? Voltamperes(this decimal? value) => ApparentPower.FromVoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ApparentPower? Voltamperes<T>(this T? value) where T : struct => ApparentPower.FromVoltamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAreaDensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAreaDensityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToAreaDensity
         #region KilogramPerSquareMeter
 
         /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity KilogramsPerSquareMeter(this int value) => AreaDensity.FromKilogramsPerSquareMeter(value);
+        public static AreaDensity KilogramsPerSquareMeter<T>(this T value) => AreaDensity.FromKilogramsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity? KilogramsPerSquareMeter(this int? value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity KilogramsPerSquareMeter(this long value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity? KilogramsPerSquareMeter(this long? value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity KilogramsPerSquareMeter(this double value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity? KilogramsPerSquareMeter(this double? value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity KilogramsPerSquareMeter(this float value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity? KilogramsPerSquareMeter(this float? value) => AreaDensity.FromKilogramsPerSquareMeter(value);
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity KilogramsPerSquareMeter(this decimal value) => AreaDensity.FromKilogramsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaDensity.FromKilogramsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static AreaDensity? KilogramsPerSquareMeter(this decimal? value) => AreaDensity.FromKilogramsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaDensity? KilogramsPerSquareMeter<T>(this T? value) where T : struct => AreaDensity.FromKilogramsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAreaExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAreaExtensions.g.cs
@@ -47,442 +47,130 @@ namespace UnitsNet.Extensions.NumberToArea
         #region Acre
 
         /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area Acres(this int value) => Area.FromAcres(value);
+        public static Area Acres<T>(this T value) => Area.FromAcres(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area? Acres(this int? value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area Acres(this long value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area? Acres(this long? value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area Acres(this double value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area? Acres(this double? value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area Acres(this float value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area? Acres(this float? value) => Area.FromAcres(value);
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area Acres(this decimal value) => Area.FromAcres(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromAcres(UnitsNet.QuantityValue)" />
-        public static Area? Acres(this decimal? value) => Area.FromAcres(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? Acres<T>(this T? value) where T : struct => Area.FromAcres(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Hectare
 
         /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area Hectares(this int value) => Area.FromHectares(value);
+        public static Area Hectares<T>(this T value) => Area.FromHectares(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area? Hectares(this int? value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area Hectares(this long value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area? Hectares(this long? value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area Hectares(this double value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area? Hectares(this double? value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area Hectares(this float value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area? Hectares(this float? value) => Area.FromHectares(value);
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area Hectares(this decimal value) => Area.FromHectares(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromHectares(UnitsNet.QuantityValue)" />
-        public static Area? Hectares(this decimal? value) => Area.FromHectares(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? Hectares<T>(this T? value) where T : struct => Area.FromHectares(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareCentimeter
 
         /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareCentimeters(this int value) => Area.FromSquareCentimeters(value);
+        public static Area SquareCentimeters<T>(this T value) => Area.FromSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareCentimeters(this int? value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareCentimeters(this long value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareCentimeters(this long? value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareCentimeters(this double value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareCentimeters(this double? value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareCentimeters(this float value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareCentimeters(this float? value) => Area.FromSquareCentimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareCentimeters(this decimal value) => Area.FromSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareCentimeters(this decimal? value) => Area.FromSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareCentimeters<T>(this T? value) where T : struct => Area.FromSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareDecimeter
 
         /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareDecimeters(this int value) => Area.FromSquareDecimeters(value);
+        public static Area SquareDecimeters<T>(this T value) => Area.FromSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareDecimeters(this int? value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareDecimeters(this long value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareDecimeters(this long? value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareDecimeters(this double value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareDecimeters(this double? value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareDecimeters(this float value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareDecimeters(this float? value) => Area.FromSquareDecimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareDecimeters(this decimal value) => Area.FromSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareDecimeters(this decimal? value) => Area.FromSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareDecimeters<T>(this T? value) where T : struct => Area.FromSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareFoot
 
         /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area SquareFeet(this int value) => Area.FromSquareFeet(value);
+        public static Area SquareFeet<T>(this T value) => Area.FromSquareFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? SquareFeet(this int? value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area SquareFeet(this long value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? SquareFeet(this long? value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area SquareFeet(this double value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? SquareFeet(this double? value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area SquareFeet(this float value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? SquareFeet(this float? value) => Area.FromSquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area SquareFeet(this decimal value) => Area.FromSquareFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? SquareFeet(this decimal? value) => Area.FromSquareFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareFeet<T>(this T? value) where T : struct => Area.FromSquareFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareInch
 
         /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area SquareInches(this int value) => Area.FromSquareInches(value);
+        public static Area SquareInches<T>(this T value) => Area.FromSquareInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area? SquareInches(this int? value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area SquareInches(this long value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area? SquareInches(this long? value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area SquareInches(this double value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area? SquareInches(this double? value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area SquareInches(this float value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area? SquareInches(this float? value) => Area.FromSquareInches(value);
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area SquareInches(this decimal value) => Area.FromSquareInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareInches(UnitsNet.QuantityValue)" />
-        public static Area? SquareInches(this decimal? value) => Area.FromSquareInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareInches<T>(this T? value) where T : struct => Area.FromSquareInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareKilometer
 
         /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area SquareKilometers(this int value) => Area.FromSquareKilometers(value);
+        public static Area SquareKilometers<T>(this T value) => Area.FromSquareKilometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareKilometers(this int? value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area SquareKilometers(this long value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareKilometers(this long? value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area SquareKilometers(this double value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareKilometers(this double? value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area SquareKilometers(this float value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareKilometers(this float? value) => Area.FromSquareKilometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area SquareKilometers(this decimal value) => Area.FromSquareKilometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareKilometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareKilometers(this decimal? value) => Area.FromSquareKilometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareKilometers<T>(this T? value) where T : struct => Area.FromSquareKilometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMeter
 
         /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMeters(this int value) => Area.FromSquareMeters(value);
+        public static Area SquareMeters<T>(this T value) => Area.FromSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMeters(this int? value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMeters(this long value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMeters(this long? value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMeters(this double value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMeters(this double? value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMeters(this float value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMeters(this float? value) => Area.FromSquareMeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMeters(this decimal value) => Area.FromSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareMeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMeters(this decimal? value) => Area.FromSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareMeters<T>(this T? value) where T : struct => Area.FromSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMicrometer
 
         /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area SquareMicrometers(this int value) => Area.FromSquareMicrometers(value);
+        public static Area SquareMicrometers<T>(this T value) => Area.FromSquareMicrometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareMicrometers(this int? value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area SquareMicrometers(this long value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareMicrometers(this long? value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area SquareMicrometers(this double value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareMicrometers(this double? value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area SquareMicrometers(this float value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareMicrometers(this float? value) => Area.FromSquareMicrometers(value);
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area SquareMicrometers(this decimal value) => Area.FromSquareMicrometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareMicrometers(UnitsNet.QuantityValue)" />
-        public static Area? SquareMicrometers(this decimal? value) => Area.FromSquareMicrometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareMicrometers<T>(this T? value) where T : struct => Area.FromSquareMicrometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMile
 
         /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area SquareMiles(this int value) => Area.FromSquareMiles(value);
+        public static Area SquareMiles<T>(this T value) => Area.FromSquareMiles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area? SquareMiles(this int? value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area SquareMiles(this long value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area? SquareMiles(this long? value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area SquareMiles(this double value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area? SquareMiles(this double? value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area SquareMiles(this float value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area? SquareMiles(this float? value) => Area.FromSquareMiles(value);
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area SquareMiles(this decimal value) => Area.FromSquareMiles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareMiles(UnitsNet.QuantityValue)" />
-        public static Area? SquareMiles(this decimal? value) => Area.FromSquareMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareMiles<T>(this T? value) where T : struct => Area.FromSquareMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMillimeter
 
         /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMillimeters(this int value) => Area.FromSquareMillimeters(value);
+        public static Area SquareMillimeters<T>(this T value) => Area.FromSquareMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMillimeters(this int? value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMillimeters(this long value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMillimeters(this long? value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMillimeters(this double value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMillimeters(this double? value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMillimeters(this float value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMillimeters(this float? value) => Area.FromSquareMillimeters(value);
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area SquareMillimeters(this decimal value) => Area.FromSquareMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static Area? SquareMillimeters(this decimal? value) => Area.FromSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareMillimeters<T>(this T? value) where T : struct => Area.FromSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareYard
 
         /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area SquareYards(this int value) => Area.FromSquareYards(value);
+        public static Area SquareYards<T>(this T value) => Area.FromSquareYards(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area? SquareYards(this int? value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area SquareYards(this long value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area? SquareYards(this long? value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area SquareYards(this double value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area? SquareYards(this double? value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area SquareYards(this float value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area? SquareYards(this float? value) => Area.FromSquareYards(value);
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area SquareYards(this decimal value) => Area.FromSquareYards(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromSquareYards(UnitsNet.QuantityValue)" />
-        public static Area? SquareYards(this decimal? value) => Area.FromSquareYards(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? SquareYards<T>(this T? value) where T : struct => Area.FromSquareYards(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsSurveySquareFoot
 
         /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area UsSurveySquareFeet(this int value) => Area.FromUsSurveySquareFeet(value);
+        public static Area UsSurveySquareFeet<T>(this T value) => Area.FromUsSurveySquareFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? UsSurveySquareFeet(this int? value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area UsSurveySquareFeet(this long value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? UsSurveySquareFeet(this long? value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area UsSurveySquareFeet(this double value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? UsSurveySquareFeet(this double? value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area UsSurveySquareFeet(this float value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? UsSurveySquareFeet(this float? value) => Area.FromUsSurveySquareFeet(value);
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area UsSurveySquareFeet(this decimal value) => Area.FromUsSurveySquareFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Area.FromUsSurveySquareFeet(UnitsNet.QuantityValue)" />
-        public static Area? UsSurveySquareFeet(this decimal? value) => Area.FromUsSurveySquareFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Area? UsSurveySquareFeet<T>(this T? value) where T : struct => Area.FromUsSurveySquareFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAreaMomentOfInertiaExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAreaMomentOfInertiaExtensions.g.cs
@@ -47,204 +47,60 @@ namespace UnitsNet.Extensions.NumberToAreaMomentOfInertia
         #region CentimeterToTheFourth
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia CentimetersToTheFourth(this int value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
+        public static AreaMomentOfInertia CentimetersToTheFourth<T>(this T value) => AreaMomentOfInertia.FromCentimetersToTheFourth(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? CentimetersToTheFourth(this int? value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia CentimetersToTheFourth(this long value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? CentimetersToTheFourth(this long? value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia CentimetersToTheFourth(this double value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? CentimetersToTheFourth(this double? value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia CentimetersToTheFourth(this float value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? CentimetersToTheFourth(this float? value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia CentimetersToTheFourth(this decimal value) => AreaMomentOfInertia.FromCentimetersToTheFourth(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromCentimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? CentimetersToTheFourth(this decimal? value) => AreaMomentOfInertia.FromCentimetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaMomentOfInertia? CentimetersToTheFourth<T>(this T? value) where T : struct => AreaMomentOfInertia.FromCentimetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecimeterToTheFourth
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia DecimetersToTheFourth(this int value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
+        public static AreaMomentOfInertia DecimetersToTheFourth<T>(this T value) => AreaMomentOfInertia.FromDecimetersToTheFourth(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? DecimetersToTheFourth(this int? value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia DecimetersToTheFourth(this long value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? DecimetersToTheFourth(this long? value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia DecimetersToTheFourth(this double value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? DecimetersToTheFourth(this double? value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia DecimetersToTheFourth(this float value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? DecimetersToTheFourth(this float? value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia DecimetersToTheFourth(this decimal value) => AreaMomentOfInertia.FromDecimetersToTheFourth(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromDecimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? DecimetersToTheFourth(this decimal? value) => AreaMomentOfInertia.FromDecimetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaMomentOfInertia? DecimetersToTheFourth<T>(this T? value) where T : struct => AreaMomentOfInertia.FromDecimetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootToTheFourth
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia FeetToTheFourth(this int value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
+        public static AreaMomentOfInertia FeetToTheFourth<T>(this T value) => AreaMomentOfInertia.FromFeetToTheFourth(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? FeetToTheFourth(this int? value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia FeetToTheFourth(this long value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? FeetToTheFourth(this long? value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia FeetToTheFourth(this double value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? FeetToTheFourth(this double? value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia FeetToTheFourth(this float value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? FeetToTheFourth(this float? value) => AreaMomentOfInertia.FromFeetToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia FeetToTheFourth(this decimal value) => AreaMomentOfInertia.FromFeetToTheFourth(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromFeetToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? FeetToTheFourth(this decimal? value) => AreaMomentOfInertia.FromFeetToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaMomentOfInertia? FeetToTheFourth<T>(this T? value) where T : struct => AreaMomentOfInertia.FromFeetToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region InchToTheFourth
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia InchesToTheFourth(this int value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
+        public static AreaMomentOfInertia InchesToTheFourth<T>(this T value) => AreaMomentOfInertia.FromInchesToTheFourth(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? InchesToTheFourth(this int? value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia InchesToTheFourth(this long value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? InchesToTheFourth(this long? value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia InchesToTheFourth(this double value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? InchesToTheFourth(this double? value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia InchesToTheFourth(this float value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? InchesToTheFourth(this float? value) => AreaMomentOfInertia.FromInchesToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia InchesToTheFourth(this decimal value) => AreaMomentOfInertia.FromInchesToTheFourth(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromInchesToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? InchesToTheFourth(this decimal? value) => AreaMomentOfInertia.FromInchesToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaMomentOfInertia? InchesToTheFourth<T>(this T? value) where T : struct => AreaMomentOfInertia.FromInchesToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeterToTheFourth
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MetersToTheFourth(this int value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
+        public static AreaMomentOfInertia MetersToTheFourth<T>(this T value) => AreaMomentOfInertia.FromMetersToTheFourth(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MetersToTheFourth(this int? value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MetersToTheFourth(this long value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MetersToTheFourth(this long? value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MetersToTheFourth(this double value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MetersToTheFourth(this double? value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MetersToTheFourth(this float value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MetersToTheFourth(this float? value) => AreaMomentOfInertia.FromMetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MetersToTheFourth(this decimal value) => AreaMomentOfInertia.FromMetersToTheFourth(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MetersToTheFourth(this decimal? value) => AreaMomentOfInertia.FromMetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaMomentOfInertia? MetersToTheFourth<T>(this T? value) where T : struct => AreaMomentOfInertia.FromMetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimeterToTheFourth
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MillimetersToTheFourth(this int value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
+        public static AreaMomentOfInertia MillimetersToTheFourth<T>(this T value) => AreaMomentOfInertia.FromMillimetersToTheFourth(Convert.ToDouble(value));
 
         /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MillimetersToTheFourth(this int? value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MillimetersToTheFourth(this long value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MillimetersToTheFourth(this long? value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MillimetersToTheFourth(this double value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MillimetersToTheFourth(this double? value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MillimetersToTheFourth(this float value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MillimetersToTheFourth(this float? value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value);
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia MillimetersToTheFourth(this decimal value) => AreaMomentOfInertia.FromMillimetersToTheFourth(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="AreaMomentOfInertia.FromMillimetersToTheFourth(UnitsNet.QuantityValue)" />
-        public static AreaMomentOfInertia? MillimetersToTheFourth(this decimal? value) => AreaMomentOfInertia.FromMillimetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static AreaMomentOfInertia? MillimetersToTheFourth<T>(this T? value) where T : struct => AreaMomentOfInertia.FromMillimetersToTheFourth(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToBitRateExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToBitRateExtensions.g.cs
@@ -47,884 +47,260 @@ namespace UnitsNet.Extensions.NumberToBitRate
         #region BitPerSecond
 
         /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BitsPerSecond(this int value) => BitRate.FromBitsPerSecond(value);
+        public static BitRate BitsPerSecond<T>(this T value) => BitRate.FromBitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BitsPerSecond(this int? value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BitsPerSecond(this long value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BitsPerSecond(this long? value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BitsPerSecond(this double value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BitsPerSecond(this double? value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BitsPerSecond(this float value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BitsPerSecond(this float? value) => BitRate.FromBitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BitsPerSecond(this decimal value) => BitRate.FromBitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromBitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BitsPerSecond(this decimal? value) => BitRate.FromBitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? BitsPerSecond<T>(this T? value) where T : struct => BitRate.FromBitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region BytePerSecond
 
         /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BytesPerSecond(this int value) => BitRate.FromBytesPerSecond(value);
+        public static BitRate BytesPerSecond<T>(this T value) => BitRate.FromBytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BytesPerSecond(this int? value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BytesPerSecond(this long value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BytesPerSecond(this long? value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BytesPerSecond(this double value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BytesPerSecond(this double? value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BytesPerSecond(this float value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BytesPerSecond(this float? value) => BitRate.FromBytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate BytesPerSecond(this decimal value) => BitRate.FromBytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromBytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? BytesPerSecond(this decimal? value) => BitRate.FromBytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? BytesPerSecond<T>(this T? value) where T : struct => BitRate.FromBytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ExabitPerSecond
 
         /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabitsPerSecond(this int value) => BitRate.FromExabitsPerSecond(value);
+        public static BitRate ExabitsPerSecond<T>(this T value) => BitRate.FromExabitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabitsPerSecond(this int? value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabitsPerSecond(this long value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabitsPerSecond(this long? value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabitsPerSecond(this double value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabitsPerSecond(this double? value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabitsPerSecond(this float value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabitsPerSecond(this float? value) => BitRate.FromExabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabitsPerSecond(this decimal value) => BitRate.FromExabitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromExabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabitsPerSecond(this decimal? value) => BitRate.FromExabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? ExabitsPerSecond<T>(this T? value) where T : struct => BitRate.FromExabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ExabytePerSecond
 
         /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabytesPerSecond(this int value) => BitRate.FromExabytesPerSecond(value);
+        public static BitRate ExabytesPerSecond<T>(this T value) => BitRate.FromExabytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabytesPerSecond(this int? value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabytesPerSecond(this long value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabytesPerSecond(this long? value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabytesPerSecond(this double value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabytesPerSecond(this double? value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabytesPerSecond(this float value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabytesPerSecond(this float? value) => BitRate.FromExabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExabytesPerSecond(this decimal value) => BitRate.FromExabytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromExabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExabytesPerSecond(this decimal? value) => BitRate.FromExabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? ExabytesPerSecond<T>(this T? value) where T : struct => BitRate.FromExabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ExbibitPerSecond
 
         /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibitsPerSecond(this int value) => BitRate.FromExbibitsPerSecond(value);
+        public static BitRate ExbibitsPerSecond<T>(this T value) => BitRate.FromExbibitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibitsPerSecond(this int? value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibitsPerSecond(this long value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibitsPerSecond(this long? value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibitsPerSecond(this double value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibitsPerSecond(this double? value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibitsPerSecond(this float value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibitsPerSecond(this float? value) => BitRate.FromExbibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibitsPerSecond(this decimal value) => BitRate.FromExbibitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromExbibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibitsPerSecond(this decimal? value) => BitRate.FromExbibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? ExbibitsPerSecond<T>(this T? value) where T : struct => BitRate.FromExbibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ExbibytePerSecond
 
         /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibytesPerSecond(this int value) => BitRate.FromExbibytesPerSecond(value);
+        public static BitRate ExbibytesPerSecond<T>(this T value) => BitRate.FromExbibytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibytesPerSecond(this int? value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibytesPerSecond(this long value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibytesPerSecond(this long? value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibytesPerSecond(this double value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibytesPerSecond(this double? value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibytesPerSecond(this float value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibytesPerSecond(this float? value) => BitRate.FromExbibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate ExbibytesPerSecond(this decimal value) => BitRate.FromExbibytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromExbibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? ExbibytesPerSecond(this decimal? value) => BitRate.FromExbibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? ExbibytesPerSecond<T>(this T? value) where T : struct => BitRate.FromExbibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GibibitPerSecond
 
         /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibitsPerSecond(this int value) => BitRate.FromGibibitsPerSecond(value);
+        public static BitRate GibibitsPerSecond<T>(this T value) => BitRate.FromGibibitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibitsPerSecond(this int? value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibitsPerSecond(this long value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibitsPerSecond(this long? value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibitsPerSecond(this double value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibitsPerSecond(this double? value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibitsPerSecond(this float value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibitsPerSecond(this float? value) => BitRate.FromGibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibitsPerSecond(this decimal value) => BitRate.FromGibibitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromGibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibitsPerSecond(this decimal? value) => BitRate.FromGibibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? GibibitsPerSecond<T>(this T? value) where T : struct => BitRate.FromGibibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GibibytePerSecond
 
         /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibytesPerSecond(this int value) => BitRate.FromGibibytesPerSecond(value);
+        public static BitRate GibibytesPerSecond<T>(this T value) => BitRate.FromGibibytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibytesPerSecond(this int? value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibytesPerSecond(this long value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibytesPerSecond(this long? value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibytesPerSecond(this double value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibytesPerSecond(this double? value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibytesPerSecond(this float value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibytesPerSecond(this float? value) => BitRate.FromGibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GibibytesPerSecond(this decimal value) => BitRate.FromGibibytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromGibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GibibytesPerSecond(this decimal? value) => BitRate.FromGibibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? GibibytesPerSecond<T>(this T? value) where T : struct => BitRate.FromGibibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigabitPerSecond
 
         /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabitsPerSecond(this int value) => BitRate.FromGigabitsPerSecond(value);
+        public static BitRate GigabitsPerSecond<T>(this T value) => BitRate.FromGigabitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabitsPerSecond(this int? value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabitsPerSecond(this long value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabitsPerSecond(this long? value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabitsPerSecond(this double value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabitsPerSecond(this double? value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabitsPerSecond(this float value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabitsPerSecond(this float? value) => BitRate.FromGigabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabitsPerSecond(this decimal value) => BitRate.FromGigabitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromGigabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabitsPerSecond(this decimal? value) => BitRate.FromGigabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? GigabitsPerSecond<T>(this T? value) where T : struct => BitRate.FromGigabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigabytePerSecond
 
         /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabytesPerSecond(this int value) => BitRate.FromGigabytesPerSecond(value);
+        public static BitRate GigabytesPerSecond<T>(this T value) => BitRate.FromGigabytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabytesPerSecond(this int? value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabytesPerSecond(this long value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabytesPerSecond(this long? value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabytesPerSecond(this double value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabytesPerSecond(this double? value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabytesPerSecond(this float value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabytesPerSecond(this float? value) => BitRate.FromGigabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate GigabytesPerSecond(this decimal value) => BitRate.FromGigabytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromGigabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? GigabytesPerSecond(this decimal? value) => BitRate.FromGigabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? GigabytesPerSecond<T>(this T? value) where T : struct => BitRate.FromGigabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KibibitPerSecond
 
         /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibitsPerSecond(this int value) => BitRate.FromKibibitsPerSecond(value);
+        public static BitRate KibibitsPerSecond<T>(this T value) => BitRate.FromKibibitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibitsPerSecond(this int? value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibitsPerSecond(this long value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibitsPerSecond(this long? value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibitsPerSecond(this double value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibitsPerSecond(this double? value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibitsPerSecond(this float value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibitsPerSecond(this float? value) => BitRate.FromKibibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibitsPerSecond(this decimal value) => BitRate.FromKibibitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromKibibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibitsPerSecond(this decimal? value) => BitRate.FromKibibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? KibibitsPerSecond<T>(this T? value) where T : struct => BitRate.FromKibibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KibibytePerSecond
 
         /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibytesPerSecond(this int value) => BitRate.FromKibibytesPerSecond(value);
+        public static BitRate KibibytesPerSecond<T>(this T value) => BitRate.FromKibibytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibytesPerSecond(this int? value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibytesPerSecond(this long value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibytesPerSecond(this long? value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibytesPerSecond(this double value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibytesPerSecond(this double? value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibytesPerSecond(this float value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibytesPerSecond(this float? value) => BitRate.FromKibibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KibibytesPerSecond(this decimal value) => BitRate.FromKibibytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromKibibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KibibytesPerSecond(this decimal? value) => BitRate.FromKibibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? KibibytesPerSecond<T>(this T? value) where T : struct => BitRate.FromKibibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilobitPerSecond
 
         /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobitsPerSecond(this int value) => BitRate.FromKilobitsPerSecond(value);
+        public static BitRate KilobitsPerSecond<T>(this T value) => BitRate.FromKilobitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobitsPerSecond(this int? value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobitsPerSecond(this long value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobitsPerSecond(this long? value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobitsPerSecond(this double value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobitsPerSecond(this double? value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobitsPerSecond(this float value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobitsPerSecond(this float? value) => BitRate.FromKilobitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobitsPerSecond(this decimal value) => BitRate.FromKilobitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromKilobitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobitsPerSecond(this decimal? value) => BitRate.FromKilobitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? KilobitsPerSecond<T>(this T? value) where T : struct => BitRate.FromKilobitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilobytePerSecond
 
         /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobytesPerSecond(this int value) => BitRate.FromKilobytesPerSecond(value);
+        public static BitRate KilobytesPerSecond<T>(this T value) => BitRate.FromKilobytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobytesPerSecond(this int? value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobytesPerSecond(this long value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobytesPerSecond(this long? value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobytesPerSecond(this double value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobytesPerSecond(this double? value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobytesPerSecond(this float value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobytesPerSecond(this float? value) => BitRate.FromKilobytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate KilobytesPerSecond(this decimal value) => BitRate.FromKilobytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromKilobytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? KilobytesPerSecond(this decimal? value) => BitRate.FromKilobytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? KilobytesPerSecond<T>(this T? value) where T : struct => BitRate.FromKilobytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MebibitPerSecond
 
         /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibitsPerSecond(this int value) => BitRate.FromMebibitsPerSecond(value);
+        public static BitRate MebibitsPerSecond<T>(this T value) => BitRate.FromMebibitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibitsPerSecond(this int? value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibitsPerSecond(this long value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibitsPerSecond(this long? value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibitsPerSecond(this double value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibitsPerSecond(this double? value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibitsPerSecond(this float value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibitsPerSecond(this float? value) => BitRate.FromMebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibitsPerSecond(this decimal value) => BitRate.FromMebibitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromMebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibitsPerSecond(this decimal? value) => BitRate.FromMebibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? MebibitsPerSecond<T>(this T? value) where T : struct => BitRate.FromMebibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MebibytePerSecond
 
         /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibytesPerSecond(this int value) => BitRate.FromMebibytesPerSecond(value);
+        public static BitRate MebibytesPerSecond<T>(this T value) => BitRate.FromMebibytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibytesPerSecond(this int? value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibytesPerSecond(this long value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibytesPerSecond(this long? value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibytesPerSecond(this double value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibytesPerSecond(this double? value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibytesPerSecond(this float value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibytesPerSecond(this float? value) => BitRate.FromMebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MebibytesPerSecond(this decimal value) => BitRate.FromMebibytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromMebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MebibytesPerSecond(this decimal? value) => BitRate.FromMebibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? MebibytesPerSecond<T>(this T? value) where T : struct => BitRate.FromMebibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegabitPerSecond
 
         /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabitsPerSecond(this int value) => BitRate.FromMegabitsPerSecond(value);
+        public static BitRate MegabitsPerSecond<T>(this T value) => BitRate.FromMegabitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabitsPerSecond(this int? value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabitsPerSecond(this long value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabitsPerSecond(this long? value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabitsPerSecond(this double value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabitsPerSecond(this double? value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabitsPerSecond(this float value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabitsPerSecond(this float? value) => BitRate.FromMegabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabitsPerSecond(this decimal value) => BitRate.FromMegabitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromMegabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabitsPerSecond(this decimal? value) => BitRate.FromMegabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? MegabitsPerSecond<T>(this T? value) where T : struct => BitRate.FromMegabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegabytePerSecond
 
         /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabytesPerSecond(this int value) => BitRate.FromMegabytesPerSecond(value);
+        public static BitRate MegabytesPerSecond<T>(this T value) => BitRate.FromMegabytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabytesPerSecond(this int? value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabytesPerSecond(this long value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabytesPerSecond(this long? value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabytesPerSecond(this double value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabytesPerSecond(this double? value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabytesPerSecond(this float value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabytesPerSecond(this float? value) => BitRate.FromMegabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate MegabytesPerSecond(this decimal value) => BitRate.FromMegabytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromMegabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? MegabytesPerSecond(this decimal? value) => BitRate.FromMegabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? MegabytesPerSecond<T>(this T? value) where T : struct => BitRate.FromMegabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PebibitPerSecond
 
         /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibitsPerSecond(this int value) => BitRate.FromPebibitsPerSecond(value);
+        public static BitRate PebibitsPerSecond<T>(this T value) => BitRate.FromPebibitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibitsPerSecond(this int? value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibitsPerSecond(this long value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibitsPerSecond(this long? value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibitsPerSecond(this double value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibitsPerSecond(this double? value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibitsPerSecond(this float value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibitsPerSecond(this float? value) => BitRate.FromPebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibitsPerSecond(this decimal value) => BitRate.FromPebibitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromPebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibitsPerSecond(this decimal? value) => BitRate.FromPebibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? PebibitsPerSecond<T>(this T? value) where T : struct => BitRate.FromPebibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PebibytePerSecond
 
         /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibytesPerSecond(this int value) => BitRate.FromPebibytesPerSecond(value);
+        public static BitRate PebibytesPerSecond<T>(this T value) => BitRate.FromPebibytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibytesPerSecond(this int? value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibytesPerSecond(this long value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibytesPerSecond(this long? value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibytesPerSecond(this double value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibytesPerSecond(this double? value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibytesPerSecond(this float value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibytesPerSecond(this float? value) => BitRate.FromPebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PebibytesPerSecond(this decimal value) => BitRate.FromPebibytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromPebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PebibytesPerSecond(this decimal? value) => BitRate.FromPebibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? PebibytesPerSecond<T>(this T? value) where T : struct => BitRate.FromPebibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PetabitPerSecond
 
         /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabitsPerSecond(this int value) => BitRate.FromPetabitsPerSecond(value);
+        public static BitRate PetabitsPerSecond<T>(this T value) => BitRate.FromPetabitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabitsPerSecond(this int? value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabitsPerSecond(this long value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabitsPerSecond(this long? value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabitsPerSecond(this double value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabitsPerSecond(this double? value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabitsPerSecond(this float value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabitsPerSecond(this float? value) => BitRate.FromPetabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabitsPerSecond(this decimal value) => BitRate.FromPetabitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromPetabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabitsPerSecond(this decimal? value) => BitRate.FromPetabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? PetabitsPerSecond<T>(this T? value) where T : struct => BitRate.FromPetabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PetabytePerSecond
 
         /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabytesPerSecond(this int value) => BitRate.FromPetabytesPerSecond(value);
+        public static BitRate PetabytesPerSecond<T>(this T value) => BitRate.FromPetabytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabytesPerSecond(this int? value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabytesPerSecond(this long value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabytesPerSecond(this long? value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabytesPerSecond(this double value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabytesPerSecond(this double? value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabytesPerSecond(this float value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabytesPerSecond(this float? value) => BitRate.FromPetabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate PetabytesPerSecond(this decimal value) => BitRate.FromPetabytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromPetabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? PetabytesPerSecond(this decimal? value) => BitRate.FromPetabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? PetabytesPerSecond<T>(this T? value) where T : struct => BitRate.FromPetabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TebibitPerSecond
 
         /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibitsPerSecond(this int value) => BitRate.FromTebibitsPerSecond(value);
+        public static BitRate TebibitsPerSecond<T>(this T value) => BitRate.FromTebibitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibitsPerSecond(this int? value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibitsPerSecond(this long value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibitsPerSecond(this long? value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibitsPerSecond(this double value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibitsPerSecond(this double? value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibitsPerSecond(this float value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibitsPerSecond(this float? value) => BitRate.FromTebibitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibitsPerSecond(this decimal value) => BitRate.FromTebibitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromTebibitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibitsPerSecond(this decimal? value) => BitRate.FromTebibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? TebibitsPerSecond<T>(this T? value) where T : struct => BitRate.FromTebibitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TebibytePerSecond
 
         /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibytesPerSecond(this int value) => BitRate.FromTebibytesPerSecond(value);
+        public static BitRate TebibytesPerSecond<T>(this T value) => BitRate.FromTebibytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibytesPerSecond(this int? value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibytesPerSecond(this long value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibytesPerSecond(this long? value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibytesPerSecond(this double value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibytesPerSecond(this double? value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibytesPerSecond(this float value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibytesPerSecond(this float? value) => BitRate.FromTebibytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TebibytesPerSecond(this decimal value) => BitRate.FromTebibytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromTebibytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TebibytesPerSecond(this decimal? value) => BitRate.FromTebibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? TebibytesPerSecond<T>(this T? value) where T : struct => BitRate.FromTebibytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TerabitPerSecond
 
         /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabitsPerSecond(this int value) => BitRate.FromTerabitsPerSecond(value);
+        public static BitRate TerabitsPerSecond<T>(this T value) => BitRate.FromTerabitsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabitsPerSecond(this int? value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabitsPerSecond(this long value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabitsPerSecond(this long? value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabitsPerSecond(this double value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabitsPerSecond(this double? value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabitsPerSecond(this float value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabitsPerSecond(this float? value) => BitRate.FromTerabitsPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabitsPerSecond(this decimal value) => BitRate.FromTerabitsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromTerabitsPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabitsPerSecond(this decimal? value) => BitRate.FromTerabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? TerabitsPerSecond<T>(this T? value) where T : struct => BitRate.FromTerabitsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TerabytePerSecond
 
         /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabytesPerSecond(this int value) => BitRate.FromTerabytesPerSecond(value);
+        public static BitRate TerabytesPerSecond<T>(this T value) => BitRate.FromTerabytesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabytesPerSecond(this int? value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabytesPerSecond(this long value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabytesPerSecond(this long? value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabytesPerSecond(this double value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabytesPerSecond(this double? value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabytesPerSecond(this float value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabytesPerSecond(this float? value) => BitRate.FromTerabytesPerSecond(value);
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate TerabytesPerSecond(this decimal value) => BitRate.FromTerabytesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BitRate.FromTerabytesPerSecond(UnitsNet.QuantityValue)" />
-        public static BitRate? TerabytesPerSecond(this decimal? value) => BitRate.FromTerabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BitRate? TerabytesPerSecond<T>(this T? value) where T : struct => BitRate.FromTerabytesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToBrakeSpecificFuelConsumptionExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToBrakeSpecificFuelConsumptionExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToBrakeSpecificFuelConsumption
         #region GramPerKiloWattHour
 
         /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption GramsPerKiloWattHour(this int value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
+        public static BrakeSpecificFuelConsumption GramsPerKiloWattHour<T>(this T value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? GramsPerKiloWattHour(this int? value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption GramsPerKiloWattHour(this long value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? GramsPerKiloWattHour(this long? value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption GramsPerKiloWattHour(this double value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? GramsPerKiloWattHour(this double? value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption GramsPerKiloWattHour(this float value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? GramsPerKiloWattHour(this float? value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption GramsPerKiloWattHour(this decimal value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? GramsPerKiloWattHour(this decimal? value) => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BrakeSpecificFuelConsumption? GramsPerKiloWattHour<T>(this T? value) where T : struct => BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerJoule
 
         /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption KilogramsPerJoule(this int value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
+        public static BrakeSpecificFuelConsumption KilogramsPerJoule<T>(this T value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? KilogramsPerJoule(this int? value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption KilogramsPerJoule(this long value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? KilogramsPerJoule(this long? value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption KilogramsPerJoule(this double value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? KilogramsPerJoule(this double? value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption KilogramsPerJoule(this float value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? KilogramsPerJoule(this float? value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption KilogramsPerJoule(this decimal value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromKilogramsPerJoule(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? KilogramsPerJoule(this decimal? value) => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BrakeSpecificFuelConsumption? KilogramsPerJoule<T>(this T? value) where T : struct => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerMechanicalHorsepowerHour
 
         /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption PoundsPerMechanicalHorsepowerHour(this int value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
+        public static BrakeSpecificFuelConsumption PoundsPerMechanicalHorsepowerHour<T>(this T value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? PoundsPerMechanicalHorsepowerHour(this int? value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption PoundsPerMechanicalHorsepowerHour(this long value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? PoundsPerMechanicalHorsepowerHour(this long? value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption PoundsPerMechanicalHorsepowerHour(this double value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? PoundsPerMechanicalHorsepowerHour(this double? value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption PoundsPerMechanicalHorsepowerHour(this float value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? PoundsPerMechanicalHorsepowerHour(this float? value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value);
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption PoundsPerMechanicalHorsepowerHour(this decimal value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(UnitsNet.QuantityValue)" />
-        public static BrakeSpecificFuelConsumption? PoundsPerMechanicalHorsepowerHour(this decimal? value) => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static BrakeSpecificFuelConsumption? PoundsPerMechanicalHorsepowerHour<T>(this T? value) where T : struct => BrakeSpecificFuelConsumption.FromPoundsPerMechanicalHorsepowerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToCapacitanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToCapacitanceExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToCapacitance
         #region Farad
 
         /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance Farads(this int value) => Capacitance.FromFarads(value);
+        public static Capacitance Farads<T>(this T value) => Capacitance.FromFarads(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance? Farads(this int? value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance Farads(this long value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance? Farads(this long? value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance Farads(this double value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance? Farads(this double? value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance Farads(this float value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance? Farads(this float? value) => Capacitance.FromFarads(value);
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance Farads(this decimal value) => Capacitance.FromFarads(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Capacitance.FromFarads(UnitsNet.QuantityValue)" />
-        public static Capacitance? Farads(this decimal? value) => Capacitance.FromFarads(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Capacitance? Farads<T>(this T? value) where T : struct => Capacitance.FromFarads(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToDensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToDensityExtensions.g.cs
@@ -47,1292 +47,380 @@ namespace UnitsNet.Extensions.NumberToDensity
         #region CentigramPerDeciliter
 
         /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerDeciLiter(this int value) => Density.FromCentigramsPerDeciLiter(value);
+        public static Density CentigramsPerDeciLiter<T>(this T value) => Density.FromCentigramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerDeciLiter(this int? value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerDeciLiter(this long value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerDeciLiter(this long? value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerDeciLiter(this double value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerDeciLiter(this double? value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerDeciLiter(this float value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerDeciLiter(this float? value) => Density.FromCentigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerDeciLiter(this decimal value) => Density.FromCentigramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromCentigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerDeciLiter(this decimal? value) => Density.FromCentigramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? CentigramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromCentigramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CentigramPerLiter
 
         /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerLiter(this int value) => Density.FromCentigramsPerLiter(value);
+        public static Density CentigramsPerLiter<T>(this T value) => Density.FromCentigramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerLiter(this int? value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerLiter(this long value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerLiter(this long? value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerLiter(this double value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerLiter(this double? value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerLiter(this float value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerLiter(this float? value) => Density.FromCentigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerLiter(this decimal value) => Density.FromCentigramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromCentigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerLiter(this decimal? value) => Density.FromCentigramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? CentigramsPerLiter<T>(this T? value) where T : struct => Density.FromCentigramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CentigramPerMilliliter
 
         /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerMilliliter(this int value) => Density.FromCentigramsPerMilliliter(value);
+        public static Density CentigramsPerMilliliter<T>(this T value) => Density.FromCentigramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerMilliliter(this int? value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerMilliliter(this long value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerMilliliter(this long? value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerMilliliter(this double value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerMilliliter(this double? value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerMilliliter(this float value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerMilliliter(this float? value) => Density.FromCentigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density CentigramsPerMilliliter(this decimal value) => Density.FromCentigramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromCentigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? CentigramsPerMilliliter(this decimal? value) => Density.FromCentigramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? CentigramsPerMilliliter<T>(this T? value) where T : struct => Density.FromCentigramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecigramPerDeciliter
 
         /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerDeciLiter(this int value) => Density.FromDecigramsPerDeciLiter(value);
+        public static Density DecigramsPerDeciLiter<T>(this T value) => Density.FromDecigramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerDeciLiter(this int? value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerDeciLiter(this long value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerDeciLiter(this long? value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerDeciLiter(this double value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerDeciLiter(this double? value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerDeciLiter(this float value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerDeciLiter(this float? value) => Density.FromDecigramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerDeciLiter(this decimal value) => Density.FromDecigramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromDecigramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerDeciLiter(this decimal? value) => Density.FromDecigramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? DecigramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromDecigramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecigramPerLiter
 
         /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerLiter(this int value) => Density.FromDecigramsPerLiter(value);
+        public static Density DecigramsPerLiter<T>(this T value) => Density.FromDecigramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerLiter(this int? value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerLiter(this long value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerLiter(this long? value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerLiter(this double value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerLiter(this double? value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerLiter(this float value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerLiter(this float? value) => Density.FromDecigramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerLiter(this decimal value) => Density.FromDecigramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromDecigramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerLiter(this decimal? value) => Density.FromDecigramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? DecigramsPerLiter<T>(this T? value) where T : struct => Density.FromDecigramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecigramPerMilliliter
 
         /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerMilliliter(this int value) => Density.FromDecigramsPerMilliliter(value);
+        public static Density DecigramsPerMilliliter<T>(this T value) => Density.FromDecigramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerMilliliter(this int? value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerMilliliter(this long value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerMilliliter(this long? value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerMilliliter(this double value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerMilliliter(this double? value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerMilliliter(this float value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerMilliliter(this float? value) => Density.FromDecigramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density DecigramsPerMilliliter(this decimal value) => Density.FromDecigramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromDecigramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? DecigramsPerMilliliter(this decimal? value) => Density.FromDecigramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? DecigramsPerMilliliter<T>(this T? value) where T : struct => Density.FromDecigramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerCubicCentimeter
 
         /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicCentimeter(this int value) => Density.FromGramsPerCubicCentimeter(value);
+        public static Density GramsPerCubicCentimeter<T>(this T value) => Density.FromGramsPerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicCentimeter(this int? value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicCentimeter(this long value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicCentimeter(this long? value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicCentimeter(this double value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicCentimeter(this double? value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicCentimeter(this float value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicCentimeter(this float? value) => Density.FromGramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicCentimeter(this decimal value) => Density.FromGramsPerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicCentimeter(this decimal? value) => Density.FromGramsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? GramsPerCubicCentimeter<T>(this T? value) where T : struct => Density.FromGramsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerCubicMeter
 
         /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMeter(this int value) => Density.FromGramsPerCubicMeter(value);
+        public static Density GramsPerCubicMeter<T>(this T value) => Density.FromGramsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMeter(this int? value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMeter(this long value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMeter(this long? value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMeter(this double value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMeter(this double? value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMeter(this float value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMeter(this float? value) => Density.FromGramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMeter(this decimal value) => Density.FromGramsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMeter(this decimal? value) => Density.FromGramsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? GramsPerCubicMeter<T>(this T? value) where T : struct => Density.FromGramsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerCubicMillimeter
 
         /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMillimeter(this int value) => Density.FromGramsPerCubicMillimeter(value);
+        public static Density GramsPerCubicMillimeter<T>(this T value) => Density.FromGramsPerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMillimeter(this int? value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMillimeter(this long value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMillimeter(this long? value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMillimeter(this double value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMillimeter(this double? value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMillimeter(this float value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMillimeter(this float? value) => Density.FromGramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerCubicMillimeter(this decimal value) => Density.FromGramsPerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromGramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerCubicMillimeter(this decimal? value) => Density.FromGramsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? GramsPerCubicMillimeter<T>(this T? value) where T : struct => Density.FromGramsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerDeciliter
 
         /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerDeciLiter(this int value) => Density.FromGramsPerDeciLiter(value);
+        public static Density GramsPerDeciLiter<T>(this T value) => Density.FromGramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerDeciLiter(this int? value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerDeciLiter(this long value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerDeciLiter(this long? value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerDeciLiter(this double value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerDeciLiter(this double? value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerDeciLiter(this float value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerDeciLiter(this float? value) => Density.FromGramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerDeciLiter(this decimal value) => Density.FromGramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromGramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerDeciLiter(this decimal? value) => Density.FromGramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? GramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromGramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerLiter
 
         /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerLiter(this int value) => Density.FromGramsPerLiter(value);
+        public static Density GramsPerLiter<T>(this T value) => Density.FromGramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerLiter(this int? value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerLiter(this long value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerLiter(this long? value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerLiter(this double value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerLiter(this double? value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerLiter(this float value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerLiter(this float? value) => Density.FromGramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerLiter(this decimal value) => Density.FromGramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromGramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerLiter(this decimal? value) => Density.FromGramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? GramsPerLiter<T>(this T? value) where T : struct => Density.FromGramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerMilliliter
 
         /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerMilliliter(this int value) => Density.FromGramsPerMilliliter(value);
+        public static Density GramsPerMilliliter<T>(this T value) => Density.FromGramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerMilliliter(this int? value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerMilliliter(this long value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerMilliliter(this long? value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerMilliliter(this double value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerMilliliter(this double? value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerMilliliter(this float value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerMilliliter(this float? value) => Density.FromGramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density GramsPerMilliliter(this decimal value) => Density.FromGramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromGramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? GramsPerMilliliter(this decimal? value) => Density.FromGramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? GramsPerMilliliter<T>(this T? value) where T : struct => Density.FromGramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerCubicCentimeter
 
         /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicCentimeter(this int value) => Density.FromKilogramsPerCubicCentimeter(value);
+        public static Density KilogramsPerCubicCentimeter<T>(this T value) => Density.FromKilogramsPerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicCentimeter(this int? value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicCentimeter(this long value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicCentimeter(this long? value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicCentimeter(this double value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicCentimeter(this double? value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicCentimeter(this float value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicCentimeter(this float? value) => Density.FromKilogramsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicCentimeter(this decimal value) => Density.FromKilogramsPerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicCentimeter(this decimal? value) => Density.FromKilogramsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? KilogramsPerCubicCentimeter<T>(this T? value) where T : struct => Density.FromKilogramsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerCubicMeter
 
         /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMeter(this int value) => Density.FromKilogramsPerCubicMeter(value);
+        public static Density KilogramsPerCubicMeter<T>(this T value) => Density.FromKilogramsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMeter(this int? value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMeter(this long value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMeter(this long? value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMeter(this double value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMeter(this double? value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMeter(this float value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMeter(this float? value) => Density.FromKilogramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMeter(this decimal value) => Density.FromKilogramsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMeter(this decimal? value) => Density.FromKilogramsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? KilogramsPerCubicMeter<T>(this T? value) where T : struct => Density.FromKilogramsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerCubicMillimeter
 
         /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMillimeter(this int value) => Density.FromKilogramsPerCubicMillimeter(value);
+        public static Density KilogramsPerCubicMillimeter<T>(this T value) => Density.FromKilogramsPerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMillimeter(this int? value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMillimeter(this long value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMillimeter(this long? value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMillimeter(this double value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMillimeter(this double? value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMillimeter(this float value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMillimeter(this float? value) => Density.FromKilogramsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density KilogramsPerCubicMillimeter(this decimal value) => Density.FromKilogramsPerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromKilogramsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? KilogramsPerCubicMillimeter(this decimal? value) => Density.FromKilogramsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? KilogramsPerCubicMillimeter<T>(this T? value) where T : struct => Density.FromKilogramsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundPerCubicFoot
 
         /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicFoot(this int value) => Density.FromKilopoundsPerCubicFoot(value);
+        public static Density KilopoundsPerCubicFoot<T>(this T value) => Density.FromKilopoundsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicFoot(this int? value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicFoot(this long value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicFoot(this long? value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicFoot(this double value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicFoot(this double? value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicFoot(this float value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicFoot(this float? value) => Density.FromKilopoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicFoot(this decimal value) => Density.FromKilopoundsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicFoot(this decimal? value) => Density.FromKilopoundsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? KilopoundsPerCubicFoot<T>(this T? value) where T : struct => Density.FromKilopoundsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundPerCubicInch
 
         /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicInch(this int value) => Density.FromKilopoundsPerCubicInch(value);
+        public static Density KilopoundsPerCubicInch<T>(this T value) => Density.FromKilopoundsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicInch(this int? value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicInch(this long value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicInch(this long? value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicInch(this double value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicInch(this double? value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicInch(this float value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicInch(this float? value) => Density.FromKilopoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density KilopoundsPerCubicInch(this decimal value) => Density.FromKilopoundsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromKilopoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? KilopoundsPerCubicInch(this decimal? value) => Density.FromKilopoundsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? KilopoundsPerCubicInch<T>(this T? value) where T : struct => Density.FromKilopoundsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrogramPerDeciliter
 
         /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerDeciLiter(this int value) => Density.FromMicrogramsPerDeciLiter(value);
+        public static Density MicrogramsPerDeciLiter<T>(this T value) => Density.FromMicrogramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerDeciLiter(this int? value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerDeciLiter(this long value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerDeciLiter(this long? value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerDeciLiter(this double value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerDeciLiter(this double? value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerDeciLiter(this float value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerDeciLiter(this float? value) => Density.FromMicrogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerDeciLiter(this decimal value) => Density.FromMicrogramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerDeciLiter(this decimal? value) => Density.FromMicrogramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MicrogramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromMicrogramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrogramPerLiter
 
         /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerLiter(this int value) => Density.FromMicrogramsPerLiter(value);
+        public static Density MicrogramsPerLiter<T>(this T value) => Density.FromMicrogramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerLiter(this int? value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerLiter(this long value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerLiter(this long? value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerLiter(this double value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerLiter(this double? value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerLiter(this float value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerLiter(this float? value) => Density.FromMicrogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerLiter(this decimal value) => Density.FromMicrogramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerLiter(this decimal? value) => Density.FromMicrogramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MicrogramsPerLiter<T>(this T? value) where T : struct => Density.FromMicrogramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrogramPerMilliliter
 
         /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerMilliliter(this int value) => Density.FromMicrogramsPerMilliliter(value);
+        public static Density MicrogramsPerMilliliter<T>(this T value) => Density.FromMicrogramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerMilliliter(this int? value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerMilliliter(this long value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerMilliliter(this long? value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerMilliliter(this double value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerMilliliter(this double? value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerMilliliter(this float value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerMilliliter(this float? value) => Density.FromMicrogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MicrogramsPerMilliliter(this decimal value) => Density.FromMicrogramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMicrogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MicrogramsPerMilliliter(this decimal? value) => Density.FromMicrogramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MicrogramsPerMilliliter<T>(this T? value) where T : struct => Density.FromMicrogramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramPerCubicMeter
 
         /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerCubicMeter(this int value) => Density.FromMilligramsPerCubicMeter(value);
+        public static Density MilligramsPerCubicMeter<T>(this T value) => Density.FromMilligramsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerCubicMeter(this int? value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerCubicMeter(this long value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerCubicMeter(this long? value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerCubicMeter(this double value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerCubicMeter(this double? value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerCubicMeter(this float value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerCubicMeter(this float? value) => Density.FromMilligramsPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerCubicMeter(this decimal value) => Density.FromMilligramsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMilligramsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerCubicMeter(this decimal? value) => Density.FromMilligramsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MilligramsPerCubicMeter<T>(this T? value) where T : struct => Density.FromMilligramsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramPerDeciliter
 
         /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerDeciLiter(this int value) => Density.FromMilligramsPerDeciLiter(value);
+        public static Density MilligramsPerDeciLiter<T>(this T value) => Density.FromMilligramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerDeciLiter(this int? value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerDeciLiter(this long value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerDeciLiter(this long? value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerDeciLiter(this double value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerDeciLiter(this double? value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerDeciLiter(this float value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerDeciLiter(this float? value) => Density.FromMilligramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerDeciLiter(this decimal value) => Density.FromMilligramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMilligramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerDeciLiter(this decimal? value) => Density.FromMilligramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MilligramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromMilligramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramPerLiter
 
         /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerLiter(this int value) => Density.FromMilligramsPerLiter(value);
+        public static Density MilligramsPerLiter<T>(this T value) => Density.FromMilligramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerLiter(this int? value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerLiter(this long value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerLiter(this long? value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerLiter(this double value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerLiter(this double? value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerLiter(this float value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerLiter(this float? value) => Density.FromMilligramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerLiter(this decimal value) => Density.FromMilligramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMilligramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerLiter(this decimal? value) => Density.FromMilligramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MilligramsPerLiter<T>(this T? value) where T : struct => Density.FromMilligramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramPerMilliliter
 
         /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerMilliliter(this int value) => Density.FromMilligramsPerMilliliter(value);
+        public static Density MilligramsPerMilliliter<T>(this T value) => Density.FromMilligramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerMilliliter(this int? value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerMilliliter(this long value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerMilliliter(this long? value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerMilliliter(this double value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerMilliliter(this double? value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerMilliliter(this float value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerMilliliter(this float? value) => Density.FromMilligramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density MilligramsPerMilliliter(this decimal value) => Density.FromMilligramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromMilligramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? MilligramsPerMilliliter(this decimal? value) => Density.FromMilligramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? MilligramsPerMilliliter<T>(this T? value) where T : struct => Density.FromMilligramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanogramPerDeciliter
 
         /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerDeciLiter(this int value) => Density.FromNanogramsPerDeciLiter(value);
+        public static Density NanogramsPerDeciLiter<T>(this T value) => Density.FromNanogramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerDeciLiter(this int? value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerDeciLiter(this long value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerDeciLiter(this long? value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerDeciLiter(this double value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerDeciLiter(this double? value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerDeciLiter(this float value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerDeciLiter(this float? value) => Density.FromNanogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerDeciLiter(this decimal value) => Density.FromNanogramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromNanogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerDeciLiter(this decimal? value) => Density.FromNanogramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? NanogramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromNanogramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanogramPerLiter
 
         /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerLiter(this int value) => Density.FromNanogramsPerLiter(value);
+        public static Density NanogramsPerLiter<T>(this T value) => Density.FromNanogramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerLiter(this int? value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerLiter(this long value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerLiter(this long? value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerLiter(this double value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerLiter(this double? value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerLiter(this float value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerLiter(this float? value) => Density.FromNanogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerLiter(this decimal value) => Density.FromNanogramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromNanogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerLiter(this decimal? value) => Density.FromNanogramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? NanogramsPerLiter<T>(this T? value) where T : struct => Density.FromNanogramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanogramPerMilliliter
 
         /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerMilliliter(this int value) => Density.FromNanogramsPerMilliliter(value);
+        public static Density NanogramsPerMilliliter<T>(this T value) => Density.FromNanogramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerMilliliter(this int? value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerMilliliter(this long value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerMilliliter(this long? value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerMilliliter(this double value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerMilliliter(this double? value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerMilliliter(this float value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerMilliliter(this float? value) => Density.FromNanogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density NanogramsPerMilliliter(this decimal value) => Density.FromNanogramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromNanogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? NanogramsPerMilliliter(this decimal? value) => Density.FromNanogramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? NanogramsPerMilliliter<T>(this T? value) where T : struct => Density.FromNanogramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicogramPerDeciliter
 
         /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerDeciLiter(this int value) => Density.FromPicogramsPerDeciLiter(value);
+        public static Density PicogramsPerDeciLiter<T>(this T value) => Density.FromPicogramsPerDeciLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerDeciLiter(this int? value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerDeciLiter(this long value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerDeciLiter(this long? value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerDeciLiter(this double value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerDeciLiter(this double? value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerDeciLiter(this float value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerDeciLiter(this float? value) => Density.FromPicogramsPerDeciLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerDeciLiter(this decimal value) => Density.FromPicogramsPerDeciLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPicogramsPerDeciLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerDeciLiter(this decimal? value) => Density.FromPicogramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PicogramsPerDeciLiter<T>(this T? value) where T : struct => Density.FromPicogramsPerDeciLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicogramPerLiter
 
         /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerLiter(this int value) => Density.FromPicogramsPerLiter(value);
+        public static Density PicogramsPerLiter<T>(this T value) => Density.FromPicogramsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerLiter(this int? value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerLiter(this long value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerLiter(this long? value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerLiter(this double value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerLiter(this double? value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerLiter(this float value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerLiter(this float? value) => Density.FromPicogramsPerLiter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerLiter(this decimal value) => Density.FromPicogramsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPicogramsPerLiter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerLiter(this decimal? value) => Density.FromPicogramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PicogramsPerLiter<T>(this T? value) where T : struct => Density.FromPicogramsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicogramPerMilliliter
 
         /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerMilliliter(this int value) => Density.FromPicogramsPerMilliliter(value);
+        public static Density PicogramsPerMilliliter<T>(this T value) => Density.FromPicogramsPerMilliliter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerMilliliter(this int? value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerMilliliter(this long value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerMilliliter(this long? value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerMilliliter(this double value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerMilliliter(this double? value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerMilliliter(this float value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerMilliliter(this float? value) => Density.FromPicogramsPerMilliliter(value);
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density PicogramsPerMilliliter(this decimal value) => Density.FromPicogramsPerMilliliter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPicogramsPerMilliliter(UnitsNet.QuantityValue)" />
-        public static Density? PicogramsPerMilliliter(this decimal? value) => Density.FromPicogramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PicogramsPerMilliliter<T>(this T? value) where T : struct => Density.FromPicogramsPerMilliliter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerCubicFoot
 
         /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicFoot(this int value) => Density.FromPoundsPerCubicFoot(value);
+        public static Density PoundsPerCubicFoot<T>(this T value) => Density.FromPoundsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicFoot(this int? value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicFoot(this long value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicFoot(this long? value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicFoot(this double value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicFoot(this double? value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicFoot(this float value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicFoot(this float? value) => Density.FromPoundsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicFoot(this decimal value) => Density.FromPoundsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicFoot(this decimal? value) => Density.FromPoundsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PoundsPerCubicFoot<T>(this T? value) where T : struct => Density.FromPoundsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerCubicInch
 
         /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicInch(this int value) => Density.FromPoundsPerCubicInch(value);
+        public static Density PoundsPerCubicInch<T>(this T value) => Density.FromPoundsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicInch(this int? value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicInch(this long value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicInch(this long? value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicInch(this double value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicInch(this double? value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicInch(this float value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicInch(this float? value) => Density.FromPoundsPerCubicInch(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerCubicInch(this decimal value) => Density.FromPoundsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPoundsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerCubicInch(this decimal? value) => Density.FromPoundsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PoundsPerCubicInch<T>(this T? value) where T : struct => Density.FromPoundsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerImperialGallon
 
         /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerImperialGallon(this int value) => Density.FromPoundsPerImperialGallon(value);
+        public static Density PoundsPerImperialGallon<T>(this T value) => Density.FromPoundsPerImperialGallon(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerImperialGallon(this int? value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerImperialGallon(this long value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerImperialGallon(this long? value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerImperialGallon(this double value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerImperialGallon(this double? value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerImperialGallon(this float value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerImperialGallon(this float? value) => Density.FromPoundsPerImperialGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerImperialGallon(this decimal value) => Density.FromPoundsPerImperialGallon(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPoundsPerImperialGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerImperialGallon(this decimal? value) => Density.FromPoundsPerImperialGallon(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PoundsPerImperialGallon<T>(this T? value) where T : struct => Density.FromPoundsPerImperialGallon(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerUSGallon
 
         /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerUSGallon(this int value) => Density.FromPoundsPerUSGallon(value);
+        public static Density PoundsPerUSGallon<T>(this T value) => Density.FromPoundsPerUSGallon(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerUSGallon(this int? value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerUSGallon(this long value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerUSGallon(this long? value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerUSGallon(this double value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerUSGallon(this double? value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerUSGallon(this float value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerUSGallon(this float? value) => Density.FromPoundsPerUSGallon(value);
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density PoundsPerUSGallon(this decimal value) => Density.FromPoundsPerUSGallon(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromPoundsPerUSGallon(UnitsNet.QuantityValue)" />
-        public static Density? PoundsPerUSGallon(this decimal? value) => Density.FromPoundsPerUSGallon(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? PoundsPerUSGallon<T>(this T? value) where T : struct => Density.FromPoundsPerUSGallon(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SlugPerCubicFoot
 
         /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density SlugsPerCubicFoot(this int value) => Density.FromSlugsPerCubicFoot(value);
+        public static Density SlugsPerCubicFoot<T>(this T value) => Density.FromSlugsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? SlugsPerCubicFoot(this int? value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density SlugsPerCubicFoot(this long value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? SlugsPerCubicFoot(this long? value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density SlugsPerCubicFoot(this double value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? SlugsPerCubicFoot(this double? value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density SlugsPerCubicFoot(this float value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? SlugsPerCubicFoot(this float? value) => Density.FromSlugsPerCubicFoot(value);
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density SlugsPerCubicFoot(this decimal value) => Density.FromSlugsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromSlugsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static Density? SlugsPerCubicFoot(this decimal? value) => Density.FromSlugsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? SlugsPerCubicFoot<T>(this T? value) where T : struct => Density.FromSlugsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonnePerCubicCentimeter
 
         /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicCentimeter(this int value) => Density.FromTonnesPerCubicCentimeter(value);
+        public static Density TonnesPerCubicCentimeter<T>(this T value) => Density.FromTonnesPerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicCentimeter(this int? value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicCentimeter(this long value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicCentimeter(this long? value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicCentimeter(this double value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicCentimeter(this double? value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicCentimeter(this float value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicCentimeter(this float? value) => Density.FromTonnesPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicCentimeter(this decimal value) => Density.FromTonnesPerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicCentimeter(this decimal? value) => Density.FromTonnesPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? TonnesPerCubicCentimeter<T>(this T? value) where T : struct => Density.FromTonnesPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonnePerCubicMeter
 
         /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMeter(this int value) => Density.FromTonnesPerCubicMeter(value);
+        public static Density TonnesPerCubicMeter<T>(this T value) => Density.FromTonnesPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMeter(this int? value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMeter(this long value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMeter(this long? value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMeter(this double value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMeter(this double? value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMeter(this float value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMeter(this float? value) => Density.FromTonnesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMeter(this decimal value) => Density.FromTonnesPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMeter(this decimal? value) => Density.FromTonnesPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? TonnesPerCubicMeter<T>(this T? value) where T : struct => Density.FromTonnesPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonnePerCubicMillimeter
 
         /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMillimeter(this int value) => Density.FromTonnesPerCubicMillimeter(value);
+        public static Density TonnesPerCubicMillimeter<T>(this T value) => Density.FromTonnesPerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMillimeter(this int? value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMillimeter(this long value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMillimeter(this long? value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMillimeter(this double value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMillimeter(this double? value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMillimeter(this float value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMillimeter(this float? value) => Density.FromTonnesPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density TonnesPerCubicMillimeter(this decimal value) => Density.FromTonnesPerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Density.FromTonnesPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static Density? TonnesPerCubicMillimeter(this decimal? value) => Density.FromTonnesPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Density? TonnesPerCubicMillimeter<T>(this T? value) where T : struct => Density.FromTonnesPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToDurationExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToDurationExtensions.g.cs
@@ -47,408 +47,120 @@ namespace UnitsNet.Extensions.NumberToDuration
         #region Day
 
         /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration Days(this int value) => Duration.FromDays(value);
+        public static Duration Days<T>(this T value) => Duration.FromDays(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration? Days(this int? value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration Days(this long value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration? Days(this long? value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration Days(this double value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration? Days(this double? value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration Days(this float value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration? Days(this float? value) => Duration.FromDays(value);
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration Days(this decimal value) => Duration.FromDays(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromDays(UnitsNet.QuantityValue)" />
-        public static Duration? Days(this decimal? value) => Duration.FromDays(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Days<T>(this T? value) where T : struct => Duration.FromDays(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Hour
 
         /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration Hours(this int value) => Duration.FromHours(value);
+        public static Duration Hours<T>(this T value) => Duration.FromHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration? Hours(this int? value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration Hours(this long value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration? Hours(this long? value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration Hours(this double value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration? Hours(this double? value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration Hours(this float value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration? Hours(this float? value) => Duration.FromHours(value);
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration Hours(this decimal value) => Duration.FromHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromHours(UnitsNet.QuantityValue)" />
-        public static Duration? Hours(this decimal? value) => Duration.FromHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Hours<T>(this T? value) where T : struct => Duration.FromHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microsecond
 
         /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration Microseconds(this int value) => Duration.FromMicroseconds(value);
+        public static Duration Microseconds<T>(this T value) => Duration.FromMicroseconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Microseconds(this int? value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration Microseconds(this long value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Microseconds(this long? value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration Microseconds(this double value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Microseconds(this double? value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration Microseconds(this float value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Microseconds(this float? value) => Duration.FromMicroseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration Microseconds(this decimal value) => Duration.FromMicroseconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromMicroseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Microseconds(this decimal? value) => Duration.FromMicroseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Microseconds<T>(this T? value) where T : struct => Duration.FromMicroseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millisecond
 
         /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration Milliseconds(this int value) => Duration.FromMilliseconds(value);
+        public static Duration Milliseconds<T>(this T value) => Duration.FromMilliseconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Milliseconds(this int? value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration Milliseconds(this long value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Milliseconds(this long? value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration Milliseconds(this double value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Milliseconds(this double? value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration Milliseconds(this float value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Milliseconds(this float? value) => Duration.FromMilliseconds(value);
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration Milliseconds(this decimal value) => Duration.FromMilliseconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromMilliseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Milliseconds(this decimal? value) => Duration.FromMilliseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Milliseconds<T>(this T? value) where T : struct => Duration.FromMilliseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Minute
 
         /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration Minutes(this int value) => Duration.FromMinutes(value);
+        public static Duration Minutes<T>(this T value) => Duration.FromMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration? Minutes(this int? value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration Minutes(this long value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration? Minutes(this long? value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration Minutes(this double value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration? Minutes(this double? value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration Minutes(this float value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration? Minutes(this float? value) => Duration.FromMinutes(value);
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration Minutes(this decimal value) => Duration.FromMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromMinutes(UnitsNet.QuantityValue)" />
-        public static Duration? Minutes(this decimal? value) => Duration.FromMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Minutes<T>(this T? value) where T : struct => Duration.FromMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Month
 
         /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration Months(this int value) => Duration.FromMonths(value);
+        public static Duration Months<T>(this T value) => Duration.FromMonths(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration? Months(this int? value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration Months(this long value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration? Months(this long? value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration Months(this double value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration? Months(this double? value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration Months(this float value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration? Months(this float? value) => Duration.FromMonths(value);
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration Months(this decimal value) => Duration.FromMonths(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromMonths(UnitsNet.QuantityValue)" />
-        public static Duration? Months(this decimal? value) => Duration.FromMonths(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Months<T>(this T? value) where T : struct => Duration.FromMonths(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Month30
 
         /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration Months30(this int value) => Duration.FromMonths30(value);
+        public static Duration Months30<T>(this T value) => Duration.FromMonths30(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration? Months30(this int? value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration Months30(this long value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration? Months30(this long? value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration Months30(this double value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration? Months30(this double? value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration Months30(this float value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration? Months30(this float? value) => Duration.FromMonths30(value);
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration Months30(this decimal value) => Duration.FromMonths30(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromMonths30(UnitsNet.QuantityValue)" />
-        public static Duration? Months30(this decimal? value) => Duration.FromMonths30(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Months30<T>(this T? value) where T : struct => Duration.FromMonths30(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanosecond
 
         /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration Nanoseconds(this int value) => Duration.FromNanoseconds(value);
+        public static Duration Nanoseconds<T>(this T value) => Duration.FromNanoseconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Nanoseconds(this int? value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration Nanoseconds(this long value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Nanoseconds(this long? value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration Nanoseconds(this double value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Nanoseconds(this double? value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration Nanoseconds(this float value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Nanoseconds(this float? value) => Duration.FromNanoseconds(value);
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration Nanoseconds(this decimal value) => Duration.FromNanoseconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromNanoseconds(UnitsNet.QuantityValue)" />
-        public static Duration? Nanoseconds(this decimal? value) => Duration.FromNanoseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Nanoseconds<T>(this T? value) where T : struct => Duration.FromNanoseconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Second
 
         /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration Seconds(this int value) => Duration.FromSeconds(value);
+        public static Duration Seconds<T>(this T value) => Duration.FromSeconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration? Seconds(this int? value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration Seconds(this long value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration? Seconds(this long? value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration Seconds(this double value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration? Seconds(this double? value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration Seconds(this float value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration? Seconds(this float? value) => Duration.FromSeconds(value);
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration Seconds(this decimal value) => Duration.FromSeconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromSeconds(UnitsNet.QuantityValue)" />
-        public static Duration? Seconds(this decimal? value) => Duration.FromSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Seconds<T>(this T? value) where T : struct => Duration.FromSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Week
 
         /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration Weeks(this int value) => Duration.FromWeeks(value);
+        public static Duration Weeks<T>(this T value) => Duration.FromWeeks(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration? Weeks(this int? value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration Weeks(this long value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration? Weeks(this long? value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration Weeks(this double value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration? Weeks(this double? value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration Weeks(this float value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration? Weeks(this float? value) => Duration.FromWeeks(value);
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration Weeks(this decimal value) => Duration.FromWeeks(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
-        public static Duration? Weeks(this decimal? value) => Duration.FromWeeks(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Weeks<T>(this T? value) where T : struct => Duration.FromWeeks(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Year
 
         /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration Years(this int value) => Duration.FromYears(value);
+        public static Duration Years<T>(this T value) => Duration.FromYears(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration? Years(this int? value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration Years(this long value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration? Years(this long? value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration Years(this double value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration? Years(this double? value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration Years(this float value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration? Years(this float? value) => Duration.FromYears(value);
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration Years(this decimal value) => Duration.FromYears(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromYears(UnitsNet.QuantityValue)" />
-        public static Duration? Years(this decimal? value) => Duration.FromYears(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Years<T>(this T? value) where T : struct => Duration.FromYears(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Year365
 
         /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration Years365(this int value) => Duration.FromYears365(value);
+        public static Duration Years365<T>(this T value) => Duration.FromYears365(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration? Years365(this int? value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration Years365(this long value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration? Years365(this long? value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration Years365(this double value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration? Years365(this double? value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration Years365(this float value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration? Years365(this float? value) => Duration.FromYears365(value);
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration Years365(this decimal value) => Duration.FromYears365(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Duration.FromYears365(UnitsNet.QuantityValue)" />
-        public static Duration? Years365(this decimal? value) => Duration.FromYears365(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Duration? Years365<T>(this T? value) where T : struct => Duration.FromYears365(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToDynamicViscosityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToDynamicViscosityExtensions.g.cs
@@ -47,204 +47,60 @@ namespace UnitsNet.Extensions.NumberToDynamicViscosity
         #region Centipoise
 
         /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Centipoise(this int value) => DynamicViscosity.FromCentipoise(value);
+        public static DynamicViscosity Centipoise<T>(this T value) => DynamicViscosity.FromCentipoise(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Centipoise(this int? value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Centipoise(this long value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Centipoise(this long? value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Centipoise(this double value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Centipoise(this double? value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Centipoise(this float value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Centipoise(this float? value) => DynamicViscosity.FromCentipoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Centipoise(this decimal value) => DynamicViscosity.FromCentipoise(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="DynamicViscosity.FromCentipoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Centipoise(this decimal? value) => DynamicViscosity.FromCentipoise(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static DynamicViscosity? Centipoise<T>(this T? value) where T : struct => DynamicViscosity.FromCentipoise(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicropascalSecond
 
         /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MicropascalSeconds(this int value) => DynamicViscosity.FromMicropascalSeconds(value);
+        public static DynamicViscosity MicropascalSeconds<T>(this T value) => DynamicViscosity.FromMicropascalSeconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MicropascalSeconds(this int? value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MicropascalSeconds(this long value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MicropascalSeconds(this long? value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MicropascalSeconds(this double value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MicropascalSeconds(this double? value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MicropascalSeconds(this float value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MicropascalSeconds(this float? value) => DynamicViscosity.FromMicropascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MicropascalSeconds(this decimal value) => DynamicViscosity.FromMicropascalSeconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="DynamicViscosity.FromMicropascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MicropascalSeconds(this decimal? value) => DynamicViscosity.FromMicropascalSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static DynamicViscosity? MicropascalSeconds<T>(this T? value) where T : struct => DynamicViscosity.FromMicropascalSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillipascalSecond
 
         /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MillipascalSeconds(this int value) => DynamicViscosity.FromMillipascalSeconds(value);
+        public static DynamicViscosity MillipascalSeconds<T>(this T value) => DynamicViscosity.FromMillipascalSeconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MillipascalSeconds(this int? value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MillipascalSeconds(this long value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MillipascalSeconds(this long? value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MillipascalSeconds(this double value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MillipascalSeconds(this double? value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MillipascalSeconds(this float value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MillipascalSeconds(this float? value) => DynamicViscosity.FromMillipascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity MillipascalSeconds(this decimal value) => DynamicViscosity.FromMillipascalSeconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="DynamicViscosity.FromMillipascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? MillipascalSeconds(this decimal? value) => DynamicViscosity.FromMillipascalSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static DynamicViscosity? MillipascalSeconds<T>(this T? value) where T : struct => DynamicViscosity.FromMillipascalSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonSecondPerMeterSquared
 
         /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity NewtonSecondsPerMeterSquared(this int value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
+        public static DynamicViscosity NewtonSecondsPerMeterSquared<T>(this T value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? NewtonSecondsPerMeterSquared(this int? value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity NewtonSecondsPerMeterSquared(this long value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? NewtonSecondsPerMeterSquared(this long? value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity NewtonSecondsPerMeterSquared(this double value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? NewtonSecondsPerMeterSquared(this double? value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity NewtonSecondsPerMeterSquared(this float value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? NewtonSecondsPerMeterSquared(this float? value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity NewtonSecondsPerMeterSquared(this decimal value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="DynamicViscosity.FromNewtonSecondsPerMeterSquared(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? NewtonSecondsPerMeterSquared(this decimal? value) => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static DynamicViscosity? NewtonSecondsPerMeterSquared<T>(this T? value) where T : struct => DynamicViscosity.FromNewtonSecondsPerMeterSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PascalSecond
 
         /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity PascalSeconds(this int value) => DynamicViscosity.FromPascalSeconds(value);
+        public static DynamicViscosity PascalSeconds<T>(this T value) => DynamicViscosity.FromPascalSeconds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? PascalSeconds(this int? value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity PascalSeconds(this long value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? PascalSeconds(this long? value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity PascalSeconds(this double value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? PascalSeconds(this double? value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity PascalSeconds(this float value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? PascalSeconds(this float? value) => DynamicViscosity.FromPascalSeconds(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity PascalSeconds(this decimal value) => DynamicViscosity.FromPascalSeconds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="DynamicViscosity.FromPascalSeconds(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? PascalSeconds(this decimal? value) => DynamicViscosity.FromPascalSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static DynamicViscosity? PascalSeconds<T>(this T? value) where T : struct => DynamicViscosity.FromPascalSeconds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Poise
 
         /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Poise(this int value) => DynamicViscosity.FromPoise(value);
+        public static DynamicViscosity Poise<T>(this T value) => DynamicViscosity.FromPoise(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Poise(this int? value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Poise(this long value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Poise(this long? value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Poise(this double value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Poise(this double? value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Poise(this float value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Poise(this float? value) => DynamicViscosity.FromPoise(value);
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity Poise(this decimal value) => DynamicViscosity.FromPoise(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="DynamicViscosity.FromPoise(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity? Poise(this decimal? value) => DynamicViscosity.FromPoise(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static DynamicViscosity? Poise<T>(this T? value) where T : struct => DynamicViscosity.FromPoise(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricAdmittanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricAdmittanceExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToElectricAdmittance
         #region Microsiemens
 
         /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Microsiemens(this int value) => ElectricAdmittance.FromMicrosiemens(value);
+        public static ElectricAdmittance Microsiemens<T>(this T value) => ElectricAdmittance.FromMicrosiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Microsiemens(this int? value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Microsiemens(this long value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Microsiemens(this long? value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Microsiemens(this double value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Microsiemens(this double? value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Microsiemens(this float value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Microsiemens(this float? value) => ElectricAdmittance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Microsiemens(this decimal value) => ElectricAdmittance.FromMicrosiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Microsiemens(this decimal? value) => ElectricAdmittance.FromMicrosiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricAdmittance? Microsiemens<T>(this T? value) where T : struct => ElectricAdmittance.FromMicrosiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millisiemens
 
         /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Millisiemens(this int value) => ElectricAdmittance.FromMillisiemens(value);
+        public static ElectricAdmittance Millisiemens<T>(this T value) => ElectricAdmittance.FromMillisiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Millisiemens(this int? value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Millisiemens(this long value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Millisiemens(this long? value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Millisiemens(this double value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Millisiemens(this double? value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Millisiemens(this float value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Millisiemens(this float? value) => ElectricAdmittance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Millisiemens(this decimal value) => ElectricAdmittance.FromMillisiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricAdmittance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Millisiemens(this decimal? value) => ElectricAdmittance.FromMillisiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricAdmittance? Millisiemens<T>(this T? value) where T : struct => ElectricAdmittance.FromMillisiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanosiemens
 
         /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Nanosiemens(this int value) => ElectricAdmittance.FromNanosiemens(value);
+        public static ElectricAdmittance Nanosiemens<T>(this T value) => ElectricAdmittance.FromNanosiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Nanosiemens(this int? value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Nanosiemens(this long value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Nanosiemens(this long? value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Nanosiemens(this double value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Nanosiemens(this double? value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Nanosiemens(this float value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Nanosiemens(this float? value) => ElectricAdmittance.FromNanosiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Nanosiemens(this decimal value) => ElectricAdmittance.FromNanosiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricAdmittance.FromNanosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Nanosiemens(this decimal? value) => ElectricAdmittance.FromNanosiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricAdmittance? Nanosiemens<T>(this T? value) where T : struct => ElectricAdmittance.FromNanosiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Siemens
 
         /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Siemens(this int value) => ElectricAdmittance.FromSiemens(value);
+        public static ElectricAdmittance Siemens<T>(this T value) => ElectricAdmittance.FromSiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Siemens(this int? value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Siemens(this long value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Siemens(this long? value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Siemens(this double value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Siemens(this double? value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Siemens(this float value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Siemens(this float? value) => ElectricAdmittance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance Siemens(this decimal value) => ElectricAdmittance.FromSiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricAdmittance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricAdmittance? Siemens(this decimal? value) => ElectricAdmittance.FromSiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricAdmittance? Siemens<T>(this T? value) where T : struct => ElectricAdmittance.FromSiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricChargeDensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricChargeDensityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricChargeDensity
         #region CoulombPerCubicMeter
 
         /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity CoulombsPerCubicMeter(this int value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
+        public static ElectricChargeDensity CoulombsPerCubicMeter<T>(this T value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity? CoulombsPerCubicMeter(this int? value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity CoulombsPerCubicMeter(this long value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity? CoulombsPerCubicMeter(this long? value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity CoulombsPerCubicMeter(this double value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity? CoulombsPerCubicMeter(this double? value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity CoulombsPerCubicMeter(this float value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity? CoulombsPerCubicMeter(this float? value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value);
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity CoulombsPerCubicMeter(this decimal value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricChargeDensity.FromCoulombsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static ElectricChargeDensity? CoulombsPerCubicMeter(this decimal? value) => ElectricChargeDensity.FromCoulombsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricChargeDensity? CoulombsPerCubicMeter<T>(this T? value) where T : struct => ElectricChargeDensity.FromCoulombsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricChargeExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricChargeExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricCharge
         #region Coulomb
 
         /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge Coulombs(this int value) => ElectricCharge.FromCoulombs(value);
+        public static ElectricCharge Coulombs<T>(this T value) => ElectricCharge.FromCoulombs(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge? Coulombs(this int? value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge Coulombs(this long value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge? Coulombs(this long? value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge Coulombs(this double value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge? Coulombs(this double? value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge Coulombs(this float value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge? Coulombs(this float? value) => ElectricCharge.FromCoulombs(value);
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge Coulombs(this decimal value) => ElectricCharge.FromCoulombs(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCharge.FromCoulombs(UnitsNet.QuantityValue)" />
-        public static ElectricCharge? Coulombs(this decimal? value) => ElectricCharge.FromCoulombs(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCharge? Coulombs<T>(this T? value) where T : struct => ElectricCharge.FromCoulombs(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricConductanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricConductanceExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToElectricConductance
         #region Microsiemens
 
         /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Microsiemens(this int value) => ElectricConductance.FromMicrosiemens(value);
+        public static ElectricConductance Microsiemens<T>(this T value) => ElectricConductance.FromMicrosiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Microsiemens(this int? value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Microsiemens(this long value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Microsiemens(this long? value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Microsiemens(this double value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Microsiemens(this double? value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Microsiemens(this float value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Microsiemens(this float? value) => ElectricConductance.FromMicrosiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Microsiemens(this decimal value) => ElectricConductance.FromMicrosiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricConductance.FromMicrosiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Microsiemens(this decimal? value) => ElectricConductance.FromMicrosiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricConductance? Microsiemens<T>(this T? value) where T : struct => ElectricConductance.FromMicrosiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millisiemens
 
         /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Millisiemens(this int value) => ElectricConductance.FromMillisiemens(value);
+        public static ElectricConductance Millisiemens<T>(this T value) => ElectricConductance.FromMillisiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Millisiemens(this int? value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Millisiemens(this long value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Millisiemens(this long? value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Millisiemens(this double value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Millisiemens(this double? value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Millisiemens(this float value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Millisiemens(this float? value) => ElectricConductance.FromMillisiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Millisiemens(this decimal value) => ElectricConductance.FromMillisiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricConductance.FromMillisiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Millisiemens(this decimal? value) => ElectricConductance.FromMillisiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricConductance? Millisiemens<T>(this T? value) where T : struct => ElectricConductance.FromMillisiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Siemens
 
         /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Siemens(this int value) => ElectricConductance.FromSiemens(value);
+        public static ElectricConductance Siemens<T>(this T value) => ElectricConductance.FromSiemens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Siemens(this int? value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Siemens(this long value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Siemens(this long? value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Siemens(this double value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Siemens(this double? value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Siemens(this float value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Siemens(this float? value) => ElectricConductance.FromSiemens(value);
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance Siemens(this decimal value) => ElectricConductance.FromSiemens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricConductance.FromSiemens(UnitsNet.QuantityValue)" />
-        public static ElectricConductance? Siemens(this decimal? value) => ElectricConductance.FromSiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricConductance? Siemens<T>(this T? value) where T : struct => ElectricConductance.FromSiemens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricConductivityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricConductivityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricConductivity
         #region SiemensPerMeter
 
         /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity SiemensPerMeter(this int value) => ElectricConductivity.FromSiemensPerMeter(value);
+        public static ElectricConductivity SiemensPerMeter<T>(this T value) => ElectricConductivity.FromSiemensPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity? SiemensPerMeter(this int? value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity SiemensPerMeter(this long value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity? SiemensPerMeter(this long? value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity SiemensPerMeter(this double value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity? SiemensPerMeter(this double? value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity SiemensPerMeter(this float value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity? SiemensPerMeter(this float? value) => ElectricConductivity.FromSiemensPerMeter(value);
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity SiemensPerMeter(this decimal value) => ElectricConductivity.FromSiemensPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricConductivity? SiemensPerMeter(this decimal? value) => ElectricConductivity.FromSiemensPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricConductivity? SiemensPerMeter<T>(this T? value) where T : struct => ElectricConductivity.FromSiemensPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricCurrentDensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricCurrentDensityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricCurrentDensity
         #region AmperePerSquareMeter
 
         /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity AmperesPerSquareMeter(this int value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
+        public static ElectricCurrentDensity AmperesPerSquareMeter<T>(this T value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity? AmperesPerSquareMeter(this int? value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity AmperesPerSquareMeter(this long value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity? AmperesPerSquareMeter(this long? value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity AmperesPerSquareMeter(this double value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity? AmperesPerSquareMeter(this double? value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity AmperesPerSquareMeter(this float value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity? AmperesPerSquareMeter(this float? value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value);
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity AmperesPerSquareMeter(this decimal value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrentDensity.FromAmperesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentDensity? AmperesPerSquareMeter(this decimal? value) => ElectricCurrentDensity.FromAmperesPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrentDensity? AmperesPerSquareMeter<T>(this T? value) where T : struct => ElectricCurrentDensity.FromAmperesPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricCurrentExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricCurrentExtensions.g.cs
@@ -47,272 +47,80 @@ namespace UnitsNet.Extensions.NumberToElectricCurrent
         #region Ampere
 
         /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Amperes(this int value) => ElectricCurrent.FromAmperes(value);
+        public static ElectricCurrent Amperes<T>(this T value) => ElectricCurrent.FromAmperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Amperes(this int? value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Amperes(this long value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Amperes(this long? value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Amperes(this double value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Amperes(this double? value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Amperes(this float value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Amperes(this float? value) => ElectricCurrent.FromAmperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Amperes(this decimal value) => ElectricCurrent.FromAmperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromAmperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Amperes(this decimal? value) => ElectricCurrent.FromAmperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Amperes<T>(this T? value) where T : struct => ElectricCurrent.FromAmperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Centiampere
 
         /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Centiamperes(this int value) => ElectricCurrent.FromCentiamperes(value);
+        public static ElectricCurrent Centiamperes<T>(this T value) => ElectricCurrent.FromCentiamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Centiamperes(this int? value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Centiamperes(this long value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Centiamperes(this long? value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Centiamperes(this double value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Centiamperes(this double? value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Centiamperes(this float value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Centiamperes(this float? value) => ElectricCurrent.FromCentiamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Centiamperes(this decimal value) => ElectricCurrent.FromCentiamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromCentiamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Centiamperes(this decimal? value) => ElectricCurrent.FromCentiamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Centiamperes<T>(this T? value) where T : struct => ElectricCurrent.FromCentiamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kiloampere
 
         /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Kiloamperes(this int value) => ElectricCurrent.FromKiloamperes(value);
+        public static ElectricCurrent Kiloamperes<T>(this T value) => ElectricCurrent.FromKiloamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Kiloamperes(this int? value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Kiloamperes(this long value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Kiloamperes(this long? value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Kiloamperes(this double value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Kiloamperes(this double? value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Kiloamperes(this float value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Kiloamperes(this float? value) => ElectricCurrent.FromKiloamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Kiloamperes(this decimal value) => ElectricCurrent.FromKiloamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromKiloamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Kiloamperes(this decimal? value) => ElectricCurrent.FromKiloamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Kiloamperes<T>(this T? value) where T : struct => ElectricCurrent.FromKiloamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megaampere
 
         /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Megaamperes(this int value) => ElectricCurrent.FromMegaamperes(value);
+        public static ElectricCurrent Megaamperes<T>(this T value) => ElectricCurrent.FromMegaamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Megaamperes(this int? value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Megaamperes(this long value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Megaamperes(this long? value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Megaamperes(this double value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Megaamperes(this double? value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Megaamperes(this float value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Megaamperes(this float? value) => ElectricCurrent.FromMegaamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Megaamperes(this decimal value) => ElectricCurrent.FromMegaamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromMegaamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Megaamperes(this decimal? value) => ElectricCurrent.FromMegaamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Megaamperes<T>(this T? value) where T : struct => ElectricCurrent.FromMegaamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microampere
 
         /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Microamperes(this int value) => ElectricCurrent.FromMicroamperes(value);
+        public static ElectricCurrent Microamperes<T>(this T value) => ElectricCurrent.FromMicroamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Microamperes(this int? value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Microamperes(this long value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Microamperes(this long? value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Microamperes(this double value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Microamperes(this double? value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Microamperes(this float value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Microamperes(this float? value) => ElectricCurrent.FromMicroamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Microamperes(this decimal value) => ElectricCurrent.FromMicroamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromMicroamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Microamperes(this decimal? value) => ElectricCurrent.FromMicroamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Microamperes<T>(this T? value) where T : struct => ElectricCurrent.FromMicroamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Milliampere
 
         /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Milliamperes(this int value) => ElectricCurrent.FromMilliamperes(value);
+        public static ElectricCurrent Milliamperes<T>(this T value) => ElectricCurrent.FromMilliamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Milliamperes(this int? value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Milliamperes(this long value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Milliamperes(this long? value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Milliamperes(this double value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Milliamperes(this double? value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Milliamperes(this float value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Milliamperes(this float? value) => ElectricCurrent.FromMilliamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Milliamperes(this decimal value) => ElectricCurrent.FromMilliamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromMilliamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Milliamperes(this decimal? value) => ElectricCurrent.FromMilliamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Milliamperes<T>(this T? value) where T : struct => ElectricCurrent.FromMilliamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanoampere
 
         /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Nanoamperes(this int value) => ElectricCurrent.FromNanoamperes(value);
+        public static ElectricCurrent Nanoamperes<T>(this T value) => ElectricCurrent.FromNanoamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Nanoamperes(this int? value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Nanoamperes(this long value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Nanoamperes(this long? value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Nanoamperes(this double value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Nanoamperes(this double? value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Nanoamperes(this float value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Nanoamperes(this float? value) => ElectricCurrent.FromNanoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Nanoamperes(this decimal value) => ElectricCurrent.FromNanoamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromNanoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Nanoamperes(this decimal? value) => ElectricCurrent.FromNanoamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Nanoamperes<T>(this T? value) where T : struct => ElectricCurrent.FromNanoamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Picoampere
 
         /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Picoamperes(this int value) => ElectricCurrent.FromPicoamperes(value);
+        public static ElectricCurrent Picoamperes<T>(this T value) => ElectricCurrent.FromPicoamperes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Picoamperes(this int? value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Picoamperes(this long value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Picoamperes(this long? value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Picoamperes(this double value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Picoamperes(this double? value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Picoamperes(this float value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Picoamperes(this float? value) => ElectricCurrent.FromPicoamperes(value);
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent Picoamperes(this decimal value) => ElectricCurrent.FromPicoamperes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrent.FromPicoamperes(UnitsNet.QuantityValue)" />
-        public static ElectricCurrent? Picoamperes(this decimal? value) => ElectricCurrent.FromPicoamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrent? Picoamperes<T>(this T? value) where T : struct => ElectricCurrent.FromPicoamperes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricCurrentGradientExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricCurrentGradientExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricCurrentGradient
         #region AmperePerSecond
 
         /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient AmperesPerSecond(this int value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
+        public static ElectricCurrentGradient AmperesPerSecond<T>(this T value) => ElectricCurrentGradient.FromAmperesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient? AmperesPerSecond(this int? value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient AmperesPerSecond(this long value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient? AmperesPerSecond(this long? value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient AmperesPerSecond(this double value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient? AmperesPerSecond(this double? value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient AmperesPerSecond(this float value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient? AmperesPerSecond(this float? value) => ElectricCurrentGradient.FromAmperesPerSecond(value);
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient AmperesPerSecond(this decimal value) => ElectricCurrentGradient.FromAmperesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
-        public static ElectricCurrentGradient? AmperesPerSecond(this decimal? value) => ElectricCurrentGradient.FromAmperesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricCurrentGradient? AmperesPerSecond<T>(this T? value) where T : struct => ElectricCurrentGradient.FromAmperesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricFieldExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricFieldExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricField
         #region VoltPerMeter
 
         /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField VoltsPerMeter(this int value) => ElectricField.FromVoltsPerMeter(value);
+        public static ElectricField VoltsPerMeter<T>(this T value) => ElectricField.FromVoltsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField? VoltsPerMeter(this int? value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField VoltsPerMeter(this long value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField? VoltsPerMeter(this long? value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField VoltsPerMeter(this double value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField? VoltsPerMeter(this double? value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField VoltsPerMeter(this float value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField? VoltsPerMeter(this float? value) => ElectricField.FromVoltsPerMeter(value);
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField VoltsPerMeter(this decimal value) => ElectricField.FromVoltsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricField.FromVoltsPerMeter(UnitsNet.QuantityValue)" />
-        public static ElectricField? VoltsPerMeter(this decimal? value) => ElectricField.FromVoltsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricField? VoltsPerMeter<T>(this T? value) where T : struct => ElectricField.FromVoltsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricInductanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricInductanceExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToElectricInductance
         #region Henry
 
         /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance Henries(this int value) => ElectricInductance.FromHenries(value);
+        public static ElectricInductance Henries<T>(this T value) => ElectricInductance.FromHenries(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance? Henries(this int? value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance Henries(this long value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance? Henries(this long? value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance Henries(this double value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance? Henries(this double? value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance Henries(this float value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance? Henries(this float? value) => ElectricInductance.FromHenries(value);
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance Henries(this decimal value) => ElectricInductance.FromHenries(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricInductance.FromHenries(UnitsNet.QuantityValue)" />
-        public static ElectricInductance? Henries(this decimal? value) => ElectricInductance.FromHenries(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricInductance? Henries<T>(this T? value) where T : struct => ElectricInductance.FromHenries(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricPotentialAcExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricPotentialAcExtensions.g.cs
@@ -47,170 +47,50 @@ namespace UnitsNet.Extensions.NumberToElectricPotentialAc
         #region KilovoltAc
 
         /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc KilovoltsAc(this int value) => ElectricPotentialAc.FromKilovoltsAc(value);
+        public static ElectricPotentialAc KilovoltsAc<T>(this T value) => ElectricPotentialAc.FromKilovoltsAc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? KilovoltsAc(this int? value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc KilovoltsAc(this long value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? KilovoltsAc(this long? value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc KilovoltsAc(this double value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? KilovoltsAc(this double? value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc KilovoltsAc(this float value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? KilovoltsAc(this float? value) => ElectricPotentialAc.FromKilovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc KilovoltsAc(this decimal value) => ElectricPotentialAc.FromKilovoltsAc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromKilovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? KilovoltsAc(this decimal? value) => ElectricPotentialAc.FromKilovoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialAc? KilovoltsAc<T>(this T? value) where T : struct => ElectricPotentialAc.FromKilovoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegavoltAc
 
         /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MegavoltsAc(this int value) => ElectricPotentialAc.FromMegavoltsAc(value);
+        public static ElectricPotentialAc MegavoltsAc<T>(this T value) => ElectricPotentialAc.FromMegavoltsAc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MegavoltsAc(this int? value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MegavoltsAc(this long value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MegavoltsAc(this long? value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MegavoltsAc(this double value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MegavoltsAc(this double? value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MegavoltsAc(this float value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MegavoltsAc(this float? value) => ElectricPotentialAc.FromMegavoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MegavoltsAc(this decimal value) => ElectricPotentialAc.FromMegavoltsAc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMegavoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MegavoltsAc(this decimal? value) => ElectricPotentialAc.FromMegavoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialAc? MegavoltsAc<T>(this T? value) where T : struct => ElectricPotentialAc.FromMegavoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrovoltAc
 
         /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MicrovoltsAc(this int value) => ElectricPotentialAc.FromMicrovoltsAc(value);
+        public static ElectricPotentialAc MicrovoltsAc<T>(this T value) => ElectricPotentialAc.FromMicrovoltsAc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MicrovoltsAc(this int? value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MicrovoltsAc(this long value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MicrovoltsAc(this long? value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MicrovoltsAc(this double value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MicrovoltsAc(this double? value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MicrovoltsAc(this float value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MicrovoltsAc(this float? value) => ElectricPotentialAc.FromMicrovoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MicrovoltsAc(this decimal value) => ElectricPotentialAc.FromMicrovoltsAc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMicrovoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MicrovoltsAc(this decimal? value) => ElectricPotentialAc.FromMicrovoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialAc? MicrovoltsAc<T>(this T? value) where T : struct => ElectricPotentialAc.FromMicrovoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillivoltAc
 
         /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MillivoltsAc(this int value) => ElectricPotentialAc.FromMillivoltsAc(value);
+        public static ElectricPotentialAc MillivoltsAc<T>(this T value) => ElectricPotentialAc.FromMillivoltsAc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MillivoltsAc(this int? value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MillivoltsAc(this long value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MillivoltsAc(this long? value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MillivoltsAc(this double value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MillivoltsAc(this double? value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MillivoltsAc(this float value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MillivoltsAc(this float? value) => ElectricPotentialAc.FromMillivoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc MillivoltsAc(this decimal value) => ElectricPotentialAc.FromMillivoltsAc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromMillivoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? MillivoltsAc(this decimal? value) => ElectricPotentialAc.FromMillivoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialAc? MillivoltsAc<T>(this T? value) where T : struct => ElectricPotentialAc.FromMillivoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region VoltAc
 
         /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc VoltsAc(this int value) => ElectricPotentialAc.FromVoltsAc(value);
+        public static ElectricPotentialAc VoltsAc<T>(this T value) => ElectricPotentialAc.FromVoltsAc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? VoltsAc(this int? value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc VoltsAc(this long value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? VoltsAc(this long? value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc VoltsAc(this double value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? VoltsAc(this double? value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc VoltsAc(this float value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? VoltsAc(this float? value) => ElectricPotentialAc.FromVoltsAc(value);
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc VoltsAc(this decimal value) => ElectricPotentialAc.FromVoltsAc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialAc.FromVoltsAc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialAc? VoltsAc(this decimal? value) => ElectricPotentialAc.FromVoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialAc? VoltsAc<T>(this T? value) where T : struct => ElectricPotentialAc.FromVoltsAc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricPotentialDcExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricPotentialDcExtensions.g.cs
@@ -47,170 +47,50 @@ namespace UnitsNet.Extensions.NumberToElectricPotentialDc
         #region KilovoltDc
 
         /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc KilovoltsDc(this int value) => ElectricPotentialDc.FromKilovoltsDc(value);
+        public static ElectricPotentialDc KilovoltsDc<T>(this T value) => ElectricPotentialDc.FromKilovoltsDc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? KilovoltsDc(this int? value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc KilovoltsDc(this long value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? KilovoltsDc(this long? value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc KilovoltsDc(this double value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? KilovoltsDc(this double? value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc KilovoltsDc(this float value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? KilovoltsDc(this float? value) => ElectricPotentialDc.FromKilovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc KilovoltsDc(this decimal value) => ElectricPotentialDc.FromKilovoltsDc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromKilovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? KilovoltsDc(this decimal? value) => ElectricPotentialDc.FromKilovoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialDc? KilovoltsDc<T>(this T? value) where T : struct => ElectricPotentialDc.FromKilovoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegavoltDc
 
         /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MegavoltsDc(this int value) => ElectricPotentialDc.FromMegavoltsDc(value);
+        public static ElectricPotentialDc MegavoltsDc<T>(this T value) => ElectricPotentialDc.FromMegavoltsDc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MegavoltsDc(this int? value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MegavoltsDc(this long value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MegavoltsDc(this long? value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MegavoltsDc(this double value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MegavoltsDc(this double? value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MegavoltsDc(this float value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MegavoltsDc(this float? value) => ElectricPotentialDc.FromMegavoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MegavoltsDc(this decimal value) => ElectricPotentialDc.FromMegavoltsDc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMegavoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MegavoltsDc(this decimal? value) => ElectricPotentialDc.FromMegavoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialDc? MegavoltsDc<T>(this T? value) where T : struct => ElectricPotentialDc.FromMegavoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrovoltDc
 
         /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MicrovoltsDc(this int value) => ElectricPotentialDc.FromMicrovoltsDc(value);
+        public static ElectricPotentialDc MicrovoltsDc<T>(this T value) => ElectricPotentialDc.FromMicrovoltsDc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MicrovoltsDc(this int? value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MicrovoltsDc(this long value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MicrovoltsDc(this long? value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MicrovoltsDc(this double value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MicrovoltsDc(this double? value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MicrovoltsDc(this float value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MicrovoltsDc(this float? value) => ElectricPotentialDc.FromMicrovoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MicrovoltsDc(this decimal value) => ElectricPotentialDc.FromMicrovoltsDc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMicrovoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MicrovoltsDc(this decimal? value) => ElectricPotentialDc.FromMicrovoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialDc? MicrovoltsDc<T>(this T? value) where T : struct => ElectricPotentialDc.FromMicrovoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillivoltDc
 
         /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MillivoltsDc(this int value) => ElectricPotentialDc.FromMillivoltsDc(value);
+        public static ElectricPotentialDc MillivoltsDc<T>(this T value) => ElectricPotentialDc.FromMillivoltsDc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MillivoltsDc(this int? value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MillivoltsDc(this long value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MillivoltsDc(this long? value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MillivoltsDc(this double value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MillivoltsDc(this double? value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MillivoltsDc(this float value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MillivoltsDc(this float? value) => ElectricPotentialDc.FromMillivoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc MillivoltsDc(this decimal value) => ElectricPotentialDc.FromMillivoltsDc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromMillivoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? MillivoltsDc(this decimal? value) => ElectricPotentialDc.FromMillivoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialDc? MillivoltsDc<T>(this T? value) where T : struct => ElectricPotentialDc.FromMillivoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region VoltDc
 
         /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc VoltsDc(this int value) => ElectricPotentialDc.FromVoltsDc(value);
+        public static ElectricPotentialDc VoltsDc<T>(this T value) => ElectricPotentialDc.FromVoltsDc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? VoltsDc(this int? value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc VoltsDc(this long value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? VoltsDc(this long? value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc VoltsDc(this double value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? VoltsDc(this double? value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc VoltsDc(this float value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? VoltsDc(this float? value) => ElectricPotentialDc.FromVoltsDc(value);
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc VoltsDc(this decimal value) => ElectricPotentialDc.FromVoltsDc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotentialDc.FromVoltsDc(UnitsNet.QuantityValue)" />
-        public static ElectricPotentialDc? VoltsDc(this decimal? value) => ElectricPotentialDc.FromVoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotentialDc? VoltsDc<T>(this T? value) where T : struct => ElectricPotentialDc.FromVoltsDc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricPotentialExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricPotentialExtensions.g.cs
@@ -47,170 +47,50 @@ namespace UnitsNet.Extensions.NumberToElectricPotential
         #region Kilovolt
 
         /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Kilovolts(this int value) => ElectricPotential.FromKilovolts(value);
+        public static ElectricPotential Kilovolts<T>(this T value) => ElectricPotential.FromKilovolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Kilovolts(this int? value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Kilovolts(this long value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Kilovolts(this long? value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Kilovolts(this double value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Kilovolts(this double? value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Kilovolts(this float value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Kilovolts(this float? value) => ElectricPotential.FromKilovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Kilovolts(this decimal value) => ElectricPotential.FromKilovolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotential.FromKilovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Kilovolts(this decimal? value) => ElectricPotential.FromKilovolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotential? Kilovolts<T>(this T? value) where T : struct => ElectricPotential.FromKilovolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megavolt
 
         /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Megavolts(this int value) => ElectricPotential.FromMegavolts(value);
+        public static ElectricPotential Megavolts<T>(this T value) => ElectricPotential.FromMegavolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Megavolts(this int? value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Megavolts(this long value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Megavolts(this long? value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Megavolts(this double value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Megavolts(this double? value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Megavolts(this float value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Megavolts(this float? value) => ElectricPotential.FromMegavolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Megavolts(this decimal value) => ElectricPotential.FromMegavolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotential.FromMegavolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Megavolts(this decimal? value) => ElectricPotential.FromMegavolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotential? Megavolts<T>(this T? value) where T : struct => ElectricPotential.FromMegavolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microvolt
 
         /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Microvolts(this int value) => ElectricPotential.FromMicrovolts(value);
+        public static ElectricPotential Microvolts<T>(this T value) => ElectricPotential.FromMicrovolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Microvolts(this int? value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Microvolts(this long value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Microvolts(this long? value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Microvolts(this double value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Microvolts(this double? value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Microvolts(this float value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Microvolts(this float? value) => ElectricPotential.FromMicrovolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Microvolts(this decimal value) => ElectricPotential.FromMicrovolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotential.FromMicrovolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Microvolts(this decimal? value) => ElectricPotential.FromMicrovolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotential? Microvolts<T>(this T? value) where T : struct => ElectricPotential.FromMicrovolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millivolt
 
         /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Millivolts(this int value) => ElectricPotential.FromMillivolts(value);
+        public static ElectricPotential Millivolts<T>(this T value) => ElectricPotential.FromMillivolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Millivolts(this int? value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Millivolts(this long value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Millivolts(this long? value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Millivolts(this double value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Millivolts(this double? value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Millivolts(this float value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Millivolts(this float? value) => ElectricPotential.FromMillivolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Millivolts(this decimal value) => ElectricPotential.FromMillivolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotential.FromMillivolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Millivolts(this decimal? value) => ElectricPotential.FromMillivolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotential? Millivolts<T>(this T? value) where T : struct => ElectricPotential.FromMillivolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Volt
 
         /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Volts(this int value) => ElectricPotential.FromVolts(value);
+        public static ElectricPotential Volts<T>(this T value) => ElectricPotential.FromVolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Volts(this int? value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Volts(this long value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Volts(this long? value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Volts(this double value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Volts(this double? value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Volts(this float value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Volts(this float? value) => ElectricPotential.FromVolts(value);
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential Volts(this decimal value) => ElectricPotential.FromVolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricPotential.FromVolts(UnitsNet.QuantityValue)" />
-        public static ElectricPotential? Volts(this decimal? value) => ElectricPotential.FromVolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricPotential? Volts<T>(this T? value) where T : struct => ElectricPotential.FromVolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricResistanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricResistanceExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToElectricResistance
         #region Kiloohm
 
         /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Kiloohms(this int value) => ElectricResistance.FromKiloohms(value);
+        public static ElectricResistance Kiloohms<T>(this T value) => ElectricResistance.FromKiloohms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Kiloohms(this int? value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Kiloohms(this long value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Kiloohms(this long? value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Kiloohms(this double value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Kiloohms(this double? value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Kiloohms(this float value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Kiloohms(this float? value) => ElectricResistance.FromKiloohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Kiloohms(this decimal value) => ElectricResistance.FromKiloohms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistance.FromKiloohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Kiloohms(this decimal? value) => ElectricResistance.FromKiloohms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistance? Kiloohms<T>(this T? value) where T : struct => ElectricResistance.FromKiloohms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megaohm
 
         /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Megaohms(this int value) => ElectricResistance.FromMegaohms(value);
+        public static ElectricResistance Megaohms<T>(this T value) => ElectricResistance.FromMegaohms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Megaohms(this int? value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Megaohms(this long value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Megaohms(this long? value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Megaohms(this double value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Megaohms(this double? value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Megaohms(this float value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Megaohms(this float? value) => ElectricResistance.FromMegaohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Megaohms(this decimal value) => ElectricResistance.FromMegaohms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistance.FromMegaohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Megaohms(this decimal? value) => ElectricResistance.FromMegaohms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistance? Megaohms<T>(this T? value) where T : struct => ElectricResistance.FromMegaohms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Milliohm
 
         /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Milliohms(this int value) => ElectricResistance.FromMilliohms(value);
+        public static ElectricResistance Milliohms<T>(this T value) => ElectricResistance.FromMilliohms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Milliohms(this int? value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Milliohms(this long value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Milliohms(this long? value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Milliohms(this double value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Milliohms(this double? value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Milliohms(this float value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Milliohms(this float? value) => ElectricResistance.FromMilliohms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Milliohms(this decimal value) => ElectricResistance.FromMilliohms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistance.FromMilliohms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Milliohms(this decimal? value) => ElectricResistance.FromMilliohms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistance? Milliohms<T>(this T? value) where T : struct => ElectricResistance.FromMilliohms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Ohm
 
         /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Ohms(this int value) => ElectricResistance.FromOhms(value);
+        public static ElectricResistance Ohms<T>(this T value) => ElectricResistance.FromOhms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Ohms(this int? value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Ohms(this long value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Ohms(this long? value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Ohms(this double value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Ohms(this double? value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Ohms(this float value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Ohms(this float? value) => ElectricResistance.FromOhms(value);
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance Ohms(this decimal value) => ElectricResistance.FromOhms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistance.FromOhms(UnitsNet.QuantityValue)" />
-        public static ElectricResistance? Ohms(this decimal? value) => ElectricResistance.FromOhms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistance? Ohms<T>(this T? value) where T : struct => ElectricResistance.FromOhms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricResistivityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToElectricResistivityExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToElectricResistivity
         #region MicroohmMeter
 
         /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MicroohmMeters(this int value) => ElectricResistivity.FromMicroohmMeters(value);
+        public static ElectricResistivity MicroohmMeters<T>(this T value) => ElectricResistivity.FromMicroohmMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MicroohmMeters(this int? value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MicroohmMeters(this long value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MicroohmMeters(this long? value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MicroohmMeters(this double value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MicroohmMeters(this double? value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MicroohmMeters(this float value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MicroohmMeters(this float? value) => ElectricResistivity.FromMicroohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MicroohmMeters(this decimal value) => ElectricResistivity.FromMicroohmMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistivity.FromMicroohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MicroohmMeters(this decimal? value) => ElectricResistivity.FromMicroohmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistivity? MicroohmMeters<T>(this T? value) where T : struct => ElectricResistivity.FromMicroohmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliohmMeter
 
         /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MilliohmMeters(this int value) => ElectricResistivity.FromMilliohmMeters(value);
+        public static ElectricResistivity MilliohmMeters<T>(this T value) => ElectricResistivity.FromMilliohmMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MilliohmMeters(this int? value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MilliohmMeters(this long value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MilliohmMeters(this long? value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MilliohmMeters(this double value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MilliohmMeters(this double? value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MilliohmMeters(this float value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MilliohmMeters(this float? value) => ElectricResistivity.FromMilliohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity MilliohmMeters(this decimal value) => ElectricResistivity.FromMilliohmMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistivity.FromMilliohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? MilliohmMeters(this decimal? value) => ElectricResistivity.FromMilliohmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistivity? MilliohmMeters<T>(this T? value) where T : struct => ElectricResistivity.FromMilliohmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanoohmMeter
 
         /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity NanoohmMeters(this int value) => ElectricResistivity.FromNanoohmMeters(value);
+        public static ElectricResistivity NanoohmMeters<T>(this T value) => ElectricResistivity.FromNanoohmMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? NanoohmMeters(this int? value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity NanoohmMeters(this long value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? NanoohmMeters(this long? value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity NanoohmMeters(this double value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? NanoohmMeters(this double? value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity NanoohmMeters(this float value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? NanoohmMeters(this float? value) => ElectricResistivity.FromNanoohmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity NanoohmMeters(this decimal value) => ElectricResistivity.FromNanoohmMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistivity.FromNanoohmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? NanoohmMeters(this decimal? value) => ElectricResistivity.FromNanoohmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistivity? NanoohmMeters<T>(this T? value) where T : struct => ElectricResistivity.FromNanoohmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region OhmMeter
 
         /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity OhmMeters(this int value) => ElectricResistivity.FromOhmMeters(value);
+        public static ElectricResistivity OhmMeters<T>(this T value) => ElectricResistivity.FromOhmMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? OhmMeters(this int? value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity OhmMeters(this long value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? OhmMeters(this long? value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity OhmMeters(this double value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? OhmMeters(this double? value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity OhmMeters(this float value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? OhmMeters(this float? value) => ElectricResistivity.FromOhmMeters(value);
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity OhmMeters(this decimal value) => ElectricResistivity.FromOhmMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ElectricResistivity.FromOhmMeters(UnitsNet.QuantityValue)" />
-        public static ElectricResistivity? OhmMeters(this decimal? value) => ElectricResistivity.FromOhmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ElectricResistivity? OhmMeters<T>(this T? value) where T : struct => ElectricResistivity.FromOhmMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToEnergyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToEnergyExtensions.g.cs
@@ -47,748 +47,220 @@ namespace UnitsNet.Extensions.NumberToEnergy
         #region BritishThermalUnit
 
         /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy BritishThermalUnits(this int value) => Energy.FromBritishThermalUnits(value);
+        public static Energy BritishThermalUnits<T>(this T value) => Energy.FromBritishThermalUnits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? BritishThermalUnits(this int? value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy BritishThermalUnits(this long value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? BritishThermalUnits(this long? value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy BritishThermalUnits(this double value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? BritishThermalUnits(this double? value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy BritishThermalUnits(this float value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? BritishThermalUnits(this float? value) => Energy.FromBritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy BritishThermalUnits(this decimal value) => Energy.FromBritishThermalUnits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromBritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? BritishThermalUnits(this decimal? value) => Energy.FromBritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? BritishThermalUnits<T>(this T? value) where T : struct => Energy.FromBritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Calorie
 
         /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy Calories(this int value) => Energy.FromCalories(value);
+        public static Energy Calories<T>(this T value) => Energy.FromCalories(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy? Calories(this int? value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy Calories(this long value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy? Calories(this long? value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy Calories(this double value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy? Calories(this double? value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy Calories(this float value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy? Calories(this float? value) => Energy.FromCalories(value);
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy Calories(this decimal value) => Energy.FromCalories(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromCalories(UnitsNet.QuantityValue)" />
-        public static Energy? Calories(this decimal? value) => Energy.FromCalories(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? Calories<T>(this T? value) where T : struct => Energy.FromCalories(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecathermEc
 
         /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsEc(this int value) => Energy.FromDecathermsEc(value);
+        public static Energy DecathermsEc<T>(this T value) => Energy.FromDecathermsEc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsEc(this int? value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsEc(this long value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsEc(this long? value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsEc(this double value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsEc(this double? value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsEc(this float value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsEc(this float? value) => Energy.FromDecathermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsEc(this decimal value) => Energy.FromDecathermsEc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromDecathermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsEc(this decimal? value) => Energy.FromDecathermsEc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? DecathermsEc<T>(this T? value) where T : struct => Energy.FromDecathermsEc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecathermImperial
 
         /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsImperial(this int value) => Energy.FromDecathermsImperial(value);
+        public static Energy DecathermsImperial<T>(this T value) => Energy.FromDecathermsImperial(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsImperial(this int? value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsImperial(this long value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsImperial(this long? value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsImperial(this double value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsImperial(this double? value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsImperial(this float value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsImperial(this float? value) => Energy.FromDecathermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsImperial(this decimal value) => Energy.FromDecathermsImperial(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromDecathermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsImperial(this decimal? value) => Energy.FromDecathermsImperial(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? DecathermsImperial<T>(this T? value) where T : struct => Energy.FromDecathermsImperial(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecathermUs
 
         /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsUs(this int value) => Energy.FromDecathermsUs(value);
+        public static Energy DecathermsUs<T>(this T value) => Energy.FromDecathermsUs(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsUs(this int? value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsUs(this long value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsUs(this long? value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsUs(this double value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsUs(this double? value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsUs(this float value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsUs(this float? value) => Energy.FromDecathermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy DecathermsUs(this decimal value) => Energy.FromDecathermsUs(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromDecathermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? DecathermsUs(this decimal? value) => Energy.FromDecathermsUs(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? DecathermsUs<T>(this T? value) where T : struct => Energy.FromDecathermsUs(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ElectronVolt
 
         /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy ElectronVolts(this int value) => Energy.FromElectronVolts(value);
+        public static Energy ElectronVolts<T>(this T value) => Energy.FromElectronVolts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy? ElectronVolts(this int? value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy ElectronVolts(this long value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy? ElectronVolts(this long? value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy ElectronVolts(this double value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy? ElectronVolts(this double? value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy ElectronVolts(this float value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy? ElectronVolts(this float? value) => Energy.FromElectronVolts(value);
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy ElectronVolts(this decimal value) => Energy.FromElectronVolts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromElectronVolts(UnitsNet.QuantityValue)" />
-        public static Energy? ElectronVolts(this decimal? value) => Energy.FromElectronVolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? ElectronVolts<T>(this T? value) where T : struct => Energy.FromElectronVolts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Erg
 
         /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy Ergs(this int value) => Energy.FromErgs(value);
+        public static Energy Ergs<T>(this T value) => Energy.FromErgs(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy? Ergs(this int? value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy Ergs(this long value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy? Ergs(this long? value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy Ergs(this double value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy? Ergs(this double? value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy Ergs(this float value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy? Ergs(this float? value) => Energy.FromErgs(value);
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy Ergs(this decimal value) => Energy.FromErgs(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromErgs(UnitsNet.QuantityValue)" />
-        public static Energy? Ergs(this decimal? value) => Energy.FromErgs(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? Ergs<T>(this T? value) where T : struct => Energy.FromErgs(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootPound
 
         /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy FootPounds(this int value) => Energy.FromFootPounds(value);
+        public static Energy FootPounds<T>(this T value) => Energy.FromFootPounds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy? FootPounds(this int? value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy FootPounds(this long value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy? FootPounds(this long? value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy FootPounds(this double value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy? FootPounds(this double? value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy FootPounds(this float value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy? FootPounds(this float? value) => Energy.FromFootPounds(value);
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy FootPounds(this decimal value) => Energy.FromFootPounds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromFootPounds(UnitsNet.QuantityValue)" />
-        public static Energy? FootPounds(this decimal? value) => Energy.FromFootPounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? FootPounds<T>(this T? value) where T : struct => Energy.FromFootPounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigabritishThermalUnit
 
         /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy GigabritishThermalUnits(this int value) => Energy.FromGigabritishThermalUnits(value);
+        public static Energy GigabritishThermalUnits<T>(this T value) => Energy.FromGigabritishThermalUnits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? GigabritishThermalUnits(this int? value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy GigabritishThermalUnits(this long value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? GigabritishThermalUnits(this long? value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy GigabritishThermalUnits(this double value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? GigabritishThermalUnits(this double? value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy GigabritishThermalUnits(this float value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? GigabritishThermalUnits(this float? value) => Energy.FromGigabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy GigabritishThermalUnits(this decimal value) => Energy.FromGigabritishThermalUnits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromGigabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? GigabritishThermalUnits(this decimal? value) => Energy.FromGigabritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? GigabritishThermalUnits<T>(this T? value) where T : struct => Energy.FromGigabritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigawattHour
 
         /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy GigawattHours(this int value) => Energy.FromGigawattHours(value);
+        public static Energy GigawattHours<T>(this T value) => Energy.FromGigawattHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? GigawattHours(this int? value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy GigawattHours(this long value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? GigawattHours(this long? value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy GigawattHours(this double value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? GigawattHours(this double? value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy GigawattHours(this float value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? GigawattHours(this float? value) => Energy.FromGigawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy GigawattHours(this decimal value) => Energy.FromGigawattHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromGigawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? GigawattHours(this decimal? value) => Energy.FromGigawattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? GigawattHours<T>(this T? value) where T : struct => Energy.FromGigawattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Joule
 
         /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy Joules(this int value) => Energy.FromJoules(value);
+        public static Energy Joules<T>(this T value) => Energy.FromJoules(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy? Joules(this int? value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy Joules(this long value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy? Joules(this long? value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy Joules(this double value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy? Joules(this double? value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy Joules(this float value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy? Joules(this float? value) => Energy.FromJoules(value);
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy Joules(this decimal value) => Energy.FromJoules(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromJoules(UnitsNet.QuantityValue)" />
-        public static Energy? Joules(this decimal? value) => Energy.FromJoules(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? Joules<T>(this T? value) where T : struct => Energy.FromJoules(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilobritishThermalUnit
 
         /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy KilobritishThermalUnits(this int value) => Energy.FromKilobritishThermalUnits(value);
+        public static Energy KilobritishThermalUnits<T>(this T value) => Energy.FromKilobritishThermalUnits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? KilobritishThermalUnits(this int? value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy KilobritishThermalUnits(this long value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? KilobritishThermalUnits(this long? value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy KilobritishThermalUnits(this double value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? KilobritishThermalUnits(this double? value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy KilobritishThermalUnits(this float value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? KilobritishThermalUnits(this float? value) => Energy.FromKilobritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy KilobritishThermalUnits(this decimal value) => Energy.FromKilobritishThermalUnits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromKilobritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? KilobritishThermalUnits(this decimal? value) => Energy.FromKilobritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? KilobritishThermalUnits<T>(this T? value) where T : struct => Energy.FromKilobritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilocalorie
 
         /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy Kilocalories(this int value) => Energy.FromKilocalories(value);
+        public static Energy Kilocalories<T>(this T value) => Energy.FromKilocalories(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy? Kilocalories(this int? value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy Kilocalories(this long value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy? Kilocalories(this long? value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy Kilocalories(this double value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy? Kilocalories(this double? value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy Kilocalories(this float value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy? Kilocalories(this float? value) => Energy.FromKilocalories(value);
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy Kilocalories(this decimal value) => Energy.FromKilocalories(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromKilocalories(UnitsNet.QuantityValue)" />
-        public static Energy? Kilocalories(this decimal? value) => Energy.FromKilocalories(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? Kilocalories<T>(this T? value) where T : struct => Energy.FromKilocalories(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilojoule
 
         /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy Kilojoules(this int value) => Energy.FromKilojoules(value);
+        public static Energy Kilojoules<T>(this T value) => Energy.FromKilojoules(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy? Kilojoules(this int? value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy Kilojoules(this long value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy? Kilojoules(this long? value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy Kilojoules(this double value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy? Kilojoules(this double? value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy Kilojoules(this float value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy? Kilojoules(this float? value) => Energy.FromKilojoules(value);
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy Kilojoules(this decimal value) => Energy.FromKilojoules(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromKilojoules(UnitsNet.QuantityValue)" />
-        public static Energy? Kilojoules(this decimal? value) => Energy.FromKilojoules(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? Kilojoules<T>(this T? value) where T : struct => Energy.FromKilojoules(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattHour
 
         /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy KilowattHours(this int value) => Energy.FromKilowattHours(value);
+        public static Energy KilowattHours<T>(this T value) => Energy.FromKilowattHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy? KilowattHours(this int? value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy KilowattHours(this long value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy? KilowattHours(this long? value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy KilowattHours(this double value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy? KilowattHours(this double? value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy KilowattHours(this float value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy? KilowattHours(this float? value) => Energy.FromKilowattHours(value);
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy KilowattHours(this decimal value) => Energy.FromKilowattHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromKilowattHours(UnitsNet.QuantityValue)" />
-        public static Energy? KilowattHours(this decimal? value) => Energy.FromKilowattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? KilowattHours<T>(this T? value) where T : struct => Energy.FromKilowattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegabritishThermalUnit
 
         /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy MegabritishThermalUnits(this int value) => Energy.FromMegabritishThermalUnits(value);
+        public static Energy MegabritishThermalUnits<T>(this T value) => Energy.FromMegabritishThermalUnits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? MegabritishThermalUnits(this int? value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy MegabritishThermalUnits(this long value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? MegabritishThermalUnits(this long? value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy MegabritishThermalUnits(this double value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? MegabritishThermalUnits(this double? value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy MegabritishThermalUnits(this float value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? MegabritishThermalUnits(this float? value) => Energy.FromMegabritishThermalUnits(value);
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy MegabritishThermalUnits(this decimal value) => Energy.FromMegabritishThermalUnits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromMegabritishThermalUnits(UnitsNet.QuantityValue)" />
-        public static Energy? MegabritishThermalUnits(this decimal? value) => Energy.FromMegabritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? MegabritishThermalUnits<T>(this T? value) where T : struct => Energy.FromMegabritishThermalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megajoule
 
         /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy Megajoules(this int value) => Energy.FromMegajoules(value);
+        public static Energy Megajoules<T>(this T value) => Energy.FromMegajoules(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy? Megajoules(this int? value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy Megajoules(this long value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy? Megajoules(this long? value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy Megajoules(this double value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy? Megajoules(this double? value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy Megajoules(this float value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy? Megajoules(this float? value) => Energy.FromMegajoules(value);
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy Megajoules(this decimal value) => Energy.FromMegajoules(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromMegajoules(UnitsNet.QuantityValue)" />
-        public static Energy? Megajoules(this decimal? value) => Energy.FromMegajoules(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? Megajoules<T>(this T? value) where T : struct => Energy.FromMegajoules(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegawattHour
 
         /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy MegawattHours(this int value) => Energy.FromMegawattHours(value);
+        public static Energy MegawattHours<T>(this T value) => Energy.FromMegawattHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? MegawattHours(this int? value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy MegawattHours(this long value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? MegawattHours(this long? value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy MegawattHours(this double value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? MegawattHours(this double? value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy MegawattHours(this float value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? MegawattHours(this float? value) => Energy.FromMegawattHours(value);
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy MegawattHours(this decimal value) => Energy.FromMegawattHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromMegawattHours(UnitsNet.QuantityValue)" />
-        public static Energy? MegawattHours(this decimal? value) => Energy.FromMegawattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? MegawattHours<T>(this T? value) where T : struct => Energy.FromMegawattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ThermEc
 
         /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy ThermsEc(this int value) => Energy.FromThermsEc(value);
+        public static Energy ThermsEc<T>(this T value) => Energy.FromThermsEc(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsEc(this int? value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy ThermsEc(this long value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsEc(this long? value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy ThermsEc(this double value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsEc(this double? value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy ThermsEc(this float value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsEc(this float? value) => Energy.FromThermsEc(value);
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy ThermsEc(this decimal value) => Energy.FromThermsEc(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromThermsEc(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsEc(this decimal? value) => Energy.FromThermsEc(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? ThermsEc<T>(this T? value) where T : struct => Energy.FromThermsEc(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ThermImperial
 
         /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy ThermsImperial(this int value) => Energy.FromThermsImperial(value);
+        public static Energy ThermsImperial<T>(this T value) => Energy.FromThermsImperial(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsImperial(this int? value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy ThermsImperial(this long value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsImperial(this long? value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy ThermsImperial(this double value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsImperial(this double? value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy ThermsImperial(this float value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsImperial(this float? value) => Energy.FromThermsImperial(value);
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy ThermsImperial(this decimal value) => Energy.FromThermsImperial(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromThermsImperial(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsImperial(this decimal? value) => Energy.FromThermsImperial(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? ThermsImperial<T>(this T? value) where T : struct => Energy.FromThermsImperial(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ThermUs
 
         /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy ThermsUs(this int value) => Energy.FromThermsUs(value);
+        public static Energy ThermsUs<T>(this T value) => Energy.FromThermsUs(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsUs(this int? value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy ThermsUs(this long value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsUs(this long? value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy ThermsUs(this double value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsUs(this double? value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy ThermsUs(this float value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsUs(this float? value) => Energy.FromThermsUs(value);
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy ThermsUs(this decimal value) => Energy.FromThermsUs(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromThermsUs(UnitsNet.QuantityValue)" />
-        public static Energy? ThermsUs(this decimal? value) => Energy.FromThermsUs(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? ThermsUs<T>(this T? value) where T : struct => Energy.FromThermsUs(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattHour
 
         /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy WattHours(this int value) => Energy.FromWattHours(value);
+        public static Energy WattHours<T>(this T value) => Energy.FromWattHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy? WattHours(this int? value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy WattHours(this long value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy? WattHours(this long? value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy WattHours(this double value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy? WattHours(this double? value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy WattHours(this float value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy? WattHours(this float? value) => Energy.FromWattHours(value);
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy WattHours(this decimal value) => Energy.FromWattHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Energy.FromWattHours(UnitsNet.QuantityValue)" />
-        public static Energy? WattHours(this decimal? value) => Energy.FromWattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Energy? WattHours<T>(this T? value) where T : struct => Energy.FromWattHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToEntropyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToEntropyExtensions.g.cs
@@ -47,238 +47,70 @@ namespace UnitsNet.Extensions.NumberToEntropy
         #region CaloriePerKelvin
 
         /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy CaloriesPerKelvin(this int value) => Entropy.FromCaloriesPerKelvin(value);
+        public static Entropy CaloriesPerKelvin<T>(this T value) => Entropy.FromCaloriesPerKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? CaloriesPerKelvin(this int? value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy CaloriesPerKelvin(this long value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? CaloriesPerKelvin(this long? value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy CaloriesPerKelvin(this double value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? CaloriesPerKelvin(this double? value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy CaloriesPerKelvin(this float value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? CaloriesPerKelvin(this float? value) => Entropy.FromCaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy CaloriesPerKelvin(this decimal value) => Entropy.FromCaloriesPerKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromCaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? CaloriesPerKelvin(this decimal? value) => Entropy.FromCaloriesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? CaloriesPerKelvin<T>(this T? value) where T : struct => Entropy.FromCaloriesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region JoulePerDegreeCelsius
 
         /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerDegreeCelsius(this int value) => Entropy.FromJoulesPerDegreeCelsius(value);
+        public static Entropy JoulesPerDegreeCelsius<T>(this T value) => Entropy.FromJoulesPerDegreeCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerDegreeCelsius(this int? value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerDegreeCelsius(this long value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerDegreeCelsius(this long? value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerDegreeCelsius(this double value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerDegreeCelsius(this double? value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerDegreeCelsius(this float value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerDegreeCelsius(this float? value) => Entropy.FromJoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerDegreeCelsius(this decimal value) => Entropy.FromJoulesPerDegreeCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerDegreeCelsius(this decimal? value) => Entropy.FromJoulesPerDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? JoulesPerDegreeCelsius<T>(this T? value) where T : struct => Entropy.FromJoulesPerDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region JoulePerKelvin
 
         /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerKelvin(this int value) => Entropy.FromJoulesPerKelvin(value);
+        public static Entropy JoulesPerKelvin<T>(this T value) => Entropy.FromJoulesPerKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerKelvin(this int? value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerKelvin(this long value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerKelvin(this long? value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerKelvin(this double value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerKelvin(this double? value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerKelvin(this float value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerKelvin(this float? value) => Entropy.FromJoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy JoulesPerKelvin(this decimal value) => Entropy.FromJoulesPerKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromJoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? JoulesPerKelvin(this decimal? value) => Entropy.FromJoulesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? JoulesPerKelvin<T>(this T? value) where T : struct => Entropy.FromJoulesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocaloriePerKelvin
 
         /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilocaloriesPerKelvin(this int value) => Entropy.FromKilocaloriesPerKelvin(value);
+        public static Entropy KilocaloriesPerKelvin<T>(this T value) => Entropy.FromKilocaloriesPerKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilocaloriesPerKelvin(this int? value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilocaloriesPerKelvin(this long value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilocaloriesPerKelvin(this long? value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilocaloriesPerKelvin(this double value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilocaloriesPerKelvin(this double? value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilocaloriesPerKelvin(this float value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilocaloriesPerKelvin(this float? value) => Entropy.FromKilocaloriesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilocaloriesPerKelvin(this decimal value) => Entropy.FromKilocaloriesPerKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromKilocaloriesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilocaloriesPerKelvin(this decimal? value) => Entropy.FromKilocaloriesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? KilocaloriesPerKelvin<T>(this T? value) where T : struct => Entropy.FromKilocaloriesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerDegreeCelsius
 
         /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerDegreeCelsius(this int value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
+        public static Entropy KilojoulesPerDegreeCelsius<T>(this T value) => Entropy.FromKilojoulesPerDegreeCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerDegreeCelsius(this int? value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerDegreeCelsius(this long value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerDegreeCelsius(this long? value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerDegreeCelsius(this double value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerDegreeCelsius(this double? value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerDegreeCelsius(this float value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerDegreeCelsius(this float? value) => Entropy.FromKilojoulesPerDegreeCelsius(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerDegreeCelsius(this decimal value) => Entropy.FromKilojoulesPerDegreeCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerDegreeCelsius(this decimal? value) => Entropy.FromKilojoulesPerDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? KilojoulesPerDegreeCelsius<T>(this T? value) where T : struct => Entropy.FromKilojoulesPerDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerKelvin
 
         /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerKelvin(this int value) => Entropy.FromKilojoulesPerKelvin(value);
+        public static Entropy KilojoulesPerKelvin<T>(this T value) => Entropy.FromKilojoulesPerKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerKelvin(this int? value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerKelvin(this long value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerKelvin(this long? value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerKelvin(this double value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerKelvin(this double? value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerKelvin(this float value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerKelvin(this float? value) => Entropy.FromKilojoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy KilojoulesPerKelvin(this decimal value) => Entropy.FromKilojoulesPerKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromKilojoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? KilojoulesPerKelvin(this decimal? value) => Entropy.FromKilojoulesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? KilojoulesPerKelvin<T>(this T? value) where T : struct => Entropy.FromKilojoulesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegajoulePerKelvin
 
         /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy MegajoulesPerKelvin(this int value) => Entropy.FromMegajoulesPerKelvin(value);
+        public static Entropy MegajoulesPerKelvin<T>(this T value) => Entropy.FromMegajoulesPerKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? MegajoulesPerKelvin(this int? value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy MegajoulesPerKelvin(this long value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? MegajoulesPerKelvin(this long? value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy MegajoulesPerKelvin(this double value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? MegajoulesPerKelvin(this double? value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy MegajoulesPerKelvin(this float value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? MegajoulesPerKelvin(this float? value) => Entropy.FromMegajoulesPerKelvin(value);
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy MegajoulesPerKelvin(this decimal value) => Entropy.FromMegajoulesPerKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Entropy.FromMegajoulesPerKelvin(UnitsNet.QuantityValue)" />
-        public static Entropy? MegajoulesPerKelvin(this decimal? value) => Entropy.FromMegajoulesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Entropy? MegajoulesPerKelvin<T>(this T? value) where T : struct => Entropy.FromMegajoulesPerKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToFlowExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToFlowExtensions.g.cs
@@ -47,816 +47,240 @@ namespace UnitsNet.Extensions.NumberToFlow
         #region CentilitersPerMinute
 
         /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CentilitersPerMinute(this int value) => Flow.FromCentilitersPerMinute(value);
+        public static Flow CentilitersPerMinute<T>(this T value) => Flow.FromCentilitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CentilitersPerMinute(this int? value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CentilitersPerMinute(this long value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CentilitersPerMinute(this long? value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CentilitersPerMinute(this double value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CentilitersPerMinute(this double? value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CentilitersPerMinute(this float value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CentilitersPerMinute(this float? value) => Flow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CentilitersPerMinute(this decimal value) => Flow.FromCentilitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CentilitersPerMinute(this decimal? value) => Flow.FromCentilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CentilitersPerMinute<T>(this T? value) where T : struct => Flow.FromCentilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicDecimeterPerMinute
 
         /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicDecimetersPerMinute(this int value) => Flow.FromCubicDecimetersPerMinute(value);
+        public static Flow CubicDecimetersPerMinute<T>(this T value) => Flow.FromCubicDecimetersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicDecimetersPerMinute(this int? value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicDecimetersPerMinute(this long value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicDecimetersPerMinute(this long? value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicDecimetersPerMinute(this double value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicDecimetersPerMinute(this double? value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicDecimetersPerMinute(this float value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicDecimetersPerMinute(this float? value) => Flow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicDecimetersPerMinute(this decimal value) => Flow.FromCubicDecimetersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicDecimetersPerMinute(this decimal? value) => Flow.FromCubicDecimetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicDecimetersPerMinute<T>(this T? value) where T : struct => Flow.FromCubicDecimetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFootPerHour
 
         /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerHour(this int value) => Flow.FromCubicFeetPerHour(value);
+        public static Flow CubicFeetPerHour<T>(this T value) => Flow.FromCubicFeetPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerHour(this int? value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerHour(this long value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerHour(this long? value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerHour(this double value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerHour(this double? value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerHour(this float value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerHour(this float? value) => Flow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerHour(this decimal value) => Flow.FromCubicFeetPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerHour(this decimal? value) => Flow.FromCubicFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicFeetPerHour<T>(this T? value) where T : struct => Flow.FromCubicFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFootPerMinute
 
         /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerMinute(this int value) => Flow.FromCubicFeetPerMinute(value);
+        public static Flow CubicFeetPerMinute<T>(this T value) => Flow.FromCubicFeetPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerMinute(this int? value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerMinute(this long value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerMinute(this long? value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerMinute(this double value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerMinute(this double? value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerMinute(this float value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerMinute(this float? value) => Flow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerMinute(this decimal value) => Flow.FromCubicFeetPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerMinute(this decimal? value) => Flow.FromCubicFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicFeetPerMinute<T>(this T? value) where T : struct => Flow.FromCubicFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFootPerSecond
 
         /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerSecond(this int value) => Flow.FromCubicFeetPerSecond(value);
+        public static Flow CubicFeetPerSecond<T>(this T value) => Flow.FromCubicFeetPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerSecond(this int? value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerSecond(this long value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerSecond(this long? value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerSecond(this double value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerSecond(this double? value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerSecond(this float value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerSecond(this float? value) => Flow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicFeetPerSecond(this decimal value) => Flow.FromCubicFeetPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicFeetPerSecond(this decimal? value) => Flow.FromCubicFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicFeetPerSecond<T>(this T? value) where T : struct => Flow.FromCubicFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerHour
 
         /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerHour(this int value) => Flow.FromCubicMetersPerHour(value);
+        public static Flow CubicMetersPerHour<T>(this T value) => Flow.FromCubicMetersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerHour(this int? value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerHour(this long value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerHour(this long? value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerHour(this double value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerHour(this double? value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerHour(this float value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerHour(this float? value) => Flow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerHour(this decimal value) => Flow.FromCubicMetersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerHour(this decimal? value) => Flow.FromCubicMetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicMetersPerHour<T>(this T? value) where T : struct => Flow.FromCubicMetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerMinute
 
         /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerMinute(this int value) => Flow.FromCubicMetersPerMinute(value);
+        public static Flow CubicMetersPerMinute<T>(this T value) => Flow.FromCubicMetersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerMinute(this int? value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerMinute(this long value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerMinute(this long? value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerMinute(this double value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerMinute(this double? value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerMinute(this float value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerMinute(this float? value) => Flow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerMinute(this decimal value) => Flow.FromCubicMetersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerMinute(this decimal? value) => Flow.FromCubicMetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicMetersPerMinute<T>(this T? value) where T : struct => Flow.FromCubicMetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerSecond
 
         /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerSecond(this int value) => Flow.FromCubicMetersPerSecond(value);
+        public static Flow CubicMetersPerSecond<T>(this T value) => Flow.FromCubicMetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerSecond(this int? value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerSecond(this long value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerSecond(this long? value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerSecond(this double value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerSecond(this double? value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerSecond(this float value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerSecond(this float? value) => Flow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicMetersPerSecond(this decimal value) => Flow.FromCubicMetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicMetersPerSecond(this decimal? value) => Flow.FromCubicMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicMetersPerSecond<T>(this T? value) where T : struct => Flow.FromCubicMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYardPerHour
 
         /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerHour(this int value) => Flow.FromCubicYardsPerHour(value);
+        public static Flow CubicYardsPerHour<T>(this T value) => Flow.FromCubicYardsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerHour(this int? value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerHour(this long value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerHour(this long? value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerHour(this double value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerHour(this double? value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerHour(this float value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerHour(this float? value) => Flow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerHour(this decimal value) => Flow.FromCubicYardsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerHour(this decimal? value) => Flow.FromCubicYardsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicYardsPerHour<T>(this T? value) where T : struct => Flow.FromCubicYardsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYardPerMinute
 
         /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerMinute(this int value) => Flow.FromCubicYardsPerMinute(value);
+        public static Flow CubicYardsPerMinute<T>(this T value) => Flow.FromCubicYardsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerMinute(this int? value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerMinute(this long value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerMinute(this long? value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerMinute(this double value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerMinute(this double? value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerMinute(this float value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerMinute(this float? value) => Flow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerMinute(this decimal value) => Flow.FromCubicYardsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerMinute(this decimal? value) => Flow.FromCubicYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicYardsPerMinute<T>(this T? value) where T : struct => Flow.FromCubicYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYardPerSecond
 
         /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerSecond(this int value) => Flow.FromCubicYardsPerSecond(value);
+        public static Flow CubicYardsPerSecond<T>(this T value) => Flow.FromCubicYardsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerSecond(this int? value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerSecond(this long value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerSecond(this long? value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerSecond(this double value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerSecond(this double? value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerSecond(this float value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerSecond(this float? value) => Flow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow CubicYardsPerSecond(this decimal value) => Flow.FromCubicYardsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? CubicYardsPerSecond(this decimal? value) => Flow.FromCubicYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? CubicYardsPerSecond<T>(this T? value) where T : struct => Flow.FromCubicYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecilitersPerMinute
 
         /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow DecilitersPerMinute(this int value) => Flow.FromDecilitersPerMinute(value);
+        public static Flow DecilitersPerMinute<T>(this T value) => Flow.FromDecilitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? DecilitersPerMinute(this int? value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow DecilitersPerMinute(this long value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? DecilitersPerMinute(this long? value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow DecilitersPerMinute(this double value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? DecilitersPerMinute(this double? value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow DecilitersPerMinute(this float value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? DecilitersPerMinute(this float? value) => Flow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow DecilitersPerMinute(this decimal value) => Flow.FromDecilitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? DecilitersPerMinute(this decimal? value) => Flow.FromDecilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? DecilitersPerMinute<T>(this T? value) where T : struct => Flow.FromDecilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilolitersPerMinute
 
         /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow KilolitersPerMinute(this int value) => Flow.FromKilolitersPerMinute(value);
+        public static Flow KilolitersPerMinute<T>(this T value) => Flow.FromKilolitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? KilolitersPerMinute(this int? value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow KilolitersPerMinute(this long value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? KilolitersPerMinute(this long? value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow KilolitersPerMinute(this double value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? KilolitersPerMinute(this double? value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow KilolitersPerMinute(this float value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? KilolitersPerMinute(this float? value) => Flow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow KilolitersPerMinute(this decimal value) => Flow.FromKilolitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? KilolitersPerMinute(this decimal? value) => Flow.FromKilolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? KilolitersPerMinute<T>(this T? value) where T : struct => Flow.FromKilolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LitersPerHour
 
         /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerHour(this int value) => Flow.FromLitersPerHour(value);
+        public static Flow LitersPerHour<T>(this T value) => Flow.FromLitersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerHour(this int? value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerHour(this long value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerHour(this long? value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerHour(this double value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerHour(this double? value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerHour(this float value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerHour(this float? value) => Flow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerHour(this decimal value) => Flow.FromLitersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerHour(this decimal? value) => Flow.FromLitersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? LitersPerHour<T>(this T? value) where T : struct => Flow.FromLitersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LitersPerMinute
 
         /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerMinute(this int value) => Flow.FromLitersPerMinute(value);
+        public static Flow LitersPerMinute<T>(this T value) => Flow.FromLitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerMinute(this int? value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerMinute(this long value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerMinute(this long? value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerMinute(this double value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerMinute(this double? value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerMinute(this float value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerMinute(this float? value) => Flow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerMinute(this decimal value) => Flow.FromLitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerMinute(this decimal? value) => Flow.FromLitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? LitersPerMinute<T>(this T? value) where T : struct => Flow.FromLitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LitersPerSecond
 
         /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerSecond(this int value) => Flow.FromLitersPerSecond(value);
+        public static Flow LitersPerSecond<T>(this T value) => Flow.FromLitersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerSecond(this int? value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerSecond(this long value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerSecond(this long? value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerSecond(this double value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerSecond(this double? value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerSecond(this float value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerSecond(this float? value) => Flow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow LitersPerSecond(this decimal value) => Flow.FromLitersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? LitersPerSecond(this decimal? value) => Flow.FromLitersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? LitersPerSecond<T>(this T? value) where T : struct => Flow.FromLitersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrolitersPerMinute
 
         /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MicrolitersPerMinute(this int value) => Flow.FromMicrolitersPerMinute(value);
+        public static Flow MicrolitersPerMinute<T>(this T value) => Flow.FromMicrolitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MicrolitersPerMinute(this int? value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MicrolitersPerMinute(this long value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MicrolitersPerMinute(this long? value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MicrolitersPerMinute(this double value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MicrolitersPerMinute(this double? value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MicrolitersPerMinute(this float value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MicrolitersPerMinute(this float? value) => Flow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MicrolitersPerMinute(this decimal value) => Flow.FromMicrolitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MicrolitersPerMinute(this decimal? value) => Flow.FromMicrolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? MicrolitersPerMinute<T>(this T? value) where T : struct => Flow.FromMicrolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillilitersPerMinute
 
         /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MillilitersPerMinute(this int value) => Flow.FromMillilitersPerMinute(value);
+        public static Flow MillilitersPerMinute<T>(this T value) => Flow.FromMillilitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MillilitersPerMinute(this int? value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MillilitersPerMinute(this long value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MillilitersPerMinute(this long? value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MillilitersPerMinute(this double value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MillilitersPerMinute(this double? value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MillilitersPerMinute(this float value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MillilitersPerMinute(this float? value) => Flow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow MillilitersPerMinute(this decimal value) => Flow.FromMillilitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? MillilitersPerMinute(this decimal? value) => Flow.FromMillilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? MillilitersPerMinute<T>(this T? value) where T : struct => Flow.FromMillilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillionUsGallonsPerDay
 
         /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow MillionUsGallonsPerDay(this int value) => Flow.FromMillionUsGallonsPerDay(value);
+        public static Flow MillionUsGallonsPerDay<T>(this T value) => Flow.FromMillionUsGallonsPerDay(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? MillionUsGallonsPerDay(this int? value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow MillionUsGallonsPerDay(this long value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? MillionUsGallonsPerDay(this long? value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow MillionUsGallonsPerDay(this double value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? MillionUsGallonsPerDay(this double? value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow MillionUsGallonsPerDay(this float value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? MillionUsGallonsPerDay(this float? value) => Flow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow MillionUsGallonsPerDay(this decimal value) => Flow.FromMillionUsGallonsPerDay(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? MillionUsGallonsPerDay(this decimal? value) => Flow.FromMillionUsGallonsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? MillionUsGallonsPerDay<T>(this T? value) where T : struct => Flow.FromMillionUsGallonsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanolitersPerMinute
 
         /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow NanolitersPerMinute(this int value) => Flow.FromNanolitersPerMinute(value);
+        public static Flow NanolitersPerMinute<T>(this T value) => Flow.FromNanolitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? NanolitersPerMinute(this int? value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow NanolitersPerMinute(this long value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? NanolitersPerMinute(this long? value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow NanolitersPerMinute(this double value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? NanolitersPerMinute(this double? value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow NanolitersPerMinute(this float value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? NanolitersPerMinute(this float? value) => Flow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow NanolitersPerMinute(this decimal value) => Flow.FromNanolitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? NanolitersPerMinute(this decimal? value) => Flow.FromNanolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? NanolitersPerMinute<T>(this T? value) where T : struct => Flow.FromNanolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region OilBarrelsPerDay
 
         /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow OilBarrelsPerDay(this int value) => Flow.FromOilBarrelsPerDay(value);
+        public static Flow OilBarrelsPerDay<T>(this T value) => Flow.FromOilBarrelsPerDay(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? OilBarrelsPerDay(this int? value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow OilBarrelsPerDay(this long value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? OilBarrelsPerDay(this long? value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow OilBarrelsPerDay(this double value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? OilBarrelsPerDay(this double? value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow OilBarrelsPerDay(this float value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? OilBarrelsPerDay(this float? value) => Flow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow OilBarrelsPerDay(this decimal value) => Flow.FromOilBarrelsPerDay(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static Flow? OilBarrelsPerDay(this decimal? value) => Flow.FromOilBarrelsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? OilBarrelsPerDay<T>(this T? value) where T : struct => Flow.FromOilBarrelsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallonsPerHour
 
         /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerHour(this int value) => Flow.FromUsGallonsPerHour(value);
+        public static Flow UsGallonsPerHour<T>(this T value) => Flow.FromUsGallonsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerHour(this int? value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerHour(this long value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerHour(this long? value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerHour(this double value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerHour(this double? value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerHour(this float value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerHour(this float? value) => Flow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerHour(this decimal value) => Flow.FromUsGallonsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerHour(this decimal? value) => Flow.FromUsGallonsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? UsGallonsPerHour<T>(this T? value) where T : struct => Flow.FromUsGallonsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallonsPerMinute
 
         /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerMinute(this int value) => Flow.FromUsGallonsPerMinute(value);
+        public static Flow UsGallonsPerMinute<T>(this T value) => Flow.FromUsGallonsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerMinute(this int? value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerMinute(this long value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerMinute(this long? value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerMinute(this double value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerMinute(this double? value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerMinute(this float value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerMinute(this float? value) => Flow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerMinute(this decimal value) => Flow.FromUsGallonsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerMinute(this decimal? value) => Flow.FromUsGallonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? UsGallonsPerMinute<T>(this T? value) where T : struct => Flow.FromUsGallonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallonsPerSecond
 
         /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerSecond(this int value) => Flow.FromUsGallonsPerSecond(value);
+        public static Flow UsGallonsPerSecond<T>(this T value) => Flow.FromUsGallonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerSecond(this int? value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerSecond(this long value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerSecond(this long? value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerSecond(this double value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerSecond(this double? value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerSecond(this float value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerSecond(this float? value) => Flow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow UsGallonsPerSecond(this decimal value) => Flow.FromUsGallonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Flow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static Flow? UsGallonsPerSecond(this decimal? value) => Flow.FromUsGallonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Flow? UsGallonsPerSecond<T>(this T? value) where T : struct => Flow.FromUsGallonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToForceChangeRateExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToForceChangeRateExtensions.g.cs
@@ -47,374 +47,110 @@ namespace UnitsNet.Extensions.NumberToForceChangeRate
         #region CentinewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate CentinewtonsPerSecond(this int value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
+        public static ForceChangeRate CentinewtonsPerSecond<T>(this T value) => ForceChangeRate.FromCentinewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? CentinewtonsPerSecond(this int? value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate CentinewtonsPerSecond(this long value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? CentinewtonsPerSecond(this long? value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate CentinewtonsPerSecond(this double value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? CentinewtonsPerSecond(this double? value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate CentinewtonsPerSecond(this float value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? CentinewtonsPerSecond(this float? value) => ForceChangeRate.FromCentinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate CentinewtonsPerSecond(this decimal value) => ForceChangeRate.FromCentinewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromCentinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? CentinewtonsPerSecond(this decimal? value) => ForceChangeRate.FromCentinewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? CentinewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromCentinewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecanewtonPerMinute
 
         /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerMinute(this int value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
+        public static ForceChangeRate DecanewtonsPerMinute<T>(this T value) => ForceChangeRate.FromDecanewtonsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerMinute(this int? value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerMinute(this long value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerMinute(this long? value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerMinute(this double value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerMinute(this double? value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerMinute(this float value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerMinute(this float? value) => ForceChangeRate.FromDecanewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerMinute(this decimal value) => ForceChangeRate.FromDecanewtonsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerMinute(this decimal? value) => ForceChangeRate.FromDecanewtonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? DecanewtonsPerMinute<T>(this T? value) where T : struct => ForceChangeRate.FromDecanewtonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecanewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerSecond(this int value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
+        public static ForceChangeRate DecanewtonsPerSecond<T>(this T value) => ForceChangeRate.FromDecanewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerSecond(this int? value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerSecond(this long value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerSecond(this long? value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerSecond(this double value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerSecond(this double? value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerSecond(this float value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerSecond(this float? value) => ForceChangeRate.FromDecanewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecanewtonsPerSecond(this decimal value) => ForceChangeRate.FromDecanewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecanewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecanewtonsPerSecond(this decimal? value) => ForceChangeRate.FromDecanewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? DecanewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromDecanewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecinewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecinewtonsPerSecond(this int value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
+        public static ForceChangeRate DecinewtonsPerSecond<T>(this T value) => ForceChangeRate.FromDecinewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecinewtonsPerSecond(this int? value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecinewtonsPerSecond(this long value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecinewtonsPerSecond(this long? value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecinewtonsPerSecond(this double value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecinewtonsPerSecond(this double? value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecinewtonsPerSecond(this float value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecinewtonsPerSecond(this float? value) => ForceChangeRate.FromDecinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate DecinewtonsPerSecond(this decimal value) => ForceChangeRate.FromDecinewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromDecinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? DecinewtonsPerSecond(this decimal? value) => ForceChangeRate.FromDecinewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? DecinewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromDecinewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerMinute
 
         /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerMinute(this int value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
+        public static ForceChangeRate KilonewtonsPerMinute<T>(this T value) => ForceChangeRate.FromKilonewtonsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerMinute(this int? value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerMinute(this long value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerMinute(this long? value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerMinute(this double value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerMinute(this double? value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerMinute(this float value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerMinute(this float? value) => ForceChangeRate.FromKilonewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerMinute(this decimal value) => ForceChangeRate.FromKilonewtonsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerMinute(this decimal? value) => ForceChangeRate.FromKilonewtonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? KilonewtonsPerMinute<T>(this T? value) where T : struct => ForceChangeRate.FromKilonewtonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerSecond(this int value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
+        public static ForceChangeRate KilonewtonsPerSecond<T>(this T value) => ForceChangeRate.FromKilonewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerSecond(this int? value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerSecond(this long value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerSecond(this long? value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerSecond(this double value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerSecond(this double? value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerSecond(this float value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerSecond(this float? value) => ForceChangeRate.FromKilonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate KilonewtonsPerSecond(this decimal value) => ForceChangeRate.FromKilonewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromKilonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? KilonewtonsPerSecond(this decimal? value) => ForceChangeRate.FromKilonewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? KilonewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromKilonewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicronewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MicronewtonsPerSecond(this int value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
+        public static ForceChangeRate MicronewtonsPerSecond<T>(this T value) => ForceChangeRate.FromMicronewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MicronewtonsPerSecond(this int? value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MicronewtonsPerSecond(this long value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MicronewtonsPerSecond(this long? value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MicronewtonsPerSecond(this double value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MicronewtonsPerSecond(this double? value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MicronewtonsPerSecond(this float value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MicronewtonsPerSecond(this float? value) => ForceChangeRate.FromMicronewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MicronewtonsPerSecond(this decimal value) => ForceChangeRate.FromMicronewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromMicronewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MicronewtonsPerSecond(this decimal? value) => ForceChangeRate.FromMicronewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? MicronewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromMicronewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillinewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MillinewtonsPerSecond(this int value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
+        public static ForceChangeRate MillinewtonsPerSecond<T>(this T value) => ForceChangeRate.FromMillinewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MillinewtonsPerSecond(this int? value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MillinewtonsPerSecond(this long value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MillinewtonsPerSecond(this long? value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MillinewtonsPerSecond(this double value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MillinewtonsPerSecond(this double? value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MillinewtonsPerSecond(this float value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MillinewtonsPerSecond(this float? value) => ForceChangeRate.FromMillinewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate MillinewtonsPerSecond(this decimal value) => ForceChangeRate.FromMillinewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromMillinewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? MillinewtonsPerSecond(this decimal? value) => ForceChangeRate.FromMillinewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? MillinewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromMillinewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanonewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NanonewtonsPerSecond(this int value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
+        public static ForceChangeRate NanonewtonsPerSecond<T>(this T value) => ForceChangeRate.FromNanonewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NanonewtonsPerSecond(this int? value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NanonewtonsPerSecond(this long value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NanonewtonsPerSecond(this long? value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NanonewtonsPerSecond(this double value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NanonewtonsPerSecond(this double? value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NanonewtonsPerSecond(this float value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NanonewtonsPerSecond(this float? value) => ForceChangeRate.FromNanonewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NanonewtonsPerSecond(this decimal value) => ForceChangeRate.FromNanonewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromNanonewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NanonewtonsPerSecond(this decimal? value) => ForceChangeRate.FromNanonewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? NanonewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromNanonewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerMinute
 
         /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerMinute(this int value) => ForceChangeRate.FromNewtonsPerMinute(value);
+        public static ForceChangeRate NewtonsPerMinute<T>(this T value) => ForceChangeRate.FromNewtonsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerMinute(this int? value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerMinute(this long value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerMinute(this long? value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerMinute(this double value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerMinute(this double? value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerMinute(this float value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerMinute(this float? value) => ForceChangeRate.FromNewtonsPerMinute(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerMinute(this decimal value) => ForceChangeRate.FromNewtonsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerMinute(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerMinute(this decimal? value) => ForceChangeRate.FromNewtonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? NewtonsPerMinute<T>(this T? value) where T : struct => ForceChangeRate.FromNewtonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerSecond
 
         /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerSecond(this int value) => ForceChangeRate.FromNewtonsPerSecond(value);
+        public static ForceChangeRate NewtonsPerSecond<T>(this T value) => ForceChangeRate.FromNewtonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerSecond(this int? value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerSecond(this long value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerSecond(this long? value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerSecond(this double value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerSecond(this double? value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerSecond(this float value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerSecond(this float? value) => ForceChangeRate.FromNewtonsPerSecond(value);
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate NewtonsPerSecond(this decimal value) => ForceChangeRate.FromNewtonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForceChangeRate.FromNewtonsPerSecond(UnitsNet.QuantityValue)" />
-        public static ForceChangeRate? NewtonsPerSecond(this decimal? value) => ForceChangeRate.FromNewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForceChangeRate? NewtonsPerSecond<T>(this T? value) where T : struct => ForceChangeRate.FromNewtonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToForceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToForceExtensions.g.cs
@@ -47,340 +47,100 @@ namespace UnitsNet.Extensions.NumberToForce
         #region Decanewton
 
         /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force Decanewtons(this int value) => Force.FromDecanewtons(value);
+        public static Force Decanewtons<T>(this T value) => Force.FromDecanewtons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force? Decanewtons(this int? value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force Decanewtons(this long value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force? Decanewtons(this long? value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force Decanewtons(this double value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force? Decanewtons(this double? value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force Decanewtons(this float value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force? Decanewtons(this float? value) => Force.FromDecanewtons(value);
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force Decanewtons(this decimal value) => Force.FromDecanewtons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromDecanewtons(UnitsNet.QuantityValue)" />
-        public static Force? Decanewtons(this decimal? value) => Force.FromDecanewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? Decanewtons<T>(this T? value) where T : struct => Force.FromDecanewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Dyn
 
         /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force Dyne(this int value) => Force.FromDyne(value);
+        public static Force Dyne<T>(this T value) => Force.FromDyne(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force? Dyne(this int? value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force Dyne(this long value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force? Dyne(this long? value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force Dyne(this double value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force? Dyne(this double? value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force Dyne(this float value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force? Dyne(this float? value) => Force.FromDyne(value);
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force Dyne(this decimal value) => Force.FromDyne(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromDyne(UnitsNet.QuantityValue)" />
-        public static Force? Dyne(this decimal? value) => Force.FromDyne(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? Dyne<T>(this T? value) where T : struct => Force.FromDyne(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForce
 
         /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force KilogramsForce(this int value) => Force.FromKilogramsForce(value);
+        public static Force KilogramsForce<T>(this T value) => Force.FromKilogramsForce(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force? KilogramsForce(this int? value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force KilogramsForce(this long value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force? KilogramsForce(this long? value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force KilogramsForce(this double value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force? KilogramsForce(this double? value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force KilogramsForce(this float value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force? KilogramsForce(this float? value) => Force.FromKilogramsForce(value);
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force KilogramsForce(this decimal value) => Force.FromKilogramsForce(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromKilogramsForce(UnitsNet.QuantityValue)" />
-        public static Force? KilogramsForce(this decimal? value) => Force.FromKilogramsForce(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? KilogramsForce<T>(this T? value) where T : struct => Force.FromKilogramsForce(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilonewton
 
         /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force Kilonewtons(this int value) => Force.FromKilonewtons(value);
+        public static Force Kilonewtons<T>(this T value) => Force.FromKilonewtons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force? Kilonewtons(this int? value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force Kilonewtons(this long value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force? Kilonewtons(this long? value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force Kilonewtons(this double value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force? Kilonewtons(this double? value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force Kilonewtons(this float value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force? Kilonewtons(this float? value) => Force.FromKilonewtons(value);
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force Kilonewtons(this decimal value) => Force.FromKilonewtons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromKilonewtons(UnitsNet.QuantityValue)" />
-        public static Force? Kilonewtons(this decimal? value) => Force.FromKilonewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? Kilonewtons<T>(this T? value) where T : struct => Force.FromKilonewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KiloPond
 
         /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force KiloPonds(this int value) => Force.FromKiloPonds(value);
+        public static Force KiloPonds<T>(this T value) => Force.FromKiloPonds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force? KiloPonds(this int? value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force KiloPonds(this long value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force? KiloPonds(this long? value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force KiloPonds(this double value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force? KiloPonds(this double? value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force KiloPonds(this float value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force? KiloPonds(this float? value) => Force.FromKiloPonds(value);
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force KiloPonds(this decimal value) => Force.FromKiloPonds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromKiloPonds(UnitsNet.QuantityValue)" />
-        public static Force? KiloPonds(this decimal? value) => Force.FromKiloPonds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? KiloPonds<T>(this T? value) where T : struct => Force.FromKiloPonds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Meganewton
 
         /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force Meganewtons(this int value) => Force.FromMeganewtons(value);
+        public static Force Meganewtons<T>(this T value) => Force.FromMeganewtons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force? Meganewtons(this int? value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force Meganewtons(this long value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force? Meganewtons(this long? value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force Meganewtons(this double value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force? Meganewtons(this double? value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force Meganewtons(this float value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force? Meganewtons(this float? value) => Force.FromMeganewtons(value);
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force Meganewtons(this decimal value) => Force.FromMeganewtons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromMeganewtons(UnitsNet.QuantityValue)" />
-        public static Force? Meganewtons(this decimal? value) => Force.FromMeganewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? Meganewtons<T>(this T? value) where T : struct => Force.FromMeganewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Newton
 
         /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force Newtons(this int value) => Force.FromNewtons(value);
+        public static Force Newtons<T>(this T value) => Force.FromNewtons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force? Newtons(this int? value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force Newtons(this long value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force? Newtons(this long? value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force Newtons(this double value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force? Newtons(this double? value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force Newtons(this float value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force? Newtons(this float? value) => Force.FromNewtons(value);
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force Newtons(this decimal value) => Force.FromNewtons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromNewtons(UnitsNet.QuantityValue)" />
-        public static Force? Newtons(this decimal? value) => Force.FromNewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? Newtons<T>(this T? value) where T : struct => Force.FromNewtons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Poundal
 
         /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force Poundals(this int value) => Force.FromPoundals(value);
+        public static Force Poundals<T>(this T value) => Force.FromPoundals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force? Poundals(this int? value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force Poundals(this long value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force? Poundals(this long? value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force Poundals(this double value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force? Poundals(this double? value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force Poundals(this float value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force? Poundals(this float? value) => Force.FromPoundals(value);
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force Poundals(this decimal value) => Force.FromPoundals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromPoundals(UnitsNet.QuantityValue)" />
-        public static Force? Poundals(this decimal? value) => Force.FromPoundals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? Poundals<T>(this T? value) where T : struct => Force.FromPoundals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForce
 
         /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force PoundsForce(this int value) => Force.FromPoundsForce(value);
+        public static Force PoundsForce<T>(this T value) => Force.FromPoundsForce(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force? PoundsForce(this int? value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force PoundsForce(this long value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force? PoundsForce(this long? value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force PoundsForce(this double value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force? PoundsForce(this double? value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force PoundsForce(this float value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force? PoundsForce(this float? value) => Force.FromPoundsForce(value);
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force PoundsForce(this decimal value) => Force.FromPoundsForce(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromPoundsForce(UnitsNet.QuantityValue)" />
-        public static Force? PoundsForce(this decimal? value) => Force.FromPoundsForce(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? PoundsForce<T>(this T? value) where T : struct => Force.FromPoundsForce(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForce
 
         /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force TonnesForce(this int value) => Force.FromTonnesForce(value);
+        public static Force TonnesForce<T>(this T value) => Force.FromTonnesForce(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force? TonnesForce(this int? value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force TonnesForce(this long value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force? TonnesForce(this long? value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force TonnesForce(this double value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force? TonnesForce(this double? value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force TonnesForce(this float value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force? TonnesForce(this float? value) => Force.FromTonnesForce(value);
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force TonnesForce(this decimal value) => Force.FromTonnesForce(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Force.FromTonnesForce(UnitsNet.QuantityValue)" />
-        public static Force? TonnesForce(this decimal? value) => Force.FromTonnesForce(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Force? TonnesForce<T>(this T? value) where T : struct => Force.FromTonnesForce(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToForcePerLengthExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToForcePerLengthExtensions.g.cs
@@ -47,306 +47,90 @@ namespace UnitsNet.Extensions.NumberToForcePerLength
         #region CentinewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength CentinewtonsPerMeter(this int value) => ForcePerLength.FromCentinewtonsPerMeter(value);
+        public static ForcePerLength CentinewtonsPerMeter<T>(this T value) => ForcePerLength.FromCentinewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? CentinewtonsPerMeter(this int? value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength CentinewtonsPerMeter(this long value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? CentinewtonsPerMeter(this long? value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength CentinewtonsPerMeter(this double value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? CentinewtonsPerMeter(this double? value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength CentinewtonsPerMeter(this float value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? CentinewtonsPerMeter(this float? value) => ForcePerLength.FromCentinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength CentinewtonsPerMeter(this decimal value) => ForcePerLength.FromCentinewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromCentinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? CentinewtonsPerMeter(this decimal? value) => ForcePerLength.FromCentinewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? CentinewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromCentinewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecinewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength DecinewtonsPerMeter(this int value) => ForcePerLength.FromDecinewtonsPerMeter(value);
+        public static ForcePerLength DecinewtonsPerMeter<T>(this T value) => ForcePerLength.FromDecinewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? DecinewtonsPerMeter(this int? value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength DecinewtonsPerMeter(this long value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? DecinewtonsPerMeter(this long? value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength DecinewtonsPerMeter(this double value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? DecinewtonsPerMeter(this double? value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength DecinewtonsPerMeter(this float value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? DecinewtonsPerMeter(this float? value) => ForcePerLength.FromDecinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength DecinewtonsPerMeter(this decimal value) => ForcePerLength.FromDecinewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromDecinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? DecinewtonsPerMeter(this decimal? value) => ForcePerLength.FromDecinewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? DecinewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromDecinewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForcePerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilogramsForcePerMeter(this int value) => ForcePerLength.FromKilogramsForcePerMeter(value);
+        public static ForcePerLength KilogramsForcePerMeter<T>(this T value) => ForcePerLength.FromKilogramsForcePerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilogramsForcePerMeter(this int? value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilogramsForcePerMeter(this long value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilogramsForcePerMeter(this long? value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilogramsForcePerMeter(this double value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilogramsForcePerMeter(this double? value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilogramsForcePerMeter(this float value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilogramsForcePerMeter(this float? value) => ForcePerLength.FromKilogramsForcePerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilogramsForcePerMeter(this decimal value) => ForcePerLength.FromKilogramsForcePerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromKilogramsForcePerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilogramsForcePerMeter(this decimal? value) => ForcePerLength.FromKilogramsForcePerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? KilogramsForcePerMeter<T>(this T? value) where T : struct => ForcePerLength.FromKilogramsForcePerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilonewtonsPerMeter(this int value) => ForcePerLength.FromKilonewtonsPerMeter(value);
+        public static ForcePerLength KilonewtonsPerMeter<T>(this T value) => ForcePerLength.FromKilonewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilonewtonsPerMeter(this int? value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilonewtonsPerMeter(this long value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilonewtonsPerMeter(this long? value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilonewtonsPerMeter(this double value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilonewtonsPerMeter(this double? value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilonewtonsPerMeter(this float value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilonewtonsPerMeter(this float? value) => ForcePerLength.FromKilonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength KilonewtonsPerMeter(this decimal value) => ForcePerLength.FromKilonewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromKilonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? KilonewtonsPerMeter(this decimal? value) => ForcePerLength.FromKilonewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? KilonewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromKilonewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MeganewtonsPerMeter(this int value) => ForcePerLength.FromMeganewtonsPerMeter(value);
+        public static ForcePerLength MeganewtonsPerMeter<T>(this T value) => ForcePerLength.FromMeganewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MeganewtonsPerMeter(this int? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MeganewtonsPerMeter(this long value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MeganewtonsPerMeter(this long? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MeganewtonsPerMeter(this double value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MeganewtonsPerMeter(this double? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MeganewtonsPerMeter(this float value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MeganewtonsPerMeter(this float? value) => ForcePerLength.FromMeganewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MeganewtonsPerMeter(this decimal value) => ForcePerLength.FromMeganewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromMeganewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MeganewtonsPerMeter(this decimal? value) => ForcePerLength.FromMeganewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? MeganewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromMeganewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicronewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MicronewtonsPerMeter(this int value) => ForcePerLength.FromMicronewtonsPerMeter(value);
+        public static ForcePerLength MicronewtonsPerMeter<T>(this T value) => ForcePerLength.FromMicronewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MicronewtonsPerMeter(this int? value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MicronewtonsPerMeter(this long value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MicronewtonsPerMeter(this long? value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MicronewtonsPerMeter(this double value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MicronewtonsPerMeter(this double? value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MicronewtonsPerMeter(this float value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MicronewtonsPerMeter(this float? value) => ForcePerLength.FromMicronewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MicronewtonsPerMeter(this decimal value) => ForcePerLength.FromMicronewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromMicronewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MicronewtonsPerMeter(this decimal? value) => ForcePerLength.FromMicronewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? MicronewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromMicronewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillinewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MillinewtonsPerMeter(this int value) => ForcePerLength.FromMillinewtonsPerMeter(value);
+        public static ForcePerLength MillinewtonsPerMeter<T>(this T value) => ForcePerLength.FromMillinewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MillinewtonsPerMeter(this int? value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MillinewtonsPerMeter(this long value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MillinewtonsPerMeter(this long? value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MillinewtonsPerMeter(this double value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MillinewtonsPerMeter(this double? value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MillinewtonsPerMeter(this float value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MillinewtonsPerMeter(this float? value) => ForcePerLength.FromMillinewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength MillinewtonsPerMeter(this decimal value) => ForcePerLength.FromMillinewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromMillinewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? MillinewtonsPerMeter(this decimal? value) => ForcePerLength.FromMillinewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? MillinewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromMillinewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanonewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NanonewtonsPerMeter(this int value) => ForcePerLength.FromNanonewtonsPerMeter(value);
+        public static ForcePerLength NanonewtonsPerMeter<T>(this T value) => ForcePerLength.FromNanonewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NanonewtonsPerMeter(this int? value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NanonewtonsPerMeter(this long value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NanonewtonsPerMeter(this long? value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NanonewtonsPerMeter(this double value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NanonewtonsPerMeter(this double? value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NanonewtonsPerMeter(this float value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NanonewtonsPerMeter(this float? value) => ForcePerLength.FromNanonewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NanonewtonsPerMeter(this decimal value) => ForcePerLength.FromNanonewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromNanonewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NanonewtonsPerMeter(this decimal? value) => ForcePerLength.FromNanonewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? NanonewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromNanonewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerMeter
 
         /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NewtonsPerMeter(this int value) => ForcePerLength.FromNewtonsPerMeter(value);
+        public static ForcePerLength NewtonsPerMeter<T>(this T value) => ForcePerLength.FromNewtonsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NewtonsPerMeter(this int? value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NewtonsPerMeter(this long value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NewtonsPerMeter(this long? value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NewtonsPerMeter(this double value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NewtonsPerMeter(this double? value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NewtonsPerMeter(this float value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NewtonsPerMeter(this float? value) => ForcePerLength.FromNewtonsPerMeter(value);
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength NewtonsPerMeter(this decimal value) => ForcePerLength.FromNewtonsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ForcePerLength.FromNewtonsPerMeter(UnitsNet.QuantityValue)" />
-        public static ForcePerLength? NewtonsPerMeter(this decimal? value) => ForcePerLength.FromNewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ForcePerLength? NewtonsPerMeter<T>(this T? value) where T : struct => ForcePerLength.FromNewtonsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToFrequencyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToFrequencyExtensions.g.cs
@@ -47,238 +47,70 @@ namespace UnitsNet.Extensions.NumberToFrequency
         #region CyclePerHour
 
         /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerHour(this int value) => Frequency.FromCyclesPerHour(value);
+        public static Frequency CyclesPerHour<T>(this T value) => Frequency.FromCyclesPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerHour(this int? value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerHour(this long value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerHour(this long? value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerHour(this double value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerHour(this double? value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerHour(this float value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerHour(this float? value) => Frequency.FromCyclesPerHour(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerHour(this decimal value) => Frequency.FromCyclesPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerHour(this decimal? value) => Frequency.FromCyclesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? CyclesPerHour<T>(this T? value) where T : struct => Frequency.FromCyclesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CyclePerMinute
 
         /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerMinute(this int value) => Frequency.FromCyclesPerMinute(value);
+        public static Frequency CyclesPerMinute<T>(this T value) => Frequency.FromCyclesPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerMinute(this int? value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerMinute(this long value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerMinute(this long? value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerMinute(this double value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerMinute(this double? value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerMinute(this float value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerMinute(this float? value) => Frequency.FromCyclesPerMinute(value);
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency CyclesPerMinute(this decimal value) => Frequency.FromCyclesPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromCyclesPerMinute(UnitsNet.QuantityValue)" />
-        public static Frequency? CyclesPerMinute(this decimal? value) => Frequency.FromCyclesPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? CyclesPerMinute<T>(this T? value) where T : struct => Frequency.FromCyclesPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gigahertz
 
         /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Gigahertz(this int value) => Frequency.FromGigahertz(value);
+        public static Frequency Gigahertz<T>(this T value) => Frequency.FromGigahertz(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Gigahertz(this int? value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Gigahertz(this long value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Gigahertz(this long? value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Gigahertz(this double value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Gigahertz(this double? value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Gigahertz(this float value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Gigahertz(this float? value) => Frequency.FromGigahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Gigahertz(this decimal value) => Frequency.FromGigahertz(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromGigahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Gigahertz(this decimal? value) => Frequency.FromGigahertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? Gigahertz<T>(this T? value) where T : struct => Frequency.FromGigahertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Hertz
 
         /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency Hertz(this int value) => Frequency.FromHertz(value);
+        public static Frequency Hertz<T>(this T value) => Frequency.FromHertz(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Hertz(this int? value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency Hertz(this long value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Hertz(this long? value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency Hertz(this double value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Hertz(this double? value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency Hertz(this float value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Hertz(this float? value) => Frequency.FromHertz(value);
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency Hertz(this decimal value) => Frequency.FromHertz(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromHertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Hertz(this decimal? value) => Frequency.FromHertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? Hertz<T>(this T? value) where T : struct => Frequency.FromHertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilohertz
 
         /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency Kilohertz(this int value) => Frequency.FromKilohertz(value);
+        public static Frequency Kilohertz<T>(this T value) => Frequency.FromKilohertz(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Kilohertz(this int? value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency Kilohertz(this long value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Kilohertz(this long? value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency Kilohertz(this double value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Kilohertz(this double? value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency Kilohertz(this float value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Kilohertz(this float? value) => Frequency.FromKilohertz(value);
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency Kilohertz(this decimal value) => Frequency.FromKilohertz(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromKilohertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Kilohertz(this decimal? value) => Frequency.FromKilohertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? Kilohertz<T>(this T? value) where T : struct => Frequency.FromKilohertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megahertz
 
         /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Megahertz(this int value) => Frequency.FromMegahertz(value);
+        public static Frequency Megahertz<T>(this T value) => Frequency.FromMegahertz(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Megahertz(this int? value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Megahertz(this long value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Megahertz(this long? value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Megahertz(this double value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Megahertz(this double? value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Megahertz(this float value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Megahertz(this float? value) => Frequency.FromMegahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Megahertz(this decimal value) => Frequency.FromMegahertz(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromMegahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Megahertz(this decimal? value) => Frequency.FromMegahertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? Megahertz<T>(this T? value) where T : struct => Frequency.FromMegahertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Terahertz
 
         /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Terahertz(this int value) => Frequency.FromTerahertz(value);
+        public static Frequency Terahertz<T>(this T value) => Frequency.FromTerahertz(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Terahertz(this int? value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Terahertz(this long value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Terahertz(this long? value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Terahertz(this double value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Terahertz(this double? value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Terahertz(this float value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Terahertz(this float? value) => Frequency.FromTerahertz(value);
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency Terahertz(this decimal value) => Frequency.FromTerahertz(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Frequency.FromTerahertz(UnitsNet.QuantityValue)" />
-        public static Frequency? Terahertz(this decimal? value) => Frequency.FromTerahertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Frequency? Terahertz<T>(this T? value) where T : struct => Frequency.FromTerahertz(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToHeatFluxExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToHeatFluxExtensions.g.cs
@@ -47,544 +47,160 @@ namespace UnitsNet.Extensions.NumberToHeatFlux
         #region BtuPerHourSquareFoot
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerHourSquareFoot(this int value) => HeatFlux.FromBtusPerHourSquareFoot(value);
+        public static HeatFlux BtusPerHourSquareFoot<T>(this T value) => HeatFlux.FromBtusPerHourSquareFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerHourSquareFoot(this int? value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerHourSquareFoot(this long value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerHourSquareFoot(this long? value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerHourSquareFoot(this double value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerHourSquareFoot(this double? value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerHourSquareFoot(this float value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerHourSquareFoot(this float? value) => HeatFlux.FromBtusPerHourSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerHourSquareFoot(this decimal value) => HeatFlux.FromBtusPerHourSquareFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerHourSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerHourSquareFoot(this decimal? value) => HeatFlux.FromBtusPerHourSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? BtusPerHourSquareFoot<T>(this T? value) where T : struct => HeatFlux.FromBtusPerHourSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region BtuPerMinuteSquareFoot
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerMinuteSquareFoot(this int value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
+        public static HeatFlux BtusPerMinuteSquareFoot<T>(this T value) => HeatFlux.FromBtusPerMinuteSquareFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerMinuteSquareFoot(this int? value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerMinuteSquareFoot(this long value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerMinuteSquareFoot(this long? value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerMinuteSquareFoot(this double value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerMinuteSquareFoot(this double? value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerMinuteSquareFoot(this float value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerMinuteSquareFoot(this float? value) => HeatFlux.FromBtusPerMinuteSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerMinuteSquareFoot(this decimal value) => HeatFlux.FromBtusPerMinuteSquareFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerMinuteSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerMinuteSquareFoot(this decimal? value) => HeatFlux.FromBtusPerMinuteSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? BtusPerMinuteSquareFoot<T>(this T? value) where T : struct => HeatFlux.FromBtusPerMinuteSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region BtuPerSecondSquareFoot
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareFoot(this int value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
+        public static HeatFlux BtusPerSecondSquareFoot<T>(this T value) => HeatFlux.FromBtusPerSecondSquareFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareFoot(this int? value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareFoot(this long value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareFoot(this long? value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareFoot(this double value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareFoot(this double? value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareFoot(this float value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareFoot(this float? value) => HeatFlux.FromBtusPerSecondSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareFoot(this decimal value) => HeatFlux.FromBtusPerSecondSquareFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareFoot(this decimal? value) => HeatFlux.FromBtusPerSecondSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? BtusPerSecondSquareFoot<T>(this T? value) where T : struct => HeatFlux.FromBtusPerSecondSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region BtuPerSecondSquareInch
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareInch(this int value) => HeatFlux.FromBtusPerSecondSquareInch(value);
+        public static HeatFlux BtusPerSecondSquareInch<T>(this T value) => HeatFlux.FromBtusPerSecondSquareInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareInch(this int? value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareInch(this long value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareInch(this long? value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareInch(this double value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareInch(this double? value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareInch(this float value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareInch(this float? value) => HeatFlux.FromBtusPerSecondSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux BtusPerSecondSquareInch(this decimal value) => HeatFlux.FromBtusPerSecondSquareInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromBtusPerSecondSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? BtusPerSecondSquareInch(this decimal? value) => HeatFlux.FromBtusPerSecondSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? BtusPerSecondSquareInch<T>(this T? value) where T : struct => HeatFlux.FromBtusPerSecondSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CaloriePerSecondSquareCentimeter
 
         /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CaloriesPerSecondSquareCentimeter(this int value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
+        public static HeatFlux CaloriesPerSecondSquareCentimeter<T>(this T value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CaloriesPerSecondSquareCentimeter(this int? value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CaloriesPerSecondSquareCentimeter(this long value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CaloriesPerSecondSquareCentimeter(this long? value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CaloriesPerSecondSquareCentimeter(this double value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CaloriesPerSecondSquareCentimeter(this double? value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CaloriesPerSecondSquareCentimeter(this float value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CaloriesPerSecondSquareCentimeter(this float? value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CaloriesPerSecondSquareCentimeter(this decimal value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromCaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CaloriesPerSecondSquareCentimeter(this decimal? value) => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? CaloriesPerSecondSquareCentimeter<T>(this T? value) where T : struct => HeatFlux.FromCaloriesPerSecondSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CentiwattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CentiwattsPerSquareMeter(this int value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
+        public static HeatFlux CentiwattsPerSquareMeter<T>(this T value) => HeatFlux.FromCentiwattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CentiwattsPerSquareMeter(this int? value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CentiwattsPerSquareMeter(this long value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CentiwattsPerSquareMeter(this long? value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CentiwattsPerSquareMeter(this double value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CentiwattsPerSquareMeter(this double? value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CentiwattsPerSquareMeter(this float value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CentiwattsPerSquareMeter(this float? value) => HeatFlux.FromCentiwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux CentiwattsPerSquareMeter(this decimal value) => HeatFlux.FromCentiwattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromCentiwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? CentiwattsPerSquareMeter(this decimal? value) => HeatFlux.FromCentiwattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? CentiwattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromCentiwattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DeciwattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux DeciwattsPerSquareMeter(this int value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
+        public static HeatFlux DeciwattsPerSquareMeter<T>(this T value) => HeatFlux.FromDeciwattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? DeciwattsPerSquareMeter(this int? value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux DeciwattsPerSquareMeter(this long value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? DeciwattsPerSquareMeter(this long? value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux DeciwattsPerSquareMeter(this double value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? DeciwattsPerSquareMeter(this double? value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux DeciwattsPerSquareMeter(this float value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? DeciwattsPerSquareMeter(this float? value) => HeatFlux.FromDeciwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux DeciwattsPerSquareMeter(this decimal value) => HeatFlux.FromDeciwattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromDeciwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? DeciwattsPerSquareMeter(this decimal? value) => HeatFlux.FromDeciwattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? DeciwattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromDeciwattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocaloriePerHourSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerHourSquareMeter(this int value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
+        public static HeatFlux KilocaloriesPerHourSquareMeter<T>(this T value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerHourSquareMeter(this int? value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerHourSquareMeter(this long value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerHourSquareMeter(this long? value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerHourSquareMeter(this double value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerHourSquareMeter(this double? value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerHourSquareMeter(this float value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerHourSquareMeter(this float? value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerHourSquareMeter(this decimal value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerHourSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerHourSquareMeter(this decimal? value) => HeatFlux.FromKilocaloriesPerHourSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? KilocaloriesPerHourSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromKilocaloriesPerHourSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocaloriePerSecondSquareCentimeter
 
         /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerSecondSquareCentimeter(this int value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
+        public static HeatFlux KilocaloriesPerSecondSquareCentimeter<T>(this T value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerSecondSquareCentimeter(this int? value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerSecondSquareCentimeter(this long value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerSecondSquareCentimeter(this long? value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerSecondSquareCentimeter(this double value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerSecondSquareCentimeter(this double? value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerSecondSquareCentimeter(this float value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerSecondSquareCentimeter(this float? value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilocaloriesPerSecondSquareCentimeter(this decimal value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilocaloriesPerSecondSquareCentimeter(this decimal? value) => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? KilocaloriesPerSecondSquareCentimeter<T>(this T? value) where T : struct => HeatFlux.FromKilocaloriesPerSecondSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilowattsPerSquareMeter(this int value) => HeatFlux.FromKilowattsPerSquareMeter(value);
+        public static HeatFlux KilowattsPerSquareMeter<T>(this T value) => HeatFlux.FromKilowattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilowattsPerSquareMeter(this int? value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilowattsPerSquareMeter(this long value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilowattsPerSquareMeter(this long? value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilowattsPerSquareMeter(this double value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilowattsPerSquareMeter(this double? value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilowattsPerSquareMeter(this float value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilowattsPerSquareMeter(this float? value) => HeatFlux.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux KilowattsPerSquareMeter(this decimal value) => HeatFlux.FromKilowattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? KilowattsPerSquareMeter(this decimal? value) => HeatFlux.FromKilowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? KilowattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromKilowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrowattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MicrowattsPerSquareMeter(this int value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
+        public static HeatFlux MicrowattsPerSquareMeter<T>(this T value) => HeatFlux.FromMicrowattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MicrowattsPerSquareMeter(this int? value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MicrowattsPerSquareMeter(this long value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MicrowattsPerSquareMeter(this long? value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MicrowattsPerSquareMeter(this double value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MicrowattsPerSquareMeter(this double? value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MicrowattsPerSquareMeter(this float value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MicrowattsPerSquareMeter(this float? value) => HeatFlux.FromMicrowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MicrowattsPerSquareMeter(this decimal value) => HeatFlux.FromMicrowattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromMicrowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MicrowattsPerSquareMeter(this decimal? value) => HeatFlux.FromMicrowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? MicrowattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromMicrowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliwattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MilliwattsPerSquareMeter(this int value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
+        public static HeatFlux MilliwattsPerSquareMeter<T>(this T value) => HeatFlux.FromMilliwattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MilliwattsPerSquareMeter(this int? value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MilliwattsPerSquareMeter(this long value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MilliwattsPerSquareMeter(this long? value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MilliwattsPerSquareMeter(this double value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MilliwattsPerSquareMeter(this double? value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MilliwattsPerSquareMeter(this float value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MilliwattsPerSquareMeter(this float? value) => HeatFlux.FromMilliwattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux MilliwattsPerSquareMeter(this decimal value) => HeatFlux.FromMilliwattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromMilliwattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? MilliwattsPerSquareMeter(this decimal? value) => HeatFlux.FromMilliwattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? MilliwattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromMilliwattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanowattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux NanowattsPerSquareMeter(this int value) => HeatFlux.FromNanowattsPerSquareMeter(value);
+        public static HeatFlux NanowattsPerSquareMeter<T>(this T value) => HeatFlux.FromNanowattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? NanowattsPerSquareMeter(this int? value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux NanowattsPerSquareMeter(this long value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? NanowattsPerSquareMeter(this long? value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux NanowattsPerSquareMeter(this double value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? NanowattsPerSquareMeter(this double? value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux NanowattsPerSquareMeter(this float value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? NanowattsPerSquareMeter(this float? value) => HeatFlux.FromNanowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux NanowattsPerSquareMeter(this decimal value) => HeatFlux.FromNanowattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromNanowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? NanowattsPerSquareMeter(this decimal? value) => HeatFlux.FromNanowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? NanowattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromNanowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerSquareFoot
 
         /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareFoot(this int value) => HeatFlux.FromWattsPerSquareFoot(value);
+        public static HeatFlux WattsPerSquareFoot<T>(this T value) => HeatFlux.FromWattsPerSquareFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareFoot(this int? value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareFoot(this long value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareFoot(this long? value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareFoot(this double value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareFoot(this double? value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareFoot(this float value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareFoot(this float? value) => HeatFlux.FromWattsPerSquareFoot(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareFoot(this decimal value) => HeatFlux.FromWattsPerSquareFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareFoot(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareFoot(this decimal? value) => HeatFlux.FromWattsPerSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? WattsPerSquareFoot<T>(this T? value) where T : struct => HeatFlux.FromWattsPerSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerSquareInch
 
         /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareInch(this int value) => HeatFlux.FromWattsPerSquareInch(value);
+        public static HeatFlux WattsPerSquareInch<T>(this T value) => HeatFlux.FromWattsPerSquareInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareInch(this int? value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareInch(this long value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareInch(this long? value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareInch(this double value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareInch(this double? value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareInch(this float value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareInch(this float? value) => HeatFlux.FromWattsPerSquareInch(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareInch(this decimal value) => HeatFlux.FromWattsPerSquareInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareInch(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareInch(this decimal? value) => HeatFlux.FromWattsPerSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? WattsPerSquareInch<T>(this T? value) where T : struct => HeatFlux.FromWattsPerSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerSquareMeter
 
         /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareMeter(this int value) => HeatFlux.FromWattsPerSquareMeter(value);
+        public static HeatFlux WattsPerSquareMeter<T>(this T value) => HeatFlux.FromWattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareMeter(this int? value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareMeter(this long value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareMeter(this long? value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareMeter(this double value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareMeter(this double? value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareMeter(this float value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareMeter(this float? value) => HeatFlux.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux WattsPerSquareMeter(this decimal value) => HeatFlux.FromWattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatFlux.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static HeatFlux? WattsPerSquareMeter(this decimal? value) => HeatFlux.FromWattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatFlux? WattsPerSquareMeter<T>(this T? value) where T : struct => HeatFlux.FromWattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToHeatTransferCoefficientExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToHeatTransferCoefficientExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToHeatTransferCoefficient
         #region WattPerSquareMeterCelsius
 
         /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterCelsius(this int value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
+        public static HeatTransferCoefficient WattsPerSquareMeterCelsius<T>(this T value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterCelsius(this int? value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterCelsius(this long value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterCelsius(this long? value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterCelsius(this double value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterCelsius(this double? value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterCelsius(this float value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterCelsius(this float? value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterCelsius(this decimal value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterCelsius(this decimal? value) => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatTransferCoefficient? WattsPerSquareMeterCelsius<T>(this T? value) where T : struct => HeatTransferCoefficient.FromWattsPerSquareMeterCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerSquareMeterKelvin
 
         /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterKelvin(this int value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
+        public static HeatTransferCoefficient WattsPerSquareMeterKelvin<T>(this T value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterKelvin(this int? value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterKelvin(this long value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterKelvin(this long? value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterKelvin(this double value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterKelvin(this double? value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterKelvin(this float value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterKelvin(this float? value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value);
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient WattsPerSquareMeterKelvin(this decimal value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(UnitsNet.QuantityValue)" />
-        public static HeatTransferCoefficient? WattsPerSquareMeterKelvin(this decimal? value) => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static HeatTransferCoefficient? WattsPerSquareMeterKelvin<T>(this T? value) where T : struct => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToIlluminanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToIlluminanceExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToIlluminance
         #region Kilolux
 
         /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance Kilolux(this int value) => Illuminance.FromKilolux(value);
+        public static Illuminance Kilolux<T>(this T value) => Illuminance.FromKilolux(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Kilolux(this int? value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance Kilolux(this long value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Kilolux(this long? value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance Kilolux(this double value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Kilolux(this double? value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance Kilolux(this float value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Kilolux(this float? value) => Illuminance.FromKilolux(value);
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance Kilolux(this decimal value) => Illuminance.FromKilolux(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Illuminance.FromKilolux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Kilolux(this decimal? value) => Illuminance.FromKilolux(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Illuminance? Kilolux<T>(this T? value) where T : struct => Illuminance.FromKilolux(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Lux
 
         /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance Lux(this int value) => Illuminance.FromLux(value);
+        public static Illuminance Lux<T>(this T value) => Illuminance.FromLux(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Lux(this int? value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance Lux(this long value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Lux(this long? value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance Lux(this double value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Lux(this double? value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance Lux(this float value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Lux(this float? value) => Illuminance.FromLux(value);
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance Lux(this decimal value) => Illuminance.FromLux(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Illuminance.FromLux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Lux(this decimal? value) => Illuminance.FromLux(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Illuminance? Lux<T>(this T? value) where T : struct => Illuminance.FromLux(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megalux
 
         /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance Megalux(this int value) => Illuminance.FromMegalux(value);
+        public static Illuminance Megalux<T>(this T value) => Illuminance.FromMegalux(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Megalux(this int? value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance Megalux(this long value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Megalux(this long? value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance Megalux(this double value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Megalux(this double? value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance Megalux(this float value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Megalux(this float? value) => Illuminance.FromMegalux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance Megalux(this decimal value) => Illuminance.FromMegalux(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Illuminance.FromMegalux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Megalux(this decimal? value) => Illuminance.FromMegalux(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Illuminance? Megalux<T>(this T? value) where T : struct => Illuminance.FromMegalux(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millilux
 
         /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance Millilux(this int value) => Illuminance.FromMillilux(value);
+        public static Illuminance Millilux<T>(this T value) => Illuminance.FromMillilux(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Millilux(this int? value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance Millilux(this long value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Millilux(this long? value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance Millilux(this double value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Millilux(this double? value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance Millilux(this float value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Millilux(this float? value) => Illuminance.FromMillilux(value);
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance Millilux(this decimal value) => Illuminance.FromMillilux(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Illuminance.FromMillilux(UnitsNet.QuantityValue)" />
-        public static Illuminance? Millilux(this decimal? value) => Illuminance.FromMillilux(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Illuminance? Millilux<T>(this T? value) where T : struct => Illuminance.FromMillilux(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToInformationExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToInformationExtensions.g.cs
@@ -47,884 +47,260 @@ namespace UnitsNet.Extensions.NumberToInformation
         #region Bit
 
         /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information Bits(this int value) => Information.FromBits(value);
+        public static Information Bits<T>(this T value) => Information.FromBits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information? Bits(this int? value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information Bits(this long value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information? Bits(this long? value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information Bits(this double value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information? Bits(this double? value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information Bits(this float value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information? Bits(this float? value) => Information.FromBits(value);
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information Bits(this decimal value) => Information.FromBits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromBits(UnitsNet.QuantityValue)" />
-        public static Information? Bits(this decimal? value) => Information.FromBits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Bits<T>(this T? value) where T : struct => Information.FromBits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Byte
 
         /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information Bytes(this int value) => Information.FromBytes(value);
+        public static Information Bytes<T>(this T value) => Information.FromBytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information? Bytes(this int? value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information Bytes(this long value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information? Bytes(this long? value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information Bytes(this double value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information? Bytes(this double? value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information Bytes(this float value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information? Bytes(this float? value) => Information.FromBytes(value);
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information Bytes(this decimal value) => Information.FromBytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromBytes(UnitsNet.QuantityValue)" />
-        public static Information? Bytes(this decimal? value) => Information.FromBytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Bytes<T>(this T? value) where T : struct => Information.FromBytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Exabit
 
         /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information Exabits(this int value) => Information.FromExabits(value);
+        public static Information Exabits<T>(this T value) => Information.FromExabits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information? Exabits(this int? value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information Exabits(this long value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information? Exabits(this long? value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information Exabits(this double value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information? Exabits(this double? value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information Exabits(this float value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information? Exabits(this float? value) => Information.FromExabits(value);
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information Exabits(this decimal value) => Information.FromExabits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromExabits(UnitsNet.QuantityValue)" />
-        public static Information? Exabits(this decimal? value) => Information.FromExabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Exabits<T>(this T? value) where T : struct => Information.FromExabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Exabyte
 
         /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information Exabytes(this int value) => Information.FromExabytes(value);
+        public static Information Exabytes<T>(this T value) => Information.FromExabytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information? Exabytes(this int? value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information Exabytes(this long value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information? Exabytes(this long? value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information Exabytes(this double value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information? Exabytes(this double? value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information Exabytes(this float value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information? Exabytes(this float? value) => Information.FromExabytes(value);
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information Exabytes(this decimal value) => Information.FromExabytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromExabytes(UnitsNet.QuantityValue)" />
-        public static Information? Exabytes(this decimal? value) => Information.FromExabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Exabytes<T>(this T? value) where T : struct => Information.FromExabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Exbibit
 
         /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information Exbibits(this int value) => Information.FromExbibits(value);
+        public static Information Exbibits<T>(this T value) => Information.FromExbibits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information? Exbibits(this int? value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information Exbibits(this long value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information? Exbibits(this long? value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information Exbibits(this double value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information? Exbibits(this double? value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information Exbibits(this float value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information? Exbibits(this float? value) => Information.FromExbibits(value);
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information Exbibits(this decimal value) => Information.FromExbibits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromExbibits(UnitsNet.QuantityValue)" />
-        public static Information? Exbibits(this decimal? value) => Information.FromExbibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Exbibits<T>(this T? value) where T : struct => Information.FromExbibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Exbibyte
 
         /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information Exbibytes(this int value) => Information.FromExbibytes(value);
+        public static Information Exbibytes<T>(this T value) => Information.FromExbibytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information? Exbibytes(this int? value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information Exbibytes(this long value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information? Exbibytes(this long? value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information Exbibytes(this double value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information? Exbibytes(this double? value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information Exbibytes(this float value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information? Exbibytes(this float? value) => Information.FromExbibytes(value);
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information Exbibytes(this decimal value) => Information.FromExbibytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromExbibytes(UnitsNet.QuantityValue)" />
-        public static Information? Exbibytes(this decimal? value) => Information.FromExbibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Exbibytes<T>(this T? value) where T : struct => Information.FromExbibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gibibit
 
         /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information Gibibits(this int value) => Information.FromGibibits(value);
+        public static Information Gibibits<T>(this T value) => Information.FromGibibits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information? Gibibits(this int? value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information Gibibits(this long value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information? Gibibits(this long? value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information Gibibits(this double value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information? Gibibits(this double? value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information Gibibits(this float value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information? Gibibits(this float? value) => Information.FromGibibits(value);
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information Gibibits(this decimal value) => Information.FromGibibits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromGibibits(UnitsNet.QuantityValue)" />
-        public static Information? Gibibits(this decimal? value) => Information.FromGibibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Gibibits<T>(this T? value) where T : struct => Information.FromGibibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gibibyte
 
         /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information Gibibytes(this int value) => Information.FromGibibytes(value);
+        public static Information Gibibytes<T>(this T value) => Information.FromGibibytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Gibibytes(this int? value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information Gibibytes(this long value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Gibibytes(this long? value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information Gibibytes(this double value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Gibibytes(this double? value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information Gibibytes(this float value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Gibibytes(this float? value) => Information.FromGibibytes(value);
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information Gibibytes(this decimal value) => Information.FromGibibytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromGibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Gibibytes(this decimal? value) => Information.FromGibibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Gibibytes<T>(this T? value) where T : struct => Information.FromGibibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gigabit
 
         /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information Gigabits(this int value) => Information.FromGigabits(value);
+        public static Information Gigabits<T>(this T value) => Information.FromGigabits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information? Gigabits(this int? value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information Gigabits(this long value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information? Gigabits(this long? value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information Gigabits(this double value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information? Gigabits(this double? value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information Gigabits(this float value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information? Gigabits(this float? value) => Information.FromGigabits(value);
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information Gigabits(this decimal value) => Information.FromGigabits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromGigabits(UnitsNet.QuantityValue)" />
-        public static Information? Gigabits(this decimal? value) => Information.FromGigabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Gigabits<T>(this T? value) where T : struct => Information.FromGigabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gigabyte
 
         /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information Gigabytes(this int value) => Information.FromGigabytes(value);
+        public static Information Gigabytes<T>(this T value) => Information.FromGigabytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information? Gigabytes(this int? value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information Gigabytes(this long value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information? Gigabytes(this long? value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information Gigabytes(this double value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information? Gigabytes(this double? value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information Gigabytes(this float value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information? Gigabytes(this float? value) => Information.FromGigabytes(value);
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information Gigabytes(this decimal value) => Information.FromGigabytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromGigabytes(UnitsNet.QuantityValue)" />
-        public static Information? Gigabytes(this decimal? value) => Information.FromGigabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Gigabytes<T>(this T? value) where T : struct => Information.FromGigabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kibibit
 
         /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information Kibibits(this int value) => Information.FromKibibits(value);
+        public static Information Kibibits<T>(this T value) => Information.FromKibibits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information? Kibibits(this int? value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information Kibibits(this long value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information? Kibibits(this long? value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information Kibibits(this double value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information? Kibibits(this double? value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information Kibibits(this float value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information? Kibibits(this float? value) => Information.FromKibibits(value);
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information Kibibits(this decimal value) => Information.FromKibibits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromKibibits(UnitsNet.QuantityValue)" />
-        public static Information? Kibibits(this decimal? value) => Information.FromKibibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Kibibits<T>(this T? value) where T : struct => Information.FromKibibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kibibyte
 
         /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information Kibibytes(this int value) => Information.FromKibibytes(value);
+        public static Information Kibibytes<T>(this T value) => Information.FromKibibytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Kibibytes(this int? value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information Kibibytes(this long value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Kibibytes(this long? value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information Kibibytes(this double value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Kibibytes(this double? value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information Kibibytes(this float value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Kibibytes(this float? value) => Information.FromKibibytes(value);
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information Kibibytes(this decimal value) => Information.FromKibibytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromKibibytes(UnitsNet.QuantityValue)" />
-        public static Information? Kibibytes(this decimal? value) => Information.FromKibibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Kibibytes<T>(this T? value) where T : struct => Information.FromKibibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilobit
 
         /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information Kilobits(this int value) => Information.FromKilobits(value);
+        public static Information Kilobits<T>(this T value) => Information.FromKilobits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information? Kilobits(this int? value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information Kilobits(this long value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information? Kilobits(this long? value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information Kilobits(this double value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information? Kilobits(this double? value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information Kilobits(this float value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information? Kilobits(this float? value) => Information.FromKilobits(value);
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information Kilobits(this decimal value) => Information.FromKilobits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromKilobits(UnitsNet.QuantityValue)" />
-        public static Information? Kilobits(this decimal? value) => Information.FromKilobits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Kilobits<T>(this T? value) where T : struct => Information.FromKilobits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilobyte
 
         /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information Kilobytes(this int value) => Information.FromKilobytes(value);
+        public static Information Kilobytes<T>(this T value) => Information.FromKilobytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information? Kilobytes(this int? value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information Kilobytes(this long value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information? Kilobytes(this long? value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information Kilobytes(this double value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information? Kilobytes(this double? value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information Kilobytes(this float value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information? Kilobytes(this float? value) => Information.FromKilobytes(value);
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information Kilobytes(this decimal value) => Information.FromKilobytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromKilobytes(UnitsNet.QuantityValue)" />
-        public static Information? Kilobytes(this decimal? value) => Information.FromKilobytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Kilobytes<T>(this T? value) where T : struct => Information.FromKilobytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Mebibit
 
         /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information Mebibits(this int value) => Information.FromMebibits(value);
+        public static Information Mebibits<T>(this T value) => Information.FromMebibits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information? Mebibits(this int? value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information Mebibits(this long value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information? Mebibits(this long? value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information Mebibits(this double value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information? Mebibits(this double? value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information Mebibits(this float value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information? Mebibits(this float? value) => Information.FromMebibits(value);
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information Mebibits(this decimal value) => Information.FromMebibits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromMebibits(UnitsNet.QuantityValue)" />
-        public static Information? Mebibits(this decimal? value) => Information.FromMebibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Mebibits<T>(this T? value) where T : struct => Information.FromMebibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Mebibyte
 
         /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information Mebibytes(this int value) => Information.FromMebibytes(value);
+        public static Information Mebibytes<T>(this T value) => Information.FromMebibytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Mebibytes(this int? value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information Mebibytes(this long value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Mebibytes(this long? value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information Mebibytes(this double value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Mebibytes(this double? value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information Mebibytes(this float value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Mebibytes(this float? value) => Information.FromMebibytes(value);
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information Mebibytes(this decimal value) => Information.FromMebibytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromMebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Mebibytes(this decimal? value) => Information.FromMebibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Mebibytes<T>(this T? value) where T : struct => Information.FromMebibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megabit
 
         /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information Megabits(this int value) => Information.FromMegabits(value);
+        public static Information Megabits<T>(this T value) => Information.FromMegabits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information? Megabits(this int? value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information Megabits(this long value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information? Megabits(this long? value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information Megabits(this double value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information? Megabits(this double? value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information Megabits(this float value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information? Megabits(this float? value) => Information.FromMegabits(value);
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information Megabits(this decimal value) => Information.FromMegabits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromMegabits(UnitsNet.QuantityValue)" />
-        public static Information? Megabits(this decimal? value) => Information.FromMegabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Megabits<T>(this T? value) where T : struct => Information.FromMegabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megabyte
 
         /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information Megabytes(this int value) => Information.FromMegabytes(value);
+        public static Information Megabytes<T>(this T value) => Information.FromMegabytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information? Megabytes(this int? value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information Megabytes(this long value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information? Megabytes(this long? value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information Megabytes(this double value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information? Megabytes(this double? value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information Megabytes(this float value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information? Megabytes(this float? value) => Information.FromMegabytes(value);
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information Megabytes(this decimal value) => Information.FromMegabytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromMegabytes(UnitsNet.QuantityValue)" />
-        public static Information? Megabytes(this decimal? value) => Information.FromMegabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Megabytes<T>(this T? value) where T : struct => Information.FromMegabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Pebibit
 
         /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information Pebibits(this int value) => Information.FromPebibits(value);
+        public static Information Pebibits<T>(this T value) => Information.FromPebibits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information? Pebibits(this int? value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information Pebibits(this long value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information? Pebibits(this long? value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information Pebibits(this double value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information? Pebibits(this double? value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information Pebibits(this float value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information? Pebibits(this float? value) => Information.FromPebibits(value);
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information Pebibits(this decimal value) => Information.FromPebibits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromPebibits(UnitsNet.QuantityValue)" />
-        public static Information? Pebibits(this decimal? value) => Information.FromPebibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Pebibits<T>(this T? value) where T : struct => Information.FromPebibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Pebibyte
 
         /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information Pebibytes(this int value) => Information.FromPebibytes(value);
+        public static Information Pebibytes<T>(this T value) => Information.FromPebibytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Pebibytes(this int? value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information Pebibytes(this long value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Pebibytes(this long? value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information Pebibytes(this double value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Pebibytes(this double? value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information Pebibytes(this float value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Pebibytes(this float? value) => Information.FromPebibytes(value);
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information Pebibytes(this decimal value) => Information.FromPebibytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromPebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Pebibytes(this decimal? value) => Information.FromPebibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Pebibytes<T>(this T? value) where T : struct => Information.FromPebibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Petabit
 
         /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information Petabits(this int value) => Information.FromPetabits(value);
+        public static Information Petabits<T>(this T value) => Information.FromPetabits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information? Petabits(this int? value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information Petabits(this long value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information? Petabits(this long? value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information Petabits(this double value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information? Petabits(this double? value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information Petabits(this float value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information? Petabits(this float? value) => Information.FromPetabits(value);
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information Petabits(this decimal value) => Information.FromPetabits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromPetabits(UnitsNet.QuantityValue)" />
-        public static Information? Petabits(this decimal? value) => Information.FromPetabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Petabits<T>(this T? value) where T : struct => Information.FromPetabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Petabyte
 
         /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information Petabytes(this int value) => Information.FromPetabytes(value);
+        public static Information Petabytes<T>(this T value) => Information.FromPetabytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information? Petabytes(this int? value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information Petabytes(this long value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information? Petabytes(this long? value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information Petabytes(this double value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information? Petabytes(this double? value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information Petabytes(this float value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information? Petabytes(this float? value) => Information.FromPetabytes(value);
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information Petabytes(this decimal value) => Information.FromPetabytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromPetabytes(UnitsNet.QuantityValue)" />
-        public static Information? Petabytes(this decimal? value) => Information.FromPetabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Petabytes<T>(this T? value) where T : struct => Information.FromPetabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Tebibit
 
         /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information Tebibits(this int value) => Information.FromTebibits(value);
+        public static Information Tebibits<T>(this T value) => Information.FromTebibits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information? Tebibits(this int? value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information Tebibits(this long value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information? Tebibits(this long? value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information Tebibits(this double value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information? Tebibits(this double? value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information Tebibits(this float value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information? Tebibits(this float? value) => Information.FromTebibits(value);
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information Tebibits(this decimal value) => Information.FromTebibits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromTebibits(UnitsNet.QuantityValue)" />
-        public static Information? Tebibits(this decimal? value) => Information.FromTebibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Tebibits<T>(this T? value) where T : struct => Information.FromTebibits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Tebibyte
 
         /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information Tebibytes(this int value) => Information.FromTebibytes(value);
+        public static Information Tebibytes<T>(this T value) => Information.FromTebibytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Tebibytes(this int? value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information Tebibytes(this long value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Tebibytes(this long? value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information Tebibytes(this double value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Tebibytes(this double? value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information Tebibytes(this float value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Tebibytes(this float? value) => Information.FromTebibytes(value);
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information Tebibytes(this decimal value) => Information.FromTebibytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromTebibytes(UnitsNet.QuantityValue)" />
-        public static Information? Tebibytes(this decimal? value) => Information.FromTebibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Tebibytes<T>(this T? value) where T : struct => Information.FromTebibytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Terabit
 
         /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information Terabits(this int value) => Information.FromTerabits(value);
+        public static Information Terabits<T>(this T value) => Information.FromTerabits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information? Terabits(this int? value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information Terabits(this long value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information? Terabits(this long? value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information Terabits(this double value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information? Terabits(this double? value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information Terabits(this float value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information? Terabits(this float? value) => Information.FromTerabits(value);
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information Terabits(this decimal value) => Information.FromTerabits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromTerabits(UnitsNet.QuantityValue)" />
-        public static Information? Terabits(this decimal? value) => Information.FromTerabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Terabits<T>(this T? value) where T : struct => Information.FromTerabits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Terabyte
 
         /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information Terabytes(this int value) => Information.FromTerabytes(value);
+        public static Information Terabytes<T>(this T value) => Information.FromTerabytes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information? Terabytes(this int? value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information Terabytes(this long value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information? Terabytes(this long? value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information Terabytes(this double value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information? Terabytes(this double? value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information Terabytes(this float value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information? Terabytes(this float? value) => Information.FromTerabytes(value);
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information Terabytes(this decimal value) => Information.FromTerabytes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Information.FromTerabytes(UnitsNet.QuantityValue)" />
-        public static Information? Terabytes(this decimal? value) => Information.FromTerabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Information? Terabytes<T>(this T? value) where T : struct => Information.FromTerabytes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToIrradianceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToIrradianceExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToIrradiance
         #region KilowattPerSquareMeter
 
         /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance KilowattsPerSquareMeter(this int value) => Irradiance.FromKilowattsPerSquareMeter(value);
+        public static Irradiance KilowattsPerSquareMeter<T>(this T value) => Irradiance.FromKilowattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? KilowattsPerSquareMeter(this int? value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance KilowattsPerSquareMeter(this long value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? KilowattsPerSquareMeter(this long? value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance KilowattsPerSquareMeter(this double value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? KilowattsPerSquareMeter(this double? value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance KilowattsPerSquareMeter(this float value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? KilowattsPerSquareMeter(this float? value) => Irradiance.FromKilowattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance KilowattsPerSquareMeter(this decimal value) => Irradiance.FromKilowattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Irradiance.FromKilowattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? KilowattsPerSquareMeter(this decimal? value) => Irradiance.FromKilowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Irradiance? KilowattsPerSquareMeter<T>(this T? value) where T : struct => Irradiance.FromKilowattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerSquareMeter
 
         /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance WattsPerSquareMeter(this int value) => Irradiance.FromWattsPerSquareMeter(value);
+        public static Irradiance WattsPerSquareMeter<T>(this T value) => Irradiance.FromWattsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? WattsPerSquareMeter(this int? value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance WattsPerSquareMeter(this long value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? WattsPerSquareMeter(this long? value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance WattsPerSquareMeter(this double value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? WattsPerSquareMeter(this double? value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance WattsPerSquareMeter(this float value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? WattsPerSquareMeter(this float? value) => Irradiance.FromWattsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance WattsPerSquareMeter(this decimal value) => Irradiance.FromWattsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Irradiance.FromWattsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiance? WattsPerSquareMeter(this decimal? value) => Irradiance.FromWattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Irradiance? WattsPerSquareMeter<T>(this T? value) where T : struct => Irradiance.FromWattsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToIrradiationExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToIrradiationExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToIrradiation
         #region JoulePerSquareMeter
 
         /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation JoulesPerSquareMeter(this int value) => Irradiation.FromJoulesPerSquareMeter(value);
+        public static Irradiation JoulesPerSquareMeter<T>(this T value) => Irradiation.FromJoulesPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? JoulesPerSquareMeter(this int? value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation JoulesPerSquareMeter(this long value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? JoulesPerSquareMeter(this long? value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation JoulesPerSquareMeter(this double value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? JoulesPerSquareMeter(this double? value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation JoulesPerSquareMeter(this float value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? JoulesPerSquareMeter(this float? value) => Irradiation.FromJoulesPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation JoulesPerSquareMeter(this decimal value) => Irradiation.FromJoulesPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Irradiation.FromJoulesPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? JoulesPerSquareMeter(this decimal? value) => Irradiation.FromJoulesPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Irradiation? JoulesPerSquareMeter<T>(this T? value) where T : struct => Irradiation.FromJoulesPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattHourPerSquareMeter
 
         /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation KilowattHoursPerSquareMeter(this int value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
+        public static Irradiation KilowattHoursPerSquareMeter<T>(this T value) => Irradiation.FromKilowattHoursPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? KilowattHoursPerSquareMeter(this int? value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation KilowattHoursPerSquareMeter(this long value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? KilowattHoursPerSquareMeter(this long? value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation KilowattHoursPerSquareMeter(this double value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? KilowattHoursPerSquareMeter(this double? value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation KilowattHoursPerSquareMeter(this float value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? KilowattHoursPerSquareMeter(this float? value) => Irradiation.FromKilowattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation KilowattHoursPerSquareMeter(this decimal value) => Irradiation.FromKilowattHoursPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Irradiation.FromKilowattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? KilowattHoursPerSquareMeter(this decimal? value) => Irradiation.FromKilowattHoursPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Irradiation? KilowattHoursPerSquareMeter<T>(this T? value) where T : struct => Irradiation.FromKilowattHoursPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattHourPerSquareMeter
 
         /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation WattHoursPerSquareMeter(this int value) => Irradiation.FromWattHoursPerSquareMeter(value);
+        public static Irradiation WattHoursPerSquareMeter<T>(this T value) => Irradiation.FromWattHoursPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? WattHoursPerSquareMeter(this int? value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation WattHoursPerSquareMeter(this long value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? WattHoursPerSquareMeter(this long? value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation WattHoursPerSquareMeter(this double value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? WattHoursPerSquareMeter(this double? value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation WattHoursPerSquareMeter(this float value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? WattHoursPerSquareMeter(this float? value) => Irradiation.FromWattHoursPerSquareMeter(value);
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation WattHoursPerSquareMeter(this decimal value) => Irradiation.FromWattHoursPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Irradiation.FromWattHoursPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Irradiation? WattHoursPerSquareMeter(this decimal? value) => Irradiation.FromWattHoursPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Irradiation? WattHoursPerSquareMeter<T>(this T? value) where T : struct => Irradiation.FromWattHoursPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToKinematicViscosityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToKinematicViscosityExtensions.g.cs
@@ -47,272 +47,80 @@ namespace UnitsNet.Extensions.NumberToKinematicViscosity
         #region Centistokes
 
         /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Centistokes(this int value) => KinematicViscosity.FromCentistokes(value);
+        public static KinematicViscosity Centistokes<T>(this T value) => KinematicViscosity.FromCentistokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Centistokes(this int? value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Centistokes(this long value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Centistokes(this long? value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Centistokes(this double value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Centistokes(this double? value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Centistokes(this float value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Centistokes(this float? value) => KinematicViscosity.FromCentistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Centistokes(this decimal value) => KinematicViscosity.FromCentistokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromCentistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Centistokes(this decimal? value) => KinematicViscosity.FromCentistokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Centistokes<T>(this T? value) where T : struct => KinematicViscosity.FromCentistokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decistokes
 
         /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Decistokes(this int value) => KinematicViscosity.FromDecistokes(value);
+        public static KinematicViscosity Decistokes<T>(this T value) => KinematicViscosity.FromDecistokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Decistokes(this int? value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Decistokes(this long value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Decistokes(this long? value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Decistokes(this double value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Decistokes(this double? value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Decistokes(this float value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Decistokes(this float? value) => KinematicViscosity.FromDecistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Decistokes(this decimal value) => KinematicViscosity.FromDecistokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromDecistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Decistokes(this decimal? value) => KinematicViscosity.FromDecistokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Decistokes<T>(this T? value) where T : struct => KinematicViscosity.FromDecistokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilostokes
 
         /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Kilostokes(this int value) => KinematicViscosity.FromKilostokes(value);
+        public static KinematicViscosity Kilostokes<T>(this T value) => KinematicViscosity.FromKilostokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Kilostokes(this int? value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Kilostokes(this long value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Kilostokes(this long? value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Kilostokes(this double value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Kilostokes(this double? value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Kilostokes(this float value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Kilostokes(this float? value) => KinematicViscosity.FromKilostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Kilostokes(this decimal value) => KinematicViscosity.FromKilostokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromKilostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Kilostokes(this decimal? value) => KinematicViscosity.FromKilostokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Kilostokes<T>(this T? value) where T : struct => KinematicViscosity.FromKilostokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microstokes
 
         /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Microstokes(this int value) => KinematicViscosity.FromMicrostokes(value);
+        public static KinematicViscosity Microstokes<T>(this T value) => KinematicViscosity.FromMicrostokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Microstokes(this int? value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Microstokes(this long value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Microstokes(this long? value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Microstokes(this double value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Microstokes(this double? value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Microstokes(this float value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Microstokes(this float? value) => KinematicViscosity.FromMicrostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Microstokes(this decimal value) => KinematicViscosity.FromMicrostokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromMicrostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Microstokes(this decimal? value) => KinematicViscosity.FromMicrostokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Microstokes<T>(this T? value) where T : struct => KinematicViscosity.FromMicrostokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millistokes
 
         /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Millistokes(this int value) => KinematicViscosity.FromMillistokes(value);
+        public static KinematicViscosity Millistokes<T>(this T value) => KinematicViscosity.FromMillistokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Millistokes(this int? value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Millistokes(this long value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Millistokes(this long? value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Millistokes(this double value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Millistokes(this double? value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Millistokes(this float value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Millistokes(this float? value) => KinematicViscosity.FromMillistokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Millistokes(this decimal value) => KinematicViscosity.FromMillistokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromMillistokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Millistokes(this decimal? value) => KinematicViscosity.FromMillistokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Millistokes<T>(this T? value) where T : struct => KinematicViscosity.FromMillistokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanostokes
 
         /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Nanostokes(this int value) => KinematicViscosity.FromNanostokes(value);
+        public static KinematicViscosity Nanostokes<T>(this T value) => KinematicViscosity.FromNanostokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Nanostokes(this int? value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Nanostokes(this long value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Nanostokes(this long? value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Nanostokes(this double value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Nanostokes(this double? value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Nanostokes(this float value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Nanostokes(this float? value) => KinematicViscosity.FromNanostokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Nanostokes(this decimal value) => KinematicViscosity.FromNanostokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromNanostokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Nanostokes(this decimal? value) => KinematicViscosity.FromNanostokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Nanostokes<T>(this T? value) where T : struct => KinematicViscosity.FromNanostokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMeterPerSecond
 
         /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity SquareMetersPerSecond(this int value) => KinematicViscosity.FromSquareMetersPerSecond(value);
+        public static KinematicViscosity SquareMetersPerSecond<T>(this T value) => KinematicViscosity.FromSquareMetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? SquareMetersPerSecond(this int? value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity SquareMetersPerSecond(this long value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? SquareMetersPerSecond(this long? value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity SquareMetersPerSecond(this double value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? SquareMetersPerSecond(this double? value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity SquareMetersPerSecond(this float value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? SquareMetersPerSecond(this float? value) => KinematicViscosity.FromSquareMetersPerSecond(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity SquareMetersPerSecond(this decimal value) => KinematicViscosity.FromSquareMetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromSquareMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? SquareMetersPerSecond(this decimal? value) => KinematicViscosity.FromSquareMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? SquareMetersPerSecond<T>(this T? value) where T : struct => KinematicViscosity.FromSquareMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Stokes
 
         /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Stokes(this int value) => KinematicViscosity.FromStokes(value);
+        public static KinematicViscosity Stokes<T>(this T value) => KinematicViscosity.FromStokes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Stokes(this int? value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Stokes(this long value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Stokes(this long? value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Stokes(this double value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Stokes(this double? value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Stokes(this float value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Stokes(this float? value) => KinematicViscosity.FromStokes(value);
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity Stokes(this decimal value) => KinematicViscosity.FromStokes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="KinematicViscosity.FromStokes(UnitsNet.QuantityValue)" />
-        public static KinematicViscosity? Stokes(this decimal? value) => KinematicViscosity.FromStokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static KinematicViscosity? Stokes<T>(this T? value) where T : struct => KinematicViscosity.FromStokes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToLapseRateExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToLapseRateExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToLapseRate
         #region DegreeCelsiusPerKilometer
 
         /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate DegreesCelciusPerKilometer(this int value) => LapseRate.FromDegreesCelciusPerKilometer(value);
+        public static LapseRate DegreesCelciusPerKilometer<T>(this T value) => LapseRate.FromDegreesCelciusPerKilometer(Convert.ToDouble(value));
 
         /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate? DegreesCelciusPerKilometer(this int? value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate DegreesCelciusPerKilometer(this long value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate? DegreesCelciusPerKilometer(this long? value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate DegreesCelciusPerKilometer(this double value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate? DegreesCelciusPerKilometer(this double? value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate DegreesCelciusPerKilometer(this float value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate? DegreesCelciusPerKilometer(this float? value) => LapseRate.FromDegreesCelciusPerKilometer(value);
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate DegreesCelciusPerKilometer(this decimal value) => LapseRate.FromDegreesCelciusPerKilometer(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="LapseRate.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static LapseRate? DegreesCelciusPerKilometer(this decimal? value) => LapseRate.FromDegreesCelciusPerKilometer(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static LapseRate? DegreesCelciusPerKilometer<T>(this T? value) where T : struct => LapseRate.FromDegreesCelciusPerKilometer(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToLengthExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToLengthExtensions.g.cs
@@ -47,748 +47,220 @@ namespace UnitsNet.Extensions.NumberToLength
         #region Centimeter
 
         /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length Centimeters(this int value) => Length.FromCentimeters(value);
+        public static Length Centimeters<T>(this T value) => Length.FromCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length? Centimeters(this int? value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length Centimeters(this long value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length? Centimeters(this long? value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length Centimeters(this double value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length? Centimeters(this double? value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length Centimeters(this float value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length? Centimeters(this float? value) => Length.FromCentimeters(value);
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length Centimeters(this decimal value) => Length.FromCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromCentimeters(UnitsNet.QuantityValue)" />
-        public static Length? Centimeters(this decimal? value) => Length.FromCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Centimeters<T>(this T? value) where T : struct => Length.FromCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decimeter
 
         /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length Decimeters(this int value) => Length.FromDecimeters(value);
+        public static Length Decimeters<T>(this T value) => Length.FromDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length? Decimeters(this int? value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length Decimeters(this long value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length? Decimeters(this long? value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length Decimeters(this double value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length? Decimeters(this double? value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length Decimeters(this float value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length? Decimeters(this float? value) => Length.FromDecimeters(value);
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length Decimeters(this decimal value) => Length.FromDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
-        public static Length? Decimeters(this decimal? value) => Length.FromDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Decimeters<T>(this T? value) where T : struct => Length.FromDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DtpPica
 
         /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length DtpPicas(this int value) => Length.FromDtpPicas(value);
+        public static Length DtpPicas<T>(this T value) => Length.FromDtpPicas(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length? DtpPicas(this int? value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length DtpPicas(this long value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length? DtpPicas(this long? value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length DtpPicas(this double value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length? DtpPicas(this double? value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length DtpPicas(this float value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length? DtpPicas(this float? value) => Length.FromDtpPicas(value);
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length DtpPicas(this decimal value) => Length.FromDtpPicas(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromDtpPicas(UnitsNet.QuantityValue)" />
-        public static Length? DtpPicas(this decimal? value) => Length.FromDtpPicas(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? DtpPicas<T>(this T? value) where T : struct => Length.FromDtpPicas(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DtpPoint
 
         /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length DtpPoints(this int value) => Length.FromDtpPoints(value);
+        public static Length DtpPoints<T>(this T value) => Length.FromDtpPoints(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length? DtpPoints(this int? value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length DtpPoints(this long value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length? DtpPoints(this long? value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length DtpPoints(this double value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length? DtpPoints(this double? value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length DtpPoints(this float value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length? DtpPoints(this float? value) => Length.FromDtpPoints(value);
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length DtpPoints(this decimal value) => Length.FromDtpPoints(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromDtpPoints(UnitsNet.QuantityValue)" />
-        public static Length? DtpPoints(this decimal? value) => Length.FromDtpPoints(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? DtpPoints<T>(this T? value) where T : struct => Length.FromDtpPoints(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Fathom
 
         /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length Fathoms(this int value) => Length.FromFathoms(value);
+        public static Length Fathoms<T>(this T value) => Length.FromFathoms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length? Fathoms(this int? value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length Fathoms(this long value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length? Fathoms(this long? value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length Fathoms(this double value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length? Fathoms(this double? value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length Fathoms(this float value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length? Fathoms(this float? value) => Length.FromFathoms(value);
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length Fathoms(this decimal value) => Length.FromFathoms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromFathoms(UnitsNet.QuantityValue)" />
-        public static Length? Fathoms(this decimal? value) => Length.FromFathoms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Fathoms<T>(this T? value) where T : struct => Length.FromFathoms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Foot
 
         /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length Feet(this int value) => Length.FromFeet(value);
+        public static Length Feet<T>(this T value) => Length.FromFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length? Feet(this int? value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length Feet(this long value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length? Feet(this long? value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length Feet(this double value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length? Feet(this double? value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length Feet(this float value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length? Feet(this float? value) => Length.FromFeet(value);
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length Feet(this decimal value) => Length.FromFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromFeet(UnitsNet.QuantityValue)" />
-        public static Length? Feet(this decimal? value) => Length.FromFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Feet<T>(this T? value) where T : struct => Length.FromFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Inch
 
         /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length Inches(this int value) => Length.FromInches(value);
+        public static Length Inches<T>(this T value) => Length.FromInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length? Inches(this int? value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length Inches(this long value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length? Inches(this long? value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length Inches(this double value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length? Inches(this double? value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length Inches(this float value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length? Inches(this float? value) => Length.FromInches(value);
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length Inches(this decimal value) => Length.FromInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromInches(UnitsNet.QuantityValue)" />
-        public static Length? Inches(this decimal? value) => Length.FromInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Inches<T>(this T? value) where T : struct => Length.FromInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilometer
 
         /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length Kilometers(this int value) => Length.FromKilometers(value);
+        public static Length Kilometers<T>(this T value) => Length.FromKilometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length? Kilometers(this int? value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length Kilometers(this long value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length? Kilometers(this long? value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length Kilometers(this double value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length? Kilometers(this double? value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length Kilometers(this float value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length? Kilometers(this float? value) => Length.FromKilometers(value);
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length Kilometers(this decimal value) => Length.FromKilometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromKilometers(UnitsNet.QuantityValue)" />
-        public static Length? Kilometers(this decimal? value) => Length.FromKilometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Kilometers<T>(this T? value) where T : struct => Length.FromKilometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Meter
 
         /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length Meters(this int value) => Length.FromMeters(value);
+        public static Length Meters<T>(this T value) => Length.FromMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length? Meters(this int? value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length Meters(this long value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length? Meters(this long? value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length Meters(this double value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length? Meters(this double? value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length Meters(this float value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length? Meters(this float? value) => Length.FromMeters(value);
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length Meters(this decimal value) => Length.FromMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromMeters(UnitsNet.QuantityValue)" />
-        public static Length? Meters(this decimal? value) => Length.FromMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Meters<T>(this T? value) where T : struct => Length.FromMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microinch
 
         /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length Microinches(this int value) => Length.FromMicroinches(value);
+        public static Length Microinches<T>(this T value) => Length.FromMicroinches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length? Microinches(this int? value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length Microinches(this long value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length? Microinches(this long? value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length Microinches(this double value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length? Microinches(this double? value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length Microinches(this float value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length? Microinches(this float? value) => Length.FromMicroinches(value);
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length Microinches(this decimal value) => Length.FromMicroinches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromMicroinches(UnitsNet.QuantityValue)" />
-        public static Length? Microinches(this decimal? value) => Length.FromMicroinches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Microinches<T>(this T? value) where T : struct => Length.FromMicroinches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Micrometer
 
         /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length Micrometers(this int value) => Length.FromMicrometers(value);
+        public static Length Micrometers<T>(this T value) => Length.FromMicrometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length? Micrometers(this int? value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length Micrometers(this long value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length? Micrometers(this long? value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length Micrometers(this double value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length? Micrometers(this double? value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length Micrometers(this float value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length? Micrometers(this float? value) => Length.FromMicrometers(value);
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length Micrometers(this decimal value) => Length.FromMicrometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromMicrometers(UnitsNet.QuantityValue)" />
-        public static Length? Micrometers(this decimal? value) => Length.FromMicrometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Micrometers<T>(this T? value) where T : struct => Length.FromMicrometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Mil
 
         /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length Mils(this int value) => Length.FromMils(value);
+        public static Length Mils<T>(this T value) => Length.FromMils(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length? Mils(this int? value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length Mils(this long value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length? Mils(this long? value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length Mils(this double value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length? Mils(this double? value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length Mils(this float value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length? Mils(this float? value) => Length.FromMils(value);
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length Mils(this decimal value) => Length.FromMils(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromMils(UnitsNet.QuantityValue)" />
-        public static Length? Mils(this decimal? value) => Length.FromMils(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Mils<T>(this T? value) where T : struct => Length.FromMils(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Mile
 
         /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length Miles(this int value) => Length.FromMiles(value);
+        public static Length Miles<T>(this T value) => Length.FromMiles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length? Miles(this int? value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length Miles(this long value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length? Miles(this long? value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length Miles(this double value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length? Miles(this double? value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length Miles(this float value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length? Miles(this float? value) => Length.FromMiles(value);
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length Miles(this decimal value) => Length.FromMiles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromMiles(UnitsNet.QuantityValue)" />
-        public static Length? Miles(this decimal? value) => Length.FromMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Miles<T>(this T? value) where T : struct => Length.FromMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millimeter
 
         /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length Millimeters(this int value) => Length.FromMillimeters(value);
+        public static Length Millimeters<T>(this T value) => Length.FromMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length? Millimeters(this int? value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length Millimeters(this long value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length? Millimeters(this long? value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length Millimeters(this double value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length? Millimeters(this double? value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length Millimeters(this float value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length? Millimeters(this float? value) => Length.FromMillimeters(value);
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length Millimeters(this decimal value) => Length.FromMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromMillimeters(UnitsNet.QuantityValue)" />
-        public static Length? Millimeters(this decimal? value) => Length.FromMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Millimeters<T>(this T? value) where T : struct => Length.FromMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanometer
 
         /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length Nanometers(this int value) => Length.FromNanometers(value);
+        public static Length Nanometers<T>(this T value) => Length.FromNanometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length? Nanometers(this int? value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length Nanometers(this long value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length? Nanometers(this long? value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length Nanometers(this double value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length? Nanometers(this double? value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length Nanometers(this float value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length? Nanometers(this float? value) => Length.FromNanometers(value);
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length Nanometers(this decimal value) => Length.FromNanometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromNanometers(UnitsNet.QuantityValue)" />
-        public static Length? Nanometers(this decimal? value) => Length.FromNanometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Nanometers<T>(this T? value) where T : struct => Length.FromNanometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NauticalMile
 
         /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length NauticalMiles(this int value) => Length.FromNauticalMiles(value);
+        public static Length NauticalMiles<T>(this T value) => Length.FromNauticalMiles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length? NauticalMiles(this int? value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length NauticalMiles(this long value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length? NauticalMiles(this long? value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length NauticalMiles(this double value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length? NauticalMiles(this double? value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length NauticalMiles(this float value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length? NauticalMiles(this float? value) => Length.FromNauticalMiles(value);
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length NauticalMiles(this decimal value) => Length.FromNauticalMiles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromNauticalMiles(UnitsNet.QuantityValue)" />
-        public static Length? NauticalMiles(this decimal? value) => Length.FromNauticalMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? NauticalMiles<T>(this T? value) where T : struct => Length.FromNauticalMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PrinterPica
 
         /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length PrinterPicas(this int value) => Length.FromPrinterPicas(value);
+        public static Length PrinterPicas<T>(this T value) => Length.FromPrinterPicas(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPicas(this int? value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length PrinterPicas(this long value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPicas(this long? value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length PrinterPicas(this double value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPicas(this double? value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length PrinterPicas(this float value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPicas(this float? value) => Length.FromPrinterPicas(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length PrinterPicas(this decimal value) => Length.FromPrinterPicas(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromPrinterPicas(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPicas(this decimal? value) => Length.FromPrinterPicas(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? PrinterPicas<T>(this T? value) where T : struct => Length.FromPrinterPicas(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PrinterPoint
 
         /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length PrinterPoints(this int value) => Length.FromPrinterPoints(value);
+        public static Length PrinterPoints<T>(this T value) => Length.FromPrinterPoints(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPoints(this int? value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length PrinterPoints(this long value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPoints(this long? value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length PrinterPoints(this double value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPoints(this double? value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length PrinterPoints(this float value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPoints(this float? value) => Length.FromPrinterPoints(value);
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length PrinterPoints(this decimal value) => Length.FromPrinterPoints(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromPrinterPoints(UnitsNet.QuantityValue)" />
-        public static Length? PrinterPoints(this decimal? value) => Length.FromPrinterPoints(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? PrinterPoints<T>(this T? value) where T : struct => Length.FromPrinterPoints(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Shackle
 
         /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length Shackles(this int value) => Length.FromShackles(value);
+        public static Length Shackles<T>(this T value) => Length.FromShackles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length? Shackles(this int? value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length Shackles(this long value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length? Shackles(this long? value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length Shackles(this double value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length? Shackles(this double? value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length Shackles(this float value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length? Shackles(this float? value) => Length.FromShackles(value);
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length Shackles(this decimal value) => Length.FromShackles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromShackles(UnitsNet.QuantityValue)" />
-        public static Length? Shackles(this decimal? value) => Length.FromShackles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Shackles<T>(this T? value) where T : struct => Length.FromShackles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Twip
 
         /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length Twips(this int value) => Length.FromTwips(value);
+        public static Length Twips<T>(this T value) => Length.FromTwips(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length? Twips(this int? value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length Twips(this long value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length? Twips(this long? value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length Twips(this double value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length? Twips(this double? value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length Twips(this float value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length? Twips(this float? value) => Length.FromTwips(value);
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length Twips(this decimal value) => Length.FromTwips(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromTwips(UnitsNet.QuantityValue)" />
-        public static Length? Twips(this decimal? value) => Length.FromTwips(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Twips<T>(this T? value) where T : struct => Length.FromTwips(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsSurveyFoot
 
         /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length UsSurveyFeet(this int value) => Length.FromUsSurveyFeet(value);
+        public static Length UsSurveyFeet<T>(this T value) => Length.FromUsSurveyFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length? UsSurveyFeet(this int? value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length UsSurveyFeet(this long value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length? UsSurveyFeet(this long? value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length UsSurveyFeet(this double value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length? UsSurveyFeet(this double? value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length UsSurveyFeet(this float value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length? UsSurveyFeet(this float? value) => Length.FromUsSurveyFeet(value);
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length UsSurveyFeet(this decimal value) => Length.FromUsSurveyFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromUsSurveyFeet(UnitsNet.QuantityValue)" />
-        public static Length? UsSurveyFeet(this decimal? value) => Length.FromUsSurveyFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? UsSurveyFeet<T>(this T? value) where T : struct => Length.FromUsSurveyFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Yard
 
         /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length Yards(this int value) => Length.FromYards(value);
+        public static Length Yards<T>(this T value) => Length.FromYards(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length? Yards(this int? value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length Yards(this long value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length? Yards(this long? value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length Yards(this double value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length? Yards(this double? value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length Yards(this float value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length? Yards(this float? value) => Length.FromYards(value);
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length Yards(this decimal value) => Length.FromYards(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Length.FromYards(UnitsNet.QuantityValue)" />
-        public static Length? Yards(this decimal? value) => Length.FromYards(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Length? Yards<T>(this T? value) where T : struct => Length.FromYards(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToLevelExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToLevelExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToLevel
         #region Decibel
 
         /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level Decibels(this int value) => Level.FromDecibels(value);
+        public static Level Decibels<T>(this T value) => Level.FromDecibels(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level? Decibels(this int? value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level Decibels(this long value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level? Decibels(this long? value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level Decibels(this double value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level? Decibels(this double? value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level Decibels(this float value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level? Decibels(this float? value) => Level.FromDecibels(value);
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level Decibels(this decimal value) => Level.FromDecibels(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Level.FromDecibels(UnitsNet.QuantityValue)" />
-        public static Level? Decibels(this decimal? value) => Level.FromDecibels(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Level? Decibels<T>(this T? value) where T : struct => Level.FromDecibels(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Neper
 
         /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level Nepers(this int value) => Level.FromNepers(value);
+        public static Level Nepers<T>(this T value) => Level.FromNepers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level? Nepers(this int? value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level Nepers(this long value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level? Nepers(this long? value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level Nepers(this double value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level? Nepers(this double? value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level Nepers(this float value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level? Nepers(this float? value) => Level.FromNepers(value);
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level Nepers(this decimal value) => Level.FromNepers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Level.FromNepers(UnitsNet.QuantityValue)" />
-        public static Level? Nepers(this decimal? value) => Level.FromNepers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Level? Nepers<T>(this T? value) where T : struct => Level.FromNepers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToLinearDensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToLinearDensityExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToLinearDensity
         #region GramPerMeter
 
         /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity GramsPerMeter(this int value) => LinearDensity.FromGramsPerMeter(value);
+        public static LinearDensity GramsPerMeter<T>(this T value) => LinearDensity.FromGramsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? GramsPerMeter(this int? value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity GramsPerMeter(this long value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? GramsPerMeter(this long? value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity GramsPerMeter(this double value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? GramsPerMeter(this double? value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity GramsPerMeter(this float value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? GramsPerMeter(this float? value) => LinearDensity.FromGramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity GramsPerMeter(this decimal value) => LinearDensity.FromGramsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="LinearDensity.FromGramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? GramsPerMeter(this decimal? value) => LinearDensity.FromGramsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static LinearDensity? GramsPerMeter<T>(this T? value) where T : struct => LinearDensity.FromGramsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerMeter
 
         /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity KilogramsPerMeter(this int value) => LinearDensity.FromKilogramsPerMeter(value);
+        public static LinearDensity KilogramsPerMeter<T>(this T value) => LinearDensity.FromKilogramsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? KilogramsPerMeter(this int? value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity KilogramsPerMeter(this long value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? KilogramsPerMeter(this long? value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity KilogramsPerMeter(this double value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? KilogramsPerMeter(this double? value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity KilogramsPerMeter(this float value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? KilogramsPerMeter(this float? value) => LinearDensity.FromKilogramsPerMeter(value);
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity KilogramsPerMeter(this decimal value) => LinearDensity.FromKilogramsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="LinearDensity.FromKilogramsPerMeter(UnitsNet.QuantityValue)" />
-        public static LinearDensity? KilogramsPerMeter(this decimal? value) => LinearDensity.FromKilogramsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static LinearDensity? KilogramsPerMeter<T>(this T? value) where T : struct => LinearDensity.FromKilogramsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerFoot
 
         /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity PoundsPerFoot(this int value) => LinearDensity.FromPoundsPerFoot(value);
+        public static LinearDensity PoundsPerFoot<T>(this T value) => LinearDensity.FromPoundsPerFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity? PoundsPerFoot(this int? value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity PoundsPerFoot(this long value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity? PoundsPerFoot(this long? value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity PoundsPerFoot(this double value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity? PoundsPerFoot(this double? value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity PoundsPerFoot(this float value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity? PoundsPerFoot(this float? value) => LinearDensity.FromPoundsPerFoot(value);
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity PoundsPerFoot(this decimal value) => LinearDensity.FromPoundsPerFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="LinearDensity.FromPoundsPerFoot(UnitsNet.QuantityValue)" />
-        public static LinearDensity? PoundsPerFoot(this decimal? value) => LinearDensity.FromPoundsPerFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static LinearDensity? PoundsPerFoot<T>(this T? value) where T : struct => LinearDensity.FromPoundsPerFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToLuminousFluxExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToLuminousFluxExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToLuminousFlux
         #region Lumen
 
         /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux Lumens(this int value) => LuminousFlux.FromLumens(value);
+        public static LuminousFlux Lumens<T>(this T value) => LuminousFlux.FromLumens(Convert.ToDouble(value));
 
         /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux? Lumens(this int? value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux Lumens(this long value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux? Lumens(this long? value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux Lumens(this double value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux? Lumens(this double? value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux Lumens(this float value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux? Lumens(this float? value) => LuminousFlux.FromLumens(value);
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux Lumens(this decimal value) => LuminousFlux.FromLumens(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="LuminousFlux.FromLumens(UnitsNet.QuantityValue)" />
-        public static LuminousFlux? Lumens(this decimal? value) => LuminousFlux.FromLumens(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static LuminousFlux? Lumens<T>(this T? value) where T : struct => LuminousFlux.FromLumens(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToLuminousIntensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToLuminousIntensityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToLuminousIntensity
         #region Candela
 
         /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity Candela(this int value) => LuminousIntensity.FromCandela(value);
+        public static LuminousIntensity Candela<T>(this T value) => LuminousIntensity.FromCandela(Convert.ToDouble(value));
 
         /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity? Candela(this int? value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity Candela(this long value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity? Candela(this long? value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity Candela(this double value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity? Candela(this double? value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity Candela(this float value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity? Candela(this float? value) => LuminousIntensity.FromCandela(value);
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity Candela(this decimal value) => LuminousIntensity.FromCandela(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="LuminousIntensity.FromCandela(UnitsNet.QuantityValue)" />
-        public static LuminousIntensity? Candela(this decimal? value) => LuminousIntensity.FromCandela(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static LuminousIntensity? Candela<T>(this T? value) where T : struct => LuminousIntensity.FromCandela(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMagneticFieldExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMagneticFieldExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToMagneticField
         #region Tesla
 
         /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField Teslas(this int value) => MagneticField.FromTeslas(value);
+        public static MagneticField Teslas<T>(this T value) => MagneticField.FromTeslas(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField? Teslas(this int? value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField Teslas(this long value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField? Teslas(this long? value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField Teslas(this double value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField? Teslas(this double? value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField Teslas(this float value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField? Teslas(this float? value) => MagneticField.FromTeslas(value);
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField Teslas(this decimal value) => MagneticField.FromTeslas(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MagneticField.FromTeslas(UnitsNet.QuantityValue)" />
-        public static MagneticField? Teslas(this decimal? value) => MagneticField.FromTeslas(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MagneticField? Teslas<T>(this T? value) where T : struct => MagneticField.FromTeslas(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMagneticFluxExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMagneticFluxExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToMagneticFlux
         #region Weber
 
         /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux Webers(this int value) => MagneticFlux.FromWebers(value);
+        public static MagneticFlux Webers<T>(this T value) => MagneticFlux.FromWebers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux? Webers(this int? value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux Webers(this long value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux? Webers(this long? value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux Webers(this double value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux? Webers(this double? value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux Webers(this float value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux? Webers(this float? value) => MagneticFlux.FromWebers(value);
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux Webers(this decimal value) => MagneticFlux.FromWebers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MagneticFlux.FromWebers(UnitsNet.QuantityValue)" />
-        public static MagneticFlux? Webers(this decimal? value) => MagneticFlux.FromWebers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MagneticFlux? Webers<T>(this T? value) where T : struct => MagneticFlux.FromWebers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMagnetizationExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMagnetizationExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToMagnetization
         #region AmperePerMeter
 
         /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization AmperesPerMeter(this int value) => Magnetization.FromAmperesPerMeter(value);
+        public static Magnetization AmperesPerMeter<T>(this T value) => Magnetization.FromAmperesPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization? AmperesPerMeter(this int? value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization AmperesPerMeter(this long value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization? AmperesPerMeter(this long? value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization AmperesPerMeter(this double value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization? AmperesPerMeter(this double? value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization AmperesPerMeter(this float value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization? AmperesPerMeter(this float? value) => Magnetization.FromAmperesPerMeter(value);
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization AmperesPerMeter(this decimal value) => Magnetization.FromAmperesPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Magnetization.FromAmperesPerMeter(UnitsNet.QuantityValue)" />
-        public static Magnetization? AmperesPerMeter(this decimal? value) => Magnetization.FromAmperesPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Magnetization? AmperesPerMeter<T>(this T? value) where T : struct => Magnetization.FromAmperesPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassExtensions.g.cs
@@ -47,714 +47,210 @@ namespace UnitsNet.Extensions.NumberToMass
         #region Centigram
 
         /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass Centigrams(this int value) => Mass.FromCentigrams(value);
+        public static Mass Centigrams<T>(this T value) => Mass.FromCentigrams(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Centigrams(this int? value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass Centigrams(this long value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Centigrams(this long? value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass Centigrams(this double value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Centigrams(this double? value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass Centigrams(this float value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Centigrams(this float? value) => Mass.FromCentigrams(value);
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass Centigrams(this decimal value) => Mass.FromCentigrams(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromCentigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Centigrams(this decimal? value) => Mass.FromCentigrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Centigrams<T>(this T? value) where T : struct => Mass.FromCentigrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decagram
 
         /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass Decagrams(this int value) => Mass.FromDecagrams(value);
+        public static Mass Decagrams<T>(this T value) => Mass.FromDecagrams(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decagrams(this int? value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass Decagrams(this long value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decagrams(this long? value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass Decagrams(this double value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decagrams(this double? value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass Decagrams(this float value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decagrams(this float? value) => Mass.FromDecagrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass Decagrams(this decimal value) => Mass.FromDecagrams(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromDecagrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decagrams(this decimal? value) => Mass.FromDecagrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Decagrams<T>(this T? value) where T : struct => Mass.FromDecagrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decigram
 
         /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass Decigrams(this int value) => Mass.FromDecigrams(value);
+        public static Mass Decigrams<T>(this T value) => Mass.FromDecigrams(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decigrams(this int? value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass Decigrams(this long value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decigrams(this long? value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass Decigrams(this double value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decigrams(this double? value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass Decigrams(this float value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decigrams(this float? value) => Mass.FromDecigrams(value);
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass Decigrams(this decimal value) => Mass.FromDecigrams(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromDecigrams(UnitsNet.QuantityValue)" />
-        public static Mass? Decigrams(this decimal? value) => Mass.FromDecigrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Decigrams<T>(this T? value) where T : struct => Mass.FromDecigrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gram
 
         /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass Grams(this int value) => Mass.FromGrams(value);
+        public static Mass Grams<T>(this T value) => Mass.FromGrams(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass? Grams(this int? value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass Grams(this long value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass? Grams(this long? value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass Grams(this double value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass? Grams(this double? value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass Grams(this float value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass? Grams(this float? value) => Mass.FromGrams(value);
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass Grams(this decimal value) => Mass.FromGrams(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromGrams(UnitsNet.QuantityValue)" />
-        public static Mass? Grams(this decimal? value) => Mass.FromGrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Grams<T>(this T? value) where T : struct => Mass.FromGrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Hectogram
 
         /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass Hectograms(this int value) => Mass.FromHectograms(value);
+        public static Mass Hectograms<T>(this T value) => Mass.FromHectograms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass? Hectograms(this int? value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass Hectograms(this long value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass? Hectograms(this long? value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass Hectograms(this double value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass? Hectograms(this double? value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass Hectograms(this float value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass? Hectograms(this float? value) => Mass.FromHectograms(value);
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass Hectograms(this decimal value) => Mass.FromHectograms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromHectograms(UnitsNet.QuantityValue)" />
-        public static Mass? Hectograms(this decimal? value) => Mass.FromHectograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Hectograms<T>(this T? value) where T : struct => Mass.FromHectograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilogram
 
         /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass Kilograms(this int value) => Mass.FromKilograms(value);
+        public static Mass Kilograms<T>(this T value) => Mass.FromKilograms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass? Kilograms(this int? value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass Kilograms(this long value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass? Kilograms(this long? value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass Kilograms(this double value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass? Kilograms(this double? value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass Kilograms(this float value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass? Kilograms(this float? value) => Mass.FromKilograms(value);
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass Kilograms(this decimal value) => Mass.FromKilograms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromKilograms(UnitsNet.QuantityValue)" />
-        public static Mass? Kilograms(this decimal? value) => Mass.FromKilograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Kilograms<T>(this T? value) where T : struct => Mass.FromKilograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilopound
 
         /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass Kilopounds(this int value) => Mass.FromKilopounds(value);
+        public static Mass Kilopounds<T>(this T value) => Mass.FromKilopounds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass? Kilopounds(this int? value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass Kilopounds(this long value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass? Kilopounds(this long? value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass Kilopounds(this double value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass? Kilopounds(this double? value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass Kilopounds(this float value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass? Kilopounds(this float? value) => Mass.FromKilopounds(value);
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass Kilopounds(this decimal value) => Mass.FromKilopounds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromKilopounds(UnitsNet.QuantityValue)" />
-        public static Mass? Kilopounds(this decimal? value) => Mass.FromKilopounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Kilopounds<T>(this T? value) where T : struct => Mass.FromKilopounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilotonne
 
         /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass Kilotonnes(this int value) => Mass.FromKilotonnes(value);
+        public static Mass Kilotonnes<T>(this T value) => Mass.FromKilotonnes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Kilotonnes(this int? value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass Kilotonnes(this long value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Kilotonnes(this long? value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass Kilotonnes(this double value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Kilotonnes(this double? value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass Kilotonnes(this float value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Kilotonnes(this float? value) => Mass.FromKilotonnes(value);
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass Kilotonnes(this decimal value) => Mass.FromKilotonnes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromKilotonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Kilotonnes(this decimal? value) => Mass.FromKilotonnes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Kilotonnes<T>(this T? value) where T : struct => Mass.FromKilotonnes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LongHundredweight
 
         /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass LongHundredweight(this int value) => Mass.FromLongHundredweight(value);
+        public static Mass LongHundredweight<T>(this T value) => Mass.FromLongHundredweight(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? LongHundredweight(this int? value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass LongHundredweight(this long value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? LongHundredweight(this long? value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass LongHundredweight(this double value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? LongHundredweight(this double? value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass LongHundredweight(this float value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? LongHundredweight(this float? value) => Mass.FromLongHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass LongHundredweight(this decimal value) => Mass.FromLongHundredweight(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromLongHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? LongHundredweight(this decimal? value) => Mass.FromLongHundredweight(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? LongHundredweight<T>(this T? value) where T : struct => Mass.FromLongHundredweight(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LongTon
 
         /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass LongTons(this int value) => Mass.FromLongTons(value);
+        public static Mass LongTons<T>(this T value) => Mass.FromLongTons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass? LongTons(this int? value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass LongTons(this long value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass? LongTons(this long? value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass LongTons(this double value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass? LongTons(this double? value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass LongTons(this float value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass? LongTons(this float? value) => Mass.FromLongTons(value);
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass LongTons(this decimal value) => Mass.FromLongTons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromLongTons(UnitsNet.QuantityValue)" />
-        public static Mass? LongTons(this decimal? value) => Mass.FromLongTons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? LongTons<T>(this T? value) where T : struct => Mass.FromLongTons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megapound
 
         /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass Megapounds(this int value) => Mass.FromMegapounds(value);
+        public static Mass Megapounds<T>(this T value) => Mass.FromMegapounds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass? Megapounds(this int? value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass Megapounds(this long value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass? Megapounds(this long? value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass Megapounds(this double value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass? Megapounds(this double? value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass Megapounds(this float value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass? Megapounds(this float? value) => Mass.FromMegapounds(value);
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass Megapounds(this decimal value) => Mass.FromMegapounds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromMegapounds(UnitsNet.QuantityValue)" />
-        public static Mass? Megapounds(this decimal? value) => Mass.FromMegapounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Megapounds<T>(this T? value) where T : struct => Mass.FromMegapounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megatonne
 
         /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass Megatonnes(this int value) => Mass.FromMegatonnes(value);
+        public static Mass Megatonnes<T>(this T value) => Mass.FromMegatonnes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Megatonnes(this int? value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass Megatonnes(this long value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Megatonnes(this long? value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass Megatonnes(this double value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Megatonnes(this double? value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass Megatonnes(this float value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Megatonnes(this float? value) => Mass.FromMegatonnes(value);
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass Megatonnes(this decimal value) => Mass.FromMegatonnes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromMegatonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Megatonnes(this decimal? value) => Mass.FromMegatonnes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Megatonnes<T>(this T? value) where T : struct => Mass.FromMegatonnes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microgram
 
         /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass Micrograms(this int value) => Mass.FromMicrograms(value);
+        public static Mass Micrograms<T>(this T value) => Mass.FromMicrograms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass? Micrograms(this int? value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass Micrograms(this long value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass? Micrograms(this long? value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass Micrograms(this double value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass? Micrograms(this double? value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass Micrograms(this float value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass? Micrograms(this float? value) => Mass.FromMicrograms(value);
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass Micrograms(this decimal value) => Mass.FromMicrograms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromMicrograms(UnitsNet.QuantityValue)" />
-        public static Mass? Micrograms(this decimal? value) => Mass.FromMicrograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Micrograms<T>(this T? value) where T : struct => Mass.FromMicrograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Milligram
 
         /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass Milligrams(this int value) => Mass.FromMilligrams(value);
+        public static Mass Milligrams<T>(this T value) => Mass.FromMilligrams(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass? Milligrams(this int? value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass Milligrams(this long value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass? Milligrams(this long? value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass Milligrams(this double value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass? Milligrams(this double? value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass Milligrams(this float value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass? Milligrams(this float? value) => Mass.FromMilligrams(value);
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass Milligrams(this decimal value) => Mass.FromMilligrams(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromMilligrams(UnitsNet.QuantityValue)" />
-        public static Mass? Milligrams(this decimal? value) => Mass.FromMilligrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Milligrams<T>(this T? value) where T : struct => Mass.FromMilligrams(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanogram
 
         /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass Nanograms(this int value) => Mass.FromNanograms(value);
+        public static Mass Nanograms<T>(this T value) => Mass.FromNanograms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass? Nanograms(this int? value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass Nanograms(this long value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass? Nanograms(this long? value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass Nanograms(this double value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass? Nanograms(this double? value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass Nanograms(this float value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass? Nanograms(this float? value) => Mass.FromNanograms(value);
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass Nanograms(this decimal value) => Mass.FromNanograms(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromNanograms(UnitsNet.QuantityValue)" />
-        public static Mass? Nanograms(this decimal? value) => Mass.FromNanograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Nanograms<T>(this T? value) where T : struct => Mass.FromNanograms(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Ounce
 
         /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass Ounces(this int value) => Mass.FromOunces(value);
+        public static Mass Ounces<T>(this T value) => Mass.FromOunces(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass? Ounces(this int? value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass Ounces(this long value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass? Ounces(this long? value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass Ounces(this double value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass? Ounces(this double? value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass Ounces(this float value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass? Ounces(this float? value) => Mass.FromOunces(value);
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass Ounces(this decimal value) => Mass.FromOunces(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
-        public static Mass? Ounces(this decimal? value) => Mass.FromOunces(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Ounces<T>(this T? value) where T : struct => Mass.FromOunces(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Pound
 
         /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass Pounds(this int value) => Mass.FromPounds(value);
+        public static Mass Pounds<T>(this T value) => Mass.FromPounds(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass? Pounds(this int? value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass Pounds(this long value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass? Pounds(this long? value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass Pounds(this double value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass? Pounds(this double? value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass Pounds(this float value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass? Pounds(this float? value) => Mass.FromPounds(value);
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass Pounds(this decimal value) => Mass.FromPounds(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
-        public static Mass? Pounds(this decimal? value) => Mass.FromPounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Pounds<T>(this T? value) where T : struct => Mass.FromPounds(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ShortHundredweight
 
         /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass ShortHundredweight(this int value) => Mass.FromShortHundredweight(value);
+        public static Mass ShortHundredweight<T>(this T value) => Mass.FromShortHundredweight(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? ShortHundredweight(this int? value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass ShortHundredweight(this long value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? ShortHundredweight(this long? value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass ShortHundredweight(this double value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? ShortHundredweight(this double? value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass ShortHundredweight(this float value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? ShortHundredweight(this float? value) => Mass.FromShortHundredweight(value);
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass ShortHundredweight(this decimal value) => Mass.FromShortHundredweight(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromShortHundredweight(UnitsNet.QuantityValue)" />
-        public static Mass? ShortHundredweight(this decimal? value) => Mass.FromShortHundredweight(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? ShortHundredweight<T>(this T? value) where T : struct => Mass.FromShortHundredweight(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ShortTon
 
         /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass ShortTons(this int value) => Mass.FromShortTons(value);
+        public static Mass ShortTons<T>(this T value) => Mass.FromShortTons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass? ShortTons(this int? value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass ShortTons(this long value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass? ShortTons(this long? value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass ShortTons(this double value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass? ShortTons(this double? value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass ShortTons(this float value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass? ShortTons(this float? value) => Mass.FromShortTons(value);
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass ShortTons(this decimal value) => Mass.FromShortTons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromShortTons(UnitsNet.QuantityValue)" />
-        public static Mass? ShortTons(this decimal? value) => Mass.FromShortTons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? ShortTons<T>(this T? value) where T : struct => Mass.FromShortTons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Stone
 
         /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass Stone(this int value) => Mass.FromStone(value);
+        public static Mass Stone<T>(this T value) => Mass.FromStone(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass? Stone(this int? value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass Stone(this long value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass? Stone(this long? value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass Stone(this double value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass? Stone(this double? value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass Stone(this float value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass? Stone(this float? value) => Mass.FromStone(value);
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass Stone(this decimal value) => Mass.FromStone(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromStone(UnitsNet.QuantityValue)" />
-        public static Mass? Stone(this decimal? value) => Mass.FromStone(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Stone<T>(this T? value) where T : struct => Mass.FromStone(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Tonne
 
         /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass Tonnes(this int value) => Mass.FromTonnes(value);
+        public static Mass Tonnes<T>(this T value) => Mass.FromTonnes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Tonnes(this int? value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass Tonnes(this long value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Tonnes(this long? value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass Tonnes(this double value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Tonnes(this double? value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass Tonnes(this float value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Tonnes(this float? value) => Mass.FromTonnes(value);
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass Tonnes(this decimal value) => Mass.FromTonnes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Mass.FromTonnes(UnitsNet.QuantityValue)" />
-        public static Mass? Tonnes(this decimal? value) => Mass.FromTonnes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Mass? Tonnes<T>(this T? value) where T : struct => Mass.FromTonnes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassFlowExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassFlowExtensions.g.cs
@@ -47,510 +47,150 @@ namespace UnitsNet.Extensions.NumberToMassFlow
         #region CentigramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow CentigramsPerSecond(this int value) => MassFlow.FromCentigramsPerSecond(value);
+        public static MassFlow CentigramsPerSecond<T>(this T value) => MassFlow.FromCentigramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? CentigramsPerSecond(this int? value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow CentigramsPerSecond(this long value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? CentigramsPerSecond(this long? value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow CentigramsPerSecond(this double value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? CentigramsPerSecond(this double? value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow CentigramsPerSecond(this float value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? CentigramsPerSecond(this float? value) => MassFlow.FromCentigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow CentigramsPerSecond(this decimal value) => MassFlow.FromCentigramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromCentigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? CentigramsPerSecond(this decimal? value) => MassFlow.FromCentigramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? CentigramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromCentigramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecagramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecagramsPerSecond(this int value) => MassFlow.FromDecagramsPerSecond(value);
+        public static MassFlow DecagramsPerSecond<T>(this T value) => MassFlow.FromDecagramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecagramsPerSecond(this int? value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecagramsPerSecond(this long value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecagramsPerSecond(this long? value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecagramsPerSecond(this double value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecagramsPerSecond(this double? value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecagramsPerSecond(this float value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecagramsPerSecond(this float? value) => MassFlow.FromDecagramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecagramsPerSecond(this decimal value) => MassFlow.FromDecagramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromDecagramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecagramsPerSecond(this decimal? value) => MassFlow.FromDecagramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? DecagramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromDecagramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecigramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecigramsPerSecond(this int value) => MassFlow.FromDecigramsPerSecond(value);
+        public static MassFlow DecigramsPerSecond<T>(this T value) => MassFlow.FromDecigramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecigramsPerSecond(this int? value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecigramsPerSecond(this long value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecigramsPerSecond(this long? value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecigramsPerSecond(this double value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecigramsPerSecond(this double? value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecigramsPerSecond(this float value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecigramsPerSecond(this float? value) => MassFlow.FromDecigramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow DecigramsPerSecond(this decimal value) => MassFlow.FromDecigramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromDecigramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? DecigramsPerSecond(this decimal? value) => MassFlow.FromDecigramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? DecigramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromDecigramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow GramsPerSecond(this int value) => MassFlow.FromGramsPerSecond(value);
+        public static MassFlow GramsPerSecond<T>(this T value) => MassFlow.FromGramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? GramsPerSecond(this int? value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow GramsPerSecond(this long value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? GramsPerSecond(this long? value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow GramsPerSecond(this double value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? GramsPerSecond(this double? value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow GramsPerSecond(this float value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? GramsPerSecond(this float? value) => MassFlow.FromGramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow GramsPerSecond(this decimal value) => MassFlow.FromGramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromGramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? GramsPerSecond(this decimal? value) => MassFlow.FromGramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? GramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromGramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region HectogramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow HectogramsPerSecond(this int value) => MassFlow.FromHectogramsPerSecond(value);
+        public static MassFlow HectogramsPerSecond<T>(this T value) => MassFlow.FromHectogramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? HectogramsPerSecond(this int? value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow HectogramsPerSecond(this long value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? HectogramsPerSecond(this long? value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow HectogramsPerSecond(this double value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? HectogramsPerSecond(this double? value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow HectogramsPerSecond(this float value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? HectogramsPerSecond(this float? value) => MassFlow.FromHectogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow HectogramsPerSecond(this decimal value) => MassFlow.FromHectogramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromHectogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? HectogramsPerSecond(this decimal? value) => MassFlow.FromHectogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? HectogramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromHectogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerHour
 
         /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerHour(this int value) => MassFlow.FromKilogramsPerHour(value);
+        public static MassFlow KilogramsPerHour<T>(this T value) => MassFlow.FromKilogramsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerHour(this int? value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerHour(this long value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerHour(this long? value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerHour(this double value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerHour(this double? value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerHour(this float value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerHour(this float? value) => MassFlow.FromKilogramsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerHour(this decimal value) => MassFlow.FromKilogramsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerHour(this decimal? value) => MassFlow.FromKilogramsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? KilogramsPerHour<T>(this T? value) where T : struct => MassFlow.FromKilogramsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerSecond(this int value) => MassFlow.FromKilogramsPerSecond(value);
+        public static MassFlow KilogramsPerSecond<T>(this T value) => MassFlow.FromKilogramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerSecond(this int? value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerSecond(this long value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerSecond(this long? value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerSecond(this double value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerSecond(this double? value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerSecond(this float value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerSecond(this float? value) => MassFlow.FromKilogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow KilogramsPerSecond(this decimal value) => MassFlow.FromKilogramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromKilogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? KilogramsPerSecond(this decimal? value) => MassFlow.FromKilogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? KilogramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromKilogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegapoundPerHour
 
         /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow MegapoundsPerHour(this int value) => MassFlow.FromMegapoundsPerHour(value);
+        public static MassFlow MegapoundsPerHour<T>(this T value) => MassFlow.FromMegapoundsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? MegapoundsPerHour(this int? value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow MegapoundsPerHour(this long value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? MegapoundsPerHour(this long? value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow MegapoundsPerHour(this double value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? MegapoundsPerHour(this double? value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow MegapoundsPerHour(this float value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? MegapoundsPerHour(this float? value) => MassFlow.FromMegapoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow MegapoundsPerHour(this decimal value) => MassFlow.FromMegapoundsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromMegapoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? MegapoundsPerHour(this decimal? value) => MassFlow.FromMegapoundsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? MegapoundsPerHour<T>(this T? value) where T : struct => MassFlow.FromMegapoundsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrogramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MicrogramsPerSecond(this int value) => MassFlow.FromMicrogramsPerSecond(value);
+        public static MassFlow MicrogramsPerSecond<T>(this T value) => MassFlow.FromMicrogramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MicrogramsPerSecond(this int? value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MicrogramsPerSecond(this long value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MicrogramsPerSecond(this long? value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MicrogramsPerSecond(this double value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MicrogramsPerSecond(this double? value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MicrogramsPerSecond(this float value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MicrogramsPerSecond(this float? value) => MassFlow.FromMicrogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MicrogramsPerSecond(this decimal value) => MassFlow.FromMicrogramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromMicrogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MicrogramsPerSecond(this decimal? value) => MassFlow.FromMicrogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? MicrogramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromMicrogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MilligramsPerSecond(this int value) => MassFlow.FromMilligramsPerSecond(value);
+        public static MassFlow MilligramsPerSecond<T>(this T value) => MassFlow.FromMilligramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MilligramsPerSecond(this int? value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MilligramsPerSecond(this long value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MilligramsPerSecond(this long? value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MilligramsPerSecond(this double value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MilligramsPerSecond(this double? value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MilligramsPerSecond(this float value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MilligramsPerSecond(this float? value) => MassFlow.FromMilligramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow MilligramsPerSecond(this decimal value) => MassFlow.FromMilligramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromMilligramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? MilligramsPerSecond(this decimal? value) => MassFlow.FromMilligramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? MilligramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromMilligramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanogramPerSecond
 
         /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow NanogramsPerSecond(this int value) => MassFlow.FromNanogramsPerSecond(value);
+        public static MassFlow NanogramsPerSecond<T>(this T value) => MassFlow.FromNanogramsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? NanogramsPerSecond(this int? value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow NanogramsPerSecond(this long value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? NanogramsPerSecond(this long? value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow NanogramsPerSecond(this double value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? NanogramsPerSecond(this double? value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow NanogramsPerSecond(this float value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? NanogramsPerSecond(this float? value) => MassFlow.FromNanogramsPerSecond(value);
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow NanogramsPerSecond(this decimal value) => MassFlow.FromNanogramsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromNanogramsPerSecond(UnitsNet.QuantityValue)" />
-        public static MassFlow? NanogramsPerSecond(this decimal? value) => MassFlow.FromNanogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? NanogramsPerSecond<T>(this T? value) where T : struct => MassFlow.FromNanogramsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerHour
 
         /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow PoundsPerHour(this int value) => MassFlow.FromPoundsPerHour(value);
+        public static MassFlow PoundsPerHour<T>(this T value) => MassFlow.FromPoundsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? PoundsPerHour(this int? value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow PoundsPerHour(this long value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? PoundsPerHour(this long? value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow PoundsPerHour(this double value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? PoundsPerHour(this double? value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow PoundsPerHour(this float value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? PoundsPerHour(this float? value) => MassFlow.FromPoundsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow PoundsPerHour(this decimal value) => MassFlow.FromPoundsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromPoundsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? PoundsPerHour(this decimal? value) => MassFlow.FromPoundsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? PoundsPerHour<T>(this T? value) where T : struct => MassFlow.FromPoundsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ShortTonPerHour
 
         /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow ShortTonsPerHour(this int value) => MassFlow.FromShortTonsPerHour(value);
+        public static MassFlow ShortTonsPerHour<T>(this T value) => MassFlow.FromShortTonsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? ShortTonsPerHour(this int? value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow ShortTonsPerHour(this long value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? ShortTonsPerHour(this long? value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow ShortTonsPerHour(this double value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? ShortTonsPerHour(this double? value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow ShortTonsPerHour(this float value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? ShortTonsPerHour(this float? value) => MassFlow.FromShortTonsPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow ShortTonsPerHour(this decimal value) => MassFlow.FromShortTonsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromShortTonsPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? ShortTonsPerHour(this decimal? value) => MassFlow.FromShortTonsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? ShortTonsPerHour<T>(this T? value) where T : struct => MassFlow.FromShortTonsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonnePerDay
 
         /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerDay(this int value) => MassFlow.FromTonnesPerDay(value);
+        public static MassFlow TonnesPerDay<T>(this T value) => MassFlow.FromTonnesPerDay(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerDay(this int? value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerDay(this long value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerDay(this long? value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerDay(this double value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerDay(this double? value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerDay(this float value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerDay(this float? value) => MassFlow.FromTonnesPerDay(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerDay(this decimal value) => MassFlow.FromTonnesPerDay(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerDay(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerDay(this decimal? value) => MassFlow.FromTonnesPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? TonnesPerDay<T>(this T? value) where T : struct => MassFlow.FromTonnesPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonnePerHour
 
         /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerHour(this int value) => MassFlow.FromTonnesPerHour(value);
+        public static MassFlow TonnesPerHour<T>(this T value) => MassFlow.FromTonnesPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerHour(this int? value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerHour(this long value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerHour(this long? value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerHour(this double value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerHour(this double? value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerHour(this float value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerHour(this float? value) => MassFlow.FromTonnesPerHour(value);
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow TonnesPerHour(this decimal value) => MassFlow.FromTonnesPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlow.FromTonnesPerHour(UnitsNet.QuantityValue)" />
-        public static MassFlow? TonnesPerHour(this decimal? value) => MassFlow.FromTonnesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlow? TonnesPerHour<T>(this T? value) where T : struct => MassFlow.FromTonnesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassFluxExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassFluxExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToMassFlux
         #region GramPerSecondPerSquareMeter
 
         /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux GramsPerSecondPerSquareMeter(this int value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
+        public static MassFlux GramsPerSecondPerSquareMeter<T>(this T value) => MassFlux.FromGramsPerSecondPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? GramsPerSecondPerSquareMeter(this int? value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux GramsPerSecondPerSquareMeter(this long value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? GramsPerSecondPerSquareMeter(this long? value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux GramsPerSecondPerSquareMeter(this double value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? GramsPerSecondPerSquareMeter(this double? value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux GramsPerSecondPerSquareMeter(this float value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? GramsPerSecondPerSquareMeter(this float? value) => MassFlux.FromGramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux GramsPerSecondPerSquareMeter(this decimal value) => MassFlux.FromGramsPerSecondPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlux.FromGramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? GramsPerSecondPerSquareMeter(this decimal? value) => MassFlux.FromGramsPerSecondPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlux? GramsPerSecondPerSquareMeter<T>(this T? value) where T : struct => MassFlux.FromGramsPerSecondPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerSecondPerSquareMeter
 
         /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux KilogramsPerSecondPerSquareMeter(this int value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
+        public static MassFlux KilogramsPerSecondPerSquareMeter<T>(this T value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? KilogramsPerSecondPerSquareMeter(this int? value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux KilogramsPerSecondPerSquareMeter(this long value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? KilogramsPerSecondPerSquareMeter(this long? value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux KilogramsPerSecondPerSquareMeter(this double value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? KilogramsPerSecondPerSquareMeter(this double? value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux KilogramsPerSecondPerSquareMeter(this float value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? KilogramsPerSecondPerSquareMeter(this float? value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value);
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux KilogramsPerSecondPerSquareMeter(this decimal value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassFlux.FromKilogramsPerSecondPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static MassFlux? KilogramsPerSecondPerSquareMeter(this decimal? value) => MassFlux.FromKilogramsPerSecondPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassFlux? KilogramsPerSecondPerSquareMeter<T>(this T? value) where T : struct => MassFlux.FromKilogramsPerSecondPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassMomentOfInertiaExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMassMomentOfInertiaExtensions.g.cs
@@ -47,884 +47,260 @@ namespace UnitsNet.Extensions.NumberToMassMomentOfInertia
         #region GramSquareCentimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareCentimeters(this int value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
+        public static MassMomentOfInertia GramSquareCentimeters<T>(this T value) => MassMomentOfInertia.FromGramSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareCentimeters(this int? value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareCentimeters(this long value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareCentimeters(this long? value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareCentimeters(this double value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareCentimeters(this double? value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareCentimeters(this float value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareCentimeters(this float? value) => MassMomentOfInertia.FromGramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareCentimeters(this decimal value) => MassMomentOfInertia.FromGramSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareCentimeters(this decimal? value) => MassMomentOfInertia.FromGramSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? GramSquareCentimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromGramSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramSquareDecimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareDecimeters(this int value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
+        public static MassMomentOfInertia GramSquareDecimeters<T>(this T value) => MassMomentOfInertia.FromGramSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareDecimeters(this int? value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareDecimeters(this long value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareDecimeters(this long? value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareDecimeters(this double value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareDecimeters(this double? value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareDecimeters(this float value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareDecimeters(this float? value) => MassMomentOfInertia.FromGramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareDecimeters(this decimal value) => MassMomentOfInertia.FromGramSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareDecimeters(this decimal? value) => MassMomentOfInertia.FromGramSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? GramSquareDecimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromGramSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramSquareMeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMeters(this int value) => MassMomentOfInertia.FromGramSquareMeters(value);
+        public static MassMomentOfInertia GramSquareMeters<T>(this T value) => MassMomentOfInertia.FromGramSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMeters(this int? value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMeters(this long value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMeters(this long? value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMeters(this double value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMeters(this double? value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMeters(this float value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMeters(this float? value) => MassMomentOfInertia.FromGramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMeters(this decimal value) => MassMomentOfInertia.FromGramSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMeters(this decimal? value) => MassMomentOfInertia.FromGramSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? GramSquareMeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromGramSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramSquareMillimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMillimeters(this int value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
+        public static MassMomentOfInertia GramSquareMillimeters<T>(this T value) => MassMomentOfInertia.FromGramSquareMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMillimeters(this int? value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMillimeters(this long value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMillimeters(this long? value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMillimeters(this double value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMillimeters(this double? value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMillimeters(this float value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMillimeters(this float? value) => MassMomentOfInertia.FromGramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia GramSquareMillimeters(this decimal value) => MassMomentOfInertia.FromGramSquareMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromGramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? GramSquareMillimeters(this decimal? value) => MassMomentOfInertia.FromGramSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? GramSquareMillimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromGramSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramSquareCentimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareCentimeters(this int value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
+        public static MassMomentOfInertia KilogramSquareCentimeters<T>(this T value) => MassMomentOfInertia.FromKilogramSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareCentimeters(this int? value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareCentimeters(this long value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareCentimeters(this long? value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareCentimeters(this double value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareCentimeters(this double? value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareCentimeters(this float value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareCentimeters(this float? value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareCentimeters(this decimal value) => MassMomentOfInertia.FromKilogramSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareCentimeters(this decimal? value) => MassMomentOfInertia.FromKilogramSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilogramSquareCentimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilogramSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramSquareDecimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareDecimeters(this int value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
+        public static MassMomentOfInertia KilogramSquareDecimeters<T>(this T value) => MassMomentOfInertia.FromKilogramSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareDecimeters(this int? value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareDecimeters(this long value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareDecimeters(this long? value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareDecimeters(this double value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareDecimeters(this double? value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareDecimeters(this float value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareDecimeters(this float? value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareDecimeters(this decimal value) => MassMomentOfInertia.FromKilogramSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareDecimeters(this decimal? value) => MassMomentOfInertia.FromKilogramSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilogramSquareDecimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilogramSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramSquareMeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMeters(this int value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
+        public static MassMomentOfInertia KilogramSquareMeters<T>(this T value) => MassMomentOfInertia.FromKilogramSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMeters(this int? value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMeters(this long value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMeters(this long? value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMeters(this double value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMeters(this double? value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMeters(this float value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMeters(this float? value) => MassMomentOfInertia.FromKilogramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMeters(this decimal value) => MassMomentOfInertia.FromKilogramSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMeters(this decimal? value) => MassMomentOfInertia.FromKilogramSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilogramSquareMeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilogramSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramSquareMillimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMillimeters(this int value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
+        public static MassMomentOfInertia KilogramSquareMillimeters<T>(this T value) => MassMomentOfInertia.FromKilogramSquareMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMillimeters(this int? value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMillimeters(this long value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMillimeters(this long? value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMillimeters(this double value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMillimeters(this double? value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMillimeters(this float value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMillimeters(this float? value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilogramSquareMillimeters(this decimal value) => MassMomentOfInertia.FromKilogramSquareMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilogramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilogramSquareMillimeters(this decimal? value) => MassMomentOfInertia.FromKilogramSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilogramSquareMillimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilogramSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilotonneSquareCentimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareCentimeters(this int value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
+        public static MassMomentOfInertia KilotonneSquareCentimeters<T>(this T value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareCentimeters(this int? value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareCentimeters(this long value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareCentimeters(this long? value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareCentimeters(this double value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareCentimeters(this double? value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareCentimeters(this float value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareCentimeters(this float? value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareCentimeters(this decimal value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareCentimeters(this decimal? value) => MassMomentOfInertia.FromKilotonneSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilotonneSquareCentimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilotonneSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilotonneSquareDecimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareDecimeters(this int value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
+        public static MassMomentOfInertia KilotonneSquareDecimeters<T>(this T value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareDecimeters(this int? value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareDecimeters(this long value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareDecimeters(this long? value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareDecimeters(this double value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareDecimeters(this double? value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareDecimeters(this float value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareDecimeters(this float? value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareDecimeters(this decimal value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareDecimeters(this decimal? value) => MassMomentOfInertia.FromKilotonneSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilotonneSquareDecimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilotonneSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilotonneSquareMeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMeters(this int value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
+        public static MassMomentOfInertia KilotonneSquareMeters<T>(this T value) => MassMomentOfInertia.FromKilotonneSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMeters(this int? value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMeters(this long value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMeters(this long? value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMeters(this double value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMeters(this double? value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMeters(this float value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMeters(this float? value) => MassMomentOfInertia.FromKilotonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMeters(this decimal value) => MassMomentOfInertia.FromKilotonneSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMeters(this decimal? value) => MassMomentOfInertia.FromKilotonneSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilotonneSquareMeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilotonneSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilotonneSquareMilimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMilimeters(this int value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
+        public static MassMomentOfInertia KilotonneSquareMilimeters<T>(this T value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMilimeters(this int? value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMilimeters(this long value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMilimeters(this long? value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMilimeters(this double value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMilimeters(this double? value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMilimeters(this float value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMilimeters(this float? value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia KilotonneSquareMilimeters(this decimal value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromKilotonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? KilotonneSquareMilimeters(this decimal? value) => MassMomentOfInertia.FromKilotonneSquareMilimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? KilotonneSquareMilimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromKilotonneSquareMilimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegatonneSquareCentimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareCentimeters(this int value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
+        public static MassMomentOfInertia MegatonneSquareCentimeters<T>(this T value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareCentimeters(this int? value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareCentimeters(this long value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareCentimeters(this long? value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareCentimeters(this double value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareCentimeters(this double? value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareCentimeters(this float value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareCentimeters(this float? value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareCentimeters(this decimal value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareCentimeters(this decimal? value) => MassMomentOfInertia.FromMegatonneSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MegatonneSquareCentimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMegatonneSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegatonneSquareDecimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareDecimeters(this int value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
+        public static MassMomentOfInertia MegatonneSquareDecimeters<T>(this T value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareDecimeters(this int? value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareDecimeters(this long value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareDecimeters(this long? value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareDecimeters(this double value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareDecimeters(this double? value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareDecimeters(this float value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareDecimeters(this float? value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareDecimeters(this decimal value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareDecimeters(this decimal? value) => MassMomentOfInertia.FromMegatonneSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MegatonneSquareDecimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMegatonneSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegatonneSquareMeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMeters(this int value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
+        public static MassMomentOfInertia MegatonneSquareMeters<T>(this T value) => MassMomentOfInertia.FromMegatonneSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMeters(this int? value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMeters(this long value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMeters(this long? value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMeters(this double value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMeters(this double? value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMeters(this float value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMeters(this float? value) => MassMomentOfInertia.FromMegatonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMeters(this decimal value) => MassMomentOfInertia.FromMegatonneSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMeters(this decimal? value) => MassMomentOfInertia.FromMegatonneSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MegatonneSquareMeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMegatonneSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegatonneSquareMilimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMilimeters(this int value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
+        public static MassMomentOfInertia MegatonneSquareMilimeters<T>(this T value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMilimeters(this int? value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMilimeters(this long value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMilimeters(this long? value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMilimeters(this double value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMilimeters(this double? value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMilimeters(this float value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMilimeters(this float? value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MegatonneSquareMilimeters(this decimal value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMegatonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MegatonneSquareMilimeters(this decimal? value) => MassMomentOfInertia.FromMegatonneSquareMilimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MegatonneSquareMilimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMegatonneSquareMilimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramSquareCentimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareCentimeters(this int value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
+        public static MassMomentOfInertia MilligramSquareCentimeters<T>(this T value) => MassMomentOfInertia.FromMilligramSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareCentimeters(this int? value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareCentimeters(this long value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareCentimeters(this long? value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareCentimeters(this double value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareCentimeters(this double? value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareCentimeters(this float value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareCentimeters(this float? value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareCentimeters(this decimal value) => MassMomentOfInertia.FromMilligramSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareCentimeters(this decimal? value) => MassMomentOfInertia.FromMilligramSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MilligramSquareCentimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMilligramSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramSquareDecimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareDecimeters(this int value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
+        public static MassMomentOfInertia MilligramSquareDecimeters<T>(this T value) => MassMomentOfInertia.FromMilligramSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareDecimeters(this int? value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareDecimeters(this long value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareDecimeters(this long? value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareDecimeters(this double value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareDecimeters(this double? value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareDecimeters(this float value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareDecimeters(this float? value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareDecimeters(this decimal value) => MassMomentOfInertia.FromMilligramSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareDecimeters(this decimal? value) => MassMomentOfInertia.FromMilligramSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MilligramSquareDecimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMilligramSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramSquareMeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMeters(this int value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
+        public static MassMomentOfInertia MilligramSquareMeters<T>(this T value) => MassMomentOfInertia.FromMilligramSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMeters(this int? value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMeters(this long value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMeters(this long? value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMeters(this double value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMeters(this double? value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMeters(this float value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMeters(this float? value) => MassMomentOfInertia.FromMilligramSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMeters(this decimal value) => MassMomentOfInertia.FromMilligramSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMeters(this decimal? value) => MassMomentOfInertia.FromMilligramSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MilligramSquareMeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMilligramSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramSquareMillimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMillimeters(this int value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
+        public static MassMomentOfInertia MilligramSquareMillimeters<T>(this T value) => MassMomentOfInertia.FromMilligramSquareMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMillimeters(this int? value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMillimeters(this long value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMillimeters(this long? value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMillimeters(this double value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMillimeters(this double? value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMillimeters(this float value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMillimeters(this float? value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia MilligramSquareMillimeters(this decimal value) => MassMomentOfInertia.FromMilligramSquareMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromMilligramSquareMillimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? MilligramSquareMillimeters(this decimal? value) => MassMomentOfInertia.FromMilligramSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? MilligramSquareMillimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromMilligramSquareMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundSquareFoot
 
         /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareFeet(this int value) => MassMomentOfInertia.FromPoundSquareFeet(value);
+        public static MassMomentOfInertia PoundSquareFeet<T>(this T value) => MassMomentOfInertia.FromPoundSquareFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareFeet(this int? value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareFeet(this long value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareFeet(this long? value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareFeet(this double value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareFeet(this double? value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareFeet(this float value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareFeet(this float? value) => MassMomentOfInertia.FromPoundSquareFeet(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareFeet(this decimal value) => MassMomentOfInertia.FromPoundSquareFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareFeet(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareFeet(this decimal? value) => MassMomentOfInertia.FromPoundSquareFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? PoundSquareFeet<T>(this T? value) where T : struct => MassMomentOfInertia.FromPoundSquareFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundSquareInch
 
         /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareInches(this int value) => MassMomentOfInertia.FromPoundSquareInches(value);
+        public static MassMomentOfInertia PoundSquareInches<T>(this T value) => MassMomentOfInertia.FromPoundSquareInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareInches(this int? value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareInches(this long value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareInches(this long? value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareInches(this double value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareInches(this double? value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareInches(this float value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareInches(this float? value) => MassMomentOfInertia.FromPoundSquareInches(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia PoundSquareInches(this decimal value) => MassMomentOfInertia.FromPoundSquareInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromPoundSquareInches(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? PoundSquareInches(this decimal? value) => MassMomentOfInertia.FromPoundSquareInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? PoundSquareInches<T>(this T? value) where T : struct => MassMomentOfInertia.FromPoundSquareInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneSquareCentimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareCentimeters(this int value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
+        public static MassMomentOfInertia TonneSquareCentimeters<T>(this T value) => MassMomentOfInertia.FromTonneSquareCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareCentimeters(this int? value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareCentimeters(this long value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareCentimeters(this long? value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareCentimeters(this double value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareCentimeters(this double? value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareCentimeters(this float value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareCentimeters(this float? value) => MassMomentOfInertia.FromTonneSquareCentimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareCentimeters(this decimal value) => MassMomentOfInertia.FromTonneSquareCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareCentimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareCentimeters(this decimal? value) => MassMomentOfInertia.FromTonneSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? TonneSquareCentimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromTonneSquareCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneSquareDecimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareDecimeters(this int value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
+        public static MassMomentOfInertia TonneSquareDecimeters<T>(this T value) => MassMomentOfInertia.FromTonneSquareDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareDecimeters(this int? value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareDecimeters(this long value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareDecimeters(this long? value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareDecimeters(this double value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareDecimeters(this double? value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareDecimeters(this float value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareDecimeters(this float? value) => MassMomentOfInertia.FromTonneSquareDecimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareDecimeters(this decimal value) => MassMomentOfInertia.FromTonneSquareDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareDecimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareDecimeters(this decimal? value) => MassMomentOfInertia.FromTonneSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? TonneSquareDecimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromTonneSquareDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneSquareMeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMeters(this int value) => MassMomentOfInertia.FromTonneSquareMeters(value);
+        public static MassMomentOfInertia TonneSquareMeters<T>(this T value) => MassMomentOfInertia.FromTonneSquareMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMeters(this int? value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMeters(this long value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMeters(this long? value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMeters(this double value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMeters(this double? value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMeters(this float value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMeters(this float? value) => MassMomentOfInertia.FromTonneSquareMeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMeters(this decimal value) => MassMomentOfInertia.FromTonneSquareMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMeters(this decimal? value) => MassMomentOfInertia.FromTonneSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? TonneSquareMeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromTonneSquareMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneSquareMilimeter
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMilimeters(this int value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
+        public static MassMomentOfInertia TonneSquareMilimeters<T>(this T value) => MassMomentOfInertia.FromTonneSquareMilimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMilimeters(this int? value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMilimeters(this long value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMilimeters(this long? value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMilimeters(this double value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMilimeters(this double? value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMilimeters(this float value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMilimeters(this float? value) => MassMomentOfInertia.FromTonneSquareMilimeters(value);
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia TonneSquareMilimeters(this decimal value) => MassMomentOfInertia.FromTonneSquareMilimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MassMomentOfInertia.FromTonneSquareMilimeters(UnitsNet.QuantityValue)" />
-        public static MassMomentOfInertia? TonneSquareMilimeters(this decimal? value) => MassMomentOfInertia.FromTonneSquareMilimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MassMomentOfInertia? TonneSquareMilimeters<T>(this T? value) where T : struct => MassMomentOfInertia.FromTonneSquareMilimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarEnergyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarEnergyExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToMolarEnergy
         #region JoulePerMole
 
         /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy JoulesPerMole(this int value) => MolarEnergy.FromJoulesPerMole(value);
+        public static MolarEnergy JoulesPerMole<T>(this T value) => MolarEnergy.FromJoulesPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? JoulesPerMole(this int? value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy JoulesPerMole(this long value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? JoulesPerMole(this long? value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy JoulesPerMole(this double value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? JoulesPerMole(this double? value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy JoulesPerMole(this float value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? JoulesPerMole(this float? value) => MolarEnergy.FromJoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy JoulesPerMole(this decimal value) => MolarEnergy.FromJoulesPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarEnergy.FromJoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? JoulesPerMole(this decimal? value) => MolarEnergy.FromJoulesPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarEnergy? JoulesPerMole<T>(this T? value) where T : struct => MolarEnergy.FromJoulesPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerMole
 
         /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy KilojoulesPerMole(this int value) => MolarEnergy.FromKilojoulesPerMole(value);
+        public static MolarEnergy KilojoulesPerMole<T>(this T value) => MolarEnergy.FromKilojoulesPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? KilojoulesPerMole(this int? value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy KilojoulesPerMole(this long value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? KilojoulesPerMole(this long? value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy KilojoulesPerMole(this double value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? KilojoulesPerMole(this double? value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy KilojoulesPerMole(this float value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? KilojoulesPerMole(this float? value) => MolarEnergy.FromKilojoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy KilojoulesPerMole(this decimal value) => MolarEnergy.FromKilojoulesPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarEnergy.FromKilojoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? KilojoulesPerMole(this decimal? value) => MolarEnergy.FromKilojoulesPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarEnergy? KilojoulesPerMole<T>(this T? value) where T : struct => MolarEnergy.FromKilojoulesPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegajoulePerMole
 
         /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy MegajoulesPerMole(this int value) => MolarEnergy.FromMegajoulesPerMole(value);
+        public static MolarEnergy MegajoulesPerMole<T>(this T value) => MolarEnergy.FromMegajoulesPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? MegajoulesPerMole(this int? value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy MegajoulesPerMole(this long value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? MegajoulesPerMole(this long? value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy MegajoulesPerMole(this double value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? MegajoulesPerMole(this double? value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy MegajoulesPerMole(this float value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? MegajoulesPerMole(this float? value) => MolarEnergy.FromMegajoulesPerMole(value);
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy MegajoulesPerMole(this decimal value) => MolarEnergy.FromMegajoulesPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarEnergy.FromMegajoulesPerMole(UnitsNet.QuantityValue)" />
-        public static MolarEnergy? MegajoulesPerMole(this decimal? value) => MolarEnergy.FromMegajoulesPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarEnergy? MegajoulesPerMole<T>(this T? value) where T : struct => MolarEnergy.FromMegajoulesPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarEntropyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarEntropyExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToMolarEntropy
         #region JoulePerMoleKelvin
 
         /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy JoulesPerMoleKelvin(this int value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
+        public static MolarEntropy JoulesPerMoleKelvin<T>(this T value) => MolarEntropy.FromJoulesPerMoleKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? JoulesPerMoleKelvin(this int? value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy JoulesPerMoleKelvin(this long value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? JoulesPerMoleKelvin(this long? value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy JoulesPerMoleKelvin(this double value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? JoulesPerMoleKelvin(this double? value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy JoulesPerMoleKelvin(this float value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? JoulesPerMoleKelvin(this float? value) => MolarEntropy.FromJoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy JoulesPerMoleKelvin(this decimal value) => MolarEntropy.FromJoulesPerMoleKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarEntropy.FromJoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? JoulesPerMoleKelvin(this decimal? value) => MolarEntropy.FromJoulesPerMoleKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarEntropy? JoulesPerMoleKelvin<T>(this T? value) where T : struct => MolarEntropy.FromJoulesPerMoleKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerMoleKelvin
 
         /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy KilojoulesPerMoleKelvin(this int value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
+        public static MolarEntropy KilojoulesPerMoleKelvin<T>(this T value) => MolarEntropy.FromKilojoulesPerMoleKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? KilojoulesPerMoleKelvin(this int? value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy KilojoulesPerMoleKelvin(this long value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? KilojoulesPerMoleKelvin(this long? value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy KilojoulesPerMoleKelvin(this double value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? KilojoulesPerMoleKelvin(this double? value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy KilojoulesPerMoleKelvin(this float value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? KilojoulesPerMoleKelvin(this float? value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy KilojoulesPerMoleKelvin(this decimal value) => MolarEntropy.FromKilojoulesPerMoleKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarEntropy.FromKilojoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? KilojoulesPerMoleKelvin(this decimal? value) => MolarEntropy.FromKilojoulesPerMoleKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarEntropy? KilojoulesPerMoleKelvin<T>(this T? value) where T : struct => MolarEntropy.FromKilojoulesPerMoleKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegajoulePerMoleKelvin
 
         /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy MegajoulesPerMoleKelvin(this int value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
+        public static MolarEntropy MegajoulesPerMoleKelvin<T>(this T value) => MolarEntropy.FromMegajoulesPerMoleKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? MegajoulesPerMoleKelvin(this int? value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy MegajoulesPerMoleKelvin(this long value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? MegajoulesPerMoleKelvin(this long? value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy MegajoulesPerMoleKelvin(this double value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? MegajoulesPerMoleKelvin(this double? value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy MegajoulesPerMoleKelvin(this float value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? MegajoulesPerMoleKelvin(this float? value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value);
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy MegajoulesPerMoleKelvin(this decimal value) => MolarEntropy.FromMegajoulesPerMoleKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarEntropy.FromMegajoulesPerMoleKelvin(UnitsNet.QuantityValue)" />
-        public static MolarEntropy? MegajoulesPerMoleKelvin(this decimal? value) => MolarEntropy.FromMegajoulesPerMoleKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarEntropy? MegajoulesPerMoleKelvin<T>(this T? value) where T : struct => MolarEntropy.FromMegajoulesPerMoleKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarMassExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarMassExtensions.g.cs
@@ -47,408 +47,120 @@ namespace UnitsNet.Extensions.NumberToMolarMass
         #region CentigramPerMole
 
         /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass CentigramsPerMole(this int value) => MolarMass.FromCentigramsPerMole(value);
+        public static MolarMass CentigramsPerMole<T>(this T value) => MolarMass.FromCentigramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? CentigramsPerMole(this int? value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass CentigramsPerMole(this long value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? CentigramsPerMole(this long? value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass CentigramsPerMole(this double value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? CentigramsPerMole(this double? value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass CentigramsPerMole(this float value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? CentigramsPerMole(this float? value) => MolarMass.FromCentigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass CentigramsPerMole(this decimal value) => MolarMass.FromCentigramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromCentigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? CentigramsPerMole(this decimal? value) => MolarMass.FromCentigramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? CentigramsPerMole<T>(this T? value) where T : struct => MolarMass.FromCentigramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecagramPerMole
 
         /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecagramsPerMole(this int value) => MolarMass.FromDecagramsPerMole(value);
+        public static MolarMass DecagramsPerMole<T>(this T value) => MolarMass.FromDecagramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecagramsPerMole(this int? value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecagramsPerMole(this long value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecagramsPerMole(this long? value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecagramsPerMole(this double value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecagramsPerMole(this double? value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecagramsPerMole(this float value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecagramsPerMole(this float? value) => MolarMass.FromDecagramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecagramsPerMole(this decimal value) => MolarMass.FromDecagramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromDecagramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecagramsPerMole(this decimal? value) => MolarMass.FromDecagramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? DecagramsPerMole<T>(this T? value) where T : struct => MolarMass.FromDecagramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecigramPerMole
 
         /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecigramsPerMole(this int value) => MolarMass.FromDecigramsPerMole(value);
+        public static MolarMass DecigramsPerMole<T>(this T value) => MolarMass.FromDecigramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecigramsPerMole(this int? value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecigramsPerMole(this long value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecigramsPerMole(this long? value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecigramsPerMole(this double value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecigramsPerMole(this double? value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecigramsPerMole(this float value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecigramsPerMole(this float? value) => MolarMass.FromDecigramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass DecigramsPerMole(this decimal value) => MolarMass.FromDecigramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromDecigramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? DecigramsPerMole(this decimal? value) => MolarMass.FromDecigramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? DecigramsPerMole<T>(this T? value) where T : struct => MolarMass.FromDecigramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GramPerMole
 
         /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass GramsPerMole(this int value) => MolarMass.FromGramsPerMole(value);
+        public static MolarMass GramsPerMole<T>(this T value) => MolarMass.FromGramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? GramsPerMole(this int? value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass GramsPerMole(this long value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? GramsPerMole(this long? value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass GramsPerMole(this double value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? GramsPerMole(this double? value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass GramsPerMole(this float value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? GramsPerMole(this float? value) => MolarMass.FromGramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass GramsPerMole(this decimal value) => MolarMass.FromGramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromGramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? GramsPerMole(this decimal? value) => MolarMass.FromGramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? GramsPerMole<T>(this T? value) where T : struct => MolarMass.FromGramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region HectogramPerMole
 
         /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass HectogramsPerMole(this int value) => MolarMass.FromHectogramsPerMole(value);
+        public static MolarMass HectogramsPerMole<T>(this T value) => MolarMass.FromHectogramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? HectogramsPerMole(this int? value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass HectogramsPerMole(this long value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? HectogramsPerMole(this long? value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass HectogramsPerMole(this double value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? HectogramsPerMole(this double? value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass HectogramsPerMole(this float value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? HectogramsPerMole(this float? value) => MolarMass.FromHectogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass HectogramsPerMole(this decimal value) => MolarMass.FromHectogramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromHectogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? HectogramsPerMole(this decimal? value) => MolarMass.FromHectogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? HectogramsPerMole<T>(this T? value) where T : struct => MolarMass.FromHectogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramPerMole
 
         /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilogramsPerMole(this int value) => MolarMass.FromKilogramsPerMole(value);
+        public static MolarMass KilogramsPerMole<T>(this T value) => MolarMass.FromKilogramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilogramsPerMole(this int? value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilogramsPerMole(this long value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilogramsPerMole(this long? value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilogramsPerMole(this double value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilogramsPerMole(this double? value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilogramsPerMole(this float value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilogramsPerMole(this float? value) => MolarMass.FromKilogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilogramsPerMole(this decimal value) => MolarMass.FromKilogramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromKilogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilogramsPerMole(this decimal? value) => MolarMass.FromKilogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? KilogramsPerMole<T>(this T? value) where T : struct => MolarMass.FromKilogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundPerMole
 
         /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilopoundsPerMole(this int value) => MolarMass.FromKilopoundsPerMole(value);
+        public static MolarMass KilopoundsPerMole<T>(this T value) => MolarMass.FromKilopoundsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilopoundsPerMole(this int? value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilopoundsPerMole(this long value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilopoundsPerMole(this long? value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilopoundsPerMole(this double value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilopoundsPerMole(this double? value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilopoundsPerMole(this float value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilopoundsPerMole(this float? value) => MolarMass.FromKilopoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass KilopoundsPerMole(this decimal value) => MolarMass.FromKilopoundsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromKilopoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? KilopoundsPerMole(this decimal? value) => MolarMass.FromKilopoundsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? KilopoundsPerMole<T>(this T? value) where T : struct => MolarMass.FromKilopoundsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegapoundPerMole
 
         /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MegapoundsPerMole(this int value) => MolarMass.FromMegapoundsPerMole(value);
+        public static MolarMass MegapoundsPerMole<T>(this T value) => MolarMass.FromMegapoundsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MegapoundsPerMole(this int? value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MegapoundsPerMole(this long value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MegapoundsPerMole(this long? value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MegapoundsPerMole(this double value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MegapoundsPerMole(this double? value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MegapoundsPerMole(this float value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MegapoundsPerMole(this float? value) => MolarMass.FromMegapoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MegapoundsPerMole(this decimal value) => MolarMass.FromMegapoundsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromMegapoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MegapoundsPerMole(this decimal? value) => MolarMass.FromMegapoundsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? MegapoundsPerMole<T>(this T? value) where T : struct => MolarMass.FromMegapoundsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrogramPerMole
 
         /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MicrogramsPerMole(this int value) => MolarMass.FromMicrogramsPerMole(value);
+        public static MolarMass MicrogramsPerMole<T>(this T value) => MolarMass.FromMicrogramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MicrogramsPerMole(this int? value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MicrogramsPerMole(this long value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MicrogramsPerMole(this long? value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MicrogramsPerMole(this double value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MicrogramsPerMole(this double? value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MicrogramsPerMole(this float value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MicrogramsPerMole(this float? value) => MolarMass.FromMicrogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MicrogramsPerMole(this decimal value) => MolarMass.FromMicrogramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromMicrogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MicrogramsPerMole(this decimal? value) => MolarMass.FromMicrogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? MicrogramsPerMole<T>(this T? value) where T : struct => MolarMass.FromMicrogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilligramPerMole
 
         /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MilligramsPerMole(this int value) => MolarMass.FromMilligramsPerMole(value);
+        public static MolarMass MilligramsPerMole<T>(this T value) => MolarMass.FromMilligramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MilligramsPerMole(this int? value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MilligramsPerMole(this long value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MilligramsPerMole(this long? value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MilligramsPerMole(this double value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MilligramsPerMole(this double? value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MilligramsPerMole(this float value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MilligramsPerMole(this float? value) => MolarMass.FromMilligramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass MilligramsPerMole(this decimal value) => MolarMass.FromMilligramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromMilligramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? MilligramsPerMole(this decimal? value) => MolarMass.FromMilligramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? MilligramsPerMole<T>(this T? value) where T : struct => MolarMass.FromMilligramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanogramPerMole
 
         /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass NanogramsPerMole(this int value) => MolarMass.FromNanogramsPerMole(value);
+        public static MolarMass NanogramsPerMole<T>(this T value) => MolarMass.FromNanogramsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? NanogramsPerMole(this int? value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass NanogramsPerMole(this long value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? NanogramsPerMole(this long? value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass NanogramsPerMole(this double value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? NanogramsPerMole(this double? value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass NanogramsPerMole(this float value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? NanogramsPerMole(this float? value) => MolarMass.FromNanogramsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass NanogramsPerMole(this decimal value) => MolarMass.FromNanogramsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromNanogramsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? NanogramsPerMole(this decimal? value) => MolarMass.FromNanogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? NanogramsPerMole<T>(this T? value) where T : struct => MolarMass.FromNanogramsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundPerMole
 
         /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass PoundsPerMole(this int value) => MolarMass.FromPoundsPerMole(value);
+        public static MolarMass PoundsPerMole<T>(this T value) => MolarMass.FromPoundsPerMole(Convert.ToDouble(value));
 
         /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? PoundsPerMole(this int? value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass PoundsPerMole(this long value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? PoundsPerMole(this long? value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass PoundsPerMole(this double value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? PoundsPerMole(this double? value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass PoundsPerMole(this float value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? PoundsPerMole(this float? value) => MolarMass.FromPoundsPerMole(value);
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass PoundsPerMole(this decimal value) => MolarMass.FromPoundsPerMole(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="MolarMass.FromPoundsPerMole(UnitsNet.QuantityValue)" />
-        public static MolarMass? PoundsPerMole(this decimal? value) => MolarMass.FromPoundsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static MolarMass? PoundsPerMole<T>(this T? value) where T : struct => MolarMass.FromPoundsPerMole(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToMolarityExtensions.g.cs
@@ -47,272 +47,80 @@ namespace UnitsNet.Extensions.NumberToMolarity
         #region CentimolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity CentimolesPerLiter(this int value) => Molarity.FromCentimolesPerLiter(value);
+        public static Molarity CentimolesPerLiter<T>(this T value) => Molarity.FromCentimolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? CentimolesPerLiter(this int? value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity CentimolesPerLiter(this long value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? CentimolesPerLiter(this long? value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity CentimolesPerLiter(this double value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? CentimolesPerLiter(this double? value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity CentimolesPerLiter(this float value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? CentimolesPerLiter(this float? value) => Molarity.FromCentimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity CentimolesPerLiter(this decimal value) => Molarity.FromCentimolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromCentimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? CentimolesPerLiter(this decimal? value) => Molarity.FromCentimolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? CentimolesPerLiter<T>(this T? value) where T : struct => Molarity.FromCentimolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecimolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity DecimolesPerLiter(this int value) => Molarity.FromDecimolesPerLiter(value);
+        public static Molarity DecimolesPerLiter<T>(this T value) => Molarity.FromDecimolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? DecimolesPerLiter(this int? value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity DecimolesPerLiter(this long value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? DecimolesPerLiter(this long? value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity DecimolesPerLiter(this double value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? DecimolesPerLiter(this double? value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity DecimolesPerLiter(this float value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? DecimolesPerLiter(this float? value) => Molarity.FromDecimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity DecimolesPerLiter(this decimal value) => Molarity.FromDecimolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromDecimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? DecimolesPerLiter(this decimal? value) => Molarity.FromDecimolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? DecimolesPerLiter<T>(this T? value) where T : struct => Molarity.FromDecimolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicromolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MicromolesPerLiter(this int value) => Molarity.FromMicromolesPerLiter(value);
+        public static Molarity MicromolesPerLiter<T>(this T value) => Molarity.FromMicromolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MicromolesPerLiter(this int? value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MicromolesPerLiter(this long value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MicromolesPerLiter(this long? value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MicromolesPerLiter(this double value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MicromolesPerLiter(this double? value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MicromolesPerLiter(this float value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MicromolesPerLiter(this float? value) => Molarity.FromMicromolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MicromolesPerLiter(this decimal value) => Molarity.FromMicromolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MicromolesPerLiter(this decimal? value) => Molarity.FromMicromolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? MicromolesPerLiter<T>(this T? value) where T : struct => Molarity.FromMicromolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MillimolesPerLiter(this int value) => Molarity.FromMillimolesPerLiter(value);
+        public static Molarity MillimolesPerLiter<T>(this T value) => Molarity.FromMillimolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MillimolesPerLiter(this int? value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MillimolesPerLiter(this long value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MillimolesPerLiter(this long? value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MillimolesPerLiter(this double value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MillimolesPerLiter(this double? value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MillimolesPerLiter(this float value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MillimolesPerLiter(this float? value) => Molarity.FromMillimolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MillimolesPerLiter(this decimal value) => Molarity.FromMillimolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromMillimolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MillimolesPerLiter(this decimal? value) => Molarity.FromMillimolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? MillimolesPerLiter<T>(this T? value) where T : struct => Molarity.FromMillimolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MolesPerCubicMeter
 
         /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerCubicMeter(this int value) => Molarity.FromMolesPerCubicMeter(value);
+        public static Molarity MolesPerCubicMeter<T>(this T value) => Molarity.FromMolesPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerCubicMeter(this int? value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerCubicMeter(this long value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerCubicMeter(this long? value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerCubicMeter(this double value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerCubicMeter(this double? value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerCubicMeter(this float value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerCubicMeter(this float? value) => Molarity.FromMolesPerCubicMeter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerCubicMeter(this decimal value) => Molarity.FromMolesPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromMolesPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerCubicMeter(this decimal? value) => Molarity.FromMolesPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? MolesPerCubicMeter<T>(this T? value) where T : struct => Molarity.FromMolesPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerLiter(this int value) => Molarity.FromMolesPerLiter(value);
+        public static Molarity MolesPerLiter<T>(this T value) => Molarity.FromMolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerLiter(this int? value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerLiter(this long value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerLiter(this long? value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerLiter(this double value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerLiter(this double? value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerLiter(this float value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerLiter(this float? value) => Molarity.FromMolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity MolesPerLiter(this decimal value) => Molarity.FromMolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromMolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? MolesPerLiter(this decimal? value) => Molarity.FromMolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? MolesPerLiter<T>(this T? value) where T : struct => Molarity.FromMolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanomolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity NanomolesPerLiter(this int value) => Molarity.FromNanomolesPerLiter(value);
+        public static Molarity NanomolesPerLiter<T>(this T value) => Molarity.FromNanomolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? NanomolesPerLiter(this int? value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity NanomolesPerLiter(this long value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? NanomolesPerLiter(this long? value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity NanomolesPerLiter(this double value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? NanomolesPerLiter(this double? value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity NanomolesPerLiter(this float value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? NanomolesPerLiter(this float? value) => Molarity.FromNanomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity NanomolesPerLiter(this decimal value) => Molarity.FromNanomolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromNanomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? NanomolesPerLiter(this decimal? value) => Molarity.FromNanomolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? NanomolesPerLiter<T>(this T? value) where T : struct => Molarity.FromNanomolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicomolesPerLiter
 
         /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity PicomolesPerLiter(this int value) => Molarity.FromPicomolesPerLiter(value);
+        public static Molarity PicomolesPerLiter<T>(this T value) => Molarity.FromPicomolesPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? PicomolesPerLiter(this int? value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity PicomolesPerLiter(this long value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? PicomolesPerLiter(this long? value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity PicomolesPerLiter(this double value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? PicomolesPerLiter(this double? value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity PicomolesPerLiter(this float value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? PicomolesPerLiter(this float? value) => Molarity.FromPicomolesPerLiter(value);
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity PicomolesPerLiter(this decimal value) => Molarity.FromPicomolesPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Molarity.FromPicomolesPerLiter(UnitsNet.QuantityValue)" />
-        public static Molarity? PicomolesPerLiter(this decimal? value) => Molarity.FromPicomolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Molarity? PicomolesPerLiter<T>(this T? value) where T : struct => Molarity.FromPicomolesPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPermeabilityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPermeabilityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToPermeability
         #region HenryPerMeter
 
         /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability HenriesPerMeter(this int value) => Permeability.FromHenriesPerMeter(value);
+        public static Permeability HenriesPerMeter<T>(this T value) => Permeability.FromHenriesPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability? HenriesPerMeter(this int? value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability HenriesPerMeter(this long value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability? HenriesPerMeter(this long? value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability HenriesPerMeter(this double value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability? HenriesPerMeter(this double? value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability HenriesPerMeter(this float value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability? HenriesPerMeter(this float? value) => Permeability.FromHenriesPerMeter(value);
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability HenriesPerMeter(this decimal value) => Permeability.FromHenriesPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Permeability.FromHenriesPerMeter(UnitsNet.QuantityValue)" />
-        public static Permeability? HenriesPerMeter(this decimal? value) => Permeability.FromHenriesPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Permeability? HenriesPerMeter<T>(this T? value) where T : struct => Permeability.FromHenriesPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPermittivityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPermittivityExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToPermittivity
         #region FaradPerMeter
 
         /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity FaradsPerMeter(this int value) => Permittivity.FromFaradsPerMeter(value);
+        public static Permittivity FaradsPerMeter<T>(this T value) => Permittivity.FromFaradsPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity? FaradsPerMeter(this int? value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity FaradsPerMeter(this long value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity? FaradsPerMeter(this long? value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity FaradsPerMeter(this double value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity? FaradsPerMeter(this double? value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity FaradsPerMeter(this float value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity? FaradsPerMeter(this float? value) => Permittivity.FromFaradsPerMeter(value);
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity FaradsPerMeter(this decimal value) => Permittivity.FromFaradsPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Permittivity.FromFaradsPerMeter(UnitsNet.QuantityValue)" />
-        public static Permittivity? FaradsPerMeter(this decimal? value) => Permittivity.FromFaradsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Permittivity? FaradsPerMeter<T>(this T? value) where T : struct => Permittivity.FromFaradsPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPowerDensityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPowerDensityExtensions.g.cs
@@ -47,1496 +47,440 @@ namespace UnitsNet.Extensions.NumberToPowerDensity
         #region DecawattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicFoot(this int value) => PowerDensity.FromDecawattsPerCubicFoot(value);
+        public static PowerDensity DecawattsPerCubicFoot<T>(this T value) => PowerDensity.FromDecawattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicFoot(this int? value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicFoot(this long value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicFoot(this long? value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicFoot(this double value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicFoot(this double? value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicFoot(this float value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicFoot(this float? value) => PowerDensity.FromDecawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicFoot(this decimal value) => PowerDensity.FromDecawattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicFoot(this decimal? value) => PowerDensity.FromDecawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DecawattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromDecawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecawattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicInch(this int value) => PowerDensity.FromDecawattsPerCubicInch(value);
+        public static PowerDensity DecawattsPerCubicInch<T>(this T value) => PowerDensity.FromDecawattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicInch(this int? value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicInch(this long value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicInch(this long? value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicInch(this double value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicInch(this double? value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicInch(this float value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicInch(this float? value) => PowerDensity.FromDecawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicInch(this decimal value) => PowerDensity.FromDecawattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicInch(this decimal? value) => PowerDensity.FromDecawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DecawattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromDecawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecawattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicMeter(this int value) => PowerDensity.FromDecawattsPerCubicMeter(value);
+        public static PowerDensity DecawattsPerCubicMeter<T>(this T value) => PowerDensity.FromDecawattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicMeter(this int? value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicMeter(this long value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicMeter(this long? value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicMeter(this double value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicMeter(this double? value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicMeter(this float value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicMeter(this float? value) => PowerDensity.FromDecawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerCubicMeter(this decimal value) => PowerDensity.FromDecawattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerCubicMeter(this decimal? value) => PowerDensity.FromDecawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DecawattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromDecawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecawattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerLiter(this int value) => PowerDensity.FromDecawattsPerLiter(value);
+        public static PowerDensity DecawattsPerLiter<T>(this T value) => PowerDensity.FromDecawattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerLiter(this int? value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerLiter(this long value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerLiter(this long? value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerLiter(this double value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerLiter(this double? value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerLiter(this float value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerLiter(this float? value) => PowerDensity.FromDecawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DecawattsPerLiter(this decimal value) => PowerDensity.FromDecawattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDecawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DecawattsPerLiter(this decimal? value) => PowerDensity.FromDecawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DecawattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromDecawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DeciwattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicFoot(this int value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
+        public static PowerDensity DeciwattsPerCubicFoot<T>(this T value) => PowerDensity.FromDeciwattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicFoot(this int? value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicFoot(this long value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicFoot(this long? value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicFoot(this double value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicFoot(this double? value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicFoot(this float value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicFoot(this float? value) => PowerDensity.FromDeciwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicFoot(this decimal value) => PowerDensity.FromDeciwattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicFoot(this decimal? value) => PowerDensity.FromDeciwattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DeciwattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromDeciwattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DeciwattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicInch(this int value) => PowerDensity.FromDeciwattsPerCubicInch(value);
+        public static PowerDensity DeciwattsPerCubicInch<T>(this T value) => PowerDensity.FromDeciwattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicInch(this int? value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicInch(this long value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicInch(this long? value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicInch(this double value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicInch(this double? value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicInch(this float value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicInch(this float? value) => PowerDensity.FromDeciwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicInch(this decimal value) => PowerDensity.FromDeciwattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicInch(this decimal? value) => PowerDensity.FromDeciwattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DeciwattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromDeciwattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DeciwattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicMeter(this int value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
+        public static PowerDensity DeciwattsPerCubicMeter<T>(this T value) => PowerDensity.FromDeciwattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicMeter(this int? value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicMeter(this long value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicMeter(this long? value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicMeter(this double value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicMeter(this double? value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicMeter(this float value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicMeter(this float? value) => PowerDensity.FromDeciwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerCubicMeter(this decimal value) => PowerDensity.FromDeciwattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerCubicMeter(this decimal? value) => PowerDensity.FromDeciwattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DeciwattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromDeciwattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DeciwattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerLiter(this int value) => PowerDensity.FromDeciwattsPerLiter(value);
+        public static PowerDensity DeciwattsPerLiter<T>(this T value) => PowerDensity.FromDeciwattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerLiter(this int? value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerLiter(this long value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerLiter(this long? value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerLiter(this double value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerLiter(this double? value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerLiter(this float value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerLiter(this float? value) => PowerDensity.FromDeciwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity DeciwattsPerLiter(this decimal value) => PowerDensity.FromDeciwattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromDeciwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? DeciwattsPerLiter(this decimal? value) => PowerDensity.FromDeciwattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? DeciwattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromDeciwattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigawattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicFoot(this int value) => PowerDensity.FromGigawattsPerCubicFoot(value);
+        public static PowerDensity GigawattsPerCubicFoot<T>(this T value) => PowerDensity.FromGigawattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicFoot(this int? value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicFoot(this long value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicFoot(this long? value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicFoot(this double value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicFoot(this double? value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicFoot(this float value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicFoot(this float? value) => PowerDensity.FromGigawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicFoot(this decimal value) => PowerDensity.FromGigawattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicFoot(this decimal? value) => PowerDensity.FromGigawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? GigawattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromGigawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigawattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicInch(this int value) => PowerDensity.FromGigawattsPerCubicInch(value);
+        public static PowerDensity GigawattsPerCubicInch<T>(this T value) => PowerDensity.FromGigawattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicInch(this int? value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicInch(this long value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicInch(this long? value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicInch(this double value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicInch(this double? value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicInch(this float value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicInch(this float? value) => PowerDensity.FromGigawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicInch(this decimal value) => PowerDensity.FromGigawattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicInch(this decimal? value) => PowerDensity.FromGigawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? GigawattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromGigawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigawattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicMeter(this int value) => PowerDensity.FromGigawattsPerCubicMeter(value);
+        public static PowerDensity GigawattsPerCubicMeter<T>(this T value) => PowerDensity.FromGigawattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicMeter(this int? value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicMeter(this long value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicMeter(this long? value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicMeter(this double value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicMeter(this double? value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicMeter(this float value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicMeter(this float? value) => PowerDensity.FromGigawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerCubicMeter(this decimal value) => PowerDensity.FromGigawattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerCubicMeter(this decimal? value) => PowerDensity.FromGigawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? GigawattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromGigawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region GigawattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerLiter(this int value) => PowerDensity.FromGigawattsPerLiter(value);
+        public static PowerDensity GigawattsPerLiter<T>(this T value) => PowerDensity.FromGigawattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerLiter(this int? value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerLiter(this long value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerLiter(this long? value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerLiter(this double value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerLiter(this double? value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerLiter(this float value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerLiter(this float? value) => PowerDensity.FromGigawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity GigawattsPerLiter(this decimal value) => PowerDensity.FromGigawattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromGigawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? GigawattsPerLiter(this decimal? value) => PowerDensity.FromGigawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? GigawattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromGigawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicFoot(this int value) => PowerDensity.FromKilowattsPerCubicFoot(value);
+        public static PowerDensity KilowattsPerCubicFoot<T>(this T value) => PowerDensity.FromKilowattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicFoot(this int? value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicFoot(this long value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicFoot(this long? value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicFoot(this double value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicFoot(this double? value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicFoot(this float value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicFoot(this float? value) => PowerDensity.FromKilowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicFoot(this decimal value) => PowerDensity.FromKilowattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicFoot(this decimal? value) => PowerDensity.FromKilowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? KilowattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromKilowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicInch(this int value) => PowerDensity.FromKilowattsPerCubicInch(value);
+        public static PowerDensity KilowattsPerCubicInch<T>(this T value) => PowerDensity.FromKilowattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicInch(this int? value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicInch(this long value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicInch(this long? value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicInch(this double value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicInch(this double? value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicInch(this float value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicInch(this float? value) => PowerDensity.FromKilowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicInch(this decimal value) => PowerDensity.FromKilowattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicInch(this decimal? value) => PowerDensity.FromKilowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? KilowattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromKilowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicMeter(this int value) => PowerDensity.FromKilowattsPerCubicMeter(value);
+        public static PowerDensity KilowattsPerCubicMeter<T>(this T value) => PowerDensity.FromKilowattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicMeter(this int? value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicMeter(this long value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicMeter(this long? value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicMeter(this double value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicMeter(this double? value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicMeter(this float value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicMeter(this float? value) => PowerDensity.FromKilowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerCubicMeter(this decimal value) => PowerDensity.FromKilowattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerCubicMeter(this decimal? value) => PowerDensity.FromKilowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? KilowattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromKilowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerLiter(this int value) => PowerDensity.FromKilowattsPerLiter(value);
+        public static PowerDensity KilowattsPerLiter<T>(this T value) => PowerDensity.FromKilowattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerLiter(this int? value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerLiter(this long value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerLiter(this long? value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerLiter(this double value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerLiter(this double? value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerLiter(this float value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerLiter(this float? value) => PowerDensity.FromKilowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity KilowattsPerLiter(this decimal value) => PowerDensity.FromKilowattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromKilowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? KilowattsPerLiter(this decimal? value) => PowerDensity.FromKilowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? KilowattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromKilowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegawattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicFoot(this int value) => PowerDensity.FromMegawattsPerCubicFoot(value);
+        public static PowerDensity MegawattsPerCubicFoot<T>(this T value) => PowerDensity.FromMegawattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicFoot(this int? value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicFoot(this long value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicFoot(this long? value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicFoot(this double value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicFoot(this double? value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicFoot(this float value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicFoot(this float? value) => PowerDensity.FromMegawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicFoot(this decimal value) => PowerDensity.FromMegawattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicFoot(this decimal? value) => PowerDensity.FromMegawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MegawattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromMegawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegawattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicInch(this int value) => PowerDensity.FromMegawattsPerCubicInch(value);
+        public static PowerDensity MegawattsPerCubicInch<T>(this T value) => PowerDensity.FromMegawattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicInch(this int? value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicInch(this long value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicInch(this long? value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicInch(this double value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicInch(this double? value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicInch(this float value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicInch(this float? value) => PowerDensity.FromMegawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicInch(this decimal value) => PowerDensity.FromMegawattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicInch(this decimal? value) => PowerDensity.FromMegawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MegawattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromMegawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegawattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicMeter(this int value) => PowerDensity.FromMegawattsPerCubicMeter(value);
+        public static PowerDensity MegawattsPerCubicMeter<T>(this T value) => PowerDensity.FromMegawattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicMeter(this int? value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicMeter(this long value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicMeter(this long? value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicMeter(this double value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicMeter(this double? value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicMeter(this float value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicMeter(this float? value) => PowerDensity.FromMegawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerCubicMeter(this decimal value) => PowerDensity.FromMegawattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerCubicMeter(this decimal? value) => PowerDensity.FromMegawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MegawattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromMegawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegawattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerLiter(this int value) => PowerDensity.FromMegawattsPerLiter(value);
+        public static PowerDensity MegawattsPerLiter<T>(this T value) => PowerDensity.FromMegawattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerLiter(this int? value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerLiter(this long value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerLiter(this long? value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerLiter(this double value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerLiter(this double? value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerLiter(this float value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerLiter(this float? value) => PowerDensity.FromMegawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MegawattsPerLiter(this decimal value) => PowerDensity.FromMegawattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMegawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MegawattsPerLiter(this decimal? value) => PowerDensity.FromMegawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MegawattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromMegawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrowattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicFoot(this int value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
+        public static PowerDensity MicrowattsPerCubicFoot<T>(this T value) => PowerDensity.FromMicrowattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicFoot(this int? value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicFoot(this long value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicFoot(this long? value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicFoot(this double value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicFoot(this double? value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicFoot(this float value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicFoot(this float? value) => PowerDensity.FromMicrowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicFoot(this decimal value) => PowerDensity.FromMicrowattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicFoot(this decimal? value) => PowerDensity.FromMicrowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MicrowattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromMicrowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrowattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicInch(this int value) => PowerDensity.FromMicrowattsPerCubicInch(value);
+        public static PowerDensity MicrowattsPerCubicInch<T>(this T value) => PowerDensity.FromMicrowattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicInch(this int? value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicInch(this long value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicInch(this long? value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicInch(this double value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicInch(this double? value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicInch(this float value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicInch(this float? value) => PowerDensity.FromMicrowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicInch(this decimal value) => PowerDensity.FromMicrowattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicInch(this decimal? value) => PowerDensity.FromMicrowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MicrowattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromMicrowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrowattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicMeter(this int value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
+        public static PowerDensity MicrowattsPerCubicMeter<T>(this T value) => PowerDensity.FromMicrowattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicMeter(this int? value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicMeter(this long value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicMeter(this long? value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicMeter(this double value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicMeter(this double? value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicMeter(this float value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicMeter(this float? value) => PowerDensity.FromMicrowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerCubicMeter(this decimal value) => PowerDensity.FromMicrowattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerCubicMeter(this decimal? value) => PowerDensity.FromMicrowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MicrowattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromMicrowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrowattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerLiter(this int value) => PowerDensity.FromMicrowattsPerLiter(value);
+        public static PowerDensity MicrowattsPerLiter<T>(this T value) => PowerDensity.FromMicrowattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerLiter(this int? value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerLiter(this long value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerLiter(this long? value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerLiter(this double value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerLiter(this double? value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerLiter(this float value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerLiter(this float? value) => PowerDensity.FromMicrowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MicrowattsPerLiter(this decimal value) => PowerDensity.FromMicrowattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMicrowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MicrowattsPerLiter(this decimal? value) => PowerDensity.FromMicrowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MicrowattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromMicrowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliwattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicFoot(this int value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
+        public static PowerDensity MilliwattsPerCubicFoot<T>(this T value) => PowerDensity.FromMilliwattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicFoot(this int? value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicFoot(this long value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicFoot(this long? value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicFoot(this double value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicFoot(this double? value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicFoot(this float value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicFoot(this float? value) => PowerDensity.FromMilliwattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicFoot(this decimal value) => PowerDensity.FromMilliwattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicFoot(this decimal? value) => PowerDensity.FromMilliwattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MilliwattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromMilliwattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliwattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicInch(this int value) => PowerDensity.FromMilliwattsPerCubicInch(value);
+        public static PowerDensity MilliwattsPerCubicInch<T>(this T value) => PowerDensity.FromMilliwattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicInch(this int? value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicInch(this long value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicInch(this long? value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicInch(this double value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicInch(this double? value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicInch(this float value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicInch(this float? value) => PowerDensity.FromMilliwattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicInch(this decimal value) => PowerDensity.FromMilliwattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicInch(this decimal? value) => PowerDensity.FromMilliwattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MilliwattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromMilliwattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliwattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicMeter(this int value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
+        public static PowerDensity MilliwattsPerCubicMeter<T>(this T value) => PowerDensity.FromMilliwattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicMeter(this int? value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicMeter(this long value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicMeter(this long? value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicMeter(this double value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicMeter(this double? value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicMeter(this float value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicMeter(this float? value) => PowerDensity.FromMilliwattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerCubicMeter(this decimal value) => PowerDensity.FromMilliwattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerCubicMeter(this decimal? value) => PowerDensity.FromMilliwattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MilliwattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromMilliwattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliwattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerLiter(this int value) => PowerDensity.FromMilliwattsPerLiter(value);
+        public static PowerDensity MilliwattsPerLiter<T>(this T value) => PowerDensity.FromMilliwattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerLiter(this int? value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerLiter(this long value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerLiter(this long? value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerLiter(this double value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerLiter(this double? value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerLiter(this float value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerLiter(this float? value) => PowerDensity.FromMilliwattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity MilliwattsPerLiter(this decimal value) => PowerDensity.FromMilliwattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromMilliwattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? MilliwattsPerLiter(this decimal? value) => PowerDensity.FromMilliwattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? MilliwattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromMilliwattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanowattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicFoot(this int value) => PowerDensity.FromNanowattsPerCubicFoot(value);
+        public static PowerDensity NanowattsPerCubicFoot<T>(this T value) => PowerDensity.FromNanowattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicFoot(this int? value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicFoot(this long value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicFoot(this long? value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicFoot(this double value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicFoot(this double? value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicFoot(this float value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicFoot(this float? value) => PowerDensity.FromNanowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicFoot(this decimal value) => PowerDensity.FromNanowattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicFoot(this decimal? value) => PowerDensity.FromNanowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? NanowattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromNanowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanowattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicInch(this int value) => PowerDensity.FromNanowattsPerCubicInch(value);
+        public static PowerDensity NanowattsPerCubicInch<T>(this T value) => PowerDensity.FromNanowattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicInch(this int? value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicInch(this long value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicInch(this long? value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicInch(this double value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicInch(this double? value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicInch(this float value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicInch(this float? value) => PowerDensity.FromNanowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicInch(this decimal value) => PowerDensity.FromNanowattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicInch(this decimal? value) => PowerDensity.FromNanowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? NanowattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromNanowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanowattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicMeter(this int value) => PowerDensity.FromNanowattsPerCubicMeter(value);
+        public static PowerDensity NanowattsPerCubicMeter<T>(this T value) => PowerDensity.FromNanowattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicMeter(this int? value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicMeter(this long value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicMeter(this long? value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicMeter(this double value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicMeter(this double? value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicMeter(this float value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicMeter(this float? value) => PowerDensity.FromNanowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerCubicMeter(this decimal value) => PowerDensity.FromNanowattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerCubicMeter(this decimal? value) => PowerDensity.FromNanowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? NanowattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromNanowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanowattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerLiter(this int value) => PowerDensity.FromNanowattsPerLiter(value);
+        public static PowerDensity NanowattsPerLiter<T>(this T value) => PowerDensity.FromNanowattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerLiter(this int? value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerLiter(this long value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerLiter(this long? value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerLiter(this double value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerLiter(this double? value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerLiter(this float value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerLiter(this float? value) => PowerDensity.FromNanowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity NanowattsPerLiter(this decimal value) => PowerDensity.FromNanowattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromNanowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? NanowattsPerLiter(this decimal? value) => PowerDensity.FromNanowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? NanowattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromNanowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicowattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicFoot(this int value) => PowerDensity.FromPicowattsPerCubicFoot(value);
+        public static PowerDensity PicowattsPerCubicFoot<T>(this T value) => PowerDensity.FromPicowattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicFoot(this int? value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicFoot(this long value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicFoot(this long? value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicFoot(this double value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicFoot(this double? value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicFoot(this float value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicFoot(this float? value) => PowerDensity.FromPicowattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicFoot(this decimal value) => PowerDensity.FromPicowattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicFoot(this decimal? value) => PowerDensity.FromPicowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? PicowattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromPicowattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicowattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicInch(this int value) => PowerDensity.FromPicowattsPerCubicInch(value);
+        public static PowerDensity PicowattsPerCubicInch<T>(this T value) => PowerDensity.FromPicowattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicInch(this int? value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicInch(this long value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicInch(this long? value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicInch(this double value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicInch(this double? value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicInch(this float value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicInch(this float? value) => PowerDensity.FromPicowattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicInch(this decimal value) => PowerDensity.FromPicowattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicInch(this decimal? value) => PowerDensity.FromPicowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? PicowattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromPicowattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicowattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicMeter(this int value) => PowerDensity.FromPicowattsPerCubicMeter(value);
+        public static PowerDensity PicowattsPerCubicMeter<T>(this T value) => PowerDensity.FromPicowattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicMeter(this int? value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicMeter(this long value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicMeter(this long? value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicMeter(this double value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicMeter(this double? value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicMeter(this float value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicMeter(this float? value) => PowerDensity.FromPicowattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerCubicMeter(this decimal value) => PowerDensity.FromPicowattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerCubicMeter(this decimal? value) => PowerDensity.FromPicowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? PicowattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromPicowattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PicowattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerLiter(this int value) => PowerDensity.FromPicowattsPerLiter(value);
+        public static PowerDensity PicowattsPerLiter<T>(this T value) => PowerDensity.FromPicowattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerLiter(this int? value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerLiter(this long value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerLiter(this long? value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerLiter(this double value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerLiter(this double? value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerLiter(this float value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerLiter(this float? value) => PowerDensity.FromPicowattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity PicowattsPerLiter(this decimal value) => PowerDensity.FromPicowattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromPicowattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? PicowattsPerLiter(this decimal? value) => PowerDensity.FromPicowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? PicowattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromPicowattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TerawattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicFoot(this int value) => PowerDensity.FromTerawattsPerCubicFoot(value);
+        public static PowerDensity TerawattsPerCubicFoot<T>(this T value) => PowerDensity.FromTerawattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicFoot(this int? value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicFoot(this long value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicFoot(this long? value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicFoot(this double value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicFoot(this double? value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicFoot(this float value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicFoot(this float? value) => PowerDensity.FromTerawattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicFoot(this decimal value) => PowerDensity.FromTerawattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicFoot(this decimal? value) => PowerDensity.FromTerawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? TerawattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromTerawattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TerawattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicInch(this int value) => PowerDensity.FromTerawattsPerCubicInch(value);
+        public static PowerDensity TerawattsPerCubicInch<T>(this T value) => PowerDensity.FromTerawattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicInch(this int? value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicInch(this long value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicInch(this long? value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicInch(this double value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicInch(this double? value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicInch(this float value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicInch(this float? value) => PowerDensity.FromTerawattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicInch(this decimal value) => PowerDensity.FromTerawattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicInch(this decimal? value) => PowerDensity.FromTerawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? TerawattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromTerawattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TerawattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicMeter(this int value) => PowerDensity.FromTerawattsPerCubicMeter(value);
+        public static PowerDensity TerawattsPerCubicMeter<T>(this T value) => PowerDensity.FromTerawattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicMeter(this int? value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicMeter(this long value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicMeter(this long? value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicMeter(this double value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicMeter(this double? value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicMeter(this float value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicMeter(this float? value) => PowerDensity.FromTerawattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerCubicMeter(this decimal value) => PowerDensity.FromTerawattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerCubicMeter(this decimal? value) => PowerDensity.FromTerawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? TerawattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromTerawattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TerawattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerLiter(this int value) => PowerDensity.FromTerawattsPerLiter(value);
+        public static PowerDensity TerawattsPerLiter<T>(this T value) => PowerDensity.FromTerawattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerLiter(this int? value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerLiter(this long value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerLiter(this long? value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerLiter(this double value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerLiter(this double? value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerLiter(this float value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerLiter(this float? value) => PowerDensity.FromTerawattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity TerawattsPerLiter(this decimal value) => PowerDensity.FromTerawattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromTerawattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? TerawattsPerLiter(this decimal? value) => PowerDensity.FromTerawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? TerawattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromTerawattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerCubicFoot
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicFoot(this int value) => PowerDensity.FromWattsPerCubicFoot(value);
+        public static PowerDensity WattsPerCubicFoot<T>(this T value) => PowerDensity.FromWattsPerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicFoot(this int? value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicFoot(this long value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicFoot(this long? value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicFoot(this double value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicFoot(this double? value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicFoot(this float value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicFoot(this float? value) => PowerDensity.FromWattsPerCubicFoot(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicFoot(this decimal value) => PowerDensity.FromWattsPerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicFoot(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicFoot(this decimal? value) => PowerDensity.FromWattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? WattsPerCubicFoot<T>(this T? value) where T : struct => PowerDensity.FromWattsPerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerCubicInch
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicInch(this int value) => PowerDensity.FromWattsPerCubicInch(value);
+        public static PowerDensity WattsPerCubicInch<T>(this T value) => PowerDensity.FromWattsPerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicInch(this int? value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicInch(this long value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicInch(this long? value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicInch(this double value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicInch(this double? value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicInch(this float value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicInch(this float? value) => PowerDensity.FromWattsPerCubicInch(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicInch(this decimal value) => PowerDensity.FromWattsPerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicInch(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicInch(this decimal? value) => PowerDensity.FromWattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? WattsPerCubicInch<T>(this T? value) where T : struct => PowerDensity.FromWattsPerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerCubicMeter
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicMeter(this int value) => PowerDensity.FromWattsPerCubicMeter(value);
+        public static PowerDensity WattsPerCubicMeter<T>(this T value) => PowerDensity.FromWattsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicMeter(this int? value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicMeter(this long value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicMeter(this long? value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicMeter(this double value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicMeter(this double? value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicMeter(this float value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicMeter(this float? value) => PowerDensity.FromWattsPerCubicMeter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerCubicMeter(this decimal value) => PowerDensity.FromWattsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerCubicMeter(this decimal? value) => PowerDensity.FromWattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? WattsPerCubicMeter<T>(this T? value) where T : struct => PowerDensity.FromWattsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerLiter
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerLiter(this int value) => PowerDensity.FromWattsPerLiter(value);
+        public static PowerDensity WattsPerLiter<T>(this T value) => PowerDensity.FromWattsPerLiter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerLiter(this int? value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerLiter(this long value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerLiter(this long? value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerLiter(this double value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerLiter(this double? value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerLiter(this float value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerLiter(this float? value) => PowerDensity.FromWattsPerLiter(value);
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity WattsPerLiter(this decimal value) => PowerDensity.FromWattsPerLiter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerDensity.FromWattsPerLiter(UnitsNet.QuantityValue)" />
-        public static PowerDensity? WattsPerLiter(this decimal? value) => PowerDensity.FromWattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerDensity? WattsPerLiter<T>(this T? value) where T : struct => PowerDensity.FromWattsPerLiter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPowerExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPowerExtensions.g.cs
@@ -47,680 +47,200 @@ namespace UnitsNet.Extensions.NumberToPower
         #region BoilerHorsepower
 
         /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power BoilerHorsepower(this int value) => Power.FromBoilerHorsepower(value);
+        public static Power BoilerHorsepower<T>(this T value) => Power.FromBoilerHorsepower(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? BoilerHorsepower(this int? value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power BoilerHorsepower(this long value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? BoilerHorsepower(this long? value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power BoilerHorsepower(this double value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? BoilerHorsepower(this double? value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power BoilerHorsepower(this float value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? BoilerHorsepower(this float? value) => Power.FromBoilerHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power BoilerHorsepower(this decimal value) => Power.FromBoilerHorsepower(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromBoilerHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? BoilerHorsepower(this decimal? value) => Power.FromBoilerHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? BoilerHorsepower<T>(this T? value) where T : struct => Power.FromBoilerHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region BritishThermalUnitPerHour
 
         /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power BritishThermalUnitsPerHour(this int value) => Power.FromBritishThermalUnitsPerHour(value);
+        public static Power BritishThermalUnitsPerHour<T>(this T value) => Power.FromBritishThermalUnitsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? BritishThermalUnitsPerHour(this int? value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power BritishThermalUnitsPerHour(this long value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? BritishThermalUnitsPerHour(this long? value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power BritishThermalUnitsPerHour(this double value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? BritishThermalUnitsPerHour(this double? value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power BritishThermalUnitsPerHour(this float value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? BritishThermalUnitsPerHour(this float? value) => Power.FromBritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power BritishThermalUnitsPerHour(this decimal value) => Power.FromBritishThermalUnitsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromBritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? BritishThermalUnitsPerHour(this decimal? value) => Power.FromBritishThermalUnitsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? BritishThermalUnitsPerHour<T>(this T? value) where T : struct => Power.FromBritishThermalUnitsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decawatt
 
         /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power Decawatts(this int value) => Power.FromDecawatts(value);
+        public static Power Decawatts<T>(this T value) => Power.FromDecawatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power? Decawatts(this int? value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power Decawatts(this long value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power? Decawatts(this long? value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power Decawatts(this double value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power? Decawatts(this double? value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power Decawatts(this float value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power? Decawatts(this float? value) => Power.FromDecawatts(value);
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power Decawatts(this decimal value) => Power.FromDecawatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromDecawatts(UnitsNet.QuantityValue)" />
-        public static Power? Decawatts(this decimal? value) => Power.FromDecawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Decawatts<T>(this T? value) where T : struct => Power.FromDecawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Deciwatt
 
         /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power Deciwatts(this int value) => Power.FromDeciwatts(value);
+        public static Power Deciwatts<T>(this T value) => Power.FromDeciwatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power? Deciwatts(this int? value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power Deciwatts(this long value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power? Deciwatts(this long? value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power Deciwatts(this double value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power? Deciwatts(this double? value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power Deciwatts(this float value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power? Deciwatts(this float? value) => Power.FromDeciwatts(value);
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power Deciwatts(this decimal value) => Power.FromDeciwatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromDeciwatts(UnitsNet.QuantityValue)" />
-        public static Power? Deciwatts(this decimal? value) => Power.FromDeciwatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Deciwatts<T>(this T? value) where T : struct => Power.FromDeciwatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ElectricalHorsepower
 
         /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power ElectricalHorsepower(this int value) => Power.FromElectricalHorsepower(value);
+        public static Power ElectricalHorsepower<T>(this T value) => Power.FromElectricalHorsepower(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? ElectricalHorsepower(this int? value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power ElectricalHorsepower(this long value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? ElectricalHorsepower(this long? value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power ElectricalHorsepower(this double value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? ElectricalHorsepower(this double? value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power ElectricalHorsepower(this float value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? ElectricalHorsepower(this float? value) => Power.FromElectricalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power ElectricalHorsepower(this decimal value) => Power.FromElectricalHorsepower(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromElectricalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? ElectricalHorsepower(this decimal? value) => Power.FromElectricalHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? ElectricalHorsepower<T>(this T? value) where T : struct => Power.FromElectricalHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Femtowatt
 
         /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power Femtowatts(this int value) => Power.FromFemtowatts(value);
+        public static Power Femtowatts<T>(this T value) => Power.FromFemtowatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power? Femtowatts(this int? value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power Femtowatts(this long value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power? Femtowatts(this long? value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power Femtowatts(this double value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power? Femtowatts(this double? value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power Femtowatts(this float value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power? Femtowatts(this float? value) => Power.FromFemtowatts(value);
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power Femtowatts(this decimal value) => Power.FromFemtowatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromFemtowatts(UnitsNet.QuantityValue)" />
-        public static Power? Femtowatts(this decimal? value) => Power.FromFemtowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Femtowatts<T>(this T? value) where T : struct => Power.FromFemtowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gigawatt
 
         /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power Gigawatts(this int value) => Power.FromGigawatts(value);
+        public static Power Gigawatts<T>(this T value) => Power.FromGigawatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power? Gigawatts(this int? value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power Gigawatts(this long value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power? Gigawatts(this long? value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power Gigawatts(this double value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power? Gigawatts(this double? value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power Gigawatts(this float value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power? Gigawatts(this float? value) => Power.FromGigawatts(value);
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power Gigawatts(this decimal value) => Power.FromGigawatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromGigawatts(UnitsNet.QuantityValue)" />
-        public static Power? Gigawatts(this decimal? value) => Power.FromGigawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Gigawatts<T>(this T? value) where T : struct => Power.FromGigawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region HydraulicHorsepower
 
         /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power HydraulicHorsepower(this int value) => Power.FromHydraulicHorsepower(value);
+        public static Power HydraulicHorsepower<T>(this T value) => Power.FromHydraulicHorsepower(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? HydraulicHorsepower(this int? value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power HydraulicHorsepower(this long value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? HydraulicHorsepower(this long? value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power HydraulicHorsepower(this double value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? HydraulicHorsepower(this double? value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power HydraulicHorsepower(this float value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? HydraulicHorsepower(this float? value) => Power.FromHydraulicHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power HydraulicHorsepower(this decimal value) => Power.FromHydraulicHorsepower(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromHydraulicHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? HydraulicHorsepower(this decimal? value) => Power.FromHydraulicHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? HydraulicHorsepower<T>(this T? value) where T : struct => Power.FromHydraulicHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilobritishThermalUnitPerHour
 
         /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power KilobritishThermalUnitsPerHour(this int value) => Power.FromKilobritishThermalUnitsPerHour(value);
+        public static Power KilobritishThermalUnitsPerHour<T>(this T value) => Power.FromKilobritishThermalUnitsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? KilobritishThermalUnitsPerHour(this int? value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power KilobritishThermalUnitsPerHour(this long value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? KilobritishThermalUnitsPerHour(this long? value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power KilobritishThermalUnitsPerHour(this double value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? KilobritishThermalUnitsPerHour(this double? value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power KilobritishThermalUnitsPerHour(this float value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? KilobritishThermalUnitsPerHour(this float? value) => Power.FromKilobritishThermalUnitsPerHour(value);
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power KilobritishThermalUnitsPerHour(this decimal value) => Power.FromKilobritishThermalUnitsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromKilobritishThermalUnitsPerHour(UnitsNet.QuantityValue)" />
-        public static Power? KilobritishThermalUnitsPerHour(this decimal? value) => Power.FromKilobritishThermalUnitsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? KilobritishThermalUnitsPerHour<T>(this T? value) where T : struct => Power.FromKilobritishThermalUnitsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilowatt
 
         /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power Kilowatts(this int value) => Power.FromKilowatts(value);
+        public static Power Kilowatts<T>(this T value) => Power.FromKilowatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power? Kilowatts(this int? value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power Kilowatts(this long value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power? Kilowatts(this long? value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power Kilowatts(this double value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power? Kilowatts(this double? value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power Kilowatts(this float value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power? Kilowatts(this float? value) => Power.FromKilowatts(value);
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power Kilowatts(this decimal value) => Power.FromKilowatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromKilowatts(UnitsNet.QuantityValue)" />
-        public static Power? Kilowatts(this decimal? value) => Power.FromKilowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Kilowatts<T>(this T? value) where T : struct => Power.FromKilowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MechanicalHorsepower
 
         /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MechanicalHorsepower(this int value) => Power.FromMechanicalHorsepower(value);
+        public static Power MechanicalHorsepower<T>(this T value) => Power.FromMechanicalHorsepower(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MechanicalHorsepower(this int? value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MechanicalHorsepower(this long value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MechanicalHorsepower(this long? value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MechanicalHorsepower(this double value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MechanicalHorsepower(this double? value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MechanicalHorsepower(this float value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MechanicalHorsepower(this float? value) => Power.FromMechanicalHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MechanicalHorsepower(this decimal value) => Power.FromMechanicalHorsepower(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromMechanicalHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MechanicalHorsepower(this decimal? value) => Power.FromMechanicalHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? MechanicalHorsepower<T>(this T? value) where T : struct => Power.FromMechanicalHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megawatt
 
         /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power Megawatts(this int value) => Power.FromMegawatts(value);
+        public static Power Megawatts<T>(this T value) => Power.FromMegawatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power? Megawatts(this int? value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power Megawatts(this long value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power? Megawatts(this long? value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power Megawatts(this double value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power? Megawatts(this double? value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power Megawatts(this float value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power? Megawatts(this float? value) => Power.FromMegawatts(value);
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power Megawatts(this decimal value) => Power.FromMegawatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromMegawatts(UnitsNet.QuantityValue)" />
-        public static Power? Megawatts(this decimal? value) => Power.FromMegawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Megawatts<T>(this T? value) where T : struct => Power.FromMegawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MetricHorsepower
 
         /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MetricHorsepower(this int value) => Power.FromMetricHorsepower(value);
+        public static Power MetricHorsepower<T>(this T value) => Power.FromMetricHorsepower(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MetricHorsepower(this int? value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MetricHorsepower(this long value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MetricHorsepower(this long? value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MetricHorsepower(this double value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MetricHorsepower(this double? value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MetricHorsepower(this float value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MetricHorsepower(this float? value) => Power.FromMetricHorsepower(value);
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power MetricHorsepower(this decimal value) => Power.FromMetricHorsepower(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromMetricHorsepower(UnitsNet.QuantityValue)" />
-        public static Power? MetricHorsepower(this decimal? value) => Power.FromMetricHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? MetricHorsepower<T>(this T? value) where T : struct => Power.FromMetricHorsepower(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microwatt
 
         /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power Microwatts(this int value) => Power.FromMicrowatts(value);
+        public static Power Microwatts<T>(this T value) => Power.FromMicrowatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power? Microwatts(this int? value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power Microwatts(this long value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power? Microwatts(this long? value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power Microwatts(this double value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power? Microwatts(this double? value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power Microwatts(this float value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power? Microwatts(this float? value) => Power.FromMicrowatts(value);
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power Microwatts(this decimal value) => Power.FromMicrowatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromMicrowatts(UnitsNet.QuantityValue)" />
-        public static Power? Microwatts(this decimal? value) => Power.FromMicrowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Microwatts<T>(this T? value) where T : struct => Power.FromMicrowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Milliwatt
 
         /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power Milliwatts(this int value) => Power.FromMilliwatts(value);
+        public static Power Milliwatts<T>(this T value) => Power.FromMilliwatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power? Milliwatts(this int? value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power Milliwatts(this long value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power? Milliwatts(this long? value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power Milliwatts(this double value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power? Milliwatts(this double? value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power Milliwatts(this float value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power? Milliwatts(this float? value) => Power.FromMilliwatts(value);
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power Milliwatts(this decimal value) => Power.FromMilliwatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromMilliwatts(UnitsNet.QuantityValue)" />
-        public static Power? Milliwatts(this decimal? value) => Power.FromMilliwatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Milliwatts<T>(this T? value) where T : struct => Power.FromMilliwatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Nanowatt
 
         /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power Nanowatts(this int value) => Power.FromNanowatts(value);
+        public static Power Nanowatts<T>(this T value) => Power.FromNanowatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power? Nanowatts(this int? value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power Nanowatts(this long value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power? Nanowatts(this long? value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power Nanowatts(this double value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power? Nanowatts(this double? value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power Nanowatts(this float value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power? Nanowatts(this float? value) => Power.FromNanowatts(value);
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power Nanowatts(this decimal value) => Power.FromNanowatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromNanowatts(UnitsNet.QuantityValue)" />
-        public static Power? Nanowatts(this decimal? value) => Power.FromNanowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Nanowatts<T>(this T? value) where T : struct => Power.FromNanowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Petawatt
 
         /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power Petawatts(this int value) => Power.FromPetawatts(value);
+        public static Power Petawatts<T>(this T value) => Power.FromPetawatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power? Petawatts(this int? value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power Petawatts(this long value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power? Petawatts(this long? value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power Petawatts(this double value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power? Petawatts(this double? value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power Petawatts(this float value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power? Petawatts(this float? value) => Power.FromPetawatts(value);
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power Petawatts(this decimal value) => Power.FromPetawatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromPetawatts(UnitsNet.QuantityValue)" />
-        public static Power? Petawatts(this decimal? value) => Power.FromPetawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Petawatts<T>(this T? value) where T : struct => Power.FromPetawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Picowatt
 
         /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power Picowatts(this int value) => Power.FromPicowatts(value);
+        public static Power Picowatts<T>(this T value) => Power.FromPicowatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power? Picowatts(this int? value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power Picowatts(this long value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power? Picowatts(this long? value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power Picowatts(this double value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power? Picowatts(this double? value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power Picowatts(this float value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power? Picowatts(this float? value) => Power.FromPicowatts(value);
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power Picowatts(this decimal value) => Power.FromPicowatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromPicowatts(UnitsNet.QuantityValue)" />
-        public static Power? Picowatts(this decimal? value) => Power.FromPicowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Picowatts<T>(this T? value) where T : struct => Power.FromPicowatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Terawatt
 
         /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power Terawatts(this int value) => Power.FromTerawatts(value);
+        public static Power Terawatts<T>(this T value) => Power.FromTerawatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power? Terawatts(this int? value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power Terawatts(this long value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power? Terawatts(this long? value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power Terawatts(this double value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power? Terawatts(this double? value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power Terawatts(this float value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power? Terawatts(this float? value) => Power.FromTerawatts(value);
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power Terawatts(this decimal value) => Power.FromTerawatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromTerawatts(UnitsNet.QuantityValue)" />
-        public static Power? Terawatts(this decimal? value) => Power.FromTerawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Terawatts<T>(this T? value) where T : struct => Power.FromTerawatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Watt
 
         /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power Watts(this int value) => Power.FromWatts(value);
+        public static Power Watts<T>(this T value) => Power.FromWatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power? Watts(this int? value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power Watts(this long value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power? Watts(this long? value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power Watts(this double value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power? Watts(this double? value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power Watts(this float value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power? Watts(this float? value) => Power.FromWatts(value);
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power Watts(this decimal value) => Power.FromWatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Power.FromWatts(UnitsNet.QuantityValue)" />
-        public static Power? Watts(this decimal? value) => Power.FromWatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Power? Watts<T>(this T? value) where T : struct => Power.FromWatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPowerRatioExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPowerRatioExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToPowerRatio
         #region DecibelMilliwatt
 
         /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelMilliwatts(this int value) => PowerRatio.FromDecibelMilliwatts(value);
+        public static PowerRatio DecibelMilliwatts<T>(this T value) => PowerRatio.FromDecibelMilliwatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelMilliwatts(this int? value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelMilliwatts(this long value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelMilliwatts(this long? value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelMilliwatts(this double value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelMilliwatts(this double? value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelMilliwatts(this float value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelMilliwatts(this float? value) => PowerRatio.FromDecibelMilliwatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelMilliwatts(this decimal value) => PowerRatio.FromDecibelMilliwatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelMilliwatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelMilliwatts(this decimal? value) => PowerRatio.FromDecibelMilliwatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerRatio? DecibelMilliwatts<T>(this T? value) where T : struct => PowerRatio.FromDecibelMilliwatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecibelWatt
 
         /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelWatts(this int value) => PowerRatio.FromDecibelWatts(value);
+        public static PowerRatio DecibelWatts<T>(this T value) => PowerRatio.FromDecibelWatts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelWatts(this int? value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelWatts(this long value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelWatts(this long? value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelWatts(this double value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelWatts(this double? value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelWatts(this float value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelWatts(this float? value) => PowerRatio.FromDecibelWatts(value);
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio DecibelWatts(this decimal value) => PowerRatio.FromDecibelWatts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PowerRatio.FromDecibelWatts(UnitsNet.QuantityValue)" />
-        public static PowerRatio? DecibelWatts(this decimal? value) => PowerRatio.FromDecibelWatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PowerRatio? DecibelWatts<T>(this T? value) where T : struct => PowerRatio.FromDecibelWatts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPressureChangeRateExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPressureChangeRateExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToPressureChangeRate
         #region AtmospherePerSecond
 
         /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate AtmospheresPerSecond(this int value) => PressureChangeRate.FromAtmospheresPerSecond(value);
+        public static PressureChangeRate AtmospheresPerSecond<T>(this T value) => PressureChangeRate.FromAtmospheresPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? AtmospheresPerSecond(this int? value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate AtmospheresPerSecond(this long value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? AtmospheresPerSecond(this long? value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate AtmospheresPerSecond(this double value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? AtmospheresPerSecond(this double? value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate AtmospheresPerSecond(this float value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? AtmospheresPerSecond(this float? value) => PressureChangeRate.FromAtmospheresPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate AtmospheresPerSecond(this decimal value) => PressureChangeRate.FromAtmospheresPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PressureChangeRate.FromAtmospheresPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? AtmospheresPerSecond(this decimal? value) => PressureChangeRate.FromAtmospheresPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PressureChangeRate? AtmospheresPerSecond<T>(this T? value) where T : struct => PressureChangeRate.FromAtmospheresPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopascalPerSecond
 
         /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate KilopascalsPerSecond(this int value) => PressureChangeRate.FromKilopascalsPerSecond(value);
+        public static PressureChangeRate KilopascalsPerSecond<T>(this T value) => PressureChangeRate.FromKilopascalsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? KilopascalsPerSecond(this int? value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate KilopascalsPerSecond(this long value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? KilopascalsPerSecond(this long? value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate KilopascalsPerSecond(this double value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? KilopascalsPerSecond(this double? value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate KilopascalsPerSecond(this float value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? KilopascalsPerSecond(this float? value) => PressureChangeRate.FromKilopascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate KilopascalsPerSecond(this decimal value) => PressureChangeRate.FromKilopascalsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? KilopascalsPerSecond(this decimal? value) => PressureChangeRate.FromKilopascalsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PressureChangeRate? KilopascalsPerSecond<T>(this T? value) where T : struct => PressureChangeRate.FromKilopascalsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegapascalPerSecond
 
         /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate MegapascalsPerSecond(this int value) => PressureChangeRate.FromMegapascalsPerSecond(value);
+        public static PressureChangeRate MegapascalsPerSecond<T>(this T value) => PressureChangeRate.FromMegapascalsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? MegapascalsPerSecond(this int? value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate MegapascalsPerSecond(this long value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? MegapascalsPerSecond(this long? value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate MegapascalsPerSecond(this double value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? MegapascalsPerSecond(this double? value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate MegapascalsPerSecond(this float value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? MegapascalsPerSecond(this float? value) => PressureChangeRate.FromMegapascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate MegapascalsPerSecond(this decimal value) => PressureChangeRate.FromMegapascalsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PressureChangeRate.FromMegapascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? MegapascalsPerSecond(this decimal? value) => PressureChangeRate.FromMegapascalsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PressureChangeRate? MegapascalsPerSecond<T>(this T? value) where T : struct => PressureChangeRate.FromMegapascalsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PascalPerSecond
 
         /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate PascalsPerSecond(this int value) => PressureChangeRate.FromPascalsPerSecond(value);
+        public static PressureChangeRate PascalsPerSecond<T>(this T value) => PressureChangeRate.FromPascalsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? PascalsPerSecond(this int? value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate PascalsPerSecond(this long value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? PascalsPerSecond(this long? value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate PascalsPerSecond(this double value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? PascalsPerSecond(this double? value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate PascalsPerSecond(this float value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? PascalsPerSecond(this float? value) => PressureChangeRate.FromPascalsPerSecond(value);
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate PascalsPerSecond(this decimal value) => PressureChangeRate.FromPascalsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="PressureChangeRate.FromPascalsPerSecond(UnitsNet.QuantityValue)" />
-        public static PressureChangeRate? PascalsPerSecond(this decimal? value) => PressureChangeRate.FromPascalsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static PressureChangeRate? PascalsPerSecond<T>(this T? value) where T : struct => PressureChangeRate.FromPascalsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToPressureExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToPressureExtensions.g.cs
@@ -47,1292 +47,380 @@ namespace UnitsNet.Extensions.NumberToPressure
         #region Atmosphere
 
         /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure Atmospheres(this int value) => Pressure.FromAtmospheres(value);
+        public static Pressure Atmospheres<T>(this T value) => Pressure.FromAtmospheres(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? Atmospheres(this int? value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure Atmospheres(this long value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? Atmospheres(this long? value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure Atmospheres(this double value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? Atmospheres(this double? value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure Atmospheres(this float value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? Atmospheres(this float? value) => Pressure.FromAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure Atmospheres(this decimal value) => Pressure.FromAtmospheres(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? Atmospheres(this decimal? value) => Pressure.FromAtmospheres(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Atmospheres<T>(this T? value) where T : struct => Pressure.FromAtmospheres(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Bar
 
         /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure Bars(this int value) => Pressure.FromBars(value);
+        public static Pressure Bars<T>(this T value) => Pressure.FromBars(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure? Bars(this int? value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure Bars(this long value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure? Bars(this long? value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure Bars(this double value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure? Bars(this double? value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure Bars(this float value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure? Bars(this float? value) => Pressure.FromBars(value);
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure Bars(this decimal value) => Pressure.FromBars(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromBars(UnitsNet.QuantityValue)" />
-        public static Pressure? Bars(this decimal? value) => Pressure.FromBars(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Bars<T>(this T? value) where T : struct => Pressure.FromBars(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Centibar
 
         /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure Centibars(this int value) => Pressure.FromCentibars(value);
+        public static Pressure Centibars<T>(this T value) => Pressure.FromCentibars(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Centibars(this int? value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure Centibars(this long value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Centibars(this long? value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure Centibars(this double value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Centibars(this double? value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure Centibars(this float value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Centibars(this float? value) => Pressure.FromCentibars(value);
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure Centibars(this decimal value) => Pressure.FromCentibars(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromCentibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Centibars(this decimal? value) => Pressure.FromCentibars(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Centibars<T>(this T? value) where T : struct => Pressure.FromCentibars(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decapascal
 
         /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Decapascals(this int value) => Pressure.FromDecapascals(value);
+        public static Pressure Decapascals<T>(this T value) => Pressure.FromDecapascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Decapascals(this int? value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Decapascals(this long value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Decapascals(this long? value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Decapascals(this double value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Decapascals(this double? value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Decapascals(this float value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Decapascals(this float? value) => Pressure.FromDecapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Decapascals(this decimal value) => Pressure.FromDecapascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromDecapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Decapascals(this decimal? value) => Pressure.FromDecapascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Decapascals<T>(this T? value) where T : struct => Pressure.FromDecapascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Decibar
 
         /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure Decibars(this int value) => Pressure.FromDecibars(value);
+        public static Pressure Decibars<T>(this T value) => Pressure.FromDecibars(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Decibars(this int? value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure Decibars(this long value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Decibars(this long? value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure Decibars(this double value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Decibars(this double? value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure Decibars(this float value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Decibars(this float? value) => Pressure.FromDecibars(value);
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure Decibars(this decimal value) => Pressure.FromDecibars(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromDecibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Decibars(this decimal? value) => Pressure.FromDecibars(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Decibars<T>(this T? value) where T : struct => Pressure.FromDecibars(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootOfHead
 
         /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure FeetOfHead(this int value) => Pressure.FromFeetOfHead(value);
+        public static Pressure FeetOfHead<T>(this T value) => Pressure.FromFeetOfHead(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? FeetOfHead(this int? value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure FeetOfHead(this long value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? FeetOfHead(this long? value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure FeetOfHead(this double value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? FeetOfHead(this double? value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure FeetOfHead(this float value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? FeetOfHead(this float? value) => Pressure.FromFeetOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure FeetOfHead(this decimal value) => Pressure.FromFeetOfHead(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromFeetOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? FeetOfHead(this decimal? value) => Pressure.FromFeetOfHead(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? FeetOfHead<T>(this T? value) where T : struct => Pressure.FromFeetOfHead(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Gigapascal
 
         /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Gigapascals(this int value) => Pressure.FromGigapascals(value);
+        public static Pressure Gigapascals<T>(this T value) => Pressure.FromGigapascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Gigapascals(this int? value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Gigapascals(this long value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Gigapascals(this long? value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Gigapascals(this double value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Gigapascals(this double? value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Gigapascals(this float value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Gigapascals(this float? value) => Pressure.FromGigapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Gigapascals(this decimal value) => Pressure.FromGigapascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromGigapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Gigapascals(this decimal? value) => Pressure.FromGigapascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Gigapascals<T>(this T? value) where T : struct => Pressure.FromGigapascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Hectopascal
 
         /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Hectopascals(this int value) => Pressure.FromHectopascals(value);
+        public static Pressure Hectopascals<T>(this T value) => Pressure.FromHectopascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Hectopascals(this int? value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Hectopascals(this long value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Hectopascals(this long? value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Hectopascals(this double value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Hectopascals(this double? value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Hectopascals(this float value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Hectopascals(this float? value) => Pressure.FromHectopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Hectopascals(this decimal value) => Pressure.FromHectopascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromHectopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Hectopascals(this decimal? value) => Pressure.FromHectopascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Hectopascals<T>(this T? value) where T : struct => Pressure.FromHectopascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region InchOfMercury
 
         /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure InchesOfMercury(this int value) => Pressure.FromInchesOfMercury(value);
+        public static Pressure InchesOfMercury<T>(this T value) => Pressure.FromInchesOfMercury(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? InchesOfMercury(this int? value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure InchesOfMercury(this long value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? InchesOfMercury(this long? value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure InchesOfMercury(this double value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? InchesOfMercury(this double? value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure InchesOfMercury(this float value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? InchesOfMercury(this float? value) => Pressure.FromInchesOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure InchesOfMercury(this decimal value) => Pressure.FromInchesOfMercury(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromInchesOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? InchesOfMercury(this decimal? value) => Pressure.FromInchesOfMercury(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? InchesOfMercury<T>(this T? value) where T : struct => Pressure.FromInchesOfMercury(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilobar
 
         /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure Kilobars(this int value) => Pressure.FromKilobars(value);
+        public static Pressure Kilobars<T>(this T value) => Pressure.FromKilobars(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilobars(this int? value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure Kilobars(this long value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilobars(this long? value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure Kilobars(this double value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilobars(this double? value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure Kilobars(this float value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilobars(this float? value) => Pressure.FromKilobars(value);
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure Kilobars(this decimal value) => Pressure.FromKilobars(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilobars(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilobars(this decimal? value) => Pressure.FromKilobars(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Kilobars<T>(this T? value) where T : struct => Pressure.FromKilobars(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForcePerSquareCentimeter
 
         /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareCentimeter(this int value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
+        public static Pressure KilogramsForcePerSquareCentimeter<T>(this T value) => Pressure.FromKilogramsForcePerSquareCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareCentimeter(this int? value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareCentimeter(this long value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareCentimeter(this long? value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareCentimeter(this double value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareCentimeter(this double? value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareCentimeter(this float value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareCentimeter(this float? value) => Pressure.FromKilogramsForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareCentimeter(this decimal value) => Pressure.FromKilogramsForcePerSquareCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareCentimeter(this decimal? value) => Pressure.FromKilogramsForcePerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilogramsForcePerSquareCentimeter<T>(this T? value) where T : struct => Pressure.FromKilogramsForcePerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForcePerSquareMeter
 
         /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMeter(this int value) => Pressure.FromKilogramsForcePerSquareMeter(value);
+        public static Pressure KilogramsForcePerSquareMeter<T>(this T value) => Pressure.FromKilogramsForcePerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMeter(this int? value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMeter(this long value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMeter(this long? value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMeter(this double value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMeter(this double? value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMeter(this float value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMeter(this float? value) => Pressure.FromKilogramsForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMeter(this decimal value) => Pressure.FromKilogramsForcePerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMeter(this decimal? value) => Pressure.FromKilogramsForcePerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilogramsForcePerSquareMeter<T>(this T? value) where T : struct => Pressure.FromKilogramsForcePerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForcePerSquareMillimeter
 
         /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMillimeter(this int value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
+        public static Pressure KilogramsForcePerSquareMillimeter<T>(this T value) => Pressure.FromKilogramsForcePerSquareMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMillimeter(this int? value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMillimeter(this long value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMillimeter(this long? value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMillimeter(this double value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMillimeter(this double? value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMillimeter(this float value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMillimeter(this float? value) => Pressure.FromKilogramsForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilogramsForcePerSquareMillimeter(this decimal value) => Pressure.FromKilogramsForcePerSquareMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilogramsForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilogramsForcePerSquareMillimeter(this decimal? value) => Pressure.FromKilogramsForcePerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilogramsForcePerSquareMillimeter<T>(this T? value) where T : struct => Pressure.FromKilogramsForcePerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerSquareCentimeter
 
         /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareCentimeter(this int value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
+        public static Pressure KilonewtonsPerSquareCentimeter<T>(this T value) => Pressure.FromKilonewtonsPerSquareCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareCentimeter(this int? value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareCentimeter(this long value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareCentimeter(this long? value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareCentimeter(this double value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareCentimeter(this double? value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareCentimeter(this float value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareCentimeter(this float? value) => Pressure.FromKilonewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareCentimeter(this decimal value) => Pressure.FromKilonewtonsPerSquareCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareCentimeter(this decimal? value) => Pressure.FromKilonewtonsPerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilonewtonsPerSquareCentimeter<T>(this T? value) where T : struct => Pressure.FromKilonewtonsPerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerSquareMeter
 
         /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMeter(this int value) => Pressure.FromKilonewtonsPerSquareMeter(value);
+        public static Pressure KilonewtonsPerSquareMeter<T>(this T value) => Pressure.FromKilonewtonsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMeter(this int? value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMeter(this long value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMeter(this long? value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMeter(this double value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMeter(this double? value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMeter(this float value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMeter(this float? value) => Pressure.FromKilonewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMeter(this decimal value) => Pressure.FromKilonewtonsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMeter(this decimal? value) => Pressure.FromKilonewtonsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilonewtonsPerSquareMeter<T>(this T? value) where T : struct => Pressure.FromKilonewtonsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerSquareMillimeter
 
         /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMillimeter(this int value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
+        public static Pressure KilonewtonsPerSquareMillimeter<T>(this T value) => Pressure.FromKilonewtonsPerSquareMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMillimeter(this int? value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMillimeter(this long value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMillimeter(this long? value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMillimeter(this double value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMillimeter(this double? value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMillimeter(this float value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMillimeter(this float? value) => Pressure.FromKilonewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure KilonewtonsPerSquareMillimeter(this decimal value) => Pressure.FromKilonewtonsPerSquareMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilonewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? KilonewtonsPerSquareMillimeter(this decimal? value) => Pressure.FromKilonewtonsPerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilonewtonsPerSquareMillimeter<T>(this T? value) where T : struct => Pressure.FromKilonewtonsPerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kilopascal
 
         /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Kilopascals(this int value) => Pressure.FromKilopascals(value);
+        public static Pressure Kilopascals<T>(this T value) => Pressure.FromKilopascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilopascals(this int? value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Kilopascals(this long value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilopascals(this long? value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Kilopascals(this double value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilopascals(this double? value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Kilopascals(this float value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilopascals(this float? value) => Pressure.FromKilopascals(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure Kilopascals(this decimal value) => Pressure.FromKilopascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilopascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Kilopascals(this decimal? value) => Pressure.FromKilopascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Kilopascals<T>(this T? value) where T : struct => Pressure.FromKilopascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundForcePerSquareFoot
 
         /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareFoot(this int value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
+        public static Pressure KilopoundsForcePerSquareFoot<T>(this T value) => Pressure.FromKilopoundsForcePerSquareFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareFoot(this int? value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareFoot(this long value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareFoot(this long? value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareFoot(this double value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareFoot(this double? value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareFoot(this float value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareFoot(this float? value) => Pressure.FromKilopoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareFoot(this decimal value) => Pressure.FromKilopoundsForcePerSquareFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareFoot(this decimal? value) => Pressure.FromKilopoundsForcePerSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilopoundsForcePerSquareFoot<T>(this T? value) where T : struct => Pressure.FromKilopoundsForcePerSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundForcePerSquareInch
 
         /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareInch(this int value) => Pressure.FromKilopoundsForcePerSquareInch(value);
+        public static Pressure KilopoundsForcePerSquareInch<T>(this T value) => Pressure.FromKilopoundsForcePerSquareInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareInch(this int? value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareInch(this long value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareInch(this long? value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareInch(this double value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareInch(this double? value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareInch(this float value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareInch(this float? value) => Pressure.FromKilopoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure KilopoundsForcePerSquareInch(this decimal value) => Pressure.FromKilopoundsForcePerSquareInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromKilopoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? KilopoundsForcePerSquareInch(this decimal? value) => Pressure.FromKilopoundsForcePerSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? KilopoundsForcePerSquareInch<T>(this T? value) where T : struct => Pressure.FromKilopoundsForcePerSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megabar
 
         /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure Megabars(this int value) => Pressure.FromMegabars(value);
+        public static Pressure Megabars<T>(this T value) => Pressure.FromMegabars(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure? Megabars(this int? value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure Megabars(this long value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure? Megabars(this long? value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure Megabars(this double value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure? Megabars(this double? value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure Megabars(this float value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure? Megabars(this float? value) => Pressure.FromMegabars(value);
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure Megabars(this decimal value) => Pressure.FromMegabars(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMegabars(UnitsNet.QuantityValue)" />
-        public static Pressure? Megabars(this decimal? value) => Pressure.FromMegabars(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Megabars<T>(this T? value) where T : struct => Pressure.FromMegabars(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonPerSquareMeter
 
         /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure MeganewtonsPerSquareMeter(this int value) => Pressure.FromMeganewtonsPerSquareMeter(value);
+        public static Pressure MeganewtonsPerSquareMeter<T>(this T value) => Pressure.FromMeganewtonsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? MeganewtonsPerSquareMeter(this int? value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure MeganewtonsPerSquareMeter(this long value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? MeganewtonsPerSquareMeter(this long? value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure MeganewtonsPerSquareMeter(this double value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? MeganewtonsPerSquareMeter(this double? value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure MeganewtonsPerSquareMeter(this float value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? MeganewtonsPerSquareMeter(this float? value) => Pressure.FromMeganewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure MeganewtonsPerSquareMeter(this decimal value) => Pressure.FromMeganewtonsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMeganewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? MeganewtonsPerSquareMeter(this decimal? value) => Pressure.FromMeganewtonsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? MeganewtonsPerSquareMeter<T>(this T? value) where T : struct => Pressure.FromMeganewtonsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Megapascal
 
         /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Megapascals(this int value) => Pressure.FromMegapascals(value);
+        public static Pressure Megapascals<T>(this T value) => Pressure.FromMegapascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Megapascals(this int? value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Megapascals(this long value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Megapascals(this long? value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Megapascals(this double value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Megapascals(this double? value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Megapascals(this float value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Megapascals(this float? value) => Pressure.FromMegapascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure Megapascals(this decimal value) => Pressure.FromMegapascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMegapascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Megapascals(this decimal? value) => Pressure.FromMegapascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Megapascals<T>(this T? value) where T : struct => Pressure.FromMegapascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeterOfHead
 
         /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure MetersOfHead(this int value) => Pressure.FromMetersOfHead(value);
+        public static Pressure MetersOfHead<T>(this T value) => Pressure.FromMetersOfHead(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? MetersOfHead(this int? value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure MetersOfHead(this long value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? MetersOfHead(this long? value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure MetersOfHead(this double value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? MetersOfHead(this double? value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure MetersOfHead(this float value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? MetersOfHead(this float? value) => Pressure.FromMetersOfHead(value);
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure MetersOfHead(this decimal value) => Pressure.FromMetersOfHead(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMetersOfHead(UnitsNet.QuantityValue)" />
-        public static Pressure? MetersOfHead(this decimal? value) => Pressure.FromMetersOfHead(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? MetersOfHead<T>(this T? value) where T : struct => Pressure.FromMetersOfHead(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Micropascal
 
         /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure Micropascals(this int value) => Pressure.FromMicropascals(value);
+        public static Pressure Micropascals<T>(this T value) => Pressure.FromMicropascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Micropascals(this int? value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure Micropascals(this long value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Micropascals(this long? value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure Micropascals(this double value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Micropascals(this double? value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure Micropascals(this float value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Micropascals(this float? value) => Pressure.FromMicropascals(value);
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure Micropascals(this decimal value) => Pressure.FromMicropascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMicropascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Micropascals(this decimal? value) => Pressure.FromMicropascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Micropascals<T>(this T? value) where T : struct => Pressure.FromMicropascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Millibar
 
         /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure Millibars(this int value) => Pressure.FromMillibars(value);
+        public static Pressure Millibars<T>(this T value) => Pressure.FromMillibars(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Millibars(this int? value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure Millibars(this long value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Millibars(this long? value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure Millibars(this double value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Millibars(this double? value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure Millibars(this float value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Millibars(this float? value) => Pressure.FromMillibars(value);
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure Millibars(this decimal value) => Pressure.FromMillibars(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMillibars(UnitsNet.QuantityValue)" />
-        public static Pressure? Millibars(this decimal? value) => Pressure.FromMillibars(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Millibars<T>(this T? value) where T : struct => Pressure.FromMillibars(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimeterOfMercury
 
         /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure MillimetersOfMercury(this int value) => Pressure.FromMillimetersOfMercury(value);
+        public static Pressure MillimetersOfMercury<T>(this T value) => Pressure.FromMillimetersOfMercury(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? MillimetersOfMercury(this int? value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure MillimetersOfMercury(this long value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? MillimetersOfMercury(this long? value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure MillimetersOfMercury(this double value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? MillimetersOfMercury(this double? value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure MillimetersOfMercury(this float value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? MillimetersOfMercury(this float? value) => Pressure.FromMillimetersOfMercury(value);
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure MillimetersOfMercury(this decimal value) => Pressure.FromMillimetersOfMercury(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromMillimetersOfMercury(UnitsNet.QuantityValue)" />
-        public static Pressure? MillimetersOfMercury(this decimal? value) => Pressure.FromMillimetersOfMercury(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? MillimetersOfMercury<T>(this T? value) where T : struct => Pressure.FromMillimetersOfMercury(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerSquareCentimeter
 
         /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareCentimeter(this int value) => Pressure.FromNewtonsPerSquareCentimeter(value);
+        public static Pressure NewtonsPerSquareCentimeter<T>(this T value) => Pressure.FromNewtonsPerSquareCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareCentimeter(this int? value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareCentimeter(this long value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareCentimeter(this long? value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareCentimeter(this double value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareCentimeter(this double? value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareCentimeter(this float value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareCentimeter(this float? value) => Pressure.FromNewtonsPerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareCentimeter(this decimal value) => Pressure.FromNewtonsPerSquareCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareCentimeter(this decimal? value) => Pressure.FromNewtonsPerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? NewtonsPerSquareCentimeter<T>(this T? value) where T : struct => Pressure.FromNewtonsPerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerSquareMeter
 
         /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMeter(this int value) => Pressure.FromNewtonsPerSquareMeter(value);
+        public static Pressure NewtonsPerSquareMeter<T>(this T value) => Pressure.FromNewtonsPerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMeter(this int? value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMeter(this long value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMeter(this long? value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMeter(this double value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMeter(this double? value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMeter(this float value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMeter(this float? value) => Pressure.FromNewtonsPerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMeter(this decimal value) => Pressure.FromNewtonsPerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMeter(this decimal? value) => Pressure.FromNewtonsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? NewtonsPerSquareMeter<T>(this T? value) where T : struct => Pressure.FromNewtonsPerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerSquareMillimeter
 
         /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMillimeter(this int value) => Pressure.FromNewtonsPerSquareMillimeter(value);
+        public static Pressure NewtonsPerSquareMillimeter<T>(this T value) => Pressure.FromNewtonsPerSquareMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMillimeter(this int? value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMillimeter(this long value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMillimeter(this long? value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMillimeter(this double value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMillimeter(this double? value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMillimeter(this float value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMillimeter(this float? value) => Pressure.FromNewtonsPerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure NewtonsPerSquareMillimeter(this decimal value) => Pressure.FromNewtonsPerSquareMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromNewtonsPerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? NewtonsPerSquareMillimeter(this decimal? value) => Pressure.FromNewtonsPerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? NewtonsPerSquareMillimeter<T>(this T? value) where T : struct => Pressure.FromNewtonsPerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Pascal
 
         /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure Pascals(this int value) => Pressure.FromPascals(value);
+        public static Pressure Pascals<T>(this T value) => Pressure.FromPascals(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Pascals(this int? value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure Pascals(this long value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Pascals(this long? value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure Pascals(this double value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Pascals(this double? value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure Pascals(this float value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Pascals(this float? value) => Pressure.FromPascals(value);
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure Pascals(this decimal value) => Pressure.FromPascals(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromPascals(UnitsNet.QuantityValue)" />
-        public static Pressure? Pascals(this decimal? value) => Pressure.FromPascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Pascals<T>(this T? value) where T : struct => Pressure.FromPascals(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForcePerSquareFoot
 
         /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareFoot(this int value) => Pressure.FromPoundsForcePerSquareFoot(value);
+        public static Pressure PoundsForcePerSquareFoot<T>(this T value) => Pressure.FromPoundsForcePerSquareFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareFoot(this int? value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareFoot(this long value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareFoot(this long? value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareFoot(this double value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareFoot(this double? value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareFoot(this float value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareFoot(this float? value) => Pressure.FromPoundsForcePerSquareFoot(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareFoot(this decimal value) => Pressure.FromPoundsForcePerSquareFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareFoot(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareFoot(this decimal? value) => Pressure.FromPoundsForcePerSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? PoundsForcePerSquareFoot<T>(this T? value) where T : struct => Pressure.FromPoundsForcePerSquareFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForcePerSquareInch
 
         /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareInch(this int value) => Pressure.FromPoundsForcePerSquareInch(value);
+        public static Pressure PoundsForcePerSquareInch<T>(this T value) => Pressure.FromPoundsForcePerSquareInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareInch(this int? value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareInch(this long value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareInch(this long? value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareInch(this double value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareInch(this double? value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareInch(this float value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareInch(this float? value) => Pressure.FromPoundsForcePerSquareInch(value);
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure PoundsForcePerSquareInch(this decimal value) => Pressure.FromPoundsForcePerSquareInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromPoundsForcePerSquareInch(UnitsNet.QuantityValue)" />
-        public static Pressure? PoundsForcePerSquareInch(this decimal? value) => Pressure.FromPoundsForcePerSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? PoundsForcePerSquareInch<T>(this T? value) where T : struct => Pressure.FromPoundsForcePerSquareInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Psi
 
         /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure Psi(this int value) => Pressure.FromPsi(value);
+        public static Pressure Psi<T>(this T value) => Pressure.FromPsi(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure? Psi(this int? value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure Psi(this long value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure? Psi(this long? value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure Psi(this double value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure? Psi(this double? value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure Psi(this float value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure? Psi(this float? value) => Pressure.FromPsi(value);
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure Psi(this decimal value) => Pressure.FromPsi(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromPsi(UnitsNet.QuantityValue)" />
-        public static Pressure? Psi(this decimal? value) => Pressure.FromPsi(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Psi<T>(this T? value) where T : struct => Pressure.FromPsi(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TechnicalAtmosphere
 
         /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure TechnicalAtmospheres(this int value) => Pressure.FromTechnicalAtmospheres(value);
+        public static Pressure TechnicalAtmospheres<T>(this T value) => Pressure.FromTechnicalAtmospheres(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? TechnicalAtmospheres(this int? value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure TechnicalAtmospheres(this long value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? TechnicalAtmospheres(this long? value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure TechnicalAtmospheres(this double value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? TechnicalAtmospheres(this double? value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure TechnicalAtmospheres(this float value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? TechnicalAtmospheres(this float? value) => Pressure.FromTechnicalAtmospheres(value);
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure TechnicalAtmospheres(this decimal value) => Pressure.FromTechnicalAtmospheres(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromTechnicalAtmospheres(UnitsNet.QuantityValue)" />
-        public static Pressure? TechnicalAtmospheres(this decimal? value) => Pressure.FromTechnicalAtmospheres(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? TechnicalAtmospheres<T>(this T? value) where T : struct => Pressure.FromTechnicalAtmospheres(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForcePerSquareCentimeter
 
         /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareCentimeter(this int value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
+        public static Pressure TonnesForcePerSquareCentimeter<T>(this T value) => Pressure.FromTonnesForcePerSquareCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareCentimeter(this int? value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareCentimeter(this long value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareCentimeter(this long? value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareCentimeter(this double value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareCentimeter(this double? value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareCentimeter(this float value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareCentimeter(this float? value) => Pressure.FromTonnesForcePerSquareCentimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareCentimeter(this decimal value) => Pressure.FromTonnesForcePerSquareCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareCentimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareCentimeter(this decimal? value) => Pressure.FromTonnesForcePerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? TonnesForcePerSquareCentimeter<T>(this T? value) where T : struct => Pressure.FromTonnesForcePerSquareCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForcePerSquareMeter
 
         /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMeter(this int value) => Pressure.FromTonnesForcePerSquareMeter(value);
+        public static Pressure TonnesForcePerSquareMeter<T>(this T value) => Pressure.FromTonnesForcePerSquareMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMeter(this int? value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMeter(this long value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMeter(this long? value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMeter(this double value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMeter(this double? value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMeter(this float value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMeter(this float? value) => Pressure.FromTonnesForcePerSquareMeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMeter(this decimal value) => Pressure.FromTonnesForcePerSquareMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMeter(this decimal? value) => Pressure.FromTonnesForcePerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? TonnesForcePerSquareMeter<T>(this T? value) where T : struct => Pressure.FromTonnesForcePerSquareMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForcePerSquareMillimeter
 
         /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMillimeter(this int value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
+        public static Pressure TonnesForcePerSquareMillimeter<T>(this T value) => Pressure.FromTonnesForcePerSquareMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMillimeter(this int? value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMillimeter(this long value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMillimeter(this long? value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMillimeter(this double value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMillimeter(this double? value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMillimeter(this float value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMillimeter(this float? value) => Pressure.FromTonnesForcePerSquareMillimeter(value);
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure TonnesForcePerSquareMillimeter(this decimal value) => Pressure.FromTonnesForcePerSquareMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromTonnesForcePerSquareMillimeter(UnitsNet.QuantityValue)" />
-        public static Pressure? TonnesForcePerSquareMillimeter(this decimal? value) => Pressure.FromTonnesForcePerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? TonnesForcePerSquareMillimeter<T>(this T? value) where T : struct => Pressure.FromTonnesForcePerSquareMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Torr
 
         /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure Torrs(this int value) => Pressure.FromTorrs(value);
+        public static Pressure Torrs<T>(this T value) => Pressure.FromTorrs(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure? Torrs(this int? value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure Torrs(this long value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure? Torrs(this long? value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure Torrs(this double value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure? Torrs(this double? value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure Torrs(this float value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure? Torrs(this float? value) => Pressure.FromTorrs(value);
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure Torrs(this decimal value) => Pressure.FromTorrs(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Pressure.FromTorrs(UnitsNet.QuantityValue)" />
-        public static Pressure? Torrs(this decimal? value) => Pressure.FromTorrs(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Pressure? Torrs<T>(this T? value) where T : struct => Pressure.FromTorrs(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToRatioExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToRatioExtensions.g.cs
@@ -47,204 +47,60 @@ namespace UnitsNet.Extensions.NumberToRatio
         #region DecimalFraction
 
         /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio DecimalFractions(this int value) => Ratio.FromDecimalFractions(value);
+        public static Ratio DecimalFractions<T>(this T value) => Ratio.FromDecimalFractions(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio? DecimalFractions(this int? value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio DecimalFractions(this long value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio? DecimalFractions(this long? value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio DecimalFractions(this double value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio? DecimalFractions(this double? value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio DecimalFractions(this float value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio? DecimalFractions(this float? value) => Ratio.FromDecimalFractions(value);
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio DecimalFractions(this decimal value) => Ratio.FromDecimalFractions(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Ratio.FromDecimalFractions(UnitsNet.QuantityValue)" />
-        public static Ratio? DecimalFractions(this decimal? value) => Ratio.FromDecimalFractions(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Ratio? DecimalFractions<T>(this T? value) where T : struct => Ratio.FromDecimalFractions(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PartPerBillion
 
         /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerBillion(this int value) => Ratio.FromPartsPerBillion(value);
+        public static Ratio PartsPerBillion<T>(this T value) => Ratio.FromPartsPerBillion(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerBillion(this int? value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerBillion(this long value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerBillion(this long? value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerBillion(this double value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerBillion(this double? value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerBillion(this float value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerBillion(this float? value) => Ratio.FromPartsPerBillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerBillion(this decimal value) => Ratio.FromPartsPerBillion(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Ratio.FromPartsPerBillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerBillion(this decimal? value) => Ratio.FromPartsPerBillion(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Ratio? PartsPerBillion<T>(this T? value) where T : struct => Ratio.FromPartsPerBillion(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PartPerMillion
 
         /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerMillion(this int value) => Ratio.FromPartsPerMillion(value);
+        public static Ratio PartsPerMillion<T>(this T value) => Ratio.FromPartsPerMillion(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerMillion(this int? value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerMillion(this long value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerMillion(this long? value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerMillion(this double value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerMillion(this double? value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerMillion(this float value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerMillion(this float? value) => Ratio.FromPartsPerMillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerMillion(this decimal value) => Ratio.FromPartsPerMillion(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Ratio.FromPartsPerMillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerMillion(this decimal? value) => Ratio.FromPartsPerMillion(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Ratio? PartsPerMillion<T>(this T? value) where T : struct => Ratio.FromPartsPerMillion(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PartPerThousand
 
         /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerThousand(this int value) => Ratio.FromPartsPerThousand(value);
+        public static Ratio PartsPerThousand<T>(this T value) => Ratio.FromPartsPerThousand(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerThousand(this int? value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerThousand(this long value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerThousand(this long? value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerThousand(this double value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerThousand(this double? value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerThousand(this float value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerThousand(this float? value) => Ratio.FromPartsPerThousand(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerThousand(this decimal value) => Ratio.FromPartsPerThousand(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Ratio.FromPartsPerThousand(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerThousand(this decimal? value) => Ratio.FromPartsPerThousand(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Ratio? PartsPerThousand<T>(this T? value) where T : struct => Ratio.FromPartsPerThousand(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PartPerTrillion
 
         /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerTrillion(this int value) => Ratio.FromPartsPerTrillion(value);
+        public static Ratio PartsPerTrillion<T>(this T value) => Ratio.FromPartsPerTrillion(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerTrillion(this int? value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerTrillion(this long value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerTrillion(this long? value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerTrillion(this double value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerTrillion(this double? value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerTrillion(this float value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerTrillion(this float? value) => Ratio.FromPartsPerTrillion(value);
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio PartsPerTrillion(this decimal value) => Ratio.FromPartsPerTrillion(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Ratio.FromPartsPerTrillion(UnitsNet.QuantityValue)" />
-        public static Ratio? PartsPerTrillion(this decimal? value) => Ratio.FromPartsPerTrillion(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Ratio? PartsPerTrillion<T>(this T? value) where T : struct => Ratio.FromPartsPerTrillion(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Percent
 
         /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio Percent(this int value) => Ratio.FromPercent(value);
+        public static Ratio Percent<T>(this T value) => Ratio.FromPercent(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio? Percent(this int? value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio Percent(this long value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio? Percent(this long? value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio Percent(this double value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio? Percent(this double? value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio Percent(this float value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio? Percent(this float? value) => Ratio.FromPercent(value);
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio Percent(this decimal value) => Ratio.FromPercent(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Ratio.FromPercent(UnitsNet.QuantityValue)" />
-        public static Ratio? Percent(this decimal? value) => Ratio.FromPercent(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Ratio? Percent<T>(this T? value) where T : struct => Ratio.FromPercent(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToReactiveEnergyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToReactiveEnergyExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToReactiveEnergy
         #region KilovoltampereReactiveHour
 
         /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy KilovoltampereReactiveHours(this int value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
+        public static ReactiveEnergy KilovoltampereReactiveHours<T>(this T value) => ReactiveEnergy.FromKilovoltampereReactiveHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? KilovoltampereReactiveHours(this int? value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy KilovoltampereReactiveHours(this long value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? KilovoltampereReactiveHours(this long? value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy KilovoltampereReactiveHours(this double value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? KilovoltampereReactiveHours(this double? value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy KilovoltampereReactiveHours(this float value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? KilovoltampereReactiveHours(this float? value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy KilovoltampereReactiveHours(this decimal value) => ReactiveEnergy.FromKilovoltampereReactiveHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactiveEnergy.FromKilovoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? KilovoltampereReactiveHours(this decimal? value) => ReactiveEnergy.FromKilovoltampereReactiveHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactiveEnergy? KilovoltampereReactiveHours<T>(this T? value) where T : struct => ReactiveEnergy.FromKilovoltampereReactiveHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegavoltampereReactiveHour
 
         /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy MegavoltampereReactiveHours(this int value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
+        public static ReactiveEnergy MegavoltampereReactiveHours<T>(this T value) => ReactiveEnergy.FromMegavoltampereReactiveHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? MegavoltampereReactiveHours(this int? value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy MegavoltampereReactiveHours(this long value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? MegavoltampereReactiveHours(this long? value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy MegavoltampereReactiveHours(this double value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? MegavoltampereReactiveHours(this double? value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy MegavoltampereReactiveHours(this float value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? MegavoltampereReactiveHours(this float? value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy MegavoltampereReactiveHours(this decimal value) => ReactiveEnergy.FromMegavoltampereReactiveHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactiveEnergy.FromMegavoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? MegavoltampereReactiveHours(this decimal? value) => ReactiveEnergy.FromMegavoltampereReactiveHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactiveEnergy? MegavoltampereReactiveHours<T>(this T? value) where T : struct => ReactiveEnergy.FromMegavoltampereReactiveHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region VoltampereReactiveHour
 
         /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy VoltampereReactiveHours(this int value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
+        public static ReactiveEnergy VoltampereReactiveHours<T>(this T value) => ReactiveEnergy.FromVoltampereReactiveHours(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? VoltampereReactiveHours(this int? value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy VoltampereReactiveHours(this long value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? VoltampereReactiveHours(this long? value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy VoltampereReactiveHours(this double value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? VoltampereReactiveHours(this double? value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy VoltampereReactiveHours(this float value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? VoltampereReactiveHours(this float? value) => ReactiveEnergy.FromVoltampereReactiveHours(value);
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy VoltampereReactiveHours(this decimal value) => ReactiveEnergy.FromVoltampereReactiveHours(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactiveEnergy.FromVoltampereReactiveHours(UnitsNet.QuantityValue)" />
-        public static ReactiveEnergy? VoltampereReactiveHours(this decimal? value) => ReactiveEnergy.FromVoltampereReactiveHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactiveEnergy? VoltampereReactiveHours<T>(this T? value) where T : struct => ReactiveEnergy.FromVoltampereReactiveHours(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToReactivePowerExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToReactivePowerExtensions.g.cs
@@ -47,136 +47,40 @@ namespace UnitsNet.Extensions.NumberToReactivePower
         #region GigavoltampereReactive
 
         /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower GigavoltamperesReactive(this int value) => ReactivePower.FromGigavoltamperesReactive(value);
+        public static ReactivePower GigavoltamperesReactive<T>(this T value) => ReactivePower.FromGigavoltamperesReactive(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? GigavoltamperesReactive(this int? value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower GigavoltamperesReactive(this long value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? GigavoltamperesReactive(this long? value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower GigavoltamperesReactive(this double value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? GigavoltamperesReactive(this double? value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower GigavoltamperesReactive(this float value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? GigavoltamperesReactive(this float? value) => ReactivePower.FromGigavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower GigavoltamperesReactive(this decimal value) => ReactivePower.FromGigavoltamperesReactive(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactivePower.FromGigavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? GigavoltamperesReactive(this decimal? value) => ReactivePower.FromGigavoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactivePower? GigavoltamperesReactive<T>(this T? value) where T : struct => ReactivePower.FromGigavoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilovoltampereReactive
 
         /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower KilovoltamperesReactive(this int value) => ReactivePower.FromKilovoltamperesReactive(value);
+        public static ReactivePower KilovoltamperesReactive<T>(this T value) => ReactivePower.FromKilovoltamperesReactive(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? KilovoltamperesReactive(this int? value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower KilovoltamperesReactive(this long value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? KilovoltamperesReactive(this long? value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower KilovoltamperesReactive(this double value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? KilovoltamperesReactive(this double? value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower KilovoltamperesReactive(this float value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? KilovoltamperesReactive(this float? value) => ReactivePower.FromKilovoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower KilovoltamperesReactive(this decimal value) => ReactivePower.FromKilovoltamperesReactive(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactivePower.FromKilovoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? KilovoltamperesReactive(this decimal? value) => ReactivePower.FromKilovoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactivePower? KilovoltamperesReactive<T>(this T? value) where T : struct => ReactivePower.FromKilovoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegavoltampereReactive
 
         /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower MegavoltamperesReactive(this int value) => ReactivePower.FromMegavoltamperesReactive(value);
+        public static ReactivePower MegavoltamperesReactive<T>(this T value) => ReactivePower.FromMegavoltamperesReactive(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? MegavoltamperesReactive(this int? value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower MegavoltamperesReactive(this long value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? MegavoltamperesReactive(this long? value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower MegavoltamperesReactive(this double value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? MegavoltamperesReactive(this double? value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower MegavoltamperesReactive(this float value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? MegavoltamperesReactive(this float? value) => ReactivePower.FromMegavoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower MegavoltamperesReactive(this decimal value) => ReactivePower.FromMegavoltamperesReactive(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactivePower.FromMegavoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? MegavoltamperesReactive(this decimal? value) => ReactivePower.FromMegavoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactivePower? MegavoltamperesReactive<T>(this T? value) where T : struct => ReactivePower.FromMegavoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region VoltampereReactive
 
         /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower VoltamperesReactive(this int value) => ReactivePower.FromVoltamperesReactive(value);
+        public static ReactivePower VoltamperesReactive<T>(this T value) => ReactivePower.FromVoltamperesReactive(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? VoltamperesReactive(this int? value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower VoltamperesReactive(this long value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? VoltamperesReactive(this long? value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower VoltamperesReactive(this double value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? VoltamperesReactive(this double? value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower VoltamperesReactive(this float value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? VoltamperesReactive(this float? value) => ReactivePower.FromVoltamperesReactive(value);
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower VoltamperesReactive(this decimal value) => ReactivePower.FromVoltamperesReactive(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ReactivePower.FromVoltamperesReactive(UnitsNet.QuantityValue)" />
-        public static ReactivePower? VoltamperesReactive(this decimal? value) => ReactivePower.FromVoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ReactivePower? VoltamperesReactive<T>(this T? value) where T : struct => ReactivePower.FromVoltamperesReactive(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalAccelerationExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalAccelerationExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToRotationalAcceleration
         #region DegreePerSecondSquared
 
         /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration DegreesPerSecondSquared(this int value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
+        public static RotationalAcceleration DegreesPerSecondSquared<T>(this T value) => RotationalAcceleration.FromDegreesPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? DegreesPerSecondSquared(this int? value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration DegreesPerSecondSquared(this long value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? DegreesPerSecondSquared(this long? value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration DegreesPerSecondSquared(this double value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? DegreesPerSecondSquared(this double? value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration DegreesPerSecondSquared(this float value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? DegreesPerSecondSquared(this float? value) => RotationalAcceleration.FromDegreesPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration DegreesPerSecondSquared(this decimal value) => RotationalAcceleration.FromDegreesPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalAcceleration.FromDegreesPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? DegreesPerSecondSquared(this decimal? value) => RotationalAcceleration.FromDegreesPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalAcceleration? DegreesPerSecondSquared<T>(this T? value) where T : struct => RotationalAcceleration.FromDegreesPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region RadianPerSecondSquared
 
         /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RadiansPerSecondSquared(this int value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
+        public static RotationalAcceleration RadiansPerSecondSquared<T>(this T value) => RotationalAcceleration.FromRadiansPerSecondSquared(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RadiansPerSecondSquared(this int? value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RadiansPerSecondSquared(this long value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RadiansPerSecondSquared(this long? value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RadiansPerSecondSquared(this double value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RadiansPerSecondSquared(this double? value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RadiansPerSecondSquared(this float value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RadiansPerSecondSquared(this float? value) => RotationalAcceleration.FromRadiansPerSecondSquared(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RadiansPerSecondSquared(this decimal value) => RotationalAcceleration.FromRadiansPerSecondSquared(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRadiansPerSecondSquared(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RadiansPerSecondSquared(this decimal? value) => RotationalAcceleration.FromRadiansPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalAcceleration? RadiansPerSecondSquared<T>(this T? value) where T : struct => RotationalAcceleration.FromRadiansPerSecondSquared(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region RevolutionPerMinutePerSecond
 
         /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RevolutionsPerMinutePerSecond(this int value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
+        public static RotationalAcceleration RevolutionsPerMinutePerSecond<T>(this T value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RevolutionsPerMinutePerSecond(this int? value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RevolutionsPerMinutePerSecond(this long value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RevolutionsPerMinutePerSecond(this long? value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RevolutionsPerMinutePerSecond(this double value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RevolutionsPerMinutePerSecond(this double? value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RevolutionsPerMinutePerSecond(this float value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RevolutionsPerMinutePerSecond(this float? value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value);
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration RevolutionsPerMinutePerSecond(this decimal value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalAcceleration.FromRevolutionsPerMinutePerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalAcceleration? RevolutionsPerMinutePerSecond(this decimal? value) => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalAcceleration? RevolutionsPerMinutePerSecond<T>(this T? value) where T : struct => RotationalAcceleration.FromRevolutionsPerMinutePerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalSpeedExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalSpeedExtensions.g.cs
@@ -47,442 +47,130 @@ namespace UnitsNet.Extensions.NumberToRotationalSpeed
         #region CentiradianPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed CentiradiansPerSecond(this int value) => RotationalSpeed.FromCentiradiansPerSecond(value);
+        public static RotationalSpeed CentiradiansPerSecond<T>(this T value) => RotationalSpeed.FromCentiradiansPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? CentiradiansPerSecond(this int? value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed CentiradiansPerSecond(this long value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? CentiradiansPerSecond(this long? value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed CentiradiansPerSecond(this double value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? CentiradiansPerSecond(this double? value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed CentiradiansPerSecond(this float value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? CentiradiansPerSecond(this float? value) => RotationalSpeed.FromCentiradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed CentiradiansPerSecond(this decimal value) => RotationalSpeed.FromCentiradiansPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromCentiradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? CentiradiansPerSecond(this decimal? value) => RotationalSpeed.FromCentiradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? CentiradiansPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromCentiradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DeciradianPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DeciradiansPerSecond(this int value) => RotationalSpeed.FromDeciradiansPerSecond(value);
+        public static RotationalSpeed DeciradiansPerSecond<T>(this T value) => RotationalSpeed.FromDeciradiansPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DeciradiansPerSecond(this int? value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DeciradiansPerSecond(this long value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DeciradiansPerSecond(this long? value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DeciradiansPerSecond(this double value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DeciradiansPerSecond(this double? value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DeciradiansPerSecond(this float value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DeciradiansPerSecond(this float? value) => RotationalSpeed.FromDeciradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DeciradiansPerSecond(this decimal value) => RotationalSpeed.FromDeciradiansPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromDeciradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DeciradiansPerSecond(this decimal? value) => RotationalSpeed.FromDeciradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? DeciradiansPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromDeciradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreePerMinute
 
         /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerMinute(this int value) => RotationalSpeed.FromDegreesPerMinute(value);
+        public static RotationalSpeed DegreesPerMinute<T>(this T value) => RotationalSpeed.FromDegreesPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerMinute(this int? value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerMinute(this long value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerMinute(this long? value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerMinute(this double value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerMinute(this double? value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerMinute(this float value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerMinute(this float? value) => RotationalSpeed.FromDegreesPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerMinute(this decimal value) => RotationalSpeed.FromDegreesPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerMinute(this decimal? value) => RotationalSpeed.FromDegreesPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? DegreesPerMinute<T>(this T? value) where T : struct => RotationalSpeed.FromDegreesPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreePerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerSecond(this int value) => RotationalSpeed.FromDegreesPerSecond(value);
+        public static RotationalSpeed DegreesPerSecond<T>(this T value) => RotationalSpeed.FromDegreesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerSecond(this int? value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerSecond(this long value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerSecond(this long? value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerSecond(this double value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerSecond(this double? value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerSecond(this float value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerSecond(this float? value) => RotationalSpeed.FromDegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed DegreesPerSecond(this decimal value) => RotationalSpeed.FromDegreesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromDegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? DegreesPerSecond(this decimal? value) => RotationalSpeed.FromDegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? DegreesPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromDegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrodegreePerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicrodegreesPerSecond(this int value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
+        public static RotationalSpeed MicrodegreesPerSecond<T>(this T value) => RotationalSpeed.FromMicrodegreesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicrodegreesPerSecond(this int? value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicrodegreesPerSecond(this long value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicrodegreesPerSecond(this long? value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicrodegreesPerSecond(this double value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicrodegreesPerSecond(this double? value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicrodegreesPerSecond(this float value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicrodegreesPerSecond(this float? value) => RotationalSpeed.FromMicrodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicrodegreesPerSecond(this decimal value) => RotationalSpeed.FromMicrodegreesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicrodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicrodegreesPerSecond(this decimal? value) => RotationalSpeed.FromMicrodegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? MicrodegreesPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromMicrodegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicroradianPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicroradiansPerSecond(this int value) => RotationalSpeed.FromMicroradiansPerSecond(value);
+        public static RotationalSpeed MicroradiansPerSecond<T>(this T value) => RotationalSpeed.FromMicroradiansPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicroradiansPerSecond(this int? value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicroradiansPerSecond(this long value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicroradiansPerSecond(this long? value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicroradiansPerSecond(this double value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicroradiansPerSecond(this double? value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicroradiansPerSecond(this float value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicroradiansPerSecond(this float? value) => RotationalSpeed.FromMicroradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MicroradiansPerSecond(this decimal value) => RotationalSpeed.FromMicroradiansPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromMicroradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MicroradiansPerSecond(this decimal? value) => RotationalSpeed.FromMicroradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? MicroradiansPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromMicroradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillidegreePerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MillidegreesPerSecond(this int value) => RotationalSpeed.FromMillidegreesPerSecond(value);
+        public static RotationalSpeed MillidegreesPerSecond<T>(this T value) => RotationalSpeed.FromMillidegreesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MillidegreesPerSecond(this int? value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MillidegreesPerSecond(this long value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MillidegreesPerSecond(this long? value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MillidegreesPerSecond(this double value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MillidegreesPerSecond(this double? value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MillidegreesPerSecond(this float value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MillidegreesPerSecond(this float? value) => RotationalSpeed.FromMillidegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MillidegreesPerSecond(this decimal value) => RotationalSpeed.FromMillidegreesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromMillidegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MillidegreesPerSecond(this decimal? value) => RotationalSpeed.FromMillidegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? MillidegreesPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromMillidegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilliradianPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MilliradiansPerSecond(this int value) => RotationalSpeed.FromMilliradiansPerSecond(value);
+        public static RotationalSpeed MilliradiansPerSecond<T>(this T value) => RotationalSpeed.FromMilliradiansPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MilliradiansPerSecond(this int? value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MilliradiansPerSecond(this long value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MilliradiansPerSecond(this long? value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MilliradiansPerSecond(this double value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MilliradiansPerSecond(this double? value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MilliradiansPerSecond(this float value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MilliradiansPerSecond(this float? value) => RotationalSpeed.FromMilliradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed MilliradiansPerSecond(this decimal value) => RotationalSpeed.FromMilliradiansPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromMilliradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? MilliradiansPerSecond(this decimal? value) => RotationalSpeed.FromMilliradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? MilliradiansPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromMilliradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanodegreePerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanodegreesPerSecond(this int value) => RotationalSpeed.FromNanodegreesPerSecond(value);
+        public static RotationalSpeed NanodegreesPerSecond<T>(this T value) => RotationalSpeed.FromNanodegreesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanodegreesPerSecond(this int? value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanodegreesPerSecond(this long value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanodegreesPerSecond(this long? value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanodegreesPerSecond(this double value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanodegreesPerSecond(this double? value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanodegreesPerSecond(this float value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanodegreesPerSecond(this float? value) => RotationalSpeed.FromNanodegreesPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanodegreesPerSecond(this decimal value) => RotationalSpeed.FromNanodegreesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanodegreesPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanodegreesPerSecond(this decimal? value) => RotationalSpeed.FromNanodegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? NanodegreesPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromNanodegreesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanoradianPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanoradiansPerSecond(this int value) => RotationalSpeed.FromNanoradiansPerSecond(value);
+        public static RotationalSpeed NanoradiansPerSecond<T>(this T value) => RotationalSpeed.FromNanoradiansPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanoradiansPerSecond(this int? value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanoradiansPerSecond(this long value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanoradiansPerSecond(this long? value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanoradiansPerSecond(this double value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanoradiansPerSecond(this double? value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanoradiansPerSecond(this float value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanoradiansPerSecond(this float? value) => RotationalSpeed.FromNanoradiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed NanoradiansPerSecond(this decimal value) => RotationalSpeed.FromNanoradiansPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromNanoradiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? NanoradiansPerSecond(this decimal? value) => RotationalSpeed.FromNanoradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? NanoradiansPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromNanoradiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region RadianPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RadiansPerSecond(this int value) => RotationalSpeed.FromRadiansPerSecond(value);
+        public static RotationalSpeed RadiansPerSecond<T>(this T value) => RotationalSpeed.FromRadiansPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RadiansPerSecond(this int? value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RadiansPerSecond(this long value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RadiansPerSecond(this long? value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RadiansPerSecond(this double value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RadiansPerSecond(this double? value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RadiansPerSecond(this float value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RadiansPerSecond(this float? value) => RotationalSpeed.FromRadiansPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RadiansPerSecond(this decimal value) => RotationalSpeed.FromRadiansPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RadiansPerSecond(this decimal? value) => RotationalSpeed.FromRadiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? RadiansPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromRadiansPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region RevolutionPerMinute
 
         /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerMinute(this int value) => RotationalSpeed.FromRevolutionsPerMinute(value);
+        public static RotationalSpeed RevolutionsPerMinute<T>(this T value) => RotationalSpeed.FromRevolutionsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerMinute(this int? value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerMinute(this long value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerMinute(this long? value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerMinute(this double value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerMinute(this double? value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerMinute(this float value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerMinute(this float? value) => RotationalSpeed.FromRevolutionsPerMinute(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerMinute(this decimal value) => RotationalSpeed.FromRevolutionsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerMinute(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerMinute(this decimal? value) => RotationalSpeed.FromRevolutionsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? RevolutionsPerMinute<T>(this T? value) where T : struct => RotationalSpeed.FromRevolutionsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region RevolutionPerSecond
 
         /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerSecond(this int value) => RotationalSpeed.FromRevolutionsPerSecond(value);
+        public static RotationalSpeed RevolutionsPerSecond<T>(this T value) => RotationalSpeed.FromRevolutionsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerSecond(this int? value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerSecond(this long value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerSecond(this long? value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerSecond(this double value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerSecond(this double? value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerSecond(this float value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerSecond(this float? value) => RotationalSpeed.FromRevolutionsPerSecond(value);
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed RevolutionsPerSecond(this decimal value) => RotationalSpeed.FromRevolutionsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalSpeed.FromRevolutionsPerSecond(UnitsNet.QuantityValue)" />
-        public static RotationalSpeed? RevolutionsPerSecond(this decimal? value) => RotationalSpeed.FromRevolutionsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalSpeed? RevolutionsPerSecond<T>(this T? value) where T : struct => RotationalSpeed.FromRevolutionsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalStiffnessExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalStiffnessExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToRotationalStiffness
         #region KilonewtonMeterPerRadian
 
         /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness KilonewtonMetersPerRadian(this int value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
+        public static RotationalStiffness KilonewtonMetersPerRadian<T>(this T value) => RotationalStiffness.FromKilonewtonMetersPerRadian(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? KilonewtonMetersPerRadian(this int? value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness KilonewtonMetersPerRadian(this long value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? KilonewtonMetersPerRadian(this long? value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness KilonewtonMetersPerRadian(this double value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? KilonewtonMetersPerRadian(this double? value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness KilonewtonMetersPerRadian(this float value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? KilonewtonMetersPerRadian(this float? value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness KilonewtonMetersPerRadian(this decimal value) => RotationalStiffness.FromKilonewtonMetersPerRadian(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalStiffness.FromKilonewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? KilonewtonMetersPerRadian(this decimal? value) => RotationalStiffness.FromKilonewtonMetersPerRadian(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalStiffness? KilonewtonMetersPerRadian<T>(this T? value) where T : struct => RotationalStiffness.FromKilonewtonMetersPerRadian(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonMeterPerRadian
 
         /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness MeganewtonMetersPerRadian(this int value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
+        public static RotationalStiffness MeganewtonMetersPerRadian<T>(this T value) => RotationalStiffness.FromMeganewtonMetersPerRadian(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? MeganewtonMetersPerRadian(this int? value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness MeganewtonMetersPerRadian(this long value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? MeganewtonMetersPerRadian(this long? value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness MeganewtonMetersPerRadian(this double value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? MeganewtonMetersPerRadian(this double? value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness MeganewtonMetersPerRadian(this float value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? MeganewtonMetersPerRadian(this float? value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness MeganewtonMetersPerRadian(this decimal value) => RotationalStiffness.FromMeganewtonMetersPerRadian(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalStiffness.FromMeganewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? MeganewtonMetersPerRadian(this decimal? value) => RotationalStiffness.FromMeganewtonMetersPerRadian(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalStiffness? MeganewtonMetersPerRadian<T>(this T? value) where T : struct => RotationalStiffness.FromMeganewtonMetersPerRadian(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonMeterPerRadian
 
         /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness NewtonMetersPerRadian(this int value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
+        public static RotationalStiffness NewtonMetersPerRadian<T>(this T value) => RotationalStiffness.FromNewtonMetersPerRadian(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? NewtonMetersPerRadian(this int? value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness NewtonMetersPerRadian(this long value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? NewtonMetersPerRadian(this long? value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness NewtonMetersPerRadian(this double value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? NewtonMetersPerRadian(this double? value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness NewtonMetersPerRadian(this float value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? NewtonMetersPerRadian(this float? value) => RotationalStiffness.FromNewtonMetersPerRadian(value);
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness NewtonMetersPerRadian(this decimal value) => RotationalStiffness.FromNewtonMetersPerRadian(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalStiffness.FromNewtonMetersPerRadian(UnitsNet.QuantityValue)" />
-        public static RotationalStiffness? NewtonMetersPerRadian(this decimal? value) => RotationalStiffness.FromNewtonMetersPerRadian(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalStiffness? NewtonMetersPerRadian<T>(this T? value) where T : struct => RotationalStiffness.FromNewtonMetersPerRadian(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalStiffnessPerLengthExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToRotationalStiffnessPerLengthExtensions.g.cs
@@ -47,102 +47,30 @@ namespace UnitsNet.Extensions.NumberToRotationalStiffnessPerLength
         #region KilonewtonMeterPerRadianPerMeter
 
         /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength KilonewtonMetersPerRadianPerMeter(this int value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
+        public static RotationalStiffnessPerLength KilonewtonMetersPerRadianPerMeter<T>(this T value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? KilonewtonMetersPerRadianPerMeter(this int? value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength KilonewtonMetersPerRadianPerMeter(this long value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? KilonewtonMetersPerRadianPerMeter(this long? value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength KilonewtonMetersPerRadianPerMeter(this double value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? KilonewtonMetersPerRadianPerMeter(this double? value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength KilonewtonMetersPerRadianPerMeter(this float value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? KilonewtonMetersPerRadianPerMeter(this float? value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength KilonewtonMetersPerRadianPerMeter(this decimal value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? KilonewtonMetersPerRadianPerMeter(this decimal? value) => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalStiffnessPerLength? KilonewtonMetersPerRadianPerMeter<T>(this T? value) where T : struct => RotationalStiffnessPerLength.FromKilonewtonMetersPerRadianPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonMeterPerRadianPerMeter
 
         /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength MeganewtonMetersPerRadianPerMeter(this int value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
+        public static RotationalStiffnessPerLength MeganewtonMetersPerRadianPerMeter<T>(this T value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? MeganewtonMetersPerRadianPerMeter(this int? value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength MeganewtonMetersPerRadianPerMeter(this long value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? MeganewtonMetersPerRadianPerMeter(this long? value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength MeganewtonMetersPerRadianPerMeter(this double value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? MeganewtonMetersPerRadianPerMeter(this double? value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength MeganewtonMetersPerRadianPerMeter(this float value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? MeganewtonMetersPerRadianPerMeter(this float? value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength MeganewtonMetersPerRadianPerMeter(this decimal value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? MeganewtonMetersPerRadianPerMeter(this decimal? value) => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalStiffnessPerLength? MeganewtonMetersPerRadianPerMeter<T>(this T? value) where T : struct => RotationalStiffnessPerLength.FromMeganewtonMetersPerRadianPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonMeterPerRadianPerMeter
 
         /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength NewtonMetersPerRadianPerMeter(this int value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
+        public static RotationalStiffnessPerLength NewtonMetersPerRadianPerMeter<T>(this T value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? NewtonMetersPerRadianPerMeter(this int? value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength NewtonMetersPerRadianPerMeter(this long value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? NewtonMetersPerRadianPerMeter(this long? value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength NewtonMetersPerRadianPerMeter(this double value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? NewtonMetersPerRadianPerMeter(this double? value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength NewtonMetersPerRadianPerMeter(this float value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? NewtonMetersPerRadianPerMeter(this float? value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value);
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength NewtonMetersPerRadianPerMeter(this decimal value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(UnitsNet.QuantityValue)" />
-        public static RotationalStiffnessPerLength? NewtonMetersPerRadianPerMeter(this decimal? value) => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static RotationalStiffnessPerLength? NewtonMetersPerRadianPerMeter<T>(this T? value) where T : struct => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSolidAngleExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSolidAngleExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToSolidAngle
         #region Steradian
 
         /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle Steradians(this int value) => SolidAngle.FromSteradians(value);
+        public static SolidAngle Steradians<T>(this T value) => SolidAngle.FromSteradians(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle? Steradians(this int? value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle Steradians(this long value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle? Steradians(this long? value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle Steradians(this double value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle? Steradians(this double? value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle Steradians(this float value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle? Steradians(this float? value) => SolidAngle.FromSteradians(value);
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle Steradians(this decimal value) => SolidAngle.FromSteradians(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SolidAngle.FromSteradians(UnitsNet.QuantityValue)" />
-        public static SolidAngle? Steradians(this decimal? value) => SolidAngle.FromSteradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SolidAngle? Steradians<T>(this T? value) where T : struct => SolidAngle.FromSteradians(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificEnergyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificEnergyExtensions.g.cs
@@ -47,272 +47,80 @@ namespace UnitsNet.Extensions.NumberToSpecificEnergy
         #region CaloriePerGram
 
         /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy CaloriesPerGram(this int value) => SpecificEnergy.FromCaloriesPerGram(value);
+        public static SpecificEnergy CaloriesPerGram<T>(this T value) => SpecificEnergy.FromCaloriesPerGram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? CaloriesPerGram(this int? value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy CaloriesPerGram(this long value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? CaloriesPerGram(this long? value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy CaloriesPerGram(this double value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? CaloriesPerGram(this double? value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy CaloriesPerGram(this float value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? CaloriesPerGram(this float? value) => SpecificEnergy.FromCaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy CaloriesPerGram(this decimal value) => SpecificEnergy.FromCaloriesPerGram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromCaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? CaloriesPerGram(this decimal? value) => SpecificEnergy.FromCaloriesPerGram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? CaloriesPerGram<T>(this T? value) where T : struct => SpecificEnergy.FromCaloriesPerGram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region JoulePerKilogram
 
         /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy JoulesPerKilogram(this int value) => SpecificEnergy.FromJoulesPerKilogram(value);
+        public static SpecificEnergy JoulesPerKilogram<T>(this T value) => SpecificEnergy.FromJoulesPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? JoulesPerKilogram(this int? value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy JoulesPerKilogram(this long value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? JoulesPerKilogram(this long? value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy JoulesPerKilogram(this double value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? JoulesPerKilogram(this double? value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy JoulesPerKilogram(this float value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? JoulesPerKilogram(this float? value) => SpecificEnergy.FromJoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy JoulesPerKilogram(this decimal value) => SpecificEnergy.FromJoulesPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromJoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? JoulesPerKilogram(this decimal? value) => SpecificEnergy.FromJoulesPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? JoulesPerKilogram<T>(this T? value) where T : struct => SpecificEnergy.FromJoulesPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocaloriePerGram
 
         /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilocaloriesPerGram(this int value) => SpecificEnergy.FromKilocaloriesPerGram(value);
+        public static SpecificEnergy KilocaloriesPerGram<T>(this T value) => SpecificEnergy.FromKilocaloriesPerGram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilocaloriesPerGram(this int? value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilocaloriesPerGram(this long value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilocaloriesPerGram(this long? value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilocaloriesPerGram(this double value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilocaloriesPerGram(this double? value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilocaloriesPerGram(this float value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilocaloriesPerGram(this float? value) => SpecificEnergy.FromKilocaloriesPerGram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilocaloriesPerGram(this decimal value) => SpecificEnergy.FromKilocaloriesPerGram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilocaloriesPerGram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilocaloriesPerGram(this decimal? value) => SpecificEnergy.FromKilocaloriesPerGram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? KilocaloriesPerGram<T>(this T? value) where T : struct => SpecificEnergy.FromKilocaloriesPerGram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerKilogram
 
         /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilojoulesPerKilogram(this int value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
+        public static SpecificEnergy KilojoulesPerKilogram<T>(this T value) => SpecificEnergy.FromKilojoulesPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilojoulesPerKilogram(this int? value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilojoulesPerKilogram(this long value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilojoulesPerKilogram(this long? value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilojoulesPerKilogram(this double value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilojoulesPerKilogram(this double? value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilojoulesPerKilogram(this float value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilojoulesPerKilogram(this float? value) => SpecificEnergy.FromKilojoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilojoulesPerKilogram(this decimal value) => SpecificEnergy.FromKilojoulesPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilojoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilojoulesPerKilogram(this decimal? value) => SpecificEnergy.FromKilojoulesPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? KilojoulesPerKilogram<T>(this T? value) where T : struct => SpecificEnergy.FromKilojoulesPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilowattHourPerKilogram
 
         /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilowattHoursPerKilogram(this int value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
+        public static SpecificEnergy KilowattHoursPerKilogram<T>(this T value) => SpecificEnergy.FromKilowattHoursPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilowattHoursPerKilogram(this int? value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilowattHoursPerKilogram(this long value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilowattHoursPerKilogram(this long? value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilowattHoursPerKilogram(this double value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilowattHoursPerKilogram(this double? value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilowattHoursPerKilogram(this float value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilowattHoursPerKilogram(this float? value) => SpecificEnergy.FromKilowattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy KilowattHoursPerKilogram(this decimal value) => SpecificEnergy.FromKilowattHoursPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromKilowattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? KilowattHoursPerKilogram(this decimal? value) => SpecificEnergy.FromKilowattHoursPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? KilowattHoursPerKilogram<T>(this T? value) where T : struct => SpecificEnergy.FromKilowattHoursPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegajoulePerKilogram
 
         /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegajoulesPerKilogram(this int value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
+        public static SpecificEnergy MegajoulesPerKilogram<T>(this T value) => SpecificEnergy.FromMegajoulesPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegajoulesPerKilogram(this int? value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegajoulesPerKilogram(this long value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegajoulesPerKilogram(this long? value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegajoulesPerKilogram(this double value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegajoulesPerKilogram(this double? value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegajoulesPerKilogram(this float value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegajoulesPerKilogram(this float? value) => SpecificEnergy.FromMegajoulesPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegajoulesPerKilogram(this decimal value) => SpecificEnergy.FromMegajoulesPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegajoulesPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegajoulesPerKilogram(this decimal? value) => SpecificEnergy.FromMegajoulesPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? MegajoulesPerKilogram<T>(this T? value) where T : struct => SpecificEnergy.FromMegajoulesPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegawattHourPerKilogram
 
         /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegawattHoursPerKilogram(this int value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
+        public static SpecificEnergy MegawattHoursPerKilogram<T>(this T value) => SpecificEnergy.FromMegawattHoursPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegawattHoursPerKilogram(this int? value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegawattHoursPerKilogram(this long value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegawattHoursPerKilogram(this long? value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegawattHoursPerKilogram(this double value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegawattHoursPerKilogram(this double? value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegawattHoursPerKilogram(this float value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegawattHoursPerKilogram(this float? value) => SpecificEnergy.FromMegawattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy MegawattHoursPerKilogram(this decimal value) => SpecificEnergy.FromMegawattHoursPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromMegawattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? MegawattHoursPerKilogram(this decimal? value) => SpecificEnergy.FromMegawattHoursPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? MegawattHoursPerKilogram<T>(this T? value) where T : struct => SpecificEnergy.FromMegawattHoursPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattHourPerKilogram
 
         /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy WattHoursPerKilogram(this int value) => SpecificEnergy.FromWattHoursPerKilogram(value);
+        public static SpecificEnergy WattHoursPerKilogram<T>(this T value) => SpecificEnergy.FromWattHoursPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? WattHoursPerKilogram(this int? value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy WattHoursPerKilogram(this long value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? WattHoursPerKilogram(this long? value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy WattHoursPerKilogram(this double value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? WattHoursPerKilogram(this double? value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy WattHoursPerKilogram(this float value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? WattHoursPerKilogram(this float? value) => SpecificEnergy.FromWattHoursPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy WattHoursPerKilogram(this decimal value) => SpecificEnergy.FromWattHoursPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEnergy.FromWattHoursPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificEnergy? WattHoursPerKilogram(this decimal? value) => SpecificEnergy.FromWattHoursPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEnergy? WattHoursPerKilogram<T>(this T? value) where T : struct => SpecificEnergy.FromWattHoursPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificEntropyExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificEntropyExtensions.g.cs
@@ -47,272 +47,80 @@ namespace UnitsNet.Extensions.NumberToSpecificEntropy
         #region CaloriePerGramKelvin
 
         /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy CaloriesPerGramKelvin(this int value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
+        public static SpecificEntropy CaloriesPerGramKelvin<T>(this T value) => SpecificEntropy.FromCaloriesPerGramKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? CaloriesPerGramKelvin(this int? value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy CaloriesPerGramKelvin(this long value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? CaloriesPerGramKelvin(this long? value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy CaloriesPerGramKelvin(this double value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? CaloriesPerGramKelvin(this double? value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy CaloriesPerGramKelvin(this float value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? CaloriesPerGramKelvin(this float? value) => SpecificEntropy.FromCaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy CaloriesPerGramKelvin(this decimal value) => SpecificEntropy.FromCaloriesPerGramKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromCaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? CaloriesPerGramKelvin(this decimal? value) => SpecificEntropy.FromCaloriesPerGramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? CaloriesPerGramKelvin<T>(this T? value) where T : struct => SpecificEntropy.FromCaloriesPerGramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region JoulePerKilogramDegreeCelsius
 
         /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramDegreeCelsius(this int value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
+        public static SpecificEntropy JoulesPerKilogramDegreeCelsius<T>(this T value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramDegreeCelsius(this int? value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramDegreeCelsius(this long value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramDegreeCelsius(this long? value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramDegreeCelsius(this double value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramDegreeCelsius(this double? value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramDegreeCelsius(this float value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramDegreeCelsius(this float? value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramDegreeCelsius(this decimal value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramDegreeCelsius(this decimal? value) => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? JoulesPerKilogramDegreeCelsius<T>(this T? value) where T : struct => SpecificEntropy.FromJoulesPerKilogramDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region JoulePerKilogramKelvin
 
         /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramKelvin(this int value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
+        public static SpecificEntropy JoulesPerKilogramKelvin<T>(this T value) => SpecificEntropy.FromJoulesPerKilogramKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramKelvin(this int? value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramKelvin(this long value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramKelvin(this long? value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramKelvin(this double value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramKelvin(this double? value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramKelvin(this float value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramKelvin(this float? value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy JoulesPerKilogramKelvin(this decimal value) => SpecificEntropy.FromJoulesPerKilogramKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromJoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? JoulesPerKilogramKelvin(this decimal? value) => SpecificEntropy.FromJoulesPerKilogramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? JoulesPerKilogramKelvin<T>(this T? value) where T : struct => SpecificEntropy.FromJoulesPerKilogramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocaloriePerGramKelvin
 
         /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilocaloriesPerGramKelvin(this int value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
+        public static SpecificEntropy KilocaloriesPerGramKelvin<T>(this T value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilocaloriesPerGramKelvin(this int? value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilocaloriesPerGramKelvin(this long value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilocaloriesPerGramKelvin(this long? value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilocaloriesPerGramKelvin(this double value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilocaloriesPerGramKelvin(this double? value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilocaloriesPerGramKelvin(this float value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilocaloriesPerGramKelvin(this float? value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilocaloriesPerGramKelvin(this decimal value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilocaloriesPerGramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilocaloriesPerGramKelvin(this decimal? value) => SpecificEntropy.FromKilocaloriesPerGramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? KilocaloriesPerGramKelvin<T>(this T? value) where T : struct => SpecificEntropy.FromKilocaloriesPerGramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerKilogramDegreeCelsius
 
         /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramDegreeCelsius(this int value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
+        public static SpecificEntropy KilojoulesPerKilogramDegreeCelsius<T>(this T value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramDegreeCelsius(this int? value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramDegreeCelsius(this long value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramDegreeCelsius(this long? value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramDegreeCelsius(this double value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramDegreeCelsius(this double? value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramDegreeCelsius(this float value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramDegreeCelsius(this float? value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramDegreeCelsius(this decimal value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramDegreeCelsius(this decimal? value) => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? KilojoulesPerKilogramDegreeCelsius<T>(this T? value) where T : struct => SpecificEntropy.FromKilojoulesPerKilogramDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilojoulePerKilogramKelvin
 
         /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramKelvin(this int value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
+        public static SpecificEntropy KilojoulesPerKilogramKelvin<T>(this T value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramKelvin(this int? value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramKelvin(this long value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramKelvin(this long? value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramKelvin(this double value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramKelvin(this double? value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramKelvin(this float value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramKelvin(this float? value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy KilojoulesPerKilogramKelvin(this decimal value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromKilojoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? KilojoulesPerKilogramKelvin(this decimal? value) => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? KilojoulesPerKilogramKelvin<T>(this T? value) where T : struct => SpecificEntropy.FromKilojoulesPerKilogramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegajoulePerKilogramDegreeCelsius
 
         /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramDegreeCelsius(this int value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
+        public static SpecificEntropy MegajoulesPerKilogramDegreeCelsius<T>(this T value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramDegreeCelsius(this int? value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramDegreeCelsius(this long value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramDegreeCelsius(this long? value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramDegreeCelsius(this double value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramDegreeCelsius(this double? value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramDegreeCelsius(this float value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramDegreeCelsius(this float? value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramDegreeCelsius(this decimal value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramDegreeCelsius(this decimal? value) => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? MegajoulesPerKilogramDegreeCelsius<T>(this T? value) where T : struct => SpecificEntropy.FromMegajoulesPerKilogramDegreeCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegajoulePerKilogramKelvin
 
         /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramKelvin(this int value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
+        public static SpecificEntropy MegajoulesPerKilogramKelvin<T>(this T value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramKelvin(this int? value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramKelvin(this long value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramKelvin(this long? value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramKelvin(this double value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramKelvin(this double? value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramKelvin(this float value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramKelvin(this float? value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value);
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy MegajoulesPerKilogramKelvin(this decimal value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificEntropy.FromMegajoulesPerKilogramKelvin(UnitsNet.QuantityValue)" />
-        public static SpecificEntropy? MegajoulesPerKilogramKelvin(this decimal? value) => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificEntropy? MegajoulesPerKilogramKelvin<T>(this T? value) where T : struct => SpecificEntropy.FromMegajoulesPerKilogramKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificVolumeExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificVolumeExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToSpecificVolume
         #region CubicFootPerPound
 
         /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicFeetPerPound(this int value) => SpecificVolume.FromCubicFeetPerPound(value);
+        public static SpecificVolume CubicFeetPerPound<T>(this T value) => SpecificVolume.FromCubicFeetPerPound(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicFeetPerPound(this int? value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicFeetPerPound(this long value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicFeetPerPound(this long? value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicFeetPerPound(this double value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicFeetPerPound(this double? value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicFeetPerPound(this float value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicFeetPerPound(this float? value) => SpecificVolume.FromCubicFeetPerPound(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicFeetPerPound(this decimal value) => SpecificVolume.FromCubicFeetPerPound(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicFeetPerPound(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicFeetPerPound(this decimal? value) => SpecificVolume.FromCubicFeetPerPound(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificVolume? CubicFeetPerPound<T>(this T? value) where T : struct => SpecificVolume.FromCubicFeetPerPound(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerKilogram
 
         /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicMetersPerKilogram(this int value) => SpecificVolume.FromCubicMetersPerKilogram(value);
+        public static SpecificVolume CubicMetersPerKilogram<T>(this T value) => SpecificVolume.FromCubicMetersPerKilogram(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicMetersPerKilogram(this int? value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicMetersPerKilogram(this long value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicMetersPerKilogram(this long? value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicMetersPerKilogram(this double value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicMetersPerKilogram(this double? value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicMetersPerKilogram(this float value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicMetersPerKilogram(this float? value) => SpecificVolume.FromCubicMetersPerKilogram(value);
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume CubicMetersPerKilogram(this decimal value) => SpecificVolume.FromCubicMetersPerKilogram(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificVolume.FromCubicMetersPerKilogram(UnitsNet.QuantityValue)" />
-        public static SpecificVolume? CubicMetersPerKilogram(this decimal? value) => SpecificVolume.FromCubicMetersPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificVolume? CubicMetersPerKilogram<T>(this T? value) where T : struct => SpecificVolume.FromCubicMetersPerKilogram(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificWeightExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpecificWeightExtensions.g.cs
@@ -47,578 +47,170 @@ namespace UnitsNet.Extensions.NumberToSpecificWeight
         #region KilogramForcePerCubicCentimeter
 
         /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicCentimeter(this int value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
+        public static SpecificWeight KilogramsForcePerCubicCentimeter<T>(this T value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicCentimeter(this int? value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicCentimeter(this long value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicCentimeter(this long? value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicCentimeter(this double value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicCentimeter(this double? value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicCentimeter(this float value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicCentimeter(this float? value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicCentimeter(this decimal value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicCentimeter(this decimal? value) => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilogramsForcePerCubicCentimeter<T>(this T? value) where T : struct => SpecificWeight.FromKilogramsForcePerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForcePerCubicMeter
 
         /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMeter(this int value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
+        public static SpecificWeight KilogramsForcePerCubicMeter<T>(this T value) => SpecificWeight.FromKilogramsForcePerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMeter(this int? value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMeter(this long value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMeter(this long? value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMeter(this double value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMeter(this double? value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMeter(this float value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMeter(this float? value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMeter(this decimal value) => SpecificWeight.FromKilogramsForcePerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMeter(this decimal? value) => SpecificWeight.FromKilogramsForcePerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilogramsForcePerCubicMeter<T>(this T? value) where T : struct => SpecificWeight.FromKilogramsForcePerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForcePerCubicMillimeter
 
         /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMillimeter(this int value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
+        public static SpecificWeight KilogramsForcePerCubicMillimeter<T>(this T value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMillimeter(this int? value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMillimeter(this long value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMillimeter(this long? value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMillimeter(this double value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMillimeter(this double? value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMillimeter(this float value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMillimeter(this float? value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilogramsForcePerCubicMillimeter(this decimal value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilogramsForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilogramsForcePerCubicMillimeter(this decimal? value) => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilogramsForcePerCubicMillimeter<T>(this T? value) where T : struct => SpecificWeight.FromKilogramsForcePerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerCubicCentimeter
 
         /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicCentimeter(this int value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
+        public static SpecificWeight KilonewtonsPerCubicCentimeter<T>(this T value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicCentimeter(this int? value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicCentimeter(this long value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicCentimeter(this long? value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicCentimeter(this double value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicCentimeter(this double? value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicCentimeter(this float value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicCentimeter(this float? value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicCentimeter(this decimal value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicCentimeter(this decimal? value) => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilonewtonsPerCubicCentimeter<T>(this T? value) where T : struct => SpecificWeight.FromKilonewtonsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerCubicMeter
 
         /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMeter(this int value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
+        public static SpecificWeight KilonewtonsPerCubicMeter<T>(this T value) => SpecificWeight.FromKilonewtonsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMeter(this int? value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMeter(this long value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMeter(this long? value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMeter(this double value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMeter(this double? value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMeter(this float value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMeter(this float? value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMeter(this decimal value) => SpecificWeight.FromKilonewtonsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMeter(this decimal? value) => SpecificWeight.FromKilonewtonsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilonewtonsPerCubicMeter<T>(this T? value) where T : struct => SpecificWeight.FromKilonewtonsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonPerCubicMillimeter
 
         /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMillimeter(this int value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
+        public static SpecificWeight KilonewtonsPerCubicMillimeter<T>(this T value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMillimeter(this int? value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMillimeter(this long value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMillimeter(this long? value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMillimeter(this double value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMillimeter(this double? value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMillimeter(this float value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMillimeter(this float? value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilonewtonsPerCubicMillimeter(this decimal value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilonewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilonewtonsPerCubicMillimeter(this decimal? value) => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilonewtonsPerCubicMillimeter<T>(this T? value) where T : struct => SpecificWeight.FromKilonewtonsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundForcePerCubicFoot
 
         /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicFoot(this int value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
+        public static SpecificWeight KilopoundsForcePerCubicFoot<T>(this T value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicFoot(this int? value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicFoot(this long value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicFoot(this long? value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicFoot(this double value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicFoot(this double? value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicFoot(this float value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicFoot(this float? value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicFoot(this decimal value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicFoot(this decimal? value) => SpecificWeight.FromKilopoundsForcePerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilopoundsForcePerCubicFoot<T>(this T? value) where T : struct => SpecificWeight.FromKilopoundsForcePerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundForcePerCubicInch
 
         /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicInch(this int value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
+        public static SpecificWeight KilopoundsForcePerCubicInch<T>(this T value) => SpecificWeight.FromKilopoundsForcePerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicInch(this int? value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicInch(this long value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicInch(this long? value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicInch(this double value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicInch(this double? value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicInch(this float value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicInch(this float? value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight KilopoundsForcePerCubicInch(this decimal value) => SpecificWeight.FromKilopoundsForcePerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromKilopoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? KilopoundsForcePerCubicInch(this decimal? value) => SpecificWeight.FromKilopoundsForcePerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? KilopoundsForcePerCubicInch<T>(this T? value) where T : struct => SpecificWeight.FromKilopoundsForcePerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonPerCubicMeter
 
         /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight MeganewtonsPerCubicMeter(this int value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
+        public static SpecificWeight MeganewtonsPerCubicMeter<T>(this T value) => SpecificWeight.FromMeganewtonsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? MeganewtonsPerCubicMeter(this int? value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight MeganewtonsPerCubicMeter(this long value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? MeganewtonsPerCubicMeter(this long? value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight MeganewtonsPerCubicMeter(this double value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? MeganewtonsPerCubicMeter(this double? value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight MeganewtonsPerCubicMeter(this float value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? MeganewtonsPerCubicMeter(this float? value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight MeganewtonsPerCubicMeter(this decimal value) => SpecificWeight.FromMeganewtonsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromMeganewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? MeganewtonsPerCubicMeter(this decimal? value) => SpecificWeight.FromMeganewtonsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? MeganewtonsPerCubicMeter<T>(this T? value) where T : struct => SpecificWeight.FromMeganewtonsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerCubicCentimeter
 
         /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicCentimeter(this int value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
+        public static SpecificWeight NewtonsPerCubicCentimeter<T>(this T value) => SpecificWeight.FromNewtonsPerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicCentimeter(this int? value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicCentimeter(this long value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicCentimeter(this long? value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicCentimeter(this double value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicCentimeter(this double? value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicCentimeter(this float value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicCentimeter(this float? value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicCentimeter(this decimal value) => SpecificWeight.FromNewtonsPerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicCentimeter(this decimal? value) => SpecificWeight.FromNewtonsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? NewtonsPerCubicCentimeter<T>(this T? value) where T : struct => SpecificWeight.FromNewtonsPerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerCubicMeter
 
         /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMeter(this int value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
+        public static SpecificWeight NewtonsPerCubicMeter<T>(this T value) => SpecificWeight.FromNewtonsPerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMeter(this int? value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMeter(this long value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMeter(this long? value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMeter(this double value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMeter(this double? value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMeter(this float value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMeter(this float? value) => SpecificWeight.FromNewtonsPerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMeter(this decimal value) => SpecificWeight.FromNewtonsPerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMeter(this decimal? value) => SpecificWeight.FromNewtonsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? NewtonsPerCubicMeter<T>(this T? value) where T : struct => SpecificWeight.FromNewtonsPerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonPerCubicMillimeter
 
         /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMillimeter(this int value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
+        public static SpecificWeight NewtonsPerCubicMillimeter<T>(this T value) => SpecificWeight.FromNewtonsPerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMillimeter(this int? value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMillimeter(this long value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMillimeter(this long? value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMillimeter(this double value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMillimeter(this double? value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMillimeter(this float value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMillimeter(this float? value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight NewtonsPerCubicMillimeter(this decimal value) => SpecificWeight.FromNewtonsPerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromNewtonsPerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? NewtonsPerCubicMillimeter(this decimal? value) => SpecificWeight.FromNewtonsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? NewtonsPerCubicMillimeter<T>(this T? value) where T : struct => SpecificWeight.FromNewtonsPerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForcePerCubicFoot
 
         /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicFoot(this int value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
+        public static SpecificWeight PoundsForcePerCubicFoot<T>(this T value) => SpecificWeight.FromPoundsForcePerCubicFoot(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicFoot(this int? value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicFoot(this long value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicFoot(this long? value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicFoot(this double value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicFoot(this double? value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicFoot(this float value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicFoot(this float? value) => SpecificWeight.FromPoundsForcePerCubicFoot(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicFoot(this decimal value) => SpecificWeight.FromPoundsForcePerCubicFoot(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicFoot(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicFoot(this decimal? value) => SpecificWeight.FromPoundsForcePerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? PoundsForcePerCubicFoot<T>(this T? value) where T : struct => SpecificWeight.FromPoundsForcePerCubicFoot(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForcePerCubicInch
 
         /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicInch(this int value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
+        public static SpecificWeight PoundsForcePerCubicInch<T>(this T value) => SpecificWeight.FromPoundsForcePerCubicInch(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicInch(this int? value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicInch(this long value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicInch(this long? value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicInch(this double value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicInch(this double? value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicInch(this float value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicInch(this float? value) => SpecificWeight.FromPoundsForcePerCubicInch(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight PoundsForcePerCubicInch(this decimal value) => SpecificWeight.FromPoundsForcePerCubicInch(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromPoundsForcePerCubicInch(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? PoundsForcePerCubicInch(this decimal? value) => SpecificWeight.FromPoundsForcePerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? PoundsForcePerCubicInch<T>(this T? value) where T : struct => SpecificWeight.FromPoundsForcePerCubicInch(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForcePerCubicCentimeter
 
         /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicCentimeter(this int value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
+        public static SpecificWeight TonnesForcePerCubicCentimeter<T>(this T value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicCentimeter(this int? value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicCentimeter(this long value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicCentimeter(this long? value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicCentimeter(this double value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicCentimeter(this double? value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicCentimeter(this float value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicCentimeter(this float? value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicCentimeter(this decimal value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicCentimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicCentimeter(this decimal? value) => SpecificWeight.FromTonnesForcePerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? TonnesForcePerCubicCentimeter<T>(this T? value) where T : struct => SpecificWeight.FromTonnesForcePerCubicCentimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForcePerCubicMeter
 
         /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMeter(this int value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
+        public static SpecificWeight TonnesForcePerCubicMeter<T>(this T value) => SpecificWeight.FromTonnesForcePerCubicMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMeter(this int? value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMeter(this long value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMeter(this long? value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMeter(this double value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMeter(this double? value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMeter(this float value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMeter(this float? value) => SpecificWeight.FromTonnesForcePerCubicMeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMeter(this decimal value) => SpecificWeight.FromTonnesForcePerCubicMeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMeter(this decimal? value) => SpecificWeight.FromTonnesForcePerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? TonnesForcePerCubicMeter<T>(this T? value) where T : struct => SpecificWeight.FromTonnesForcePerCubicMeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForcePerCubicMillimeter
 
         /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMillimeter(this int value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
+        public static SpecificWeight TonnesForcePerCubicMillimeter<T>(this T value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMillimeter(this int? value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMillimeter(this long value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMillimeter(this long? value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMillimeter(this double value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMillimeter(this double? value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMillimeter(this float value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMillimeter(this float? value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value);
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight TonnesForcePerCubicMillimeter(this decimal value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="SpecificWeight.FromTonnesForcePerCubicMillimeter(UnitsNet.QuantityValue)" />
-        public static SpecificWeight? TonnesForcePerCubicMillimeter(this decimal? value) => SpecificWeight.FromTonnesForcePerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static SpecificWeight? TonnesForcePerCubicMillimeter<T>(this T? value) where T : struct => SpecificWeight.FromTonnesForcePerCubicMillimeter(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpeedExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpeedExtensions.g.cs
@@ -47,1088 +47,320 @@ namespace UnitsNet.Extensions.NumberToSpeed
         #region CentimeterPerHour
 
         /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerHour(this int value) => Speed.FromCentimetersPerHour(value);
+        public static Speed CentimetersPerHour<T>(this T value) => Speed.FromCentimetersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerHour(this int? value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerHour(this long value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerHour(this long? value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerHour(this double value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerHour(this double? value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerHour(this float value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerHour(this float? value) => Speed.FromCentimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerHour(this decimal value) => Speed.FromCentimetersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerHour(this decimal? value) => Speed.FromCentimetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? CentimetersPerHour<T>(this T? value) where T : struct => Speed.FromCentimetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CentimeterPerMinute
 
         /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerMinutes(this int value) => Speed.FromCentimetersPerMinutes(value);
+        public static Speed CentimetersPerMinutes<T>(this T value) => Speed.FromCentimetersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerMinutes(this int? value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerMinutes(this long value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerMinutes(this long? value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerMinutes(this double value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerMinutes(this double? value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerMinutes(this float value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerMinutes(this float? value) => Speed.FromCentimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerMinutes(this decimal value) => Speed.FromCentimetersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerMinutes(this decimal? value) => Speed.FromCentimetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? CentimetersPerMinutes<T>(this T? value) where T : struct => Speed.FromCentimetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CentimeterPerSecond
 
         /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerSecond(this int value) => Speed.FromCentimetersPerSecond(value);
+        public static Speed CentimetersPerSecond<T>(this T value) => Speed.FromCentimetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerSecond(this int? value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerSecond(this long value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerSecond(this long? value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerSecond(this double value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerSecond(this double? value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerSecond(this float value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerSecond(this float? value) => Speed.FromCentimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed CentimetersPerSecond(this decimal value) => Speed.FromCentimetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromCentimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? CentimetersPerSecond(this decimal? value) => Speed.FromCentimetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? CentimetersPerSecond<T>(this T? value) where T : struct => Speed.FromCentimetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecimeterPerMinute
 
         /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerMinutes(this int value) => Speed.FromDecimetersPerMinutes(value);
+        public static Speed DecimetersPerMinutes<T>(this T value) => Speed.FromDecimetersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerMinutes(this int? value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerMinutes(this long value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerMinutes(this long? value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerMinutes(this double value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerMinutes(this double? value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerMinutes(this float value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerMinutes(this float? value) => Speed.FromDecimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerMinutes(this decimal value) => Speed.FromDecimetersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerMinutes(this decimal? value) => Speed.FromDecimetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? DecimetersPerMinutes<T>(this T? value) where T : struct => Speed.FromDecimetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecimeterPerSecond
 
         /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerSecond(this int value) => Speed.FromDecimetersPerSecond(value);
+        public static Speed DecimetersPerSecond<T>(this T value) => Speed.FromDecimetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerSecond(this int? value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerSecond(this long value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerSecond(this long? value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerSecond(this double value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerSecond(this double? value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerSecond(this float value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerSecond(this float? value) => Speed.FromDecimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed DecimetersPerSecond(this decimal value) => Speed.FromDecimetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromDecimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? DecimetersPerSecond(this decimal? value) => Speed.FromDecimetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? DecimetersPerSecond<T>(this T? value) where T : struct => Speed.FromDecimetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootPerHour
 
         /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerHour(this int value) => Speed.FromFeetPerHour(value);
+        public static Speed FeetPerHour<T>(this T value) => Speed.FromFeetPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerHour(this int? value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerHour(this long value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerHour(this long? value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerHour(this double value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerHour(this double? value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerHour(this float value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerHour(this float? value) => Speed.FromFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerHour(this decimal value) => Speed.FromFeetPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerHour(this decimal? value) => Speed.FromFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? FeetPerHour<T>(this T? value) where T : struct => Speed.FromFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootPerMinute
 
         /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerMinute(this int value) => Speed.FromFeetPerMinute(value);
+        public static Speed FeetPerMinute<T>(this T value) => Speed.FromFeetPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerMinute(this int? value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerMinute(this long value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerMinute(this long? value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerMinute(this double value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerMinute(this double? value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerMinute(this float value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerMinute(this float? value) => Speed.FromFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerMinute(this decimal value) => Speed.FromFeetPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerMinute(this decimal? value) => Speed.FromFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? FeetPerMinute<T>(this T? value) where T : struct => Speed.FromFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region FootPerSecond
 
         /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerSecond(this int value) => Speed.FromFeetPerSecond(value);
+        public static Speed FeetPerSecond<T>(this T value) => Speed.FromFeetPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerSecond(this int? value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerSecond(this long value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerSecond(this long? value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerSecond(this double value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerSecond(this double? value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerSecond(this float value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerSecond(this float? value) => Speed.FromFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed FeetPerSecond(this decimal value) => Speed.FromFeetPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? FeetPerSecond(this decimal? value) => Speed.FromFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? FeetPerSecond<T>(this T? value) where T : struct => Speed.FromFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region InchPerHour
 
         /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerHour(this int value) => Speed.FromInchesPerHour(value);
+        public static Speed InchesPerHour<T>(this T value) => Speed.FromInchesPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerHour(this int? value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerHour(this long value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerHour(this long? value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerHour(this double value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerHour(this double? value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerHour(this float value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerHour(this float? value) => Speed.FromInchesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerHour(this decimal value) => Speed.FromInchesPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromInchesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerHour(this decimal? value) => Speed.FromInchesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? InchesPerHour<T>(this T? value) where T : struct => Speed.FromInchesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region InchPerMinute
 
         /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerMinute(this int value) => Speed.FromInchesPerMinute(value);
+        public static Speed InchesPerMinute<T>(this T value) => Speed.FromInchesPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerMinute(this int? value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerMinute(this long value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerMinute(this long? value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerMinute(this double value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerMinute(this double? value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerMinute(this float value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerMinute(this float? value) => Speed.FromInchesPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerMinute(this decimal value) => Speed.FromInchesPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromInchesPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerMinute(this decimal? value) => Speed.FromInchesPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? InchesPerMinute<T>(this T? value) where T : struct => Speed.FromInchesPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region InchPerSecond
 
         /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerSecond(this int value) => Speed.FromInchesPerSecond(value);
+        public static Speed InchesPerSecond<T>(this T value) => Speed.FromInchesPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerSecond(this int? value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerSecond(this long value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerSecond(this long? value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerSecond(this double value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerSecond(this double? value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerSecond(this float value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerSecond(this float? value) => Speed.FromInchesPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed InchesPerSecond(this decimal value) => Speed.FromInchesPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromInchesPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? InchesPerSecond(this decimal? value) => Speed.FromInchesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? InchesPerSecond<T>(this T? value) where T : struct => Speed.FromInchesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilometerPerHour
 
         /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerHour(this int value) => Speed.FromKilometersPerHour(value);
+        public static Speed KilometersPerHour<T>(this T value) => Speed.FromKilometersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerHour(this int? value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerHour(this long value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerHour(this long? value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerHour(this double value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerHour(this double? value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerHour(this float value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerHour(this float? value) => Speed.FromKilometersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerHour(this decimal value) => Speed.FromKilometersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromKilometersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerHour(this decimal? value) => Speed.FromKilometersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? KilometersPerHour<T>(this T? value) where T : struct => Speed.FromKilometersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilometerPerMinute
 
         /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerMinutes(this int value) => Speed.FromKilometersPerMinutes(value);
+        public static Speed KilometersPerMinutes<T>(this T value) => Speed.FromKilometersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerMinutes(this int? value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerMinutes(this long value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerMinutes(this long? value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerMinutes(this double value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerMinutes(this double? value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerMinutes(this float value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerMinutes(this float? value) => Speed.FromKilometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerMinutes(this decimal value) => Speed.FromKilometersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromKilometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerMinutes(this decimal? value) => Speed.FromKilometersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? KilometersPerMinutes<T>(this T? value) where T : struct => Speed.FromKilometersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilometerPerSecond
 
         /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerSecond(this int value) => Speed.FromKilometersPerSecond(value);
+        public static Speed KilometersPerSecond<T>(this T value) => Speed.FromKilometersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerSecond(this int? value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerSecond(this long value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerSecond(this long? value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerSecond(this double value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerSecond(this double? value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerSecond(this float value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerSecond(this float? value) => Speed.FromKilometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed KilometersPerSecond(this decimal value) => Speed.FromKilometersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromKilometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? KilometersPerSecond(this decimal? value) => Speed.FromKilometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? KilometersPerSecond<T>(this T? value) where T : struct => Speed.FromKilometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Knot
 
         /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed Knots(this int value) => Speed.FromKnots(value);
+        public static Speed Knots<T>(this T value) => Speed.FromKnots(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed? Knots(this int? value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed Knots(this long value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed? Knots(this long? value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed Knots(this double value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed? Knots(this double? value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed Knots(this float value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed? Knots(this float? value) => Speed.FromKnots(value);
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed Knots(this decimal value) => Speed.FromKnots(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromKnots(UnitsNet.QuantityValue)" />
-        public static Speed? Knots(this decimal? value) => Speed.FromKnots(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? Knots<T>(this T? value) where T : struct => Speed.FromKnots(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeterPerHour
 
         /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerHour(this int value) => Speed.FromMetersPerHour(value);
+        public static Speed MetersPerHour<T>(this T value) => Speed.FromMetersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerHour(this int? value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerHour(this long value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerHour(this long? value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerHour(this double value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerHour(this double? value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerHour(this float value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerHour(this float? value) => Speed.FromMetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerHour(this decimal value) => Speed.FromMetersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerHour(this decimal? value) => Speed.FromMetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MetersPerHour<T>(this T? value) where T : struct => Speed.FromMetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeterPerMinute
 
         /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerMinutes(this int value) => Speed.FromMetersPerMinutes(value);
+        public static Speed MetersPerMinutes<T>(this T value) => Speed.FromMetersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerMinutes(this int? value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerMinutes(this long value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerMinutes(this long? value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerMinutes(this double value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerMinutes(this double? value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerMinutes(this float value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerMinutes(this float? value) => Speed.FromMetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerMinutes(this decimal value) => Speed.FromMetersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerMinutes(this decimal? value) => Speed.FromMetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MetersPerMinutes<T>(this T? value) where T : struct => Speed.FromMetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeterPerSecond
 
         /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerSecond(this int value) => Speed.FromMetersPerSecond(value);
+        public static Speed MetersPerSecond<T>(this T value) => Speed.FromMetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerSecond(this int? value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerSecond(this long value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerSecond(this long? value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerSecond(this double value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerSecond(this double? value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerSecond(this float value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerSecond(this float? value) => Speed.FromMetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MetersPerSecond(this decimal value) => Speed.FromMetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MetersPerSecond(this decimal? value) => Speed.FromMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MetersPerSecond<T>(this T? value) where T : struct => Speed.FromMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrometerPerMinute
 
         /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerMinutes(this int value) => Speed.FromMicrometersPerMinutes(value);
+        public static Speed MicrometersPerMinutes<T>(this T value) => Speed.FromMicrometersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerMinutes(this int? value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerMinutes(this long value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerMinutes(this long? value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerMinutes(this double value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerMinutes(this double? value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerMinutes(this float value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerMinutes(this float? value) => Speed.FromMicrometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerMinutes(this decimal value) => Speed.FromMicrometersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerMinutes(this decimal? value) => Speed.FromMicrometersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MicrometersPerMinutes<T>(this T? value) where T : struct => Speed.FromMicrometersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrometerPerSecond
 
         /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerSecond(this int value) => Speed.FromMicrometersPerSecond(value);
+        public static Speed MicrometersPerSecond<T>(this T value) => Speed.FromMicrometersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerSecond(this int? value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerSecond(this long value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerSecond(this long? value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerSecond(this double value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerSecond(this double? value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerSecond(this float value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerSecond(this float? value) => Speed.FromMicrometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MicrometersPerSecond(this decimal value) => Speed.FromMicrometersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMicrometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MicrometersPerSecond(this decimal? value) => Speed.FromMicrometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MicrometersPerSecond<T>(this T? value) where T : struct => Speed.FromMicrometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MilePerHour
 
         /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MilesPerHour(this int value) => Speed.FromMilesPerHour(value);
+        public static Speed MilesPerHour<T>(this T value) => Speed.FromMilesPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MilesPerHour(this int? value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MilesPerHour(this long value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MilesPerHour(this long? value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MilesPerHour(this double value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MilesPerHour(this double? value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MilesPerHour(this float value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MilesPerHour(this float? value) => Speed.FromMilesPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MilesPerHour(this decimal value) => Speed.FromMilesPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMilesPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MilesPerHour(this decimal? value) => Speed.FromMilesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MilesPerHour<T>(this T? value) where T : struct => Speed.FromMilesPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimeterPerHour
 
         /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerHour(this int value) => Speed.FromMillimetersPerHour(value);
+        public static Speed MillimetersPerHour<T>(this T value) => Speed.FromMillimetersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerHour(this int? value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerHour(this long value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerHour(this long? value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerHour(this double value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerHour(this double? value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerHour(this float value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerHour(this float? value) => Speed.FromMillimetersPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerHour(this decimal value) => Speed.FromMillimetersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerHour(this decimal? value) => Speed.FromMillimetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MillimetersPerHour<T>(this T? value) where T : struct => Speed.FromMillimetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimeterPerMinute
 
         /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerMinutes(this int value) => Speed.FromMillimetersPerMinutes(value);
+        public static Speed MillimetersPerMinutes<T>(this T value) => Speed.FromMillimetersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerMinutes(this int? value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerMinutes(this long value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerMinutes(this long? value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerMinutes(this double value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerMinutes(this double? value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerMinutes(this float value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerMinutes(this float? value) => Speed.FromMillimetersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerMinutes(this decimal value) => Speed.FromMillimetersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerMinutes(this decimal? value) => Speed.FromMillimetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MillimetersPerMinutes<T>(this T? value) where T : struct => Speed.FromMillimetersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillimeterPerSecond
 
         /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerSecond(this int value) => Speed.FromMillimetersPerSecond(value);
+        public static Speed MillimetersPerSecond<T>(this T value) => Speed.FromMillimetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerSecond(this int? value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerSecond(this long value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerSecond(this long? value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerSecond(this double value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerSecond(this double? value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerSecond(this float value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerSecond(this float? value) => Speed.FromMillimetersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed MillimetersPerSecond(this decimal value) => Speed.FromMillimetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromMillimetersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? MillimetersPerSecond(this decimal? value) => Speed.FromMillimetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? MillimetersPerSecond<T>(this T? value) where T : struct => Speed.FromMillimetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanometerPerMinute
 
         /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerMinutes(this int value) => Speed.FromNanometersPerMinutes(value);
+        public static Speed NanometersPerMinutes<T>(this T value) => Speed.FromNanometersPerMinutes(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerMinutes(this int? value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerMinutes(this long value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerMinutes(this long? value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerMinutes(this double value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerMinutes(this double? value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerMinutes(this float value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerMinutes(this float? value) => Speed.FromNanometersPerMinutes(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerMinutes(this decimal value) => Speed.FromNanometersPerMinutes(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromNanometersPerMinutes(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerMinutes(this decimal? value) => Speed.FromNanometersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? NanometersPerMinutes<T>(this T? value) where T : struct => Speed.FromNanometersPerMinutes(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanometerPerSecond
 
         /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerSecond(this int value) => Speed.FromNanometersPerSecond(value);
+        public static Speed NanometersPerSecond<T>(this T value) => Speed.FromNanometersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerSecond(this int? value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerSecond(this long value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerSecond(this long? value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerSecond(this double value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerSecond(this double? value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerSecond(this float value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerSecond(this float? value) => Speed.FromNanometersPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed NanometersPerSecond(this decimal value) => Speed.FromNanometersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromNanometersPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? NanometersPerSecond(this decimal? value) => Speed.FromNanometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? NanometersPerSecond<T>(this T? value) where T : struct => Speed.FromNanometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsSurveyFootPerHour
 
         /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerHour(this int value) => Speed.FromUsSurveyFeetPerHour(value);
+        public static Speed UsSurveyFeetPerHour<T>(this T value) => Speed.FromUsSurveyFeetPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerHour(this int? value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerHour(this long value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerHour(this long? value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerHour(this double value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerHour(this double? value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerHour(this float value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerHour(this float? value) => Speed.FromUsSurveyFeetPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerHour(this decimal value) => Speed.FromUsSurveyFeetPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerHour(this decimal? value) => Speed.FromUsSurveyFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? UsSurveyFeetPerHour<T>(this T? value) where T : struct => Speed.FromUsSurveyFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsSurveyFootPerMinute
 
         /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerMinute(this int value) => Speed.FromUsSurveyFeetPerMinute(value);
+        public static Speed UsSurveyFeetPerMinute<T>(this T value) => Speed.FromUsSurveyFeetPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerMinute(this int? value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerMinute(this long value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerMinute(this long? value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerMinute(this double value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerMinute(this double? value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerMinute(this float value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerMinute(this float? value) => Speed.FromUsSurveyFeetPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerMinute(this decimal value) => Speed.FromUsSurveyFeetPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerMinute(this decimal? value) => Speed.FromUsSurveyFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? UsSurveyFeetPerMinute<T>(this T? value) where T : struct => Speed.FromUsSurveyFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsSurveyFootPerSecond
 
         /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerSecond(this int value) => Speed.FromUsSurveyFeetPerSecond(value);
+        public static Speed UsSurveyFeetPerSecond<T>(this T value) => Speed.FromUsSurveyFeetPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerSecond(this int? value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerSecond(this long value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerSecond(this long? value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerSecond(this double value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerSecond(this double? value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerSecond(this float value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerSecond(this float? value) => Speed.FromUsSurveyFeetPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed UsSurveyFeetPerSecond(this decimal value) => Speed.FromUsSurveyFeetPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromUsSurveyFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? UsSurveyFeetPerSecond(this decimal? value) => Speed.FromUsSurveyFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? UsSurveyFeetPerSecond<T>(this T? value) where T : struct => Speed.FromUsSurveyFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region YardPerHour
 
         /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerHour(this int value) => Speed.FromYardsPerHour(value);
+        public static Speed YardsPerHour<T>(this T value) => Speed.FromYardsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerHour(this int? value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerHour(this long value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerHour(this long? value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerHour(this double value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerHour(this double? value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerHour(this float value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerHour(this float? value) => Speed.FromYardsPerHour(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerHour(this decimal value) => Speed.FromYardsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromYardsPerHour(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerHour(this decimal? value) => Speed.FromYardsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? YardsPerHour<T>(this T? value) where T : struct => Speed.FromYardsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region YardPerMinute
 
         /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerMinute(this int value) => Speed.FromYardsPerMinute(value);
+        public static Speed YardsPerMinute<T>(this T value) => Speed.FromYardsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerMinute(this int? value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerMinute(this long value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerMinute(this long? value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerMinute(this double value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerMinute(this double? value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerMinute(this float value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerMinute(this float? value) => Speed.FromYardsPerMinute(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerMinute(this decimal value) => Speed.FromYardsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerMinute(this decimal? value) => Speed.FromYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? YardsPerMinute<T>(this T? value) where T : struct => Speed.FromYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region YardPerSecond
 
         /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerSecond(this int value) => Speed.FromYardsPerSecond(value);
+        public static Speed YardsPerSecond<T>(this T value) => Speed.FromYardsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerSecond(this int? value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerSecond(this long value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerSecond(this long? value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerSecond(this double value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerSecond(this double? value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerSecond(this float value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerSecond(this float? value) => Speed.FromYardsPerSecond(value);
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed YardsPerSecond(this decimal value) => Speed.FromYardsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Speed.FromYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static Speed? YardsPerSecond(this decimal? value) => Speed.FromYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Speed? YardsPerSecond<T>(this T? value) where T : struct => Speed.FromYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToTemperatureChangeRateExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToTemperatureChangeRateExtensions.g.cs
@@ -47,340 +47,100 @@ namespace UnitsNet.Extensions.NumberToTemperatureChangeRate
         #region CentidegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate CentidegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate CentidegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? CentidegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate CentidegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? CentidegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate CentidegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? CentidegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate CentidegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? CentidegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate CentidegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? CentidegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? CentidegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromCentidegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecadegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecadegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate DecadegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecadegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecadegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecadegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecadegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecadegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecadegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecadegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecadegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecadegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? DecadegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromDecadegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecidegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecidegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate DecidegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecidegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecidegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecidegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecidegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecidegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecidegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecidegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DecidegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DecidegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? DecidegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromDecidegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeCelsiusPerMinute
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerMinute(this int value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
+        public static TemperatureChangeRate DegreesCelsiusPerMinute<T>(this T value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerMinute(this int? value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerMinute(this long value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerMinute(this long? value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerMinute(this double value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerMinute(this double? value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerMinute(this float value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerMinute(this float? value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerMinute(this decimal value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerMinute(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerMinute(this decimal? value) => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? DegreesCelsiusPerMinute<T>(this T? value) where T : struct => TemperatureChangeRate.FromDegreesCelsiusPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate DegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate DegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromDegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? DegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? DegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromDegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region HectodegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate HectodegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate HectodegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? HectodegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate HectodegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? HectodegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate HectodegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? HectodegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate HectodegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? HectodegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate HectodegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? HectodegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? HectodegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromHectodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilodegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate KilodegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate KilodegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? KilodegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate KilodegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? KilodegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate KilodegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? KilodegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate KilodegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? KilodegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate KilodegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? KilodegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? KilodegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromKilodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrodegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MicrodegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate MicrodegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MicrodegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MicrodegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MicrodegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MicrodegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MicrodegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MicrodegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MicrodegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MicrodegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MicrodegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? MicrodegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromMicrodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillidegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MillidegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate MillidegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MillidegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MillidegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MillidegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MillidegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MillidegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MillidegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MillidegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate MillidegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? MillidegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? MillidegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromMillidegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanodegreeCelsiusPerSecond
 
         /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate NanodegreesCelsiusPerSecond(this int value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
+        public static TemperatureChangeRate NanodegreesCelsiusPerSecond<T>(this T value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? NanodegreesCelsiusPerSecond(this int? value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate NanodegreesCelsiusPerSecond(this long value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? NanodegreesCelsiusPerSecond(this long? value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate NanodegreesCelsiusPerSecond(this double value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? NanodegreesCelsiusPerSecond(this double? value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate NanodegreesCelsiusPerSecond(this float value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? NanodegreesCelsiusPerSecond(this float? value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value);
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate NanodegreesCelsiusPerSecond(this decimal value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(UnitsNet.QuantityValue)" />
-        public static TemperatureChangeRate? NanodegreesCelsiusPerSecond(this decimal? value) => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureChangeRate? NanodegreesCelsiusPerSecond<T>(this T? value) where T : struct => TemperatureChangeRate.FromNanodegreesCelsiusPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToTemperatureDeltaExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToTemperatureDeltaExtensions.g.cs
@@ -47,544 +47,160 @@ namespace UnitsNet.Extensions.NumberToTemperatureDelta
         #region DegreeCelsius
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsius(this int value) => TemperatureDelta.FromDegreesCelsius(value);
+        public static TemperatureDelta DegreesCelsius<T>(this T value) => TemperatureDelta.FromDegreesCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsius(this int? value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsius(this long value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsius(this long? value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsius(this double value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsius(this double? value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsius(this float value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsius(this float? value) => TemperatureDelta.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsius(this decimal value) => TemperatureDelta.FromDegreesCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsius(this decimal? value) => TemperatureDelta.FromDegreesCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesCelsius<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeCelsiusDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsiusDelta(this int value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
+        public static TemperatureDelta DegreesCelsiusDelta<T>(this T value) => TemperatureDelta.FromDegreesCelsiusDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsiusDelta(this int? value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsiusDelta(this long value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsiusDelta(this long? value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsiusDelta(this double value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsiusDelta(this double? value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsiusDelta(this float value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsiusDelta(this float? value) => TemperatureDelta.FromDegreesCelsiusDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesCelsiusDelta(this decimal value) => TemperatureDelta.FromDegreesCelsiusDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesCelsiusDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesCelsiusDelta(this decimal? value) => TemperatureDelta.FromDegreesCelsiusDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesCelsiusDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesCelsiusDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeDelisle
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisle(this int value) => TemperatureDelta.FromDegreesDelisle(value);
+        public static TemperatureDelta DegreesDelisle<T>(this T value) => TemperatureDelta.FromDegreesDelisle(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisle(this int? value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisle(this long value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisle(this long? value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisle(this double value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisle(this double? value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisle(this float value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisle(this float? value) => TemperatureDelta.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisle(this decimal value) => TemperatureDelta.FromDegreesDelisle(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisle(this decimal? value) => TemperatureDelta.FromDegreesDelisle(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesDelisle<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesDelisle(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeDelisleDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisleDelta(this int value) => TemperatureDelta.FromDegreesDelisleDelta(value);
+        public static TemperatureDelta DegreesDelisleDelta<T>(this T value) => TemperatureDelta.FromDegreesDelisleDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisleDelta(this int? value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisleDelta(this long value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisleDelta(this long? value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisleDelta(this double value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisleDelta(this double? value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisleDelta(this float value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisleDelta(this float? value) => TemperatureDelta.FromDegreesDelisleDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesDelisleDelta(this decimal value) => TemperatureDelta.FromDegreesDelisleDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesDelisleDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesDelisleDelta(this decimal? value) => TemperatureDelta.FromDegreesDelisleDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesDelisleDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesDelisleDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeFahrenheit
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheit(this int value) => TemperatureDelta.FromDegreesFahrenheit(value);
+        public static TemperatureDelta DegreesFahrenheit<T>(this T value) => TemperatureDelta.FromDegreesFahrenheit(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheit(this int? value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheit(this long value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheit(this long? value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheit(this double value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheit(this double? value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheit(this float value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheit(this float? value) => TemperatureDelta.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheit(this decimal value) => TemperatureDelta.FromDegreesFahrenheit(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheit(this decimal? value) => TemperatureDelta.FromDegreesFahrenheit(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesFahrenheit<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesFahrenheit(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeFahrenheitDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheitDelta(this int value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
+        public static TemperatureDelta DegreesFahrenheitDelta<T>(this T value) => TemperatureDelta.FromDegreesFahrenheitDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheitDelta(this int? value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheitDelta(this long value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheitDelta(this long? value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheitDelta(this double value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheitDelta(this double? value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheitDelta(this float value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheitDelta(this float? value) => TemperatureDelta.FromDegreesFahrenheitDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesFahrenheitDelta(this decimal value) => TemperatureDelta.FromDegreesFahrenheitDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesFahrenheitDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesFahrenheitDelta(this decimal? value) => TemperatureDelta.FromDegreesFahrenheitDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesFahrenheitDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesFahrenheitDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeNewton
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewton(this int value) => TemperatureDelta.FromDegreesNewton(value);
+        public static TemperatureDelta DegreesNewton<T>(this T value) => TemperatureDelta.FromDegreesNewton(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewton(this int? value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewton(this long value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewton(this long? value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewton(this double value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewton(this double? value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewton(this float value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewton(this float? value) => TemperatureDelta.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewton(this decimal value) => TemperatureDelta.FromDegreesNewton(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewton(this decimal? value) => TemperatureDelta.FromDegreesNewton(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesNewton<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesNewton(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeNewtonDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewtonDelta(this int value) => TemperatureDelta.FromDegreesNewtonDelta(value);
+        public static TemperatureDelta DegreesNewtonDelta<T>(this T value) => TemperatureDelta.FromDegreesNewtonDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewtonDelta(this int? value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewtonDelta(this long value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewtonDelta(this long? value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewtonDelta(this double value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewtonDelta(this double? value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewtonDelta(this float value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewtonDelta(this float? value) => TemperatureDelta.FromDegreesNewtonDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesNewtonDelta(this decimal value) => TemperatureDelta.FromDegreesNewtonDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesNewtonDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesNewtonDelta(this decimal? value) => TemperatureDelta.FromDegreesNewtonDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesNewtonDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesNewtonDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeRankine
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankine(this int value) => TemperatureDelta.FromDegreesRankine(value);
+        public static TemperatureDelta DegreesRankine<T>(this T value) => TemperatureDelta.FromDegreesRankine(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankine(this int? value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankine(this long value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankine(this long? value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankine(this double value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankine(this double? value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankine(this float value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankine(this float? value) => TemperatureDelta.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankine(this decimal value) => TemperatureDelta.FromDegreesRankine(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankine(this decimal? value) => TemperatureDelta.FromDegreesRankine(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesRankine<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesRankine(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeRankineDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankineDelta(this int value) => TemperatureDelta.FromDegreesRankineDelta(value);
+        public static TemperatureDelta DegreesRankineDelta<T>(this T value) => TemperatureDelta.FromDegreesRankineDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankineDelta(this int? value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankineDelta(this long value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankineDelta(this long? value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankineDelta(this double value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankineDelta(this double? value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankineDelta(this float value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankineDelta(this float? value) => TemperatureDelta.FromDegreesRankineDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRankineDelta(this decimal value) => TemperatureDelta.FromDegreesRankineDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRankineDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRankineDelta(this decimal? value) => TemperatureDelta.FromDegreesRankineDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesRankineDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesRankineDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeReaumur
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumur(this int value) => TemperatureDelta.FromDegreesReaumur(value);
+        public static TemperatureDelta DegreesReaumur<T>(this T value) => TemperatureDelta.FromDegreesReaumur(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumur(this int? value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumur(this long value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumur(this long? value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumur(this double value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumur(this double? value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumur(this float value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumur(this float? value) => TemperatureDelta.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumur(this decimal value) => TemperatureDelta.FromDegreesReaumur(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumur(this decimal? value) => TemperatureDelta.FromDegreesReaumur(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesReaumur<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesReaumur(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeReaumurDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumurDelta(this int value) => TemperatureDelta.FromDegreesReaumurDelta(value);
+        public static TemperatureDelta DegreesReaumurDelta<T>(this T value) => TemperatureDelta.FromDegreesReaumurDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumurDelta(this int? value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumurDelta(this long value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumurDelta(this long? value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumurDelta(this double value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumurDelta(this double? value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumurDelta(this float value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumurDelta(this float? value) => TemperatureDelta.FromDegreesReaumurDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesReaumurDelta(this decimal value) => TemperatureDelta.FromDegreesReaumurDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesReaumurDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesReaumurDelta(this decimal? value) => TemperatureDelta.FromDegreesReaumurDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesReaumurDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesReaumurDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeRoemer
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemer(this int value) => TemperatureDelta.FromDegreesRoemer(value);
+        public static TemperatureDelta DegreesRoemer<T>(this T value) => TemperatureDelta.FromDegreesRoemer(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemer(this int? value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemer(this long value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemer(this long? value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemer(this double value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemer(this double? value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemer(this float value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemer(this float? value) => TemperatureDelta.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemer(this decimal value) => TemperatureDelta.FromDegreesRoemer(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemer(this decimal? value) => TemperatureDelta.FromDegreesRoemer(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesRoemer<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesRoemer(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeRoemerDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemerDelta(this int value) => TemperatureDelta.FromDegreesRoemerDelta(value);
+        public static TemperatureDelta DegreesRoemerDelta<T>(this T value) => TemperatureDelta.FromDegreesRoemerDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemerDelta(this int? value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemerDelta(this long value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemerDelta(this long? value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemerDelta(this double value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemerDelta(this double? value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemerDelta(this float value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemerDelta(this float? value) => TemperatureDelta.FromDegreesRoemerDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta DegreesRoemerDelta(this decimal value) => TemperatureDelta.FromDegreesRoemerDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromDegreesRoemerDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? DegreesRoemerDelta(this decimal? value) => TemperatureDelta.FromDegreesRoemerDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? DegreesRoemerDelta<T>(this T? value) where T : struct => TemperatureDelta.FromDegreesRoemerDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kelvin
 
         /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta Kelvins(this int value) => TemperatureDelta.FromKelvins(value);
+        public static TemperatureDelta Kelvins<T>(this T value) => TemperatureDelta.FromKelvins(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? Kelvins(this int? value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta Kelvins(this long value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? Kelvins(this long? value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta Kelvins(this double value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? Kelvins(this double? value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta Kelvins(this float value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? Kelvins(this float? value) => TemperatureDelta.FromKelvins(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta Kelvins(this decimal value) => TemperatureDelta.FromKelvins(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvins(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? Kelvins(this decimal? value) => TemperatureDelta.FromKelvins(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? Kelvins<T>(this T? value) where T : struct => TemperatureDelta.FromKelvins(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KelvinDelta
 
         /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta KelvinsDelta(this int value) => TemperatureDelta.FromKelvinsDelta(value);
+        public static TemperatureDelta KelvinsDelta<T>(this T value) => TemperatureDelta.FromKelvinsDelta(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? KelvinsDelta(this int? value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta KelvinsDelta(this long value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? KelvinsDelta(this long? value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta KelvinsDelta(this double value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? KelvinsDelta(this double? value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta KelvinsDelta(this float value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? KelvinsDelta(this float? value) => TemperatureDelta.FromKelvinsDelta(value);
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta KelvinsDelta(this decimal value) => TemperatureDelta.FromKelvinsDelta(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="TemperatureDelta.FromKelvinsDelta(UnitsNet.QuantityValue)" />
-        public static TemperatureDelta? KelvinsDelta(this decimal? value) => TemperatureDelta.FromKelvinsDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static TemperatureDelta? KelvinsDelta<T>(this T? value) where T : struct => TemperatureDelta.FromKelvinsDelta(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToTemperatureExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToTemperatureExtensions.g.cs
@@ -47,272 +47,80 @@ namespace UnitsNet.Extensions.NumberToTemperature
         #region DegreeCelsius
 
         /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesCelsius(this int value) => Temperature.FromDegreesCelsius(value);
+        public static Temperature DegreesCelsius<T>(this T value) => Temperature.FromDegreesCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesCelsius(this int? value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesCelsius(this long value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesCelsius(this long? value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesCelsius(this double value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesCelsius(this double? value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesCelsius(this float value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesCelsius(this float? value) => Temperature.FromDegreesCelsius(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesCelsius(this decimal value) => Temperature.FromDegreesCelsius(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesCelsius(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesCelsius(this decimal? value) => Temperature.FromDegreesCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesCelsius<T>(this T? value) where T : struct => Temperature.FromDegreesCelsius(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeDelisle
 
         /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesDelisle(this int value) => Temperature.FromDegreesDelisle(value);
+        public static Temperature DegreesDelisle<T>(this T value) => Temperature.FromDegreesDelisle(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesDelisle(this int? value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesDelisle(this long value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesDelisle(this long? value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesDelisle(this double value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesDelisle(this double? value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesDelisle(this float value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesDelisle(this float? value) => Temperature.FromDegreesDelisle(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesDelisle(this decimal value) => Temperature.FromDegreesDelisle(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesDelisle(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesDelisle(this decimal? value) => Temperature.FromDegreesDelisle(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesDelisle<T>(this T? value) where T : struct => Temperature.FromDegreesDelisle(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeFahrenheit
 
         /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesFahrenheit(this int value) => Temperature.FromDegreesFahrenheit(value);
+        public static Temperature DegreesFahrenheit<T>(this T value) => Temperature.FromDegreesFahrenheit(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesFahrenheit(this int? value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesFahrenheit(this long value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesFahrenheit(this long? value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesFahrenheit(this double value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesFahrenheit(this double? value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesFahrenheit(this float value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesFahrenheit(this float? value) => Temperature.FromDegreesFahrenheit(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesFahrenheit(this decimal value) => Temperature.FromDegreesFahrenheit(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesFahrenheit(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesFahrenheit(this decimal? value) => Temperature.FromDegreesFahrenheit(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesFahrenheit<T>(this T? value) where T : struct => Temperature.FromDegreesFahrenheit(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeNewton
 
         /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesNewton(this int value) => Temperature.FromDegreesNewton(value);
+        public static Temperature DegreesNewton<T>(this T value) => Temperature.FromDegreesNewton(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesNewton(this int? value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesNewton(this long value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesNewton(this long? value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesNewton(this double value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesNewton(this double? value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesNewton(this float value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesNewton(this float? value) => Temperature.FromDegreesNewton(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesNewton(this decimal value) => Temperature.FromDegreesNewton(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesNewton(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesNewton(this decimal? value) => Temperature.FromDegreesNewton(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesNewton<T>(this T? value) where T : struct => Temperature.FromDegreesNewton(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeRankine
 
         /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRankine(this int value) => Temperature.FromDegreesRankine(value);
+        public static Temperature DegreesRankine<T>(this T value) => Temperature.FromDegreesRankine(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRankine(this int? value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRankine(this long value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRankine(this long? value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRankine(this double value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRankine(this double? value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRankine(this float value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRankine(this float? value) => Temperature.FromDegreesRankine(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRankine(this decimal value) => Temperature.FromDegreesRankine(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesRankine(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRankine(this decimal? value) => Temperature.FromDegreesRankine(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesRankine<T>(this T? value) where T : struct => Temperature.FromDegreesRankine(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeReaumur
 
         /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesReaumur(this int value) => Temperature.FromDegreesReaumur(value);
+        public static Temperature DegreesReaumur<T>(this T value) => Temperature.FromDegreesReaumur(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesReaumur(this int? value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesReaumur(this long value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesReaumur(this long? value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesReaumur(this double value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesReaumur(this double? value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesReaumur(this float value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesReaumur(this float? value) => Temperature.FromDegreesReaumur(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesReaumur(this decimal value) => Temperature.FromDegreesReaumur(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesReaumur(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesReaumur(this decimal? value) => Temperature.FromDegreesReaumur(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesReaumur<T>(this T? value) where T : struct => Temperature.FromDegreesReaumur(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DegreeRoemer
 
         /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRoemer(this int value) => Temperature.FromDegreesRoemer(value);
+        public static Temperature DegreesRoemer<T>(this T value) => Temperature.FromDegreesRoemer(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRoemer(this int? value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRoemer(this long value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRoemer(this long? value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRoemer(this double value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRoemer(this double? value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRoemer(this float value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRoemer(this float? value) => Temperature.FromDegreesRoemer(value);
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature DegreesRoemer(this decimal value) => Temperature.FromDegreesRoemer(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromDegreesRoemer(UnitsNet.QuantityValue)" />
-        public static Temperature? DegreesRoemer(this decimal? value) => Temperature.FromDegreesRoemer(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? DegreesRoemer<T>(this T? value) where T : struct => Temperature.FromDegreesRoemer(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Kelvin
 
         /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature Kelvins(this int value) => Temperature.FromKelvins(value);
+        public static Temperature Kelvins<T>(this T value) => Temperature.FromKelvins(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature? Kelvins(this int? value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature Kelvins(this long value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature? Kelvins(this long? value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature Kelvins(this double value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature? Kelvins(this double? value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature Kelvins(this float value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature? Kelvins(this float? value) => Temperature.FromKelvins(value);
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature Kelvins(this decimal value) => Temperature.FromKelvins(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Temperature.FromKelvins(UnitsNet.QuantityValue)" />
-        public static Temperature? Kelvins(this decimal? value) => Temperature.FromKelvins(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Temperature? Kelvins<T>(this T? value) where T : struct => Temperature.FromKelvins(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToThermalConductivityExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToThermalConductivityExtensions.g.cs
@@ -47,68 +47,20 @@ namespace UnitsNet.Extensions.NumberToThermalConductivity
         #region BtuPerHourFootFahrenheit
 
         /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity BtusPerHourFootFahrenheit(this int value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
+        public static ThermalConductivity BtusPerHourFootFahrenheit<T>(this T value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? BtusPerHourFootFahrenheit(this int? value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity BtusPerHourFootFahrenheit(this long value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? BtusPerHourFootFahrenheit(this long? value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity BtusPerHourFootFahrenheit(this double value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? BtusPerHourFootFahrenheit(this double? value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity BtusPerHourFootFahrenheit(this float value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? BtusPerHourFootFahrenheit(this float? value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity BtusPerHourFootFahrenheit(this decimal value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalConductivity.FromBtusPerHourFootFahrenheit(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? BtusPerHourFootFahrenheit(this decimal? value) => ThermalConductivity.FromBtusPerHourFootFahrenheit(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalConductivity? BtusPerHourFootFahrenheit<T>(this T? value) where T : struct => ThermalConductivity.FromBtusPerHourFootFahrenheit(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region WattPerMeterKelvin
 
         /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity WattsPerMeterKelvin(this int value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
+        public static ThermalConductivity WattsPerMeterKelvin<T>(this T value) => ThermalConductivity.FromWattsPerMeterKelvin(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? WattsPerMeterKelvin(this int? value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity WattsPerMeterKelvin(this long value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? WattsPerMeterKelvin(this long? value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity WattsPerMeterKelvin(this double value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? WattsPerMeterKelvin(this double? value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity WattsPerMeterKelvin(this float value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? WattsPerMeterKelvin(this float? value) => ThermalConductivity.FromWattsPerMeterKelvin(value);
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity WattsPerMeterKelvin(this decimal value) => ThermalConductivity.FromWattsPerMeterKelvin(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalConductivity.FromWattsPerMeterKelvin(UnitsNet.QuantityValue)" />
-        public static ThermalConductivity? WattsPerMeterKelvin(this decimal? value) => ThermalConductivity.FromWattsPerMeterKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalConductivity? WattsPerMeterKelvin<T>(this T? value) where T : struct => ThermalConductivity.FromWattsPerMeterKelvin(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToThermalResistanceExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToThermalResistanceExtensions.g.cs
@@ -47,170 +47,50 @@ namespace UnitsNet.Extensions.NumberToThermalResistance
         #region HourSquareFeetDegreeFahrenheitPerBtu
 
         /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance HourSquareFeetDegreesFahrenheitPerBtu(this int value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
+        public static ThermalResistance HourSquareFeetDegreesFahrenheitPerBtu<T>(this T value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? HourSquareFeetDegreesFahrenheitPerBtu(this int? value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance HourSquareFeetDegreesFahrenheitPerBtu(this long value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? HourSquareFeetDegreesFahrenheitPerBtu(this long? value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance HourSquareFeetDegreesFahrenheitPerBtu(this double value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? HourSquareFeetDegreesFahrenheitPerBtu(this double? value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance HourSquareFeetDegreesFahrenheitPerBtu(this float value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? HourSquareFeetDegreesFahrenheitPerBtu(this float? value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance HourSquareFeetDegreesFahrenheitPerBtu(this decimal value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? HourSquareFeetDegreesFahrenheitPerBtu(this decimal? value) => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalResistance? HourSquareFeetDegreesFahrenheitPerBtu<T>(this T? value) where T : struct => ThermalResistance.FromHourSquareFeetDegreesFahrenheitPerBtu(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareCentimeterHourDegreeCelsiusPerKilocalorie
 
         /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterHourDegreesCelsiusPerKilocalorie(this int value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
+        public static ThermalResistance SquareCentimeterHourDegreesCelsiusPerKilocalorie<T>(this T value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterHourDegreesCelsiusPerKilocalorie(this int? value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterHourDegreesCelsiusPerKilocalorie(this long value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterHourDegreesCelsiusPerKilocalorie(this long? value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterHourDegreesCelsiusPerKilocalorie(this double value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterHourDegreesCelsiusPerKilocalorie(this double? value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterHourDegreesCelsiusPerKilocalorie(this float value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterHourDegreesCelsiusPerKilocalorie(this float? value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterHourDegreesCelsiusPerKilocalorie(this decimal value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterHourDegreesCelsiusPerKilocalorie(this decimal? value) => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalResistance? SquareCentimeterHourDegreesCelsiusPerKilocalorie<T>(this T? value) where T : struct => ThermalResistance.FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareCentimeterKelvinPerWatt
 
         /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterKelvinsPerWatt(this int value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
+        public static ThermalResistance SquareCentimeterKelvinsPerWatt<T>(this T value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterKelvinsPerWatt(this int? value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterKelvinsPerWatt(this long value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterKelvinsPerWatt(this long? value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterKelvinsPerWatt(this double value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterKelvinsPerWatt(this double? value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterKelvinsPerWatt(this float value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterKelvinsPerWatt(this float? value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareCentimeterKelvinsPerWatt(this decimal value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareCentimeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareCentimeterKelvinsPerWatt(this decimal? value) => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalResistance? SquareCentimeterKelvinsPerWatt<T>(this T? value) where T : struct => ThermalResistance.FromSquareCentimeterKelvinsPerWatt(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMeterDegreeCelsiusPerWatt
 
         /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterDegreesCelsiusPerWatt(this int value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
+        public static ThermalResistance SquareMeterDegreesCelsiusPerWatt<T>(this T value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterDegreesCelsiusPerWatt(this int? value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterDegreesCelsiusPerWatt(this long value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterDegreesCelsiusPerWatt(this long? value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterDegreesCelsiusPerWatt(this double value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterDegreesCelsiusPerWatt(this double? value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterDegreesCelsiusPerWatt(this float value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterDegreesCelsiusPerWatt(this float? value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterDegreesCelsiusPerWatt(this decimal value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterDegreesCelsiusPerWatt(this decimal? value) => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalResistance? SquareMeterDegreesCelsiusPerWatt<T>(this T? value) where T : struct => ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region SquareMeterKelvinPerKilowatt
 
         /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterKelvinsPerKilowatt(this int value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
+        public static ThermalResistance SquareMeterKelvinsPerKilowatt<T>(this T value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(Convert.ToDouble(value));
 
         /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterKelvinsPerKilowatt(this int? value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterKelvinsPerKilowatt(this long value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterKelvinsPerKilowatt(this long? value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterKelvinsPerKilowatt(this double value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterKelvinsPerKilowatt(this double? value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterKelvinsPerKilowatt(this float value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterKelvinsPerKilowatt(this float? value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value);
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance SquareMeterKelvinsPerKilowatt(this decimal value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerKilowatt(UnitsNet.QuantityValue)" />
-        public static ThermalResistance? SquareMeterKelvinsPerKilowatt(this decimal? value) => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static ThermalResistance? SquareMeterKelvinsPerKilowatt<T>(this T? value) where T : struct => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToTorqueExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToTorqueExtensions.g.cs
@@ -47,714 +47,210 @@ namespace UnitsNet.Extensions.NumberToTorque
         #region KilogramForceCentimeter
 
         /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceCentimeters(this int value) => Torque.FromKilogramForceCentimeters(value);
+        public static Torque KilogramForceCentimeters<T>(this T value) => Torque.FromKilogramForceCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceCentimeters(this int? value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceCentimeters(this long value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceCentimeters(this long? value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceCentimeters(this double value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceCentimeters(this double? value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceCentimeters(this float value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceCentimeters(this float? value) => Torque.FromKilogramForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceCentimeters(this decimal value) => Torque.FromKilogramForceCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilogramForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceCentimeters(this decimal? value) => Torque.FromKilogramForceCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilogramForceCentimeters<T>(this T? value) where T : struct => Torque.FromKilogramForceCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForceMeter
 
         /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMeters(this int value) => Torque.FromKilogramForceMeters(value);
+        public static Torque KilogramForceMeters<T>(this T value) => Torque.FromKilogramForceMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMeters(this int? value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMeters(this long value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMeters(this long? value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMeters(this double value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMeters(this double? value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMeters(this float value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMeters(this float? value) => Torque.FromKilogramForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMeters(this decimal value) => Torque.FromKilogramForceMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMeters(this decimal? value) => Torque.FromKilogramForceMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilogramForceMeters<T>(this T? value) where T : struct => Torque.FromKilogramForceMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilogramForceMillimeter
 
         /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMillimeters(this int value) => Torque.FromKilogramForceMillimeters(value);
+        public static Torque KilogramForceMillimeters<T>(this T value) => Torque.FromKilogramForceMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMillimeters(this int? value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMillimeters(this long value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMillimeters(this long? value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMillimeters(this double value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMillimeters(this double? value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMillimeters(this float value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMillimeters(this float? value) => Torque.FromKilogramForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilogramForceMillimeters(this decimal value) => Torque.FromKilogramForceMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilogramForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilogramForceMillimeters(this decimal? value) => Torque.FromKilogramForceMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilogramForceMillimeters<T>(this T? value) where T : struct => Torque.FromKilogramForceMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonCentimeter
 
         /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonCentimeters(this int value) => Torque.FromKilonewtonCentimeters(value);
+        public static Torque KilonewtonCentimeters<T>(this T value) => Torque.FromKilonewtonCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonCentimeters(this int? value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonCentimeters(this long value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonCentimeters(this long? value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonCentimeters(this double value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonCentimeters(this double? value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonCentimeters(this float value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonCentimeters(this float? value) => Torque.FromKilonewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonCentimeters(this decimal value) => Torque.FromKilonewtonCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilonewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonCentimeters(this decimal? value) => Torque.FromKilonewtonCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilonewtonCentimeters<T>(this T? value) where T : struct => Torque.FromKilonewtonCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonMeter
 
         /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMeters(this int value) => Torque.FromKilonewtonMeters(value);
+        public static Torque KilonewtonMeters<T>(this T value) => Torque.FromKilonewtonMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMeters(this int? value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMeters(this long value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMeters(this long? value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMeters(this double value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMeters(this double? value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMeters(this float value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMeters(this float? value) => Torque.FromKilonewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMeters(this decimal value) => Torque.FromKilonewtonMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMeters(this decimal? value) => Torque.FromKilonewtonMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilonewtonMeters<T>(this T? value) where T : struct => Torque.FromKilonewtonMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilonewtonMillimeter
 
         /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMillimeters(this int value) => Torque.FromKilonewtonMillimeters(value);
+        public static Torque KilonewtonMillimeters<T>(this T value) => Torque.FromKilonewtonMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMillimeters(this int? value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMillimeters(this long value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMillimeters(this long? value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMillimeters(this double value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMillimeters(this double? value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMillimeters(this float value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMillimeters(this float? value) => Torque.FromKilonewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque KilonewtonMillimeters(this decimal value) => Torque.FromKilonewtonMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilonewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? KilonewtonMillimeters(this decimal? value) => Torque.FromKilonewtonMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilonewtonMillimeters<T>(this T? value) where T : struct => Torque.FromKilonewtonMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundForceFoot
 
         /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceFeet(this int value) => Torque.FromKilopoundForceFeet(value);
+        public static Torque KilopoundForceFeet<T>(this T value) => Torque.FromKilopoundForceFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceFeet(this int? value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceFeet(this long value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceFeet(this long? value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceFeet(this double value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceFeet(this double? value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceFeet(this float value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceFeet(this float? value) => Torque.FromKilopoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceFeet(this decimal value) => Torque.FromKilopoundForceFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceFeet(this decimal? value) => Torque.FromKilopoundForceFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilopoundForceFeet<T>(this T? value) where T : struct => Torque.FromKilopoundForceFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilopoundForceInch
 
         /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceInches(this int value) => Torque.FromKilopoundForceInches(value);
+        public static Torque KilopoundForceInches<T>(this T value) => Torque.FromKilopoundForceInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceInches(this int? value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceInches(this long value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceInches(this long? value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceInches(this double value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceInches(this double? value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceInches(this float value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceInches(this float? value) => Torque.FromKilopoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque KilopoundForceInches(this decimal value) => Torque.FromKilopoundForceInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromKilopoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? KilopoundForceInches(this decimal? value) => Torque.FromKilopoundForceInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? KilopoundForceInches<T>(this T? value) where T : struct => Torque.FromKilopoundForceInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonCentimeter
 
         /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonCentimeters(this int value) => Torque.FromMeganewtonCentimeters(value);
+        public static Torque MeganewtonCentimeters<T>(this T value) => Torque.FromMeganewtonCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonCentimeters(this int? value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonCentimeters(this long value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonCentimeters(this long? value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonCentimeters(this double value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonCentimeters(this double? value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonCentimeters(this float value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonCentimeters(this float? value) => Torque.FromMeganewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonCentimeters(this decimal value) => Torque.FromMeganewtonCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromMeganewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonCentimeters(this decimal? value) => Torque.FromMeganewtonCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? MeganewtonCentimeters<T>(this T? value) where T : struct => Torque.FromMeganewtonCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonMeter
 
         /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMeters(this int value) => Torque.FromMeganewtonMeters(value);
+        public static Torque MeganewtonMeters<T>(this T value) => Torque.FromMeganewtonMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMeters(this int? value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMeters(this long value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMeters(this long? value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMeters(this double value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMeters(this double? value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMeters(this float value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMeters(this float? value) => Torque.FromMeganewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMeters(this decimal value) => Torque.FromMeganewtonMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMeters(this decimal? value) => Torque.FromMeganewtonMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? MeganewtonMeters<T>(this T? value) where T : struct => Torque.FromMeganewtonMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MeganewtonMillimeter
 
         /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMillimeters(this int value) => Torque.FromMeganewtonMillimeters(value);
+        public static Torque MeganewtonMillimeters<T>(this T value) => Torque.FromMeganewtonMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMillimeters(this int? value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMillimeters(this long value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMillimeters(this long? value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMillimeters(this double value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMillimeters(this double? value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMillimeters(this float value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMillimeters(this float? value) => Torque.FromMeganewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque MeganewtonMillimeters(this decimal value) => Torque.FromMeganewtonMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromMeganewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? MeganewtonMillimeters(this decimal? value) => Torque.FromMeganewtonMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? MeganewtonMillimeters<T>(this T? value) where T : struct => Torque.FromMeganewtonMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegapoundForceFoot
 
         /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceFeet(this int value) => Torque.FromMegapoundForceFeet(value);
+        public static Torque MegapoundForceFeet<T>(this T value) => Torque.FromMegapoundForceFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceFeet(this int? value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceFeet(this long value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceFeet(this long? value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceFeet(this double value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceFeet(this double? value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceFeet(this float value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceFeet(this float? value) => Torque.FromMegapoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceFeet(this decimal value) => Torque.FromMegapoundForceFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceFeet(this decimal? value) => Torque.FromMegapoundForceFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? MegapoundForceFeet<T>(this T? value) where T : struct => Torque.FromMegapoundForceFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegapoundForceInch
 
         /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceInches(this int value) => Torque.FromMegapoundForceInches(value);
+        public static Torque MegapoundForceInches<T>(this T value) => Torque.FromMegapoundForceInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceInches(this int? value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceInches(this long value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceInches(this long? value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceInches(this double value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceInches(this double? value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceInches(this float value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceInches(this float? value) => Torque.FromMegapoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque MegapoundForceInches(this decimal value) => Torque.FromMegapoundForceInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromMegapoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? MegapoundForceInches(this decimal? value) => Torque.FromMegapoundForceInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? MegapoundForceInches<T>(this T? value) where T : struct => Torque.FromMegapoundForceInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonCentimeter
 
         /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonCentimeters(this int value) => Torque.FromNewtonCentimeters(value);
+        public static Torque NewtonCentimeters<T>(this T value) => Torque.FromNewtonCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonCentimeters(this int? value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonCentimeters(this long value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonCentimeters(this long? value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonCentimeters(this double value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonCentimeters(this double? value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonCentimeters(this float value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonCentimeters(this float? value) => Torque.FromNewtonCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonCentimeters(this decimal value) => Torque.FromNewtonCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromNewtonCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonCentimeters(this decimal? value) => Torque.FromNewtonCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? NewtonCentimeters<T>(this T? value) where T : struct => Torque.FromNewtonCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonMeter
 
         /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMeters(this int value) => Torque.FromNewtonMeters(value);
+        public static Torque NewtonMeters<T>(this T value) => Torque.FromNewtonMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMeters(this int? value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMeters(this long value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMeters(this long? value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMeters(this double value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMeters(this double? value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMeters(this float value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMeters(this float? value) => Torque.FromNewtonMeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMeters(this decimal value) => Torque.FromNewtonMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromNewtonMeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMeters(this decimal? value) => Torque.FromNewtonMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? NewtonMeters<T>(this T? value) where T : struct => Torque.FromNewtonMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NewtonMillimeter
 
         /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMillimeters(this int value) => Torque.FromNewtonMillimeters(value);
+        public static Torque NewtonMillimeters<T>(this T value) => Torque.FromNewtonMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMillimeters(this int? value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMillimeters(this long value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMillimeters(this long? value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMillimeters(this double value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMillimeters(this double? value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMillimeters(this float value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMillimeters(this float? value) => Torque.FromNewtonMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque NewtonMillimeters(this decimal value) => Torque.FromNewtonMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromNewtonMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? NewtonMillimeters(this decimal? value) => Torque.FromNewtonMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? NewtonMillimeters<T>(this T? value) where T : struct => Torque.FromNewtonMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForceFoot
 
         /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceFeet(this int value) => Torque.FromPoundForceFeet(value);
+        public static Torque PoundForceFeet<T>(this T value) => Torque.FromPoundForceFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceFeet(this int? value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceFeet(this long value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceFeet(this long? value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceFeet(this double value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceFeet(this double? value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceFeet(this float value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceFeet(this float? value) => Torque.FromPoundForceFeet(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceFeet(this decimal value) => Torque.FromPoundForceFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromPoundForceFeet(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceFeet(this decimal? value) => Torque.FromPoundForceFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? PoundForceFeet<T>(this T? value) where T : struct => Torque.FromPoundForceFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region PoundForceInch
 
         /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceInches(this int value) => Torque.FromPoundForceInches(value);
+        public static Torque PoundForceInches<T>(this T value) => Torque.FromPoundForceInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceInches(this int? value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceInches(this long value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceInches(this long? value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceInches(this double value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceInches(this double? value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceInches(this float value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceInches(this float? value) => Torque.FromPoundForceInches(value);
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque PoundForceInches(this decimal value) => Torque.FromPoundForceInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromPoundForceInches(UnitsNet.QuantityValue)" />
-        public static Torque? PoundForceInches(this decimal? value) => Torque.FromPoundForceInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? PoundForceInches<T>(this T? value) where T : struct => Torque.FromPoundForceInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForceCentimeter
 
         /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceCentimeters(this int value) => Torque.FromTonneForceCentimeters(value);
+        public static Torque TonneForceCentimeters<T>(this T value) => Torque.FromTonneForceCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceCentimeters(this int? value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceCentimeters(this long value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceCentimeters(this long? value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceCentimeters(this double value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceCentimeters(this double? value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceCentimeters(this float value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceCentimeters(this float? value) => Torque.FromTonneForceCentimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceCentimeters(this decimal value) => Torque.FromTonneForceCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromTonneForceCentimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceCentimeters(this decimal? value) => Torque.FromTonneForceCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? TonneForceCentimeters<T>(this T? value) where T : struct => Torque.FromTonneForceCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForceMeter
 
         /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMeters(this int value) => Torque.FromTonneForceMeters(value);
+        public static Torque TonneForceMeters<T>(this T value) => Torque.FromTonneForceMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMeters(this int? value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMeters(this long value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMeters(this long? value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMeters(this double value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMeters(this double? value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMeters(this float value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMeters(this float? value) => Torque.FromTonneForceMeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMeters(this decimal value) => Torque.FromTonneForceMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromTonneForceMeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMeters(this decimal? value) => Torque.FromTonneForceMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? TonneForceMeters<T>(this T? value) where T : struct => Torque.FromTonneForceMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region TonneForceMillimeter
 
         /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMillimeters(this int value) => Torque.FromTonneForceMillimeters(value);
+        public static Torque TonneForceMillimeters<T>(this T value) => Torque.FromTonneForceMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMillimeters(this int? value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMillimeters(this long value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMillimeters(this long? value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMillimeters(this double value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMillimeters(this double? value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMillimeters(this float value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMillimeters(this float? value) => Torque.FromTonneForceMillimeters(value);
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque TonneForceMillimeters(this decimal value) => Torque.FromTonneForceMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Torque.FromTonneForceMillimeters(UnitsNet.QuantityValue)" />
-        public static Torque? TonneForceMillimeters(this decimal? value) => Torque.FromTonneForceMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Torque? TonneForceMillimeters<T>(this T? value) where T : struct => Torque.FromTonneForceMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToVitaminAExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToVitaminAExtensions.g.cs
@@ -47,34 +47,10 @@ namespace UnitsNet.Extensions.NumberToVitaminA
         #region InternationalUnit
 
         /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA InternationalUnits(this int value) => VitaminA.FromInternationalUnits(value);
+        public static VitaminA InternationalUnits<T>(this T value) => VitaminA.FromInternationalUnits(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA? InternationalUnits(this int? value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA InternationalUnits(this long value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA? InternationalUnits(this long? value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA InternationalUnits(this double value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA? InternationalUnits(this double? value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA InternationalUnits(this float value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA? InternationalUnits(this float? value) => VitaminA.FromInternationalUnits(value);
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA InternationalUnits(this decimal value) => VitaminA.FromInternationalUnits(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VitaminA.FromInternationalUnits(UnitsNet.QuantityValue)" />
-        public static VitaminA? InternationalUnits(this decimal? value) => VitaminA.FromInternationalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VitaminA? InternationalUnits<T>(this T? value) where T : struct => VitaminA.FromInternationalUnits(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeExtensions.g.cs
@@ -47,1496 +47,440 @@ namespace UnitsNet.Extensions.NumberToVolume
         #region AuTablespoon
 
         /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume AuTablespoons(this int value) => Volume.FromAuTablespoons(value);
+        public static Volume AuTablespoons<T>(this T value) => Volume.FromAuTablespoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? AuTablespoons(this int? value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume AuTablespoons(this long value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? AuTablespoons(this long? value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume AuTablespoons(this double value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? AuTablespoons(this double? value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume AuTablespoons(this float value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? AuTablespoons(this float? value) => Volume.FromAuTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume AuTablespoons(this decimal value) => Volume.FromAuTablespoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromAuTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? AuTablespoons(this decimal? value) => Volume.FromAuTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? AuTablespoons<T>(this T? value) where T : struct => Volume.FromAuTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Centiliter
 
         /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume Centiliters(this int value) => Volume.FromCentiliters(value);
+        public static Volume Centiliters<T>(this T value) => Volume.FromCentiliters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume? Centiliters(this int? value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume Centiliters(this long value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume? Centiliters(this long? value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume Centiliters(this double value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume? Centiliters(this double? value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume Centiliters(this float value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume? Centiliters(this float? value) => Volume.FromCentiliters(value);
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume Centiliters(this decimal value) => Volume.FromCentiliters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCentiliters(UnitsNet.QuantityValue)" />
-        public static Volume? Centiliters(this decimal? value) => Volume.FromCentiliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Centiliters<T>(this T? value) where T : struct => Volume.FromCentiliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicCentimeter
 
         /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicCentimeters(this int value) => Volume.FromCubicCentimeters(value);
+        public static Volume CubicCentimeters<T>(this T value) => Volume.FromCubicCentimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicCentimeters(this int? value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicCentimeters(this long value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicCentimeters(this long? value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicCentimeters(this double value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicCentimeters(this double? value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicCentimeters(this float value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicCentimeters(this float? value) => Volume.FromCubicCentimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicCentimeters(this decimal value) => Volume.FromCubicCentimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicCentimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicCentimeters(this decimal? value) => Volume.FromCubicCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicCentimeters<T>(this T? value) where T : struct => Volume.FromCubicCentimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicDecimeter
 
         /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicDecimeters(this int value) => Volume.FromCubicDecimeters(value);
+        public static Volume CubicDecimeters<T>(this T value) => Volume.FromCubicDecimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicDecimeters(this int? value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicDecimeters(this long value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicDecimeters(this long? value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicDecimeters(this double value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicDecimeters(this double? value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicDecimeters(this float value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicDecimeters(this float? value) => Volume.FromCubicDecimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicDecimeters(this decimal value) => Volume.FromCubicDecimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicDecimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicDecimeters(this decimal? value) => Volume.FromCubicDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicDecimeters<T>(this T? value) where T : struct => Volume.FromCubicDecimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFoot
 
         /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume CubicFeet(this int value) => Volume.FromCubicFeet(value);
+        public static Volume CubicFeet<T>(this T value) => Volume.FromCubicFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? CubicFeet(this int? value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume CubicFeet(this long value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? CubicFeet(this long? value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume CubicFeet(this double value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? CubicFeet(this double? value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume CubicFeet(this float value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? CubicFeet(this float? value) => Volume.FromCubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume CubicFeet(this decimal value) => Volume.FromCubicFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? CubicFeet(this decimal? value) => Volume.FromCubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicFeet<T>(this T? value) where T : struct => Volume.FromCubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicInch
 
         /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume CubicInches(this int value) => Volume.FromCubicInches(value);
+        public static Volume CubicInches<T>(this T value) => Volume.FromCubicInches(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume? CubicInches(this int? value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume CubicInches(this long value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume? CubicInches(this long? value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume CubicInches(this double value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume? CubicInches(this double? value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume CubicInches(this float value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume? CubicInches(this float? value) => Volume.FromCubicInches(value);
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume CubicInches(this decimal value) => Volume.FromCubicInches(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicInches(UnitsNet.QuantityValue)" />
-        public static Volume? CubicInches(this decimal? value) => Volume.FromCubicInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicInches<T>(this T? value) where T : struct => Volume.FromCubicInches(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicKilometer
 
         /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicKilometers(this int value) => Volume.FromCubicKilometers(value);
+        public static Volume CubicKilometers<T>(this T value) => Volume.FromCubicKilometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicKilometers(this int? value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicKilometers(this long value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicKilometers(this long? value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicKilometers(this double value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicKilometers(this double? value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicKilometers(this float value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicKilometers(this float? value) => Volume.FromCubicKilometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicKilometers(this decimal value) => Volume.FromCubicKilometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicKilometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicKilometers(this decimal? value) => Volume.FromCubicKilometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicKilometers<T>(this T? value) where T : struct => Volume.FromCubicKilometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeter
 
         /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMeters(this int value) => Volume.FromCubicMeters(value);
+        public static Volume CubicMeters<T>(this T value) => Volume.FromCubicMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMeters(this int? value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMeters(this long value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMeters(this long? value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMeters(this double value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMeters(this double? value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMeters(this float value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMeters(this float? value) => Volume.FromCubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMeters(this decimal value) => Volume.FromCubicMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMeters(this decimal? value) => Volume.FromCubicMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicMeters<T>(this T? value) where T : struct => Volume.FromCubicMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMicrometer
 
         /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicMicrometers(this int value) => Volume.FromCubicMicrometers(value);
+        public static Volume CubicMicrometers<T>(this T value) => Volume.FromCubicMicrometers(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMicrometers(this int? value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicMicrometers(this long value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMicrometers(this long? value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicMicrometers(this double value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMicrometers(this double? value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicMicrometers(this float value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMicrometers(this float? value) => Volume.FromCubicMicrometers(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume CubicMicrometers(this decimal value) => Volume.FromCubicMicrometers(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicMicrometers(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMicrometers(this decimal? value) => Volume.FromCubicMicrometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicMicrometers<T>(this T? value) where T : struct => Volume.FromCubicMicrometers(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMile
 
         /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume CubicMiles(this int value) => Volume.FromCubicMiles(value);
+        public static Volume CubicMiles<T>(this T value) => Volume.FromCubicMiles(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMiles(this int? value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume CubicMiles(this long value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMiles(this long? value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume CubicMiles(this double value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMiles(this double? value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume CubicMiles(this float value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMiles(this float? value) => Volume.FromCubicMiles(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume CubicMiles(this decimal value) => Volume.FromCubicMiles(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicMiles(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMiles(this decimal? value) => Volume.FromCubicMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicMiles<T>(this T? value) where T : struct => Volume.FromCubicMiles(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMillimeter
 
         /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMillimeters(this int value) => Volume.FromCubicMillimeters(value);
+        public static Volume CubicMillimeters<T>(this T value) => Volume.FromCubicMillimeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMillimeters(this int? value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMillimeters(this long value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMillimeters(this long? value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMillimeters(this double value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMillimeters(this double? value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMillimeters(this float value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMillimeters(this float? value) => Volume.FromCubicMillimeters(value);
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume CubicMillimeters(this decimal value) => Volume.FromCubicMillimeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicMillimeters(UnitsNet.QuantityValue)" />
-        public static Volume? CubicMillimeters(this decimal? value) => Volume.FromCubicMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicMillimeters<T>(this T? value) where T : struct => Volume.FromCubicMillimeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYard
 
         /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume CubicYards(this int value) => Volume.FromCubicYards(value);
+        public static Volume CubicYards<T>(this T value) => Volume.FromCubicYards(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume? CubicYards(this int? value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume CubicYards(this long value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume? CubicYards(this long? value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume CubicYards(this double value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume? CubicYards(this double? value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume CubicYards(this float value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume? CubicYards(this float? value) => Volume.FromCubicYards(value);
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume CubicYards(this decimal value) => Volume.FromCubicYards(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromCubicYards(UnitsNet.QuantityValue)" />
-        public static Volume? CubicYards(this decimal? value) => Volume.FromCubicYards(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? CubicYards<T>(this T? value) where T : struct => Volume.FromCubicYards(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Deciliter
 
         /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume Deciliters(this int value) => Volume.FromDeciliters(value);
+        public static Volume Deciliters<T>(this T value) => Volume.FromDeciliters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume? Deciliters(this int? value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume Deciliters(this long value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume? Deciliters(this long? value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume Deciliters(this double value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume? Deciliters(this double? value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume Deciliters(this float value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume? Deciliters(this float? value) => Volume.FromDeciliters(value);
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume Deciliters(this decimal value) => Volume.FromDeciliters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromDeciliters(UnitsNet.QuantityValue)" />
-        public static Volume? Deciliters(this decimal? value) => Volume.FromDeciliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Deciliters<T>(this T? value) where T : struct => Volume.FromDeciliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region HectocubicFoot
 
         /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicFeet(this int value) => Volume.FromHectocubicFeet(value);
+        public static Volume HectocubicFeet<T>(this T value) => Volume.FromHectocubicFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicFeet(this int? value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicFeet(this long value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicFeet(this long? value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicFeet(this double value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicFeet(this double? value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicFeet(this float value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicFeet(this float? value) => Volume.FromHectocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicFeet(this decimal value) => Volume.FromHectocubicFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromHectocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicFeet(this decimal? value) => Volume.FromHectocubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? HectocubicFeet<T>(this T? value) where T : struct => Volume.FromHectocubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region HectocubicMeter
 
         /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicMeters(this int value) => Volume.FromHectocubicMeters(value);
+        public static Volume HectocubicMeters<T>(this T value) => Volume.FromHectocubicMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicMeters(this int? value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicMeters(this long value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicMeters(this long? value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicMeters(this double value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicMeters(this double? value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicMeters(this float value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicMeters(this float? value) => Volume.FromHectocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume HectocubicMeters(this decimal value) => Volume.FromHectocubicMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromHectocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? HectocubicMeters(this decimal? value) => Volume.FromHectocubicMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? HectocubicMeters<T>(this T? value) where T : struct => Volume.FromHectocubicMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Hectoliter
 
         /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume Hectoliters(this int value) => Volume.FromHectoliters(value);
+        public static Volume Hectoliters<T>(this T value) => Volume.FromHectoliters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume? Hectoliters(this int? value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume Hectoliters(this long value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume? Hectoliters(this long? value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume Hectoliters(this double value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume? Hectoliters(this double? value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume Hectoliters(this float value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume? Hectoliters(this float? value) => Volume.FromHectoliters(value);
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume Hectoliters(this decimal value) => Volume.FromHectoliters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromHectoliters(UnitsNet.QuantityValue)" />
-        public static Volume? Hectoliters(this decimal? value) => Volume.FromHectoliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Hectoliters<T>(this T? value) where T : struct => Volume.FromHectoliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ImperialBeerBarrel
 
         /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume ImperialBeerBarrels(this int value) => Volume.FromImperialBeerBarrels(value);
+        public static Volume ImperialBeerBarrels<T>(this T value) => Volume.FromImperialBeerBarrels(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialBeerBarrels(this int? value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume ImperialBeerBarrels(this long value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialBeerBarrels(this long? value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume ImperialBeerBarrels(this double value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialBeerBarrels(this double? value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume ImperialBeerBarrels(this float value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialBeerBarrels(this float? value) => Volume.FromImperialBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume ImperialBeerBarrels(this decimal value) => Volume.FromImperialBeerBarrels(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialBeerBarrels(this decimal? value) => Volume.FromImperialBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? ImperialBeerBarrels<T>(this T? value) where T : struct => Volume.FromImperialBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ImperialGallon
 
         /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume ImperialGallons(this int value) => Volume.FromImperialGallons(value);
+        public static Volume ImperialGallons<T>(this T value) => Volume.FromImperialGallons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialGallons(this int? value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume ImperialGallons(this long value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialGallons(this long? value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume ImperialGallons(this double value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialGallons(this double? value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume ImperialGallons(this float value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialGallons(this float? value) => Volume.FromImperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume ImperialGallons(this decimal value) => Volume.FromImperialGallons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromImperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialGallons(this decimal? value) => Volume.FromImperialGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? ImperialGallons<T>(this T? value) where T : struct => Volume.FromImperialGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region ImperialOunce
 
         /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume ImperialOunces(this int value) => Volume.FromImperialOunces(value);
+        public static Volume ImperialOunces<T>(this T value) => Volume.FromImperialOunces(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialOunces(this int? value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume ImperialOunces(this long value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialOunces(this long? value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume ImperialOunces(this double value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialOunces(this double? value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume ImperialOunces(this float value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialOunces(this float? value) => Volume.FromImperialOunces(value);
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume ImperialOunces(this decimal value) => Volume.FromImperialOunces(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromImperialOunces(UnitsNet.QuantityValue)" />
-        public static Volume? ImperialOunces(this decimal? value) => Volume.FromImperialOunces(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? ImperialOunces<T>(this T? value) where T : struct => Volume.FromImperialOunces(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocubicFoot
 
         /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicFeet(this int value) => Volume.FromKilocubicFeet(value);
+        public static Volume KilocubicFeet<T>(this T value) => Volume.FromKilocubicFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicFeet(this int? value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicFeet(this long value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicFeet(this long? value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicFeet(this double value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicFeet(this double? value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicFeet(this float value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicFeet(this float? value) => Volume.FromKilocubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicFeet(this decimal value) => Volume.FromKilocubicFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromKilocubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicFeet(this decimal? value) => Volume.FromKilocubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? KilocubicFeet<T>(this T? value) where T : struct => Volume.FromKilocubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilocubicMeter
 
         /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicMeters(this int value) => Volume.FromKilocubicMeters(value);
+        public static Volume KilocubicMeters<T>(this T value) => Volume.FromKilocubicMeters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicMeters(this int? value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicMeters(this long value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicMeters(this long? value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicMeters(this double value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicMeters(this double? value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicMeters(this float value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicMeters(this float? value) => Volume.FromKilocubicMeters(value);
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume KilocubicMeters(this decimal value) => Volume.FromKilocubicMeters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromKilocubicMeters(UnitsNet.QuantityValue)" />
-        public static Volume? KilocubicMeters(this decimal? value) => Volume.FromKilocubicMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? KilocubicMeters<T>(this T? value) where T : struct => Volume.FromKilocubicMeters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KiloimperialGallon
 
         /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume KiloimperialGallons(this int value) => Volume.FromKiloimperialGallons(value);
+        public static Volume KiloimperialGallons<T>(this T value) => Volume.FromKiloimperialGallons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KiloimperialGallons(this int? value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume KiloimperialGallons(this long value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KiloimperialGallons(this long? value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume KiloimperialGallons(this double value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KiloimperialGallons(this double? value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume KiloimperialGallons(this float value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KiloimperialGallons(this float? value) => Volume.FromKiloimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume KiloimperialGallons(this decimal value) => Volume.FromKiloimperialGallons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromKiloimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KiloimperialGallons(this decimal? value) => Volume.FromKiloimperialGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? KiloimperialGallons<T>(this T? value) where T : struct => Volume.FromKiloimperialGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilousGallon
 
         /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume KilousGallons(this int value) => Volume.FromKilousGallons(value);
+        public static Volume KilousGallons<T>(this T value) => Volume.FromKilousGallons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KilousGallons(this int? value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume KilousGallons(this long value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KilousGallons(this long? value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume KilousGallons(this double value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KilousGallons(this double? value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume KilousGallons(this float value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KilousGallons(this float? value) => Volume.FromKilousGallons(value);
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume KilousGallons(this decimal value) => Volume.FromKilousGallons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromKilousGallons(UnitsNet.QuantityValue)" />
-        public static Volume? KilousGallons(this decimal? value) => Volume.FromKilousGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? KilousGallons<T>(this T? value) where T : struct => Volume.FromKilousGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Liter
 
         /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume Liters(this int value) => Volume.FromLiters(value);
+        public static Volume Liters<T>(this T value) => Volume.FromLiters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume? Liters(this int? value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume Liters(this long value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume? Liters(this long? value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume Liters(this double value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume? Liters(this double? value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume Liters(this float value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume? Liters(this float? value) => Volume.FromLiters(value);
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume Liters(this decimal value) => Volume.FromLiters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromLiters(UnitsNet.QuantityValue)" />
-        public static Volume? Liters(this decimal? value) => Volume.FromLiters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Liters<T>(this T? value) where T : struct => Volume.FromLiters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegacubicFoot
 
         /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume MegacubicFeet(this int value) => Volume.FromMegacubicFeet(value);
+        public static Volume MegacubicFeet<T>(this T value) => Volume.FromMegacubicFeet(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? MegacubicFeet(this int? value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume MegacubicFeet(this long value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? MegacubicFeet(this long? value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume MegacubicFeet(this double value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? MegacubicFeet(this double? value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume MegacubicFeet(this float value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? MegacubicFeet(this float? value) => Volume.FromMegacubicFeet(value);
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume MegacubicFeet(this decimal value) => Volume.FromMegacubicFeet(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMegacubicFeet(UnitsNet.QuantityValue)" />
-        public static Volume? MegacubicFeet(this decimal? value) => Volume.FromMegacubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? MegacubicFeet<T>(this T? value) where T : struct => Volume.FromMegacubicFeet(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegaimperialGallon
 
         /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegaimperialGallons(this int value) => Volume.FromMegaimperialGallons(value);
+        public static Volume MegaimperialGallons<T>(this T value) => Volume.FromMegaimperialGallons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegaimperialGallons(this int? value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegaimperialGallons(this long value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegaimperialGallons(this long? value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegaimperialGallons(this double value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegaimperialGallons(this double? value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegaimperialGallons(this float value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegaimperialGallons(this float? value) => Volume.FromMegaimperialGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegaimperialGallons(this decimal value) => Volume.FromMegaimperialGallons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMegaimperialGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegaimperialGallons(this decimal? value) => Volume.FromMegaimperialGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? MegaimperialGallons<T>(this T? value) where T : struct => Volume.FromMegaimperialGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MegausGallon
 
         /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegausGallons(this int value) => Volume.FromMegausGallons(value);
+        public static Volume MegausGallons<T>(this T value) => Volume.FromMegausGallons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegausGallons(this int? value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegausGallons(this long value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegausGallons(this long? value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegausGallons(this double value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegausGallons(this double? value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegausGallons(this float value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegausGallons(this float? value) => Volume.FromMegausGallons(value);
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume MegausGallons(this decimal value) => Volume.FromMegausGallons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMegausGallons(UnitsNet.QuantityValue)" />
-        public static Volume? MegausGallons(this decimal? value) => Volume.FromMegausGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? MegausGallons<T>(this T? value) where T : struct => Volume.FromMegausGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MetricCup
 
         /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume MetricCups(this int value) => Volume.FromMetricCups(value);
+        public static Volume MetricCups<T>(this T value) => Volume.FromMetricCups(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume? MetricCups(this int? value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume MetricCups(this long value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume? MetricCups(this long? value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume MetricCups(this double value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume? MetricCups(this double? value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume MetricCups(this float value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume? MetricCups(this float? value) => Volume.FromMetricCups(value);
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume MetricCups(this decimal value) => Volume.FromMetricCups(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMetricCups(UnitsNet.QuantityValue)" />
-        public static Volume? MetricCups(this decimal? value) => Volume.FromMetricCups(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? MetricCups<T>(this T? value) where T : struct => Volume.FromMetricCups(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MetricTeaspoon
 
         /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume MetricTeaspoons(this int value) => Volume.FromMetricTeaspoons(value);
+        public static Volume MetricTeaspoons<T>(this T value) => Volume.FromMetricTeaspoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? MetricTeaspoons(this int? value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume MetricTeaspoons(this long value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? MetricTeaspoons(this long? value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume MetricTeaspoons(this double value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? MetricTeaspoons(this double? value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume MetricTeaspoons(this float value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? MetricTeaspoons(this float? value) => Volume.FromMetricTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume MetricTeaspoons(this decimal value) => Volume.FromMetricTeaspoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMetricTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? MetricTeaspoons(this decimal? value) => Volume.FromMetricTeaspoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? MetricTeaspoons<T>(this T? value) where T : struct => Volume.FromMetricTeaspoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Microliter
 
         /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume Microliters(this int value) => Volume.FromMicroliters(value);
+        public static Volume Microliters<T>(this T value) => Volume.FromMicroliters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume? Microliters(this int? value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume Microliters(this long value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume? Microliters(this long? value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume Microliters(this double value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume? Microliters(this double? value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume Microliters(this float value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume? Microliters(this float? value) => Volume.FromMicroliters(value);
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume Microliters(this decimal value) => Volume.FromMicroliters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMicroliters(UnitsNet.QuantityValue)" />
-        public static Volume? Microliters(this decimal? value) => Volume.FromMicroliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Microliters<T>(this T? value) where T : struct => Volume.FromMicroliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Milliliter
 
         /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume Milliliters(this int value) => Volume.FromMilliliters(value);
+        public static Volume Milliliters<T>(this T value) => Volume.FromMilliliters(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume? Milliliters(this int? value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume Milliliters(this long value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume? Milliliters(this long? value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume Milliliters(this double value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume? Milliliters(this double? value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume Milliliters(this float value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume? Milliliters(this float? value) => Volume.FromMilliliters(value);
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume Milliliters(this decimal value) => Volume.FromMilliliters(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromMilliliters(UnitsNet.QuantityValue)" />
-        public static Volume? Milliliters(this decimal? value) => Volume.FromMilliliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Milliliters<T>(this T? value) where T : struct => Volume.FromMilliliters(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region OilBarrel
 
         /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume OilBarrels(this int value) => Volume.FromOilBarrels(value);
+        public static Volume OilBarrels<T>(this T value) => Volume.FromOilBarrels(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? OilBarrels(this int? value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume OilBarrels(this long value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? OilBarrels(this long? value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume OilBarrels(this double value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? OilBarrels(this double? value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume OilBarrels(this float value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? OilBarrels(this float? value) => Volume.FromOilBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume OilBarrels(this decimal value) => Volume.FromOilBarrels(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromOilBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? OilBarrels(this decimal? value) => Volume.FromOilBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? OilBarrels<T>(this T? value) where T : struct => Volume.FromOilBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Tablespoon
 
         /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume Tablespoons(this int value) => Volume.FromTablespoons(value);
+        public static Volume Tablespoons<T>(this T value) => Volume.FromTablespoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? Tablespoons(this int? value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume Tablespoons(this long value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? Tablespoons(this long? value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume Tablespoons(this double value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? Tablespoons(this double? value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume Tablespoons(this float value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? Tablespoons(this float? value) => Volume.FromTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume Tablespoons(this decimal value) => Volume.FromTablespoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? Tablespoons(this decimal? value) => Volume.FromTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Tablespoons<T>(this T? value) where T : struct => Volume.FromTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region Teaspoon
 
         /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume Teaspoons(this int value) => Volume.FromTeaspoons(value);
+        public static Volume Teaspoons<T>(this T value) => Volume.FromTeaspoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? Teaspoons(this int? value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume Teaspoons(this long value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? Teaspoons(this long? value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume Teaspoons(this double value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? Teaspoons(this double? value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume Teaspoons(this float value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? Teaspoons(this float? value) => Volume.FromTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume Teaspoons(this decimal value) => Volume.FromTeaspoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? Teaspoons(this decimal? value) => Volume.FromTeaspoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? Teaspoons<T>(this T? value) where T : struct => Volume.FromTeaspoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UkTablespoon
 
         /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UkTablespoons(this int value) => Volume.FromUkTablespoons(value);
+        public static Volume UkTablespoons<T>(this T value) => Volume.FromUkTablespoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UkTablespoons(this int? value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UkTablespoons(this long value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UkTablespoons(this long? value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UkTablespoons(this double value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UkTablespoons(this double? value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UkTablespoons(this float value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UkTablespoons(this float? value) => Volume.FromUkTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UkTablespoons(this decimal value) => Volume.FromUkTablespoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUkTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UkTablespoons(this decimal? value) => Volume.FromUkTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UkTablespoons<T>(this T? value) where T : struct => Volume.FromUkTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsBeerBarrel
 
         /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume UsBeerBarrels(this int value) => Volume.FromUsBeerBarrels(value);
+        public static Volume UsBeerBarrels<T>(this T value) => Volume.FromUsBeerBarrels(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? UsBeerBarrels(this int? value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume UsBeerBarrels(this long value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? UsBeerBarrels(this long? value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume UsBeerBarrels(this double value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? UsBeerBarrels(this double? value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume UsBeerBarrels(this float value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? UsBeerBarrels(this float? value) => Volume.FromUsBeerBarrels(value);
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume UsBeerBarrels(this decimal value) => Volume.FromUsBeerBarrels(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsBeerBarrels(UnitsNet.QuantityValue)" />
-        public static Volume? UsBeerBarrels(this decimal? value) => Volume.FromUsBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsBeerBarrels<T>(this T? value) where T : struct => Volume.FromUsBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsCustomaryCup
 
         /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume UsCustomaryCups(this int value) => Volume.FromUsCustomaryCups(value);
+        public static Volume UsCustomaryCups<T>(this T value) => Volume.FromUsCustomaryCups(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsCustomaryCups(this int? value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume UsCustomaryCups(this long value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsCustomaryCups(this long? value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume UsCustomaryCups(this double value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsCustomaryCups(this double? value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume UsCustomaryCups(this float value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsCustomaryCups(this float? value) => Volume.FromUsCustomaryCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume UsCustomaryCups(this decimal value) => Volume.FromUsCustomaryCups(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsCustomaryCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsCustomaryCups(this decimal? value) => Volume.FromUsCustomaryCups(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsCustomaryCups<T>(this T? value) where T : struct => Volume.FromUsCustomaryCups(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallon
 
         /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume UsGallons(this int value) => Volume.FromUsGallons(value);
+        public static Volume UsGallons<T>(this T value) => Volume.FromUsGallons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume? UsGallons(this int? value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume UsGallons(this long value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume? UsGallons(this long? value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume UsGallons(this double value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume? UsGallons(this double? value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume UsGallons(this float value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume? UsGallons(this float? value) => Volume.FromUsGallons(value);
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume UsGallons(this decimal value) => Volume.FromUsGallons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsGallons(UnitsNet.QuantityValue)" />
-        public static Volume? UsGallons(this decimal? value) => Volume.FromUsGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsGallons<T>(this T? value) where T : struct => Volume.FromUsGallons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsLegalCup
 
         /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume UsLegalCups(this int value) => Volume.FromUsLegalCups(value);
+        public static Volume UsLegalCups<T>(this T value) => Volume.FromUsLegalCups(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsLegalCups(this int? value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume UsLegalCups(this long value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsLegalCups(this long? value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume UsLegalCups(this double value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsLegalCups(this double? value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume UsLegalCups(this float value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsLegalCups(this float? value) => Volume.FromUsLegalCups(value);
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume UsLegalCups(this decimal value) => Volume.FromUsLegalCups(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsLegalCups(UnitsNet.QuantityValue)" />
-        public static Volume? UsLegalCups(this decimal? value) => Volume.FromUsLegalCups(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsLegalCups<T>(this T? value) where T : struct => Volume.FromUsLegalCups(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsOunce
 
         /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume UsOunces(this int value) => Volume.FromUsOunces(value);
+        public static Volume UsOunces<T>(this T value) => Volume.FromUsOunces(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume? UsOunces(this int? value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume UsOunces(this long value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume? UsOunces(this long? value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume UsOunces(this double value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume? UsOunces(this double? value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume UsOunces(this float value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume? UsOunces(this float? value) => Volume.FromUsOunces(value);
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume UsOunces(this decimal value) => Volume.FromUsOunces(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsOunces(UnitsNet.QuantityValue)" />
-        public static Volume? UsOunces(this decimal? value) => Volume.FromUsOunces(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsOunces<T>(this T? value) where T : struct => Volume.FromUsOunces(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsPint
 
         /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume UsPints(this int value) => Volume.FromUsPints(value);
+        public static Volume UsPints<T>(this T value) => Volume.FromUsPints(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume? UsPints(this int? value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume UsPints(this long value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume? UsPints(this long? value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume UsPints(this double value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume? UsPints(this double? value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume UsPints(this float value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume? UsPints(this float? value) => Volume.FromUsPints(value);
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume UsPints(this decimal value) => Volume.FromUsPints(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsPints(UnitsNet.QuantityValue)" />
-        public static Volume? UsPints(this decimal? value) => Volume.FromUsPints(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsPints<T>(this T? value) where T : struct => Volume.FromUsPints(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsQuart
 
         /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume UsQuarts(this int value) => Volume.FromUsQuarts(value);
+        public static Volume UsQuarts<T>(this T value) => Volume.FromUsQuarts(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume? UsQuarts(this int? value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume UsQuarts(this long value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume? UsQuarts(this long? value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume UsQuarts(this double value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume? UsQuarts(this double? value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume UsQuarts(this float value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume? UsQuarts(this float? value) => Volume.FromUsQuarts(value);
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume UsQuarts(this decimal value) => Volume.FromUsQuarts(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsQuarts(UnitsNet.QuantityValue)" />
-        public static Volume? UsQuarts(this decimal? value) => Volume.FromUsQuarts(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsQuarts<T>(this T? value) where T : struct => Volume.FromUsQuarts(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsTablespoon
 
         /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTablespoons(this int value) => Volume.FromUsTablespoons(value);
+        public static Volume UsTablespoons<T>(this T value) => Volume.FromUsTablespoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTablespoons(this int? value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTablespoons(this long value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTablespoons(this long? value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTablespoons(this double value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTablespoons(this double? value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTablespoons(this float value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTablespoons(this float? value) => Volume.FromUsTablespoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTablespoons(this decimal value) => Volume.FromUsTablespoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsTablespoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTablespoons(this decimal? value) => Volume.FromUsTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsTablespoons<T>(this T? value) where T : struct => Volume.FromUsTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsTeaspoon
 
         /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTeaspoons(this int value) => Volume.FromUsTeaspoons(value);
+        public static Volume UsTeaspoons<T>(this T value) => Volume.FromUsTeaspoons(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTeaspoons(this int? value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTeaspoons(this long value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTeaspoons(this long? value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTeaspoons(this double value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTeaspoons(this double? value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTeaspoons(this float value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTeaspoons(this float? value) => Volume.FromUsTeaspoons(value);
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume UsTeaspoons(this decimal value) => Volume.FromUsTeaspoons(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="Volume.FromUsTeaspoons(UnitsNet.QuantityValue)" />
-        public static Volume? UsTeaspoons(this decimal? value) => Volume.FromUsTeaspoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static Volume? UsTeaspoons<T>(this T? value) where T : struct => Volume.FromUsTeaspoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeFlowExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeFlowExtensions.g.cs
@@ -47,884 +47,260 @@ namespace UnitsNet.Extensions.NumberToVolumeFlow
         #region CentilitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CentilitersPerMinute(this int value) => VolumeFlow.FromCentilitersPerMinute(value);
+        public static VolumeFlow CentilitersPerMinute<T>(this T value) => VolumeFlow.FromCentilitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CentilitersPerMinute(this int? value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CentilitersPerMinute(this long value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CentilitersPerMinute(this long? value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CentilitersPerMinute(this double value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CentilitersPerMinute(this double? value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CentilitersPerMinute(this float value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CentilitersPerMinute(this float? value) => VolumeFlow.FromCentilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CentilitersPerMinute(this decimal value) => VolumeFlow.FromCentilitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCentilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CentilitersPerMinute(this decimal? value) => VolumeFlow.FromCentilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CentilitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromCentilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicDecimeterPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicDecimetersPerMinute(this int value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
+        public static VolumeFlow CubicDecimetersPerMinute<T>(this T value) => VolumeFlow.FromCubicDecimetersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicDecimetersPerMinute(this int? value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicDecimetersPerMinute(this long value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicDecimetersPerMinute(this long? value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicDecimetersPerMinute(this double value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicDecimetersPerMinute(this double? value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicDecimetersPerMinute(this float value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicDecimetersPerMinute(this float? value) => VolumeFlow.FromCubicDecimetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicDecimetersPerMinute(this decimal value) => VolumeFlow.FromCubicDecimetersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicDecimetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicDecimetersPerMinute(this decimal? value) => VolumeFlow.FromCubicDecimetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicDecimetersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromCubicDecimetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFootPerHour
 
         /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerHour(this int value) => VolumeFlow.FromCubicFeetPerHour(value);
+        public static VolumeFlow CubicFeetPerHour<T>(this T value) => VolumeFlow.FromCubicFeetPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerHour(this int? value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerHour(this long value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerHour(this long? value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerHour(this double value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerHour(this double? value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerHour(this float value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerHour(this float? value) => VolumeFlow.FromCubicFeetPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerHour(this decimal value) => VolumeFlow.FromCubicFeetPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerHour(this decimal? value) => VolumeFlow.FromCubicFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicFeetPerHour<T>(this T? value) where T : struct => VolumeFlow.FromCubicFeetPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFootPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerMinute(this int value) => VolumeFlow.FromCubicFeetPerMinute(value);
+        public static VolumeFlow CubicFeetPerMinute<T>(this T value) => VolumeFlow.FromCubicFeetPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerMinute(this int? value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerMinute(this long value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerMinute(this long? value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerMinute(this double value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerMinute(this double? value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerMinute(this float value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerMinute(this float? value) => VolumeFlow.FromCubicFeetPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerMinute(this decimal value) => VolumeFlow.FromCubicFeetPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerMinute(this decimal? value) => VolumeFlow.FromCubicFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicFeetPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromCubicFeetPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicFootPerSecond
 
         /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerSecond(this int value) => VolumeFlow.FromCubicFeetPerSecond(value);
+        public static VolumeFlow CubicFeetPerSecond<T>(this T value) => VolumeFlow.FromCubicFeetPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerSecond(this int? value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerSecond(this long value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerSecond(this long? value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerSecond(this double value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerSecond(this double? value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerSecond(this float value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerSecond(this float? value) => VolumeFlow.FromCubicFeetPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicFeetPerSecond(this decimal value) => VolumeFlow.FromCubicFeetPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicFeetPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicFeetPerSecond(this decimal? value) => VolumeFlow.FromCubicFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicFeetPerSecond<T>(this T? value) where T : struct => VolumeFlow.FromCubicFeetPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerHour
 
         /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerHour(this int value) => VolumeFlow.FromCubicMetersPerHour(value);
+        public static VolumeFlow CubicMetersPerHour<T>(this T value) => VolumeFlow.FromCubicMetersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerHour(this int? value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerHour(this long value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerHour(this long? value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerHour(this double value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerHour(this double? value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerHour(this float value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerHour(this float? value) => VolumeFlow.FromCubicMetersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerHour(this decimal value) => VolumeFlow.FromCubicMetersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerHour(this decimal? value) => VolumeFlow.FromCubicMetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicMetersPerHour<T>(this T? value) where T : struct => VolumeFlow.FromCubicMetersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerMinute(this int value) => VolumeFlow.FromCubicMetersPerMinute(value);
+        public static VolumeFlow CubicMetersPerMinute<T>(this T value) => VolumeFlow.FromCubicMetersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerMinute(this int? value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerMinute(this long value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerMinute(this long? value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerMinute(this double value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerMinute(this double? value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerMinute(this float value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerMinute(this float? value) => VolumeFlow.FromCubicMetersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerMinute(this decimal value) => VolumeFlow.FromCubicMetersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerMinute(this decimal? value) => VolumeFlow.FromCubicMetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicMetersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromCubicMetersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicMeterPerSecond
 
         /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerSecond(this int value) => VolumeFlow.FromCubicMetersPerSecond(value);
+        public static VolumeFlow CubicMetersPerSecond<T>(this T value) => VolumeFlow.FromCubicMetersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerSecond(this int? value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerSecond(this long value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerSecond(this long? value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerSecond(this double value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerSecond(this double? value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerSecond(this float value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerSecond(this float? value) => VolumeFlow.FromCubicMetersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicMetersPerSecond(this decimal value) => VolumeFlow.FromCubicMetersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicMetersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicMetersPerSecond(this decimal? value) => VolumeFlow.FromCubicMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicMetersPerSecond<T>(this T? value) where T : struct => VolumeFlow.FromCubicMetersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYardPerHour
 
         /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerHour(this int value) => VolumeFlow.FromCubicYardsPerHour(value);
+        public static VolumeFlow CubicYardsPerHour<T>(this T value) => VolumeFlow.FromCubicYardsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerHour(this int? value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerHour(this long value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerHour(this long? value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerHour(this double value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerHour(this double? value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerHour(this float value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerHour(this float? value) => VolumeFlow.FromCubicYardsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerHour(this decimal value) => VolumeFlow.FromCubicYardsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerHour(this decimal? value) => VolumeFlow.FromCubicYardsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicYardsPerHour<T>(this T? value) where T : struct => VolumeFlow.FromCubicYardsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYardPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerMinute(this int value) => VolumeFlow.FromCubicYardsPerMinute(value);
+        public static VolumeFlow CubicYardsPerMinute<T>(this T value) => VolumeFlow.FromCubicYardsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerMinute(this int? value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerMinute(this long value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerMinute(this long? value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerMinute(this double value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerMinute(this double? value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerMinute(this float value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerMinute(this float? value) => VolumeFlow.FromCubicYardsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerMinute(this decimal value) => VolumeFlow.FromCubicYardsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerMinute(this decimal? value) => VolumeFlow.FromCubicYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicYardsPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromCubicYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region CubicYardPerSecond
 
         /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerSecond(this int value) => VolumeFlow.FromCubicYardsPerSecond(value);
+        public static VolumeFlow CubicYardsPerSecond<T>(this T value) => VolumeFlow.FromCubicYardsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerSecond(this int? value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerSecond(this long value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerSecond(this long? value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerSecond(this double value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerSecond(this double? value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerSecond(this float value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerSecond(this float? value) => VolumeFlow.FromCubicYardsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow CubicYardsPerSecond(this decimal value) => VolumeFlow.FromCubicYardsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromCubicYardsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? CubicYardsPerSecond(this decimal? value) => VolumeFlow.FromCubicYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? CubicYardsPerSecond<T>(this T? value) where T : struct => VolumeFlow.FromCubicYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region DecilitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow DecilitersPerMinute(this int value) => VolumeFlow.FromDecilitersPerMinute(value);
+        public static VolumeFlow DecilitersPerMinute<T>(this T value) => VolumeFlow.FromDecilitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? DecilitersPerMinute(this int? value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow DecilitersPerMinute(this long value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? DecilitersPerMinute(this long? value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow DecilitersPerMinute(this double value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? DecilitersPerMinute(this double? value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow DecilitersPerMinute(this float value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? DecilitersPerMinute(this float? value) => VolumeFlow.FromDecilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow DecilitersPerMinute(this decimal value) => VolumeFlow.FromDecilitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromDecilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? DecilitersPerMinute(this decimal? value) => VolumeFlow.FromDecilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? DecilitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromDecilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region KilolitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow KilolitersPerMinute(this int value) => VolumeFlow.FromKilolitersPerMinute(value);
+        public static VolumeFlow KilolitersPerMinute<T>(this T value) => VolumeFlow.FromKilolitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? KilolitersPerMinute(this int? value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow KilolitersPerMinute(this long value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? KilolitersPerMinute(this long? value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow KilolitersPerMinute(this double value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? KilolitersPerMinute(this double? value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow KilolitersPerMinute(this float value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? KilolitersPerMinute(this float? value) => VolumeFlow.FromKilolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow KilolitersPerMinute(this decimal value) => VolumeFlow.FromKilolitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromKilolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? KilolitersPerMinute(this decimal? value) => VolumeFlow.FromKilolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? KilolitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromKilolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LitersPerHour
 
         /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerHour(this int value) => VolumeFlow.FromLitersPerHour(value);
+        public static VolumeFlow LitersPerHour<T>(this T value) => VolumeFlow.FromLitersPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerHour(this int? value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerHour(this long value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerHour(this long? value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerHour(this double value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerHour(this double? value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerHour(this float value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerHour(this float? value) => VolumeFlow.FromLitersPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerHour(this decimal value) => VolumeFlow.FromLitersPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerHour(this decimal? value) => VolumeFlow.FromLitersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? LitersPerHour<T>(this T? value) where T : struct => VolumeFlow.FromLitersPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerMinute(this int value) => VolumeFlow.FromLitersPerMinute(value);
+        public static VolumeFlow LitersPerMinute<T>(this T value) => VolumeFlow.FromLitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerMinute(this int? value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerMinute(this long value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerMinute(this long? value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerMinute(this double value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerMinute(this double? value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerMinute(this float value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerMinute(this float? value) => VolumeFlow.FromLitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerMinute(this decimal value) => VolumeFlow.FromLitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerMinute(this decimal? value) => VolumeFlow.FromLitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? LitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromLitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region LitersPerSecond
 
         /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerSecond(this int value) => VolumeFlow.FromLitersPerSecond(value);
+        public static VolumeFlow LitersPerSecond<T>(this T value) => VolumeFlow.FromLitersPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerSecond(this int? value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerSecond(this long value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerSecond(this long? value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerSecond(this double value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerSecond(this double? value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerSecond(this float value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerSecond(this float? value) => VolumeFlow.FromLitersPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow LitersPerSecond(this decimal value) => VolumeFlow.FromLitersPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromLitersPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? LitersPerSecond(this decimal? value) => VolumeFlow.FromLitersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? LitersPerSecond<T>(this T? value) where T : struct => VolumeFlow.FromLitersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MicrolitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MicrolitersPerMinute(this int value) => VolumeFlow.FromMicrolitersPerMinute(value);
+        public static VolumeFlow MicrolitersPerMinute<T>(this T value) => VolumeFlow.FromMicrolitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MicrolitersPerMinute(this int? value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MicrolitersPerMinute(this long value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MicrolitersPerMinute(this long? value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MicrolitersPerMinute(this double value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MicrolitersPerMinute(this double? value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MicrolitersPerMinute(this float value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MicrolitersPerMinute(this float? value) => VolumeFlow.FromMicrolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MicrolitersPerMinute(this decimal value) => VolumeFlow.FromMicrolitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromMicrolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MicrolitersPerMinute(this decimal? value) => VolumeFlow.FromMicrolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? MicrolitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromMicrolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillilitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillilitersPerMinute(this int value) => VolumeFlow.FromMillilitersPerMinute(value);
+        public static VolumeFlow MillilitersPerMinute<T>(this T value) => VolumeFlow.FromMillilitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillilitersPerMinute(this int? value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillilitersPerMinute(this long value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillilitersPerMinute(this long? value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillilitersPerMinute(this double value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillilitersPerMinute(this double? value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillilitersPerMinute(this float value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillilitersPerMinute(this float? value) => VolumeFlow.FromMillilitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillilitersPerMinute(this decimal value) => VolumeFlow.FromMillilitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromMillilitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillilitersPerMinute(this decimal? value) => VolumeFlow.FromMillilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? MillilitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromMillilitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region MillionUsGallonsPerDay
 
         /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillionUsGallonsPerDay(this int value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
+        public static VolumeFlow MillionUsGallonsPerDay<T>(this T value) => VolumeFlow.FromMillionUsGallonsPerDay(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillionUsGallonsPerDay(this int? value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillionUsGallonsPerDay(this long value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillionUsGallonsPerDay(this long? value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillionUsGallonsPerDay(this double value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillionUsGallonsPerDay(this double? value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillionUsGallonsPerDay(this float value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillionUsGallonsPerDay(this float? value) => VolumeFlow.FromMillionUsGallonsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow MillionUsGallonsPerDay(this decimal value) => VolumeFlow.FromMillionUsGallonsPerDay(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromMillionUsGallonsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? MillionUsGallonsPerDay(this decimal? value) => VolumeFlow.FromMillionUsGallonsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? MillionUsGallonsPerDay<T>(this T? value) where T : struct => VolumeFlow.FromMillionUsGallonsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region NanolitersPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow NanolitersPerMinute(this int value) => VolumeFlow.FromNanolitersPerMinute(value);
+        public static VolumeFlow NanolitersPerMinute<T>(this T value) => VolumeFlow.FromNanolitersPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? NanolitersPerMinute(this int? value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow NanolitersPerMinute(this long value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? NanolitersPerMinute(this long? value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow NanolitersPerMinute(this double value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? NanolitersPerMinute(this double? value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow NanolitersPerMinute(this float value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? NanolitersPerMinute(this float? value) => VolumeFlow.FromNanolitersPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow NanolitersPerMinute(this decimal value) => VolumeFlow.FromNanolitersPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromNanolitersPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? NanolitersPerMinute(this decimal? value) => VolumeFlow.FromNanolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? NanolitersPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromNanolitersPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region OilBarrelsPerDay
 
         /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerDay(this int value) => VolumeFlow.FromOilBarrelsPerDay(value);
+        public static VolumeFlow OilBarrelsPerDay<T>(this T value) => VolumeFlow.FromOilBarrelsPerDay(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerDay(this int? value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerDay(this long value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerDay(this long? value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerDay(this double value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerDay(this double? value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerDay(this float value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerDay(this float? value) => VolumeFlow.FromOilBarrelsPerDay(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerDay(this decimal value) => VolumeFlow.FromOilBarrelsPerDay(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerDay(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerDay(this decimal? value) => VolumeFlow.FromOilBarrelsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? OilBarrelsPerDay<T>(this T? value) where T : struct => VolumeFlow.FromOilBarrelsPerDay(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region OilBarrelsPerHour
 
         /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerHour(this int value) => VolumeFlow.FromOilBarrelsPerHour(value);
+        public static VolumeFlow OilBarrelsPerHour<T>(this T value) => VolumeFlow.FromOilBarrelsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerHour(this int? value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerHour(this long value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerHour(this long? value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerHour(this double value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerHour(this double? value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerHour(this float value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerHour(this float? value) => VolumeFlow.FromOilBarrelsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerHour(this decimal value) => VolumeFlow.FromOilBarrelsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerHour(this decimal? value) => VolumeFlow.FromOilBarrelsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? OilBarrelsPerHour<T>(this T? value) where T : struct => VolumeFlow.FromOilBarrelsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region OilBarrelsPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerMinute(this int value) => VolumeFlow.FromOilBarrelsPerMinute(value);
+        public static VolumeFlow OilBarrelsPerMinute<T>(this T value) => VolumeFlow.FromOilBarrelsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerMinute(this int? value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerMinute(this long value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerMinute(this long? value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerMinute(this double value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerMinute(this double? value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerMinute(this float value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerMinute(this float? value) => VolumeFlow.FromOilBarrelsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow OilBarrelsPerMinute(this decimal value) => VolumeFlow.FromOilBarrelsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromOilBarrelsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? OilBarrelsPerMinute(this decimal? value) => VolumeFlow.FromOilBarrelsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? OilBarrelsPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromOilBarrelsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallonsPerHour
 
         /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerHour(this int value) => VolumeFlow.FromUsGallonsPerHour(value);
+        public static VolumeFlow UsGallonsPerHour<T>(this T value) => VolumeFlow.FromUsGallonsPerHour(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerHour(this int? value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerHour(this long value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerHour(this long? value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerHour(this double value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerHour(this double? value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerHour(this float value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerHour(this float? value) => VolumeFlow.FromUsGallonsPerHour(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerHour(this decimal value) => VolumeFlow.FromUsGallonsPerHour(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerHour(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerHour(this decimal? value) => VolumeFlow.FromUsGallonsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? UsGallonsPerHour<T>(this T? value) where T : struct => VolumeFlow.FromUsGallonsPerHour(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallonsPerMinute
 
         /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerMinute(this int value) => VolumeFlow.FromUsGallonsPerMinute(value);
+        public static VolumeFlow UsGallonsPerMinute<T>(this T value) => VolumeFlow.FromUsGallonsPerMinute(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerMinute(this int? value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerMinute(this long value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerMinute(this long? value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerMinute(this double value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerMinute(this double? value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerMinute(this float value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerMinute(this float? value) => VolumeFlow.FromUsGallonsPerMinute(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerMinute(this decimal value) => VolumeFlow.FromUsGallonsPerMinute(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerMinute(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerMinute(this decimal? value) => VolumeFlow.FromUsGallonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? UsGallonsPerMinute<T>(this T? value) where T : struct => VolumeFlow.FromUsGallonsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 
         #region UsGallonsPerSecond
 
         /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerSecond(this int value) => VolumeFlow.FromUsGallonsPerSecond(value);
+        public static VolumeFlow UsGallonsPerSecond<T>(this T value) => VolumeFlow.FromUsGallonsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerSecond(this int? value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerSecond(this long value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerSecond(this long? value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerSecond(this double value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerSecond(this double? value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerSecond(this float value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerSecond(this float? value) => VolumeFlow.FromUsGallonsPerSecond(value);
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow UsGallonsPerSecond(this decimal value) => VolumeFlow.FromUsGallonsPerSecond(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="VolumeFlow.FromUsGallonsPerSecond(UnitsNet.QuantityValue)" />
-        public static VolumeFlow? UsGallonsPerSecond(this decimal? value) => VolumeFlow.FromUsGallonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static VolumeFlow? UsGallonsPerSecond<T>(this T? value) where T : struct => VolumeFlow.FromUsGallonsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/Scripts/Include-GenerateNumberExtensionsSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateNumberExtensionsSourceCode.ps1
@@ -1,4 +1,4 @@
-function GenerateNumberExtensionsSourceCode($quantity)
+﻿function GenerateNumberExtensionsSourceCode($quantity)
 {
     $quantityName = $quantity.Name;
     $units = $quantity.Units;
@@ -52,38 +52,15 @@ namespace UnitsNet.Extensions.NumberTo$quantityName
 "@; foreach ($unit in $units) {
         # A few units share the exact same name across quantities, which give extension method name conflicts.
         # We add "OmitExtensionMethod": true on all but one of the conflicting units in JSON.
-        if ($unit.OmitExtensionMethod) { continue }@"
+        if ($unit.OmitExtensionMethod) { continue }
+@"
         #region $($unit.SingularName)
 
         /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $quantityName $($unit.PluralName)(this int value) => $quantityName.From$($unit.PluralName)(value);
+        public static $quantityName $($unit.PluralName)<T>(this T value) => $quantityName.From$($unit.PluralName)(Convert.ToDouble(value));
 
         /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $($quantityName)? $($unit.PluralName)(this int? value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $quantityName $($unit.PluralName)(this long value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $($quantityName)? $($unit.PluralName)(this long? value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $quantityName $($unit.PluralName)(this double value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $($quantityName)? $($unit.PluralName)(this double? value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $quantityName $($unit.PluralName)(this float value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $($quantityName)? $($unit.PluralName)(this float? value) => $quantityName.From$($unit.PluralName)(value);
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $quantityName $($unit.PluralName)(this decimal value) => $quantityName.From$($unit.PluralName)(Convert.ToDouble(value));
-
-        /// <inheritdoc cref="$quantityName.From$($unit.PluralName)(UnitsNet.QuantityValue)" />
-        public static $($quantityName)? $($unit.PluralName)(this decimal? value) => $quantityName.From$($unit.PluralName)(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        public static $($quantityName)? $($unit.PluralName)<T>(this T? value) where T : struct => $quantityName.From$($unit.PluralName)(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 


### PR DESCRIPTION
Changing extension methods to use generics. Allows for broader use wherever Convert.ToDouble can be used, and also reduces library size significantly.

Work towards reducing library size #372.

This has decreased the size from 1451 KB to 994 KB.