### PR TITLE
Remove UnitSystem static methods

### DIFF
--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -157,9 +157,8 @@ namespace UnitsNet
 
         /// <summary>
         /// Whether this instance is for the <see cref="FallbackCulture"/>.
-        /// TODO Make this private.
         /// </summary>
-        public bool IsFallbackCulture => Culture.Equals(FallbackCulture);
+        private bool IsFallbackCulture => Culture.Equals(FallbackCulture);
 
         /// <summary>
         /// Clear the cached singleton instances.

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -528,12 +528,11 @@ namespace UnitsNet
                 foreach (CulturesForEnumValue ev in localization.EnumValues)
                 {
                     int unitEnumValue = ev.Value;
-                    var usCulture = new CultureInfo("en-US");
 
                     // Fall back to US English if localization not found
-                    AbbreviationsForCulture matchingCulture =
+                    var matchingCulture =
                         ev.Cultures.FirstOrDefault(a => a.Cult.Equals(culture)) ??
-                        ev.Cultures.FirstOrDefault(a => a.Cult.Equals(usCulture));
+                        ev.Cultures.FirstOrDefault(a => a.Cult.Equals(FallbackCulture));
 
                     if (matchingCulture == null)
                         continue;


### PR DESCRIPTION
Remove static where a similar instance method also exists.
Make `IsFallbackCulture` private, can't see how that is used externally.
Add some xmldoc while at it too.