### PR TITLE
Do not allow NaN or Infinity

### DIFF
--- a/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from CentimetersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromCentimetersPerSecondSquared(double centimeterspersecondsquared)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from DecimetersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromDecimetersPerSecondSquared(double decimeterspersecondsquared)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from FeetPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromFeetPerSecondSquared(double feetpersecondsquared)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from InchesPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromInchesPerSecondSquared(double inchespersecondsquared)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KilometersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKilometersPerSecondSquared(double kilometerspersecondsquared)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KnotsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKnotsPerHour(double knotsperhour)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KnotsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKnotsPerMinute(double knotsperminute)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KnotsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKnotsPerSecond(double knotspersecond)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MetersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromMetersPerSecondSquared(double meterspersecondsquared)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MicrometersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromMicrometersPerSecondSquared(double micrometerspersecondsquared)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MillimetersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromMillimetersPerSecondSquared(double millimeterspersecondsquared)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from NanometersPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromNanometersPerSecondSquared(double nanometerspersecondsquared)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from StandardGravity.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromStandardGravity(double standardgravity)

--- a/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == AccelerationUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -204,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from CentimetersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromCentimetersPerSecondSquared(double centimeterspersecondsquared)
@@ -218,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from DecimetersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromDecimetersPerSecondSquared(double decimeterspersecondsquared)
@@ -232,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from FeetPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromFeetPerSecondSquared(double feetpersecondsquared)
@@ -246,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from InchesPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromInchesPerSecondSquared(double inchespersecondsquared)
@@ -260,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KilometersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKilometersPerSecondSquared(double kilometerspersecondsquared)
@@ -274,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KnotsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKnotsPerHour(double knotsperhour)
@@ -288,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KnotsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKnotsPerMinute(double knotsperminute)
@@ -302,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from KnotsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromKnotsPerSecond(double knotspersecond)
@@ -316,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MetersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromMetersPerSecondSquared(double meterspersecondsquared)
@@ -330,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MicrometersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromMicrometersPerSecondSquared(double micrometerspersecondsquared)
@@ -344,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from MillimetersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromMillimetersPerSecondSquared(double millimeterspersecondsquared)
@@ -358,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from NanometersPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromNanometersPerSecondSquared(double nanometerspersecondsquared)
@@ -372,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Acceleration from StandardGravity.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Acceleration FromStandardGravity(double standardgravity)

--- a/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Centimoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromCentimoles(double centimoles)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from CentipoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromCentipoundMoles(double centipoundmoles)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Decimoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromDecimoles(double decimoles)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from DecipoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromDecipoundMoles(double decipoundmoles)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Kilomoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromKilomoles(double kilomoles)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from KilopoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromKilopoundMoles(double kilopoundmoles)
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Micromoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMicromoles(double micromoles)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from MicropoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMicropoundMoles(double micropoundmoles)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Millimoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMillimoles(double millimoles)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from MillipoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMillipoundMoles(double millipoundmoles)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Moles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMoles(double moles)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Nanomoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromNanomoles(double nanomoles)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from NanopoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromNanopoundMoles(double nanopoundmoles)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from PoundMoles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromPoundMoles(double poundmoles)

--- a/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == AmountOfSubstanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -209,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Centimoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromCentimoles(double centimoles)
@@ -223,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from CentipoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromCentipoundMoles(double centipoundmoles)
@@ -237,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Decimoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromDecimoles(double decimoles)
@@ -251,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from DecipoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromDecipoundMoles(double decipoundmoles)
@@ -265,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Kilomoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromKilomoles(double kilomoles)
@@ -279,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from KilopoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromKilopoundMoles(double kilopoundmoles)
@@ -293,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Micromoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMicromoles(double micromoles)
@@ -307,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from MicropoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMicropoundMoles(double micropoundmoles)
@@ -321,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Millimoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMillimoles(double millimoles)
@@ -335,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from MillipoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMillipoundMoles(double millipoundmoles)
@@ -349,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Moles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromMoles(double moles)
@@ -363,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from Nanomoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromNanomoles(double nanomoles)
@@ -377,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from NanopoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromNanopoundMoles(double nanopoundmoles)
@@ -391,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmountOfSubstance from PoundMoles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmountOfSubstance FromPoundMoles(double poundmoles)

--- a/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -160,7 +160,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelMicrovolts(double decibelmicrovolts)
@@ -175,7 +175,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelMillivolts(double decibelmillivolts)
@@ -190,7 +190,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelsUnloaded(double decibelsunloaded)
@@ -205,7 +205,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelVolts(double decibelvolts)

--- a/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == AmplitudeRatioUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -158,6 +160,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMicrovolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelMicrovolts(double decibelmicrovolts)
@@ -172,6 +175,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelMillivolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelMillivolts(double decibelmillivolts)
@@ -186,6 +190,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelsUnloaded.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelsUnloaded(double decibelsunloaded)
@@ -200,6 +205,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AmplitudeRatio from DecibelVolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AmplitudeRatio FromDecibelVolts(double decibelvolts)

--- a/Common/GeneratedCode/Quantities/Angle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Angle.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == AngleUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -208,6 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcminutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromArcminutes(double arcminutes)
@@ -222,6 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromArcseconds(double arcseconds)
@@ -236,6 +240,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Centiradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromCentiradians(double centiradians)
@@ -250,6 +255,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromDeciradians(double deciradians)
@@ -264,6 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Degrees.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromDegrees(double degrees)
@@ -278,6 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromGradians(double gradians)
@@ -292,6 +300,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Microdegrees.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMicrodegrees(double microdegrees)
@@ -306,6 +315,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMicroradians(double microradians)
@@ -320,6 +330,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Millidegrees.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMillidegrees(double millidegrees)
@@ -334,6 +345,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMilliradians(double milliradians)
@@ -348,6 +360,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Nanodegrees.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromNanodegrees(double nanodegrees)
@@ -362,6 +375,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromNanoradians(double nanoradians)
@@ -376,6 +390,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Radians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromRadians(double radians)
@@ -390,6 +405,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Revolutions.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromRevolutions(double revolutions)

--- a/Common/GeneratedCode/Quantities/Angle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Angle.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -210,7 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcminutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromArcminutes(double arcminutes)
@@ -225,7 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Arcseconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromArcseconds(double arcseconds)
@@ -240,7 +240,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Centiradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromCentiradians(double centiradians)
@@ -255,7 +255,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Deciradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromDeciradians(double deciradians)
@@ -270,7 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Degrees.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromDegrees(double degrees)
@@ -285,7 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Gradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromGradians(double gradians)
@@ -300,7 +300,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Microdegrees.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMicrodegrees(double microdegrees)
@@ -315,7 +315,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Microradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMicroradians(double microradians)
@@ -330,7 +330,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Millidegrees.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMillidegrees(double millidegrees)
@@ -345,7 +345,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Milliradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromMilliradians(double milliradians)
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Nanodegrees.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromNanodegrees(double nanodegrees)
@@ -375,7 +375,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Nanoradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromNanoradians(double nanoradians)
@@ -390,7 +390,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Radians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromRadians(double radians)
@@ -405,7 +405,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Angle from Revolutions.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Angle FromRevolutions(double revolutions)

--- a/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ApparentEnergyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentEnergy from KilovoltampereHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentEnergy FromKilovoltampereHours(double kilovoltamperehours)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentEnergy from MegavoltampereHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentEnergy FromMegavoltampereHours(double megavoltamperehours)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentEnergy from VoltampereHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentEnergy FromVoltampereHours(double voltamperehours)

--- a/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentEnergy from KilovoltampereHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentEnergy FromKilovoltampereHours(double kilovoltamperehours)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentEnergy from MegavoltampereHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentEnergy FromMegavoltampereHours(double megavoltamperehours)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentEnergy from VoltampereHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentEnergy FromVoltampereHours(double voltamperehours)

--- a/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Gigavoltamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromGigavoltamperes(double gigavoltamperes)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Kilovoltamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromKilovoltamperes(double kilovoltamperes)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromMegavoltamperes(double megavoltamperes)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Voltamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromVoltamperes(double voltamperes)

--- a/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ApparentPowerUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Gigavoltamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromGigavoltamperes(double gigavoltamperes)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Kilovoltamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromKilovoltamperes(double kilovoltamperes)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Megavoltamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromMegavoltamperes(double megavoltamperes)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ApparentPower from Voltamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ApparentPower FromVoltamperes(double voltamperes)

--- a/Common/GeneratedCode/Quantities/Area.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Area.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Acres.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromAcres(double acres)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromHectares(double hectares)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareCentimeters(double squarecentimeters)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareDecimeters(double squaredecimeters)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareFeet(double squarefeet)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareInches(double squareinches)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareKilometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareKilometers(double squarekilometers)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMeters(double squaremeters)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMicrometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMicrometers(double squaremicrometers)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMiles(double squaremiles)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMillimeters(double squaremillimeters)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareYards(double squareyards)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from UsSurveySquareFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromUsSurveySquareFeet(double ussurveysquarefeet)

--- a/Common/GeneratedCode/Quantities/Area.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Area.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == AreaUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -204,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Acres.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromAcres(double acres)
@@ -218,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from Hectares.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromHectares(double hectares)
@@ -232,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareCentimeters(double squarecentimeters)
@@ -246,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareDecimeters(double squaredecimeters)
@@ -260,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareFeet(double squarefeet)
@@ -274,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareInches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareInches(double squareinches)
@@ -288,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareKilometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareKilometers(double squarekilometers)
@@ -302,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMeters(double squaremeters)
@@ -316,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMicrometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMicrometers(double squaremicrometers)
@@ -330,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMiles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMiles(double squaremiles)
@@ -344,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareMillimeters(double squaremillimeters)
@@ -358,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from SquareYards.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromSquareYards(double squareyards)
@@ -372,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Area from UsSurveySquareFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Area FromUsSurveySquareFeet(double ussurveysquarefeet)

--- a/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaDensity from KilogramsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaDensity FromKilogramsPerSquareMeter(double kilogramspersquaremeter)

--- a/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == AreaDensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaDensity from KilogramsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaDensity FromKilogramsPerSquareMeter(double kilogramspersquaremeter)

--- a/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == AreaMomentOfInertiaUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -169,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromCentimetersToTheFourth(double centimeterstothefourth)
@@ -183,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromDecimetersToTheFourth(double decimeterstothefourth)
@@ -197,6 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromFeetToTheFourth(double feettothefourth)
@@ -211,6 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromInchesToTheFourth(double inchestothefourth)
@@ -225,6 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromMetersToTheFourth(double meterstothefourth)
@@ -239,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromMillimetersToTheFourth(double millimeterstothefourth)

--- a/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from CentimetersToTheFourth.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromCentimetersToTheFourth(double centimeterstothefourth)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from DecimetersToTheFourth.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromDecimetersToTheFourth(double decimeterstothefourth)
@@ -201,7 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from FeetToTheFourth.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromFeetToTheFourth(double feettothefourth)
@@ -216,7 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from InchesToTheFourth.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromInchesToTheFourth(double inchestothefourth)
@@ -231,7 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from MetersToTheFourth.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromMetersToTheFourth(double meterstothefourth)
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get AreaMomentOfInertia from MillimetersToTheFourth.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static AreaMomentOfInertia FromMillimetersToTheFourth(double millimeterstothefourth)

--- a/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -268,6 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from BitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromBitsPerSecond(double bitspersecond)
@@ -282,6 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from BytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromBytesPerSecond(double bytespersecond)
@@ -296,6 +300,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExabitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExabitsPerSecond(double exabitspersecond)
@@ -310,6 +315,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExabytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExabytesPerSecond(double exabytespersecond)
@@ -324,6 +330,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExbibitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExbibitsPerSecond(double exbibitspersecond)
@@ -338,6 +345,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExbibytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExbibytesPerSecond(double exbibytespersecond)
@@ -352,6 +360,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GibibitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGibibitsPerSecond(double gibibitspersecond)
@@ -366,6 +375,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GibibytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGibibytesPerSecond(double gibibytespersecond)
@@ -380,6 +390,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GigabitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGigabitsPerSecond(double gigabitspersecond)
@@ -394,6 +405,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GigabytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGigabytesPerSecond(double gigabytespersecond)
@@ -408,6 +420,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KibibitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKibibitsPerSecond(double kibibitspersecond)
@@ -422,6 +435,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KibibytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKibibytesPerSecond(double kibibytespersecond)
@@ -436,6 +450,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KilobitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKilobitsPerSecond(double kilobitspersecond)
@@ -450,6 +465,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KilobytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKilobytesPerSecond(double kilobytespersecond)
@@ -464,6 +480,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MebibitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMebibitsPerSecond(double mebibitspersecond)
@@ -478,6 +495,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MebibytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMebibytesPerSecond(double mebibytespersecond)
@@ -492,6 +510,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MegabitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMegabitsPerSecond(double megabitspersecond)
@@ -506,6 +525,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MegabytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMegabytesPerSecond(double megabytespersecond)
@@ -520,6 +540,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PebibitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPebibitsPerSecond(double pebibitspersecond)
@@ -534,6 +555,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PebibytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPebibytesPerSecond(double pebibytespersecond)
@@ -548,6 +570,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PetabitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPetabitsPerSecond(double petabitspersecond)
@@ -562,6 +585,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PetabytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPetabytesPerSecond(double petabytespersecond)
@@ -576,6 +600,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TebibitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTebibitsPerSecond(double tebibitspersecond)
@@ -590,6 +615,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TebibytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTebibytesPerSecond(double tebibytespersecond)
@@ -604,6 +630,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TerabitsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTerabitsPerSecond(double terabitspersecond)
@@ -618,6 +645,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TerabytesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTerabytesPerSecond(double terabytespersecond)

--- a/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -270,7 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from BitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromBitsPerSecond(double bitspersecond)
@@ -285,7 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from BytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromBytesPerSecond(double bytespersecond)
@@ -300,7 +300,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExabitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExabitsPerSecond(double exabitspersecond)
@@ -315,7 +315,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExabytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExabytesPerSecond(double exabytespersecond)
@@ -330,7 +330,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExbibitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExbibitsPerSecond(double exbibitspersecond)
@@ -345,7 +345,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from ExbibytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromExbibytesPerSecond(double exbibytespersecond)
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GibibitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGibibitsPerSecond(double gibibitspersecond)
@@ -375,7 +375,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GibibytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGibibytesPerSecond(double gibibytespersecond)
@@ -390,7 +390,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GigabitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGigabitsPerSecond(double gigabitspersecond)
@@ -405,7 +405,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from GigabytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromGigabytesPerSecond(double gigabytespersecond)
@@ -420,7 +420,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KibibitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKibibitsPerSecond(double kibibitspersecond)
@@ -435,7 +435,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KibibytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKibibytesPerSecond(double kibibytespersecond)
@@ -450,7 +450,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KilobitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKilobitsPerSecond(double kilobitspersecond)
@@ -465,7 +465,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from KilobytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromKilobytesPerSecond(double kilobytespersecond)
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MebibitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMebibitsPerSecond(double mebibitspersecond)
@@ -495,7 +495,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MebibytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMebibytesPerSecond(double mebibytespersecond)
@@ -510,7 +510,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MegabitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMegabitsPerSecond(double megabitspersecond)
@@ -525,7 +525,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from MegabytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromMegabytesPerSecond(double megabytespersecond)
@@ -540,7 +540,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PebibitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPebibitsPerSecond(double pebibitspersecond)
@@ -555,7 +555,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PebibytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPebibytesPerSecond(double pebibytespersecond)
@@ -570,7 +570,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PetabitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPetabitsPerSecond(double petabitspersecond)
@@ -585,7 +585,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from PetabytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromPetabytesPerSecond(double petabytespersecond)
@@ -600,7 +600,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TebibitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTebibitsPerSecond(double tebibitspersecond)
@@ -615,7 +615,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TebibytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTebibytesPerSecond(double tebibytespersecond)
@@ -630,7 +630,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TerabitsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTerabitsPerSecond(double terabitspersecond)
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BitRate from TerabytesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BitRate FromTerabytesPerSecond(double terabytespersecond)

--- a/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(double gramsperkilowatthour)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(double kilogramsperjoule)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(double poundspermechanicalhorsepowerhour)

--- a/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == BrakeSpecificFuelConsumptionUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from GramsPerKiloWattHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BrakeSpecificFuelConsumption FromGramsPerKiloWattHour(double gramsperkilowatthour)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from KilogramsPerJoule.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BrakeSpecificFuelConsumption FromKilogramsPerJoule(double kilogramsperjoule)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get BrakeSpecificFuelConsumption from PoundsPerMechanicalHorsepowerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static BrakeSpecificFuelConsumption FromPoundsPerMechanicalHorsepowerHour(double poundspermechanicalhorsepowerhour)

--- a/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == CapacitanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Capacitance from Farads.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Capacitance FromFarads(double farads)

--- a/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Capacitance from Farads.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Capacitance FromFarads(double farads)

--- a/Common/GeneratedCode/Quantities/Density.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Density.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == DensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -329,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromCentigramsPerDeciLiter(double centigramsperdeciliter)
@@ -343,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromCentigramsPerLiter(double centigramsperliter)
@@ -357,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromCentigramsPerMilliliter(double centigramspermilliliter)
@@ -371,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromDecigramsPerDeciLiter(double decigramsperdeciliter)
@@ -385,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromDecigramsPerLiter(double decigramsperliter)
@@ -399,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromDecigramsPerMilliliter(double decigramspermilliliter)
@@ -413,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerCubicCentimeter(double gramspercubiccentimeter)
@@ -427,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerCubicMeter(double gramspercubicmeter)
@@ -441,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerCubicMillimeter(double gramspercubicmillimeter)
@@ -455,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerDeciLiter(double gramsperdeciliter)
@@ -469,6 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerLiter(double gramsperliter)
@@ -483,6 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerMilliliter(double gramspermilliliter)
@@ -497,6 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilogramsPerCubicCentimeter(double kilogramspercubiccentimeter)
@@ -511,6 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilogramsPerCubicMeter(double kilogramspercubicmeter)
@@ -525,6 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilogramsPerCubicMillimeter(double kilogramspercubicmillimeter)
@@ -539,6 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilopoundsPerCubicFoot(double kilopoundspercubicfoot)
@@ -553,6 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilopoundsPerCubicInch(double kilopoundspercubicinch)
@@ -567,6 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMicrogramsPerDeciLiter(double microgramsperdeciliter)
@@ -581,6 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMicrogramsPerLiter(double microgramsperliter)
@@ -595,6 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMicrogramsPerMilliliter(double microgramspermilliliter)
@@ -609,6 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerCubicMeter(double milligramspercubicmeter)
@@ -623,6 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerDeciLiter(double milligramsperdeciliter)
@@ -637,6 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerLiter(double milligramsperliter)
@@ -651,6 +676,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerMilliliter(double milligramspermilliliter)
@@ -665,6 +691,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromNanogramsPerDeciLiter(double nanogramsperdeciliter)
@@ -679,6 +706,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromNanogramsPerLiter(double nanogramsperliter)
@@ -693,6 +721,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromNanogramsPerMilliliter(double nanogramspermilliliter)
@@ -707,6 +736,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPicogramsPerDeciLiter(double picogramsperdeciliter)
@@ -721,6 +751,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPicogramsPerLiter(double picogramsperliter)
@@ -735,6 +766,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPicogramsPerMilliliter(double picogramspermilliliter)
@@ -749,6 +781,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerCubicFoot(double poundspercubicfoot)
@@ -763,6 +796,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerCubicInch(double poundspercubicinch)
@@ -777,6 +811,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerImperialGallon.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerImperialGallon(double poundsperimperialgallon)
@@ -791,6 +826,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerUSGallon.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerUSGallon(double poundsperusgallon)
@@ -805,6 +841,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromSlugsPerCubicFoot(double slugspercubicfoot)
@@ -819,6 +856,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromTonnesPerCubicCentimeter(double tonnespercubiccentimeter)
@@ -833,6 +871,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromTonnesPerCubicMeter(double tonnespercubicmeter)
@@ -847,6 +886,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromTonnesPerCubicMillimeter(double tonnespercubicmillimeter)

--- a/Common/GeneratedCode/Quantities/Density.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Density.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromCentigramsPerDeciLiter(double centigramsperdeciliter)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromCentigramsPerLiter(double centigramsperliter)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from CentigramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromCentigramsPerMilliliter(double centigramspermilliliter)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromDecigramsPerDeciLiter(double decigramsperdeciliter)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromDecigramsPerLiter(double decigramsperliter)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from DecigramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromDecigramsPerMilliliter(double decigramspermilliliter)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerCubicCentimeter(double gramspercubiccentimeter)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerCubicMeter(double gramspercubicmeter)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerCubicMillimeter(double gramspercubicmillimeter)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerDeciLiter(double gramsperdeciliter)
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerLiter(double gramsperliter)
@@ -496,7 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from GramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromGramsPerMilliliter(double gramspermilliliter)
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilogramsPerCubicCentimeter(double kilogramspercubiccentimeter)
@@ -526,7 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilogramsPerCubicMeter(double kilogramspercubicmeter)
@@ -541,7 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilogramsPerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilogramsPerCubicMillimeter(double kilogramspercubicmillimeter)
@@ -556,7 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilopoundsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilopoundsPerCubicFoot(double kilopoundspercubicfoot)
@@ -571,7 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from KilopoundsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromKilopoundsPerCubicInch(double kilopoundspercubicinch)
@@ -586,7 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMicrogramsPerDeciLiter(double microgramsperdeciliter)
@@ -601,7 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMicrogramsPerLiter(double microgramsperliter)
@@ -616,7 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MicrogramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMicrogramsPerMilliliter(double microgramspermilliliter)
@@ -631,7 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerCubicMeter(double milligramspercubicmeter)
@@ -646,7 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerDeciLiter(double milligramsperdeciliter)
@@ -661,7 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerLiter(double milligramsperliter)
@@ -676,7 +676,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from MilligramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromMilligramsPerMilliliter(double milligramspermilliliter)
@@ -691,7 +691,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromNanogramsPerDeciLiter(double nanogramsperdeciliter)
@@ -706,7 +706,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromNanogramsPerLiter(double nanogramsperliter)
@@ -721,7 +721,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from NanogramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromNanogramsPerMilliliter(double nanogramspermilliliter)
@@ -736,7 +736,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerDeciLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPicogramsPerDeciLiter(double picogramsperdeciliter)
@@ -751,7 +751,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPicogramsPerLiter(double picogramsperliter)
@@ -766,7 +766,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PicogramsPerMilliliter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPicogramsPerMilliliter(double picogramspermilliliter)
@@ -781,7 +781,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerCubicFoot(double poundspercubicfoot)
@@ -796,7 +796,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerCubicInch(double poundspercubicinch)
@@ -811,7 +811,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerImperialGallon.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerImperialGallon(double poundsperimperialgallon)
@@ -826,7 +826,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from PoundsPerUSGallon.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromPoundsPerUSGallon(double poundsperusgallon)
@@ -841,7 +841,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from SlugsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromSlugsPerCubicFoot(double slugspercubicfoot)
@@ -856,7 +856,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromTonnesPerCubicCentimeter(double tonnespercubiccentimeter)
@@ -871,7 +871,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromTonnesPerCubicMeter(double tonnespercubicmeter)
@@ -886,7 +886,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Density from TonnesPerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Density FromTonnesPerCubicMillimeter(double tonnespercubicmillimeter)

--- a/Common/GeneratedCode/Quantities/Duration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Duration.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == DurationUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -189,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Days.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromDays(double days)
@@ -203,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromHours(double hours)
@@ -217,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Microseconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMicroseconds(double microseconds)
@@ -231,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMilliseconds(double milliseconds)
@@ -245,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Minutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMinutes(double minutes)
@@ -259,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Months30.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMonths30(double months30)
@@ -273,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Nanoseconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromNanoseconds(double nanoseconds)
@@ -287,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromSeconds(double seconds)
@@ -301,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Weeks.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromWeeks(double weeks)
@@ -315,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Years365.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromYears365(double years365)

--- a/Common/GeneratedCode/Quantities/Duration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Duration.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Days.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromDays(double days)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Hours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromHours(double hours)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Microseconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMicroseconds(double microseconds)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Milliseconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMilliseconds(double milliseconds)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Minutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMinutes(double minutes)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Months30.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromMonths30(double months30)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Nanoseconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromNanoseconds(double nanoseconds)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Seconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromSeconds(double seconds)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Weeks.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromWeeks(double weeks)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Duration from Years365.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Duration FromYears365(double years365)

--- a/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Centipoise.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromCentipoise(double centipoise)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from MicropascalSeconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromMicropascalSeconds(double micropascalseconds)
@@ -201,7 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromMillipascalSeconds(double millipascalseconds)
@@ -216,7 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(double newtonsecondspermetersquared)
@@ -231,7 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromPascalSeconds(double pascalseconds)
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Poise.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromPoise(double poise)

--- a/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == DynamicViscosityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -169,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Centipoise.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromCentipoise(double centipoise)
@@ -183,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from MicropascalSeconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromMicropascalSeconds(double micropascalseconds)
@@ -197,6 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from MillipascalSeconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromMillipascalSeconds(double millipascalseconds)
@@ -211,6 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from NewtonSecondsPerMeterSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromNewtonSecondsPerMeterSquared(double newtonsecondspermetersquared)
@@ -225,6 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from PascalSeconds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromPascalSeconds(double pascalseconds)
@@ -239,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get DynamicViscosity from Poise.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static DynamicViscosity FromPoise(double poise)

--- a/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricAdmittanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Microsiemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromMicrosiemens(double microsiemens)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromMillisiemens(double millisiemens)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromNanosiemens(double nanosiemens)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromSiemens(double siemens)

--- a/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Microsiemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromMicrosiemens(double microsiemens)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Millisiemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromMillisiemens(double millisiemens)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Nanosiemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromNanosiemens(double nanosiemens)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricAdmittance from Siemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricAdmittance FromSiemens(double siemens)

--- a/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCharge from Coulombs.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCharge FromCoulombs(double coulombs)

--- a/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricChargeUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCharge from Coulombs.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCharge FromCoulombs(double coulombs)

--- a/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricChargeDensity from CoulombsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricChargeDensity FromCoulombsPerCubicMeter(double coulombspercubicmeter)

--- a/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricChargeDensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricChargeDensity from CoulombsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricChargeDensity FromCoulombsPerCubicMeter(double coulombspercubicmeter)

--- a/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductance from Microsiemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductance FromMicrosiemens(double microsiemens)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductance from Millisiemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductance FromMillisiemens(double millisiemens)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductance from Siemens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductance FromSiemens(double siemens)

--- a/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricConductanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductance from Microsiemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductance FromMicrosiemens(double microsiemens)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductance from Millisiemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductance FromMillisiemens(double millisiemens)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductance from Siemens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductance FromSiemens(double siemens)

--- a/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricConductivityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductivity from SiemensPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductivity FromSiemensPerMeter(double siemenspermeter)

--- a/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricConductivity from SiemensPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricConductivity FromSiemensPerMeter(double siemenspermeter)

--- a/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Amperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromAmperes(double amperes)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Centiamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromCentiamperes(double centiamperes)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromKiloamperes(double kiloamperes)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromMegaamperes(double megaamperes)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromMicroamperes(double microamperes)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromMilliamperes(double milliamperes)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromNanoamperes(double nanoamperes)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromPicoamperes(double picoamperes)

--- a/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricCurrentUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Amperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromAmperes(double amperes)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Centiamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromCentiamperes(double centiamperes)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Kiloamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromKiloamperes(double kiloamperes)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Megaamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromMegaamperes(double megaamperes)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Microamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromMicroamperes(double microamperes)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Milliamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromMilliamperes(double milliamperes)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Nanoamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromNanoamperes(double nanoamperes)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrent from Picoamperes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrent FromPicoamperes(double picoamperes)

--- a/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrentDensity from AmperesPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrentDensity FromAmperesPerSquareMeter(double amperespersquaremeter)

--- a/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricCurrentDensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrentDensity from AmperesPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrentDensity FromAmperesPerSquareMeter(double amperespersquaremeter)

--- a/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricCurrentGradientUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrentGradient from AmperesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrentGradient FromAmperesPerSecond(double amperespersecond)

--- a/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricCurrentGradient from AmperesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricCurrentGradient FromAmperesPerSecond(double amperespersecond)

--- a/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricFieldUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricField from VoltsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricField FromVoltsPerMeter(double voltspermeter)

--- a/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricField from VoltsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricField FromVoltsPerMeter(double voltspermeter)

--- a/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricInductance from Henries.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricInductance FromHenries(double henries)

--- a/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricInductanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricInductance from Henries.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricInductance FromHenries(double henries)

--- a/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricPotentialUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -164,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Kilovolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromKilovolts(double kilovolts)
@@ -178,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromMegavolts(double megavolts)
@@ -192,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromMicrovolts(double microvolts)
@@ -206,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromMillivolts(double millivolts)
@@ -220,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Volts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromVolts(double volts)

--- a/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Kilovolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromKilovolts(double kilovolts)
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Megavolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromMegavolts(double megavolts)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Microvolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromMicrovolts(double microvolts)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Millivolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromMillivolts(double millivolts)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotential from Volts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotential FromVolts(double volts)

--- a/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -165,7 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromKilovoltsAc(double kilovoltsac)
@@ -180,7 +180,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromMegavoltsAc(double megavoltsac)
@@ -195,7 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromMicrovoltsAc(double microvoltsac)
@@ -210,7 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromMillivoltsAc(double millivoltsac)
@@ -225,7 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromVoltsAc(double voltsac)

--- a/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == ElectricPotentialAcUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -163,6 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from KilovoltsAc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromKilovoltsAc(double kilovoltsac)
@@ -177,6 +180,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MegavoltsAc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromMegavoltsAc(double megavoltsac)
@@ -191,6 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MicrovoltsAc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromMicrovoltsAc(double microvoltsac)
@@ -205,6 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from MillivoltsAc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromMillivoltsAc(double millivoltsac)
@@ -219,6 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialAc from VoltsAc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialAc FromVoltsAc(double voltsac)

--- a/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == ElectricPotentialDcUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -163,6 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromKilovoltsDc(double kilovoltsdc)
@@ -177,6 +180,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromMegavoltsDc(double megavoltsdc)
@@ -191,6 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromMicrovoltsDc(double microvoltsdc)
@@ -205,6 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromMillivoltsDc(double millivoltsdc)
@@ -219,6 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromVoltsDc(double voltsdc)

--- a/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -165,7 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from KilovoltsDc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromKilovoltsDc(double kilovoltsdc)
@@ -180,7 +180,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MegavoltsDc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromMegavoltsDc(double megavoltsdc)
@@ -195,7 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MicrovoltsDc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromMicrovoltsDc(double microvoltsdc)
@@ -210,7 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from MillivoltsDc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromMillivoltsDc(double millivoltsdc)
@@ -225,7 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricPotentialDc from VoltsDc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricPotentialDc FromVoltsDc(double voltsdc)

--- a/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Kiloohms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromKiloohms(double kiloohms)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromMegaohms(double megaohms)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Milliohms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromMilliohms(double milliohms)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromOhms(double ohms)

--- a/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricResistanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Kiloohms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromKiloohms(double kiloohms)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Megaohms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromMegaohms(double megaohms)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Milliohms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromMilliohms(double milliohms)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistance from Ohms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistance FromOhms(double ohms)

--- a/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from MicroohmMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromMicroohmMeters(double microohmmeters)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from MilliohmMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromMilliohmMeters(double milliohmmeters)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from NanoohmMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromNanoohmMeters(double nanoohmmeters)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from OhmMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromOhmMeters(double ohmmeters)

--- a/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ElectricResistivityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from MicroohmMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromMicroohmMeters(double microohmmeters)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from MilliohmMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromMilliohmMeters(double milliohmmeters)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from NanoohmMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromNanoohmMeters(double nanoohmmeters)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ElectricResistivity from OhmMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ElectricResistivity FromOhmMeters(double ohmmeters)

--- a/Common/GeneratedCode/Quantities/Energy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Energy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == EnergyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -249,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from BritishThermalUnits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromBritishThermalUnits(double britishthermalunits)
@@ -263,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromCalories(double calories)
@@ -277,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsEc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromDecathermsEc(double decathermsec)
@@ -291,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromDecathermsImperial(double decathermsimperial)
@@ -305,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsUs.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromDecathermsUs(double decathermsus)
@@ -319,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromElectronVolts(double electronvolts)
@@ -333,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Ergs.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromErgs(double ergs)
@@ -347,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromFootPounds(double footpounds)
@@ -361,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromGigabritishThermalUnits(double gigabritishthermalunits)
@@ -375,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromGigawattHours(double gigawatthours)
@@ -389,6 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Joules.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromJoules(double joules)
@@ -403,6 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilobritishThermalUnits(double kilobritishthermalunits)
@@ -417,6 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Kilocalories.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilocalories(double kilocalories)
@@ -431,6 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilojoules(double kilojoules)
@@ -445,6 +461,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from KilowattHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilowattHours(double kilowatthours)
@@ -459,6 +476,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromMegabritishThermalUnits(double megabritishthermalunits)
@@ -473,6 +491,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Megajoules.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromMegajoules(double megajoules)
@@ -487,6 +506,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromMegawattHours(double megawatthours)
@@ -501,6 +521,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsEc.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromThermsEc(double thermsec)
@@ -515,6 +536,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromThermsImperial(double thermsimperial)
@@ -529,6 +551,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsUs.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromThermsUs(double thermsus)
@@ -543,6 +566,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromWattHours(double watthours)

--- a/Common/GeneratedCode/Quantities/Energy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Energy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from BritishThermalUnits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromBritishThermalUnits(double britishthermalunits)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Calories.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromCalories(double calories)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsEc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromDecathermsEc(double decathermsec)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsImperial.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromDecathermsImperial(double decathermsimperial)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from DecathermsUs.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromDecathermsUs(double decathermsus)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ElectronVolts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromElectronVolts(double electronvolts)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Ergs.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromErgs(double ergs)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from FootPounds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromFootPounds(double footpounds)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from GigabritishThermalUnits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromGigabritishThermalUnits(double gigabritishthermalunits)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from GigawattHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromGigawattHours(double gigawatthours)
@@ -401,7 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Joules.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromJoules(double joules)
@@ -416,7 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from KilobritishThermalUnits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilobritishThermalUnits(double kilobritishthermalunits)
@@ -431,7 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Kilocalories.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilocalories(double kilocalories)
@@ -446,7 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Kilojoules.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilojoules(double kilojoules)
@@ -461,7 +461,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from KilowattHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromKilowattHours(double kilowatthours)
@@ -476,7 +476,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from MegabritishThermalUnits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromMegabritishThermalUnits(double megabritishthermalunits)
@@ -491,7 +491,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from Megajoules.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromMegajoules(double megajoules)
@@ -506,7 +506,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from MegawattHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromMegawattHours(double megawatthours)
@@ -521,7 +521,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsEc.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromThermsEc(double thermsec)
@@ -536,7 +536,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsImperial.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromThermsImperial(double thermsimperial)
@@ -551,7 +551,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from ThermsUs.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromThermsUs(double thermsus)
@@ -566,7 +566,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Energy from WattHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Energy FromWattHours(double watthours)

--- a/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == EntropyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -174,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from CaloriesPerKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromCaloriesPerKelvin(double caloriesperkelvin)
@@ -188,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from JoulesPerDegreeCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromJoulesPerDegreeCelsius(double joulesperdegreecelsius)
@@ -202,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from JoulesPerKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromJoulesPerKelvin(double joulesperkelvin)
@@ -216,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from KilocaloriesPerKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromKilocaloriesPerKelvin(double kilocaloriesperkelvin)
@@ -230,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from KilojoulesPerDegreeCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromKilojoulesPerDegreeCelsius(double kilojoulesperdegreecelsius)
@@ -244,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from KilojoulesPerKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromKilojoulesPerKelvin(double kilojoulesperkelvin)
@@ -258,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from MegajoulesPerKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromMegajoulesPerKelvin(double megajoulesperkelvin)

--- a/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from CaloriesPerKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromCaloriesPerKelvin(double caloriesperkelvin)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from JoulesPerDegreeCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromJoulesPerDegreeCelsius(double joulesperdegreecelsius)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from JoulesPerKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromJoulesPerKelvin(double joulesperkelvin)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from KilocaloriesPerKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromKilocaloriesPerKelvin(double kilocaloriesperkelvin)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from KilojoulesPerDegreeCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromKilojoulesPerDegreeCelsius(double kilojoulesperdegreecelsius)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from KilojoulesPerKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromKilojoulesPerKelvin(double kilojoulesperkelvin)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Entropy from MegajoulesPerKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Entropy FromMegajoulesPerKelvin(double megajoulesperkelvin)

--- a/Common/GeneratedCode/Quantities/Force.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Force.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Decanewtons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromDecanewtons(double decanewtons)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromDyne(double dyne)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from KilogramsForce.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromKilogramsForce(double kilogramsforce)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromKilonewtons(double kilonewtons)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from KiloPonds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromKiloPonds(double kiloponds)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Meganewtons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromMeganewtons(double meganewtons)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromNewtons(double newtons)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Poundals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromPoundals(double poundals)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromPoundsForce(double poundsforce)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from TonnesForce.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromTonnesForce(double tonnesforce)

--- a/Common/GeneratedCode/Quantities/Force.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Force.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ForceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -189,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Decanewtons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromDecanewtons(double decanewtons)
@@ -203,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Dyne.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromDyne(double dyne)
@@ -217,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from KilogramsForce.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromKilogramsForce(double kilogramsforce)
@@ -231,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Kilonewtons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromKilonewtons(double kilonewtons)
@@ -245,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from KiloPonds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromKiloPonds(double kiloponds)
@@ -259,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Meganewtons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromMeganewtons(double meganewtons)
@@ -273,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Newtons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromNewtons(double newtons)
@@ -287,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from Poundals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromPoundals(double poundals)
@@ -301,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from PoundsForce.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromPoundsForce(double poundsforce)
@@ -315,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Force from TonnesForce.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Force FromTonnesForce(double tonnesforce)

--- a/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromCentinewtonsPerSecond(double centinewtonspersecond)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromDecanewtonsPerMinute(double decanewtonsperminute)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromDecanewtonsPerSecond(double decanewtonspersecond)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromDecinewtonsPerSecond(double decinewtonspersecond)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromKilonewtonsPerMinute(double kilonewtonsperminute)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromKilonewtonsPerSecond(double kilonewtonspersecond)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromMicronewtonsPerSecond(double micronewtonspersecond)
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromMillinewtonsPerSecond(double millinewtonspersecond)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromNanonewtonsPerSecond(double nanonewtonspersecond)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromNewtonsPerMinute(double newtonsperminute)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromNewtonsPerSecond(double newtonspersecond)

--- a/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ForceChangeRateUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -194,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from CentinewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromCentinewtonsPerSecond(double centinewtonspersecond)
@@ -208,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromDecanewtonsPerMinute(double decanewtonsperminute)
@@ -222,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecanewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromDecanewtonsPerSecond(double decanewtonspersecond)
@@ -236,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from DecinewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromDecinewtonsPerSecond(double decinewtonspersecond)
@@ -250,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromKilonewtonsPerMinute(double kilonewtonsperminute)
@@ -264,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from KilonewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromKilonewtonsPerSecond(double kilonewtonspersecond)
@@ -278,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from MicronewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromMicronewtonsPerSecond(double micronewtonspersecond)
@@ -292,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from MillinewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromMillinewtonsPerSecond(double millinewtonspersecond)
@@ -306,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NanonewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromNanonewtonsPerSecond(double nanonewtonspersecond)
@@ -320,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromNewtonsPerMinute(double newtonsperminute)
@@ -334,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForceChangeRate from NewtonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForceChangeRate FromNewtonsPerSecond(double newtonspersecond)

--- a/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ForcePerLengthUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -184,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromCentinewtonsPerMeter(double centinewtonspermeter)
@@ -198,6 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromDecinewtonsPerMeter(double decinewtonspermeter)
@@ -212,6 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromKilogramsForcePerMeter(double kilogramsforcepermeter)
@@ -226,6 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromKilonewtonsPerMeter(double kilonewtonspermeter)
@@ -240,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MeganewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromMeganewtonsPerMeter(double meganewtonspermeter)
@@ -254,6 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromMicronewtonsPerMeter(double micronewtonspermeter)
@@ -268,6 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromMillinewtonsPerMeter(double millinewtonspermeter)
@@ -282,6 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromNanonewtonsPerMeter(double nanonewtonspermeter)
@@ -296,6 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromNewtonsPerMeter(double newtonspermeter)

--- a/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from CentinewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromCentinewtonsPerMeter(double centinewtonspermeter)
@@ -201,7 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from DecinewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromDecinewtonsPerMeter(double decinewtonspermeter)
@@ -216,7 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from KilogramsForcePerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromKilogramsForcePerMeter(double kilogramsforcepermeter)
@@ -231,7 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from KilonewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromKilonewtonsPerMeter(double kilonewtonspermeter)
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MeganewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromMeganewtonsPerMeter(double meganewtonspermeter)
@@ -261,7 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MicronewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromMicronewtonsPerMeter(double micronewtonspermeter)
@@ -276,7 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from MillinewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromMillinewtonsPerMeter(double millinewtonspermeter)
@@ -291,7 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from NanonewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromNanonewtonsPerMeter(double nanonewtonspermeter)
@@ -306,7 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ForcePerLength from NewtonsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ForcePerLength FromNewtonsPerMeter(double newtonspermeter)

--- a/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == FrequencyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromCyclesPerHour(double cyclesperhour)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromCyclesPerMinute(double cyclesperminute)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Gigahertz.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromGigahertz(double gigahertz)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromHertz(double hertz)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Kilohertz.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromKilohertz(double kilohertz)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromMegahertz(double megahertz)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromRadiansPerSecond(double radianspersecond)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromTerahertz(double terahertz)

--- a/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromCyclesPerHour(double cyclesperhour)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from CyclesPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromCyclesPerMinute(double cyclesperminute)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Gigahertz.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromGigahertz(double gigahertz)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Hertz.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromHertz(double hertz)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Kilohertz.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromKilohertz(double kilohertz)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Megahertz.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromMegahertz(double megahertz)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromRadiansPerSecond(double radianspersecond)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Frequency from Terahertz.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Frequency FromTerahertz(double terahertz)

--- a/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerHourSquareFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerHourSquareFoot(double btusperhoursquarefoot)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerMinuteSquareFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerMinuteSquareFoot(double btusperminutesquarefoot)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerSecondSquareFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerSecondSquareFoot(double btuspersecondsquarefoot)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerSecondSquareInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerSecondSquareInch(double btuspersecondsquareinch)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from CaloriesPerSecondSquareCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromCaloriesPerSecondSquareCentimeter(double caloriespersecondsquarecentimeter)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from CentiwattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromCentiwattsPerSquareMeter(double centiwattspersquaremeter)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from DeciwattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromDeciwattsPerSquareMeter(double deciwattspersquaremeter)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from KilocaloriesPerHourSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromKilocaloriesPerHourSquareMeter(double kilocaloriesperhoursquaremeter)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from KilocaloriesPerSecondSquareCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromKilocaloriesPerSecondSquareCentimeter(double kilocaloriespersecondsquarecentimeter)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from KilowattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromKilowattsPerSquareMeter(double kilowattspersquaremeter)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from MicrowattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromMicrowattsPerSquareMeter(double microwattspersquaremeter)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from MilliwattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromMilliwattsPerSquareMeter(double milliwattspersquaremeter)
@@ -401,7 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from NanowattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromNanowattsPerSquareMeter(double nanowattspersquaremeter)
@@ -416,7 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from WattsPerSquareFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromWattsPerSquareFoot(double wattspersquarefoot)
@@ -431,7 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from WattsPerSquareInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromWattsPerSquareInch(double wattspersquareinch)
@@ -446,7 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from WattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromWattsPerSquareMeter(double wattspersquaremeter)

--- a/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == HeatFluxUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -219,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerHourSquareFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerHourSquareFoot(double btusperhoursquarefoot)
@@ -233,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerMinuteSquareFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerMinuteSquareFoot(double btusperminutesquarefoot)
@@ -247,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerSecondSquareFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerSecondSquareFoot(double btuspersecondsquarefoot)
@@ -261,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from BtusPerSecondSquareInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromBtusPerSecondSquareInch(double btuspersecondsquareinch)
@@ -275,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from CaloriesPerSecondSquareCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromCaloriesPerSecondSquareCentimeter(double caloriespersecondsquarecentimeter)
@@ -289,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from CentiwattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromCentiwattsPerSquareMeter(double centiwattspersquaremeter)
@@ -303,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from DeciwattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromDeciwattsPerSquareMeter(double deciwattspersquaremeter)
@@ -317,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from KilocaloriesPerHourSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromKilocaloriesPerHourSquareMeter(double kilocaloriesperhoursquaremeter)
@@ -331,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from KilocaloriesPerSecondSquareCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromKilocaloriesPerSecondSquareCentimeter(double kilocaloriespersecondsquarecentimeter)
@@ -345,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from KilowattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromKilowattsPerSquareMeter(double kilowattspersquaremeter)
@@ -359,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from MicrowattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromMicrowattsPerSquareMeter(double microwattspersquaremeter)
@@ -373,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from MilliwattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromMilliwattsPerSquareMeter(double milliwattspersquaremeter)
@@ -387,6 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from NanowattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromNanowattsPerSquareMeter(double nanowattspersquaremeter)
@@ -401,6 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from WattsPerSquareFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromWattsPerSquareFoot(double wattspersquarefoot)
@@ -415,6 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from WattsPerSquareInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromWattsPerSquareInch(double wattspersquareinch)
@@ -429,6 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatFlux from WattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatFlux FromWattsPerSquareMeter(double wattspersquaremeter)

--- a/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == HeatTransferCoefficientUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -149,6 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatTransferCoefficient from WattsPerSquareMeterCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatTransferCoefficient FromWattsPerSquareMeterCelsius(double wattspersquaremetercelsius)
@@ -163,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatTransferCoefficient from WattsPerSquareMeterKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatTransferCoefficient FromWattsPerSquareMeterKelvin(double wattspersquaremeterkelvin)

--- a/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -151,7 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatTransferCoefficient from WattsPerSquareMeterCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatTransferCoefficient FromWattsPerSquareMeterCelsius(double wattspersquaremetercelsius)
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get HeatTransferCoefficient from WattsPerSquareMeterKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static HeatTransferCoefficient FromWattsPerSquareMeterKelvin(double wattspersquaremeterkelvin)

--- a/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Kilolux.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromKilolux(double kilolux)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Lux.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromLux(double lux)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Megalux.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromMegalux(double megalux)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Millilux.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromMillilux(double millilux)

--- a/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == IlluminanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Kilolux.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromKilolux(double kilolux)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Lux.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromLux(double lux)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Megalux.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromMegalux(double megalux)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Illuminance from Millilux.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Illuminance FromMillilux(double millilux)

--- a/Common/GeneratedCode/Quantities/Information.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Information.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -270,7 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromBits(double bits)
@@ -285,7 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromBytes(double bytes)
@@ -300,7 +300,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exabits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExabits(double exabits)
@@ -315,7 +315,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExabytes(double exabytes)
@@ -330,7 +330,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExbibits(double exbibits)
@@ -345,7 +345,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExbibytes(double exbibytes)
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gibibits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGibibits(double gibibits)
@@ -375,7 +375,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGibibytes(double gibibytes)
@@ -390,7 +390,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gigabits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGigabits(double gigabits)
@@ -405,7 +405,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGigabytes(double gigabytes)
@@ -420,7 +420,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kibibits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKibibits(double kibibits)
@@ -435,7 +435,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKibibytes(double kibibytes)
@@ -450,7 +450,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kilobits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKilobits(double kilobits)
@@ -465,7 +465,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKilobytes(double kilobytes)
@@ -480,7 +480,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Mebibits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMebibits(double mebibits)
@@ -495,7 +495,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMebibytes(double mebibytes)
@@ -510,7 +510,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Megabits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMegabits(double megabits)
@@ -525,7 +525,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMegabytes(double megabytes)
@@ -540,7 +540,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Pebibits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPebibits(double pebibits)
@@ -555,7 +555,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPebibytes(double pebibytes)
@@ -570,7 +570,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Petabits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPetabits(double petabits)
@@ -585,7 +585,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPetabytes(double petabytes)
@@ -600,7 +600,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Tebibits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTebibits(double tebibits)
@@ -615,7 +615,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTebibytes(double tebibytes)
@@ -630,7 +630,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Terabits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTerabits(double terabits)
@@ -645,7 +645,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTerabytes(double terabytes)

--- a/Common/GeneratedCode/Quantities/Information.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Information.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -268,6 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromBits(double bits)
@@ -282,6 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Bytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromBytes(double bytes)
@@ -296,6 +300,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exabits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExabits(double exabits)
@@ -310,6 +315,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExabytes(double exabytes)
@@ -324,6 +330,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExbibits(double exbibits)
@@ -338,6 +345,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Exbibytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromExbibytes(double exbibytes)
@@ -352,6 +360,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gibibits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGibibits(double gibibits)
@@ -366,6 +375,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gibibytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGibibytes(double gibibytes)
@@ -380,6 +390,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gigabits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGigabits(double gigabits)
@@ -394,6 +405,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Gigabytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromGigabytes(double gigabytes)
@@ -408,6 +420,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kibibits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKibibits(double kibibits)
@@ -422,6 +435,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kibibytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKibibytes(double kibibytes)
@@ -436,6 +450,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kilobits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKilobits(double kilobits)
@@ -450,6 +465,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Kilobytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromKilobytes(double kilobytes)
@@ -464,6 +480,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Mebibits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMebibits(double mebibits)
@@ -478,6 +495,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Mebibytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMebibytes(double mebibytes)
@@ -492,6 +510,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Megabits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMegabits(double megabits)
@@ -506,6 +525,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Megabytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromMegabytes(double megabytes)
@@ -520,6 +540,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Pebibits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPebibits(double pebibits)
@@ -534,6 +555,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Pebibytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPebibytes(double pebibytes)
@@ -548,6 +570,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Petabits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPetabits(double petabits)
@@ -562,6 +585,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Petabytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromPetabytes(double petabytes)
@@ -576,6 +600,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Tebibits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTebibits(double tebibits)
@@ -590,6 +615,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Tebibytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTebibytes(double tebibytes)
@@ -604,6 +630,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Terabits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTerabits(double terabits)
@@ -618,6 +645,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Information from Terabytes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Information FromTerabytes(double terabytes)

--- a/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == IrradianceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -149,6 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiance from KilowattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiance FromKilowattsPerSquareMeter(double kilowattspersquaremeter)
@@ -163,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiance from WattsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiance FromWattsPerSquareMeter(double wattspersquaremeter)

--- a/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -151,7 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiance from KilowattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiance FromKilowattsPerSquareMeter(double kilowattspersquaremeter)
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiance from WattsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiance FromWattsPerSquareMeter(double wattspersquaremeter)

--- a/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == IrradiationUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiation from JoulesPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiation FromJoulesPerSquareMeter(double joulespersquaremeter)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiation from KilowattHoursPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiation FromKilowattHoursPerSquareMeter(double kilowatthourspersquaremeter)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiation from WattHoursPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiation FromWattHoursPerSquareMeter(double watthourspersquaremeter)

--- a/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiation from JoulesPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiation FromJoulesPerSquareMeter(double joulespersquaremeter)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiation from KilowattHoursPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiation FromKilowattHoursPerSquareMeter(double kilowatthourspersquaremeter)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Irradiation from WattHoursPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Irradiation FromWattHoursPerSquareMeter(double watthourspersquaremeter)

--- a/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Centistokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromCentistokes(double centistokes)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromDecistokes(double decistokes)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromKilostokes(double kilostokes)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromMicrostokes(double microstokes)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Millistokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromMillistokes(double millistokes)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromNanostokes(double nanostokes)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromSquareMetersPerSecond(double squaremeterspersecond)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromStokes(double stokes)

--- a/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == KinematicViscosityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Centistokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromCentistokes(double centistokes)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Decistokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromDecistokes(double decistokes)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Kilostokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromKilostokes(double kilostokes)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Microstokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromMicrostokes(double microstokes)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Millistokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromMillistokes(double millistokes)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Nanostokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromNanostokes(double nanostokes)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from SquareMetersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromSquareMetersPerSecond(double squaremeterspersecond)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get KinematicViscosity from Stokes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static KinematicViscosity FromStokes(double stokes)

--- a/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == LapseRateUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LapseRate from DegreesCelciusPerKilometer.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LapseRate FromDegreesCelciusPerKilometer(double degreescelciusperkilometer)

--- a/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LapseRate from DegreesCelciusPerKilometer.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LapseRate FromDegreesCelciusPerKilometer(double degreescelciusperkilometer)

--- a/Common/GeneratedCode/Quantities/Length.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Length.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == LengthUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -249,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Centimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromCentimeters(double centimeters)
@@ -263,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromDecimeters(double decimeters)
@@ -277,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from DtpPicas.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromDtpPicas(double dtppicas)
@@ -291,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromDtpPoints(double dtppoints)
@@ -305,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Fathoms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromFathoms(double fathoms)
@@ -319,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Feet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromFeet(double feet)
@@ -333,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Inches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromInches(double inches)
@@ -347,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromKilometers(double kilometers)
@@ -361,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Meters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMeters(double meters)
@@ -375,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMicroinches(double microinches)
@@ -389,6 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Micrometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMicrometers(double micrometers)
@@ -403,6 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Mils.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMils(double mils)
@@ -417,6 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Miles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMiles(double miles)
@@ -431,6 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMillimeters(double millimeters)
@@ -445,6 +461,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Nanometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromNanometers(double nanometers)
@@ -459,6 +476,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromNauticalMiles(double nauticalmiles)
@@ -473,6 +491,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from PrinterPicas.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromPrinterPicas(double printerpicas)
@@ -487,6 +506,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromPrinterPoints(double printerpoints)
@@ -501,6 +521,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Shackles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromShackles(double shackles)
@@ -515,6 +536,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Twips.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromTwips(double twips)
@@ -529,6 +551,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from UsSurveyFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromUsSurveyFeet(double ussurveyfeet)
@@ -543,6 +566,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Yards.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromYards(double yards)

--- a/Common/GeneratedCode/Quantities/Length.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Length.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Centimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromCentimeters(double centimeters)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Decimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromDecimeters(double decimeters)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from DtpPicas.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromDtpPicas(double dtppicas)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from DtpPoints.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromDtpPoints(double dtppoints)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Fathoms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromFathoms(double fathoms)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Feet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromFeet(double feet)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Inches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromInches(double inches)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Kilometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromKilometers(double kilometers)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Meters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMeters(double meters)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Microinches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMicroinches(double microinches)
@@ -401,7 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Micrometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMicrometers(double micrometers)
@@ -416,7 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Mils.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMils(double mils)
@@ -431,7 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Miles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMiles(double miles)
@@ -446,7 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Millimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromMillimeters(double millimeters)
@@ -461,7 +461,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Nanometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromNanometers(double nanometers)
@@ -476,7 +476,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from NauticalMiles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromNauticalMiles(double nauticalmiles)
@@ -491,7 +491,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from PrinterPicas.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromPrinterPicas(double printerpicas)
@@ -506,7 +506,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from PrinterPoints.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromPrinterPoints(double printerpoints)
@@ -521,7 +521,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Shackles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromShackles(double shackles)
@@ -536,7 +536,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Twips.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromTwips(double twips)
@@ -551,7 +551,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from UsSurveyFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromUsSurveyFeet(double ussurveyfeet)
@@ -566,7 +566,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Length from Yards.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Length FromYards(double yards)

--- a/Common/GeneratedCode/Quantities/Level.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Level.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == LevelUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -148,6 +150,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Decibels.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Level FromDecibels(double decibels)
@@ -162,6 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Level FromNepers(double nepers)

--- a/Common/GeneratedCode/Quantities/Level.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Level.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -150,7 +150,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Decibels.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Level FromDecibels(double decibels)
@@ -165,7 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Level from Nepers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Level FromNepers(double nepers)

--- a/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LinearDensity from GramsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LinearDensity FromGramsPerMeter(double gramspermeter)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LinearDensity from KilogramsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LinearDensity FromKilogramsPerMeter(double kilogramspermeter)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LinearDensity from PoundsPerFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LinearDensity FromPoundsPerFoot(double poundsperfoot)

--- a/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == LinearDensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LinearDensity from GramsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LinearDensity FromGramsPerMeter(double gramspermeter)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LinearDensity from KilogramsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LinearDensity FromKilogramsPerMeter(double kilogramspermeter)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LinearDensity from PoundsPerFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LinearDensity FromPoundsPerFoot(double poundsperfoot)

--- a/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == LuminousFluxUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LuminousFlux from Lumens.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LuminousFlux FromLumens(double lumens)

--- a/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LuminousFlux from Lumens.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LuminousFlux FromLumens(double lumens)

--- a/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == LuminousIntensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LuminousIntensity from Candela.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LuminousIntensity FromCandela(double candela)

--- a/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get LuminousIntensity from Candela.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static LuminousIntensity FromCandela(double candela)

--- a/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MagneticField from Teslas.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MagneticField FromTeslas(double teslas)

--- a/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MagneticFieldUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MagneticField from Teslas.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MagneticField FromTeslas(double teslas)

--- a/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MagneticFlux from Webers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MagneticFlux FromWebers(double webers)

--- a/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MagneticFluxUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MagneticFlux from Webers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MagneticFlux FromWebers(double webers)

--- a/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Magnetization from AmperesPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Magnetization FromAmperesPerMeter(double amperespermeter)

--- a/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MagnetizationUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Magnetization from AmperesPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Magnetization FromAmperesPerMeter(double amperespermeter)

--- a/Common/GeneratedCode/Quantities/Mass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Mass.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MassUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -244,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Centigrams.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromCentigrams(double centigrams)
@@ -258,6 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromDecagrams(double decagrams)
@@ -272,6 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Decigrams.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromDecigrams(double decigrams)
@@ -286,6 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromGrams(double grams)
@@ -300,6 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Hectograms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromHectograms(double hectograms)
@@ -314,6 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromKilograms(double kilograms)
@@ -328,6 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilopounds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromKilopounds(double kilopounds)
@@ -342,6 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromKilotonnes(double kilotonnes)
@@ -356,6 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from LongHundredweight.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromLongHundredweight(double longhundredweight)
@@ -370,6 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromLongTons(double longtons)
@@ -384,6 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Megapounds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMegapounds(double megapounds)
@@ -398,6 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMegatonnes(double megatonnes)
@@ -412,6 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Micrograms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMicrograms(double micrograms)
@@ -426,6 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMilligrams(double milligrams)
@@ -440,6 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Nanograms.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromNanograms(double nanograms)
@@ -454,6 +471,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromOunces(double ounces)
@@ -468,6 +486,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Pounds.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromPounds(double pounds)
@@ -482,6 +501,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromShortHundredweight(double shorthundredweight)
@@ -496,6 +516,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from ShortTons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromShortTons(double shorttons)
@@ -510,6 +531,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromStone(double stone)
@@ -524,6 +546,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Tonnes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromTonnes(double tonnes)

--- a/Common/GeneratedCode/Quantities/Mass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Mass.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Centigrams.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromCentigrams(double centigrams)
@@ -261,7 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Decagrams.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromDecagrams(double decagrams)
@@ -276,7 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Decigrams.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromDecigrams(double decigrams)
@@ -291,7 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Grams.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromGrams(double grams)
@@ -306,7 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Hectograms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromHectograms(double hectograms)
@@ -321,7 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilograms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromKilograms(double kilograms)
@@ -336,7 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilopounds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromKilopounds(double kilopounds)
@@ -351,7 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Kilotonnes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromKilotonnes(double kilotonnes)
@@ -366,7 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from LongHundredweight.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromLongHundredweight(double longhundredweight)
@@ -381,7 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from LongTons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromLongTons(double longtons)
@@ -396,7 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Megapounds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMegapounds(double megapounds)
@@ -411,7 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Megatonnes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMegatonnes(double megatonnes)
@@ -426,7 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Micrograms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMicrograms(double micrograms)
@@ -441,7 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Milligrams.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromMilligrams(double milligrams)
@@ -456,7 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Nanograms.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromNanograms(double nanograms)
@@ -471,7 +471,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Ounces.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromOunces(double ounces)
@@ -486,7 +486,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Pounds.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromPounds(double pounds)
@@ -501,7 +501,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from ShortHundredweight.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromShortHundredweight(double shorthundredweight)
@@ -516,7 +516,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from ShortTons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromShortTons(double shorttons)
@@ -531,7 +531,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Stone.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromStone(double stone)
@@ -546,7 +546,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Mass from Tonnes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Mass FromTonnes(double tonnes)

--- a/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -216,7 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from CentigramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromCentigramsPerSecond(double centigramspersecond)
@@ -231,7 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromDecagramsPerSecond(double decagramspersecond)
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromDecigramsPerSecond(double decigramspersecond)
@@ -261,7 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromGramsPerSecond(double gramspersecond)
@@ -276,7 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromHectogramsPerSecond(double hectogramspersecond)
@@ -291,7 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromKilogramsPerHour(double kilogramsperhour)
@@ -306,7 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromKilogramsPerSecond(double kilogramspersecond)
@@ -321,7 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromMegapoundsPerHour(double megapoundsperhour)
@@ -336,7 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromMicrogramsPerSecond(double microgramspersecond)
@@ -351,7 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromMilligramsPerSecond(double milligramspersecond)
@@ -366,7 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromNanogramsPerSecond(double nanogramspersecond)
@@ -381,7 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromPoundsPerHour(double poundsperhour)
@@ -396,7 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromShortTonsPerHour(double shorttonsperhour)
@@ -411,7 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromTonnesPerDay(double tonnesperday)
@@ -426,7 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from TonnesPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromTonnesPerHour(double tonnesperhour)

--- a/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MassFlowUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -214,6 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from CentigramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromCentigramsPerSecond(double centigramspersecond)
@@ -228,6 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from DecagramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromDecagramsPerSecond(double decagramspersecond)
@@ -242,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from DecigramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromDecigramsPerSecond(double decigramspersecond)
@@ -256,6 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from GramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromGramsPerSecond(double gramspersecond)
@@ -270,6 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from HectogramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromHectogramsPerSecond(double hectogramspersecond)
@@ -284,6 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from KilogramsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromKilogramsPerHour(double kilogramsperhour)
@@ -298,6 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from KilogramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromKilogramsPerSecond(double kilogramspersecond)
@@ -312,6 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MegapoundsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromMegapoundsPerHour(double megapoundsperhour)
@@ -326,6 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MicrogramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromMicrogramsPerSecond(double microgramspersecond)
@@ -340,6 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from MilligramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromMilligramsPerSecond(double milligramspersecond)
@@ -354,6 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from NanogramsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromNanogramsPerSecond(double nanogramspersecond)
@@ -368,6 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from PoundsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromPoundsPerHour(double poundsperhour)
@@ -382,6 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from ShortTonsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromShortTonsPerHour(double shorttonsperhour)
@@ -396,6 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from TonnesPerDay.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromTonnesPerDay(double tonnesperday)
@@ -410,6 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlow from TonnesPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlow FromTonnesPerHour(double tonnesperhour)

--- a/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -151,7 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlux from GramsPerSecondPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlux FromGramsPerSecondPerSquareMeter(double gramspersecondpersquaremeter)
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlux from KilogramsPerSecondPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlux FromKilogramsPerSecondPerSquareMeter(double kilogramspersecondpersquaremeter)

--- a/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MassFluxUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -149,6 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlux from GramsPerSecondPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlux FromGramsPerSecondPerSquareMeter(double gramspersecondpersquaremeter)
@@ -163,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassFlux from KilogramsPerSecondPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassFlux FromKilogramsPerSecondPerSquareMeter(double kilogramspersecondpersquaremeter)

--- a/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MassMomentOfInertiaUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -269,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareCentimeters(double gramsquarecentimeters)
@@ -283,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareDecimeters(double gramsquaredecimeters)
@@ -297,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareMeters(double gramsquaremeters)
@@ -311,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareMillimeters(double gramsquaremillimeters)
@@ -325,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareCentimeters(double kilogramsquarecentimeters)
@@ -339,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareDecimeters(double kilogramsquaredecimeters)
@@ -353,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareMeters(double kilogramsquaremeters)
@@ -367,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareMillimeters(double kilogramsquaremillimeters)
@@ -381,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(double kilotonnesquarecentimeters)
@@ -395,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(double kilotonnesquaredecimeters)
@@ -409,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareMeters(double kilotonnesquaremeters)
@@ -423,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(double kilotonnesquaremilimeters)
@@ -437,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(double megatonnesquarecentimeters)
@@ -451,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(double megatonnesquaredecimeters)
@@ -465,6 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareMeters(double megatonnesquaremeters)
@@ -479,6 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(double megatonnesquaremilimeters)
@@ -493,6 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareCentimeters(double milligramsquarecentimeters)
@@ -507,6 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareDecimeters(double milligramsquaredecimeters)
@@ -521,6 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareMeters(double milligramsquaremeters)
@@ -535,6 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareMillimeters(double milligramsquaremillimeters)
@@ -549,6 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromPoundSquareFeet(double poundsquarefeet)
@@ -563,6 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromPoundSquareInches(double poundsquareinches)
@@ -577,6 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareCentimeters(double tonnesquarecentimeters)
@@ -591,6 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareDecimeters(double tonnesquaredecimeters)
@@ -605,6 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareMeters(double tonnesquaremeters)
@@ -619,6 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareMilimeters(double tonnesquaremilimeters)

--- a/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareCentimeters(double gramsquarecentimeters)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareDecimeters(double gramsquaredecimeters)
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareMeters(double gramsquaremeters)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from GramSquareMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromGramSquareMillimeters(double gramsquaremillimeters)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareCentimeters(double kilogramsquarecentimeters)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareDecimeters(double kilogramsquaredecimeters)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareMeters(double kilogramsquaremeters)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilogramSquareMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilogramSquareMillimeters(double kilogramsquaremillimeters)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareCentimeters(double kilotonnesquarecentimeters)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareDecimeters(double kilotonnesquaredecimeters)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareMeters(double kilotonnesquaremeters)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from KilotonneSquareMilimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromKilotonneSquareMilimeters(double kilotonnesquaremilimeters)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareCentimeters(double megatonnesquarecentimeters)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareDecimeters(double megatonnesquaredecimeters)
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareMeters(double megatonnesquaremeters)
@@ -496,7 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MegatonneSquareMilimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMegatonneSquareMilimeters(double megatonnesquaremilimeters)
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareCentimeters(double milligramsquarecentimeters)
@@ -526,7 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareDecimeters(double milligramsquaredecimeters)
@@ -541,7 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareMeters(double milligramsquaremeters)
@@ -556,7 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from MilligramSquareMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromMilligramSquareMillimeters(double milligramsquaremillimeters)
@@ -571,7 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromPoundSquareFeet(double poundsquarefeet)
@@ -586,7 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from PoundSquareInches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromPoundSquareInches(double poundsquareinches)
@@ -601,7 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareCentimeters(double tonnesquarecentimeters)
@@ -616,7 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareDecimeters(double tonnesquaredecimeters)
@@ -631,7 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareMeters(double tonnesquaremeters)
@@ -646,7 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MassMomentOfInertia from TonneSquareMilimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MassMomentOfInertia FromTonneSquareMilimeters(double tonnesquaremilimeters)

--- a/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MolarEnergyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from JoulesPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEnergy FromJoulesPerMole(double joulespermole)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from KilojoulesPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEnergy FromKilojoulesPerMole(double kilojoulespermole)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from MegajoulesPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEnergy FromMegajoulesPerMole(double megajoulespermole)

--- a/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from JoulesPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEnergy FromJoulesPerMole(double joulespermole)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from KilojoulesPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEnergy FromKilojoulesPerMole(double kilojoulespermole)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEnergy from MegajoulesPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEnergy FromMegajoulesPerMole(double megajoulespermole)

--- a/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MolarEntropyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from JoulesPerMoleKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEntropy FromJoulesPerMoleKelvin(double joulespermolekelvin)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from KilojoulesPerMoleKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEntropy FromKilojoulesPerMoleKelvin(double kilojoulespermolekelvin)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from MegajoulesPerMoleKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEntropy FromMegajoulesPerMoleKelvin(double megajoulespermolekelvin)

--- a/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from JoulesPerMoleKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEntropy FromJoulesPerMoleKelvin(double joulespermolekelvin)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from KilojoulesPerMoleKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEntropy FromKilojoulesPerMoleKelvin(double kilojoulespermolekelvin)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarEntropy from MegajoulesPerMoleKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarEntropy FromMegajoulesPerMoleKelvin(double megajoulespermolekelvin)

--- a/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MolarMassUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -199,6 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from CentigramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromCentigramsPerMole(double centigramspermole)
@@ -213,6 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from DecagramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromDecagramsPerMole(double decagramspermole)
@@ -227,6 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from DecigramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromDecigramsPerMole(double decigramspermole)
@@ -241,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from GramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromGramsPerMole(double gramspermole)
@@ -255,6 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from HectogramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromHectogramsPerMole(double hectogramspermole)
@@ -269,6 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from KilogramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromKilogramsPerMole(double kilogramspermole)
@@ -283,6 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from KilopoundsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromKilopoundsPerMole(double kilopoundspermole)
@@ -297,6 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from MegapoundsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromMegapoundsPerMole(double megapoundspermole)
@@ -311,6 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from MicrogramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromMicrogramsPerMole(double microgramspermole)
@@ -325,6 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from MilligramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromMilligramsPerMole(double milligramspermole)
@@ -339,6 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from NanogramsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromNanogramsPerMole(double nanogramspermole)
@@ -353,6 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from PoundsPerMole.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromPoundsPerMole(double poundspermole)

--- a/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -201,7 +201,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from CentigramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromCentigramsPerMole(double centigramspermole)
@@ -216,7 +216,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from DecagramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromDecagramsPerMole(double decagramspermole)
@@ -231,7 +231,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from DecigramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromDecigramsPerMole(double decigramspermole)
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from GramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromGramsPerMole(double gramspermole)
@@ -261,7 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from HectogramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromHectogramsPerMole(double hectogramspermole)
@@ -276,7 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from KilogramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromKilogramsPerMole(double kilogramspermole)
@@ -291,7 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from KilopoundsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromKilopoundsPerMole(double kilopoundspermole)
@@ -306,7 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from MegapoundsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromMegapoundsPerMole(double megapoundspermole)
@@ -321,7 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from MicrogramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromMicrogramsPerMole(double microgramspermole)
@@ -336,7 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from MilligramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromMilligramsPerMole(double milligramspermole)
@@ -351,7 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from NanogramsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromNanogramsPerMole(double nanogramspermole)
@@ -366,7 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get MolarMass from PoundsPerMole.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static MolarMass FromPoundsPerMole(double poundspermole)

--- a/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == MolarityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from CentimolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromCentimolesPerLiter(double centimolesperliter)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromDecimolesPerLiter(double decimolesperliter)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMicromolesPerLiter(double micromolesperliter)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMillimolesPerLiter(double millimolesperliter)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMolesPerCubicMeter(double molespercubicmeter)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMolesPerLiter(double molesperliter)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromNanomolesPerLiter(double nanomolesperliter)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromPicomolesPerLiter(double picomolesperliter)

--- a/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from CentimolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromCentimolesPerLiter(double centimolesperliter)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from DecimolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromDecimolesPerLiter(double decimolesperliter)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MicromolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMicromolesPerLiter(double micromolesperliter)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MillimolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMillimolesPerLiter(double millimolesperliter)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MolesPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMolesPerCubicMeter(double molespercubicmeter)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from MolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromMolesPerLiter(double molesperliter)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from NanomolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromNanomolesPerLiter(double nanomolesperliter)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Molarity from PicomolesPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Molarity FromPicomolesPerLiter(double picomolesperliter)

--- a/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Permeability from HenriesPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Permeability FromHenriesPerMeter(double henriespermeter)

--- a/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == PermeabilityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Permeability from HenriesPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Permeability FromHenriesPerMeter(double henriespermeter)

--- a/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -146,7 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Permittivity from FaradsPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Permittivity FromFaradsPerMeter(double faradspermeter)

--- a/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == PermittivityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -144,6 +146,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Permittivity from FaradsPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Permittivity FromFaradsPerMeter(double faradspermeter)

--- a/Common/GeneratedCode/Quantities/Power.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Power.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BoilerHorsepower.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromBoilerHorsepower(double boilerhorsepower)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromBritishThermalUnitsPerHour(double britishthermalunitsperhour)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Decawatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromDecawatts(double decawatts)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Deciwatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromDeciwatts(double deciwatts)
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from ElectricalHorsepower.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromElectricalHorsepower(double electricalhorsepower)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromFemtowatts(double femtowatts)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Gigawatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromGigawatts(double gigawatts)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromHydraulicHorsepower(double hydraulichorsepower)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromKilobritishThermalUnitsPerHour(double kilobritishthermalunitsperhour)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromKilowatts(double kilowatts)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from MechanicalHorsepower.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMechanicalHorsepower(double mechanicalhorsepower)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMegawatts(double megawatts)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from MetricHorsepower.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMetricHorsepower(double metrichorsepower)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMicrowatts(double microwatts)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Milliwatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMilliwatts(double milliwatts)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromNanowatts(double nanowatts)
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Petawatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromPetawatts(double petawatts)
@@ -496,7 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromPicowatts(double picowatts)
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Terawatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromTerawatts(double terawatts)
@@ -526,7 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Watts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromWatts(double watts)

--- a/Common/GeneratedCode/Quantities/Power.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Power.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -239,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BoilerHorsepower.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromBoilerHorsepower(double boilerhorsepower)
@@ -253,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from BritishThermalUnitsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromBritishThermalUnitsPerHour(double britishthermalunitsperhour)
@@ -267,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Decawatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromDecawatts(double decawatts)
@@ -281,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Deciwatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromDeciwatts(double deciwatts)
@@ -295,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from ElectricalHorsepower.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromElectricalHorsepower(double electricalhorsepower)
@@ -309,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Femtowatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromFemtowatts(double femtowatts)
@@ -323,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Gigawatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromGigawatts(double gigawatts)
@@ -337,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from HydraulicHorsepower.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromHydraulicHorsepower(double hydraulichorsepower)
@@ -351,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from KilobritishThermalUnitsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromKilobritishThermalUnitsPerHour(double kilobritishthermalunitsperhour)
@@ -365,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Kilowatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromKilowatts(double kilowatts)
@@ -379,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from MechanicalHorsepower.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMechanicalHorsepower(double mechanicalhorsepower)
@@ -393,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Megawatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMegawatts(double megawatts)
@@ -407,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from MetricHorsepower.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMetricHorsepower(double metrichorsepower)
@@ -421,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Microwatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMicrowatts(double microwatts)
@@ -435,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Milliwatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromMilliwatts(double milliwatts)
@@ -449,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Nanowatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromNanowatts(double nanowatts)
@@ -463,6 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Petawatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromPetawatts(double petawatts)
@@ -477,6 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Picowatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromPicowatts(double picowatts)
@@ -491,6 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Terawatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromTerawatts(double terawatts)
@@ -505,6 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Power from Watts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Power FromWatts(double watts)

--- a/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == PowerDensityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -359,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerCubicFoot(double decawattspercubicfoot)
@@ -373,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerCubicInch(double decawattspercubicinch)
@@ -387,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerCubicMeter(double decawattspercubicmeter)
@@ -401,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerLiter(double decawattsperliter)
@@ -415,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerCubicFoot(double deciwattspercubicfoot)
@@ -429,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerCubicInch(double deciwattspercubicinch)
@@ -443,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerCubicMeter(double deciwattspercubicmeter)
@@ -457,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerLiter(double deciwattsperliter)
@@ -471,6 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerCubicFoot(double gigawattspercubicfoot)
@@ -485,6 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerCubicInch(double gigawattspercubicinch)
@@ -499,6 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerCubicMeter(double gigawattspercubicmeter)
@@ -513,6 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerLiter(double gigawattsperliter)
@@ -527,6 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerCubicFoot(double kilowattspercubicfoot)
@@ -541,6 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerCubicInch(double kilowattspercubicinch)
@@ -555,6 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerCubicMeter(double kilowattspercubicmeter)
@@ -569,6 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerLiter(double kilowattsperliter)
@@ -583,6 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerCubicFoot(double megawattspercubicfoot)
@@ -597,6 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerCubicInch(double megawattspercubicinch)
@@ -611,6 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerCubicMeter(double megawattspercubicmeter)
@@ -625,6 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerLiter(double megawattsperliter)
@@ -639,6 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerCubicFoot(double microwattspercubicfoot)
@@ -653,6 +676,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerCubicInch(double microwattspercubicinch)
@@ -667,6 +691,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerCubicMeter(double microwattspercubicmeter)
@@ -681,6 +706,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerLiter(double microwattsperliter)
@@ -695,6 +721,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerCubicFoot(double milliwattspercubicfoot)
@@ -709,6 +736,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerCubicInch(double milliwattspercubicinch)
@@ -723,6 +751,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerCubicMeter(double milliwattspercubicmeter)
@@ -737,6 +766,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerLiter(double milliwattsperliter)
@@ -751,6 +781,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerCubicFoot(double nanowattspercubicfoot)
@@ -765,6 +796,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerCubicInch(double nanowattspercubicinch)
@@ -779,6 +811,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerCubicMeter(double nanowattspercubicmeter)
@@ -793,6 +826,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerLiter(double nanowattsperliter)
@@ -807,6 +841,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerCubicFoot(double picowattspercubicfoot)
@@ -821,6 +856,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerCubicInch(double picowattspercubicinch)
@@ -835,6 +871,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerCubicMeter(double picowattspercubicmeter)
@@ -849,6 +886,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerLiter(double picowattsperliter)
@@ -863,6 +901,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerCubicFoot(double terawattspercubicfoot)
@@ -877,6 +916,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerCubicInch(double terawattspercubicinch)
@@ -891,6 +931,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerCubicMeter(double terawattspercubicmeter)
@@ -905,6 +946,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerLiter(double terawattsperliter)
@@ -919,6 +961,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerCubicFoot(double wattspercubicfoot)
@@ -933,6 +976,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerCubicInch(double wattspercubicinch)
@@ -947,6 +991,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerCubicMeter(double wattspercubicmeter)
@@ -961,6 +1006,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerLiter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerLiter(double wattsperliter)

--- a/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerCubicFoot(double decawattspercubicfoot)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerCubicInch(double decawattspercubicinch)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerCubicMeter(double decawattspercubicmeter)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DecawattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDecawattsPerLiter(double decawattsperliter)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerCubicFoot(double deciwattspercubicfoot)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerCubicInch(double deciwattspercubicinch)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerCubicMeter(double deciwattspercubicmeter)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from DeciwattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromDeciwattsPerLiter(double deciwattsperliter)
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerCubicFoot(double gigawattspercubicfoot)
@@ -496,7 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerCubicInch(double gigawattspercubicinch)
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerCubicMeter(double gigawattspercubicmeter)
@@ -526,7 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from GigawattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromGigawattsPerLiter(double gigawattsperliter)
@@ -541,7 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerCubicFoot(double kilowattspercubicfoot)
@@ -556,7 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerCubicInch(double kilowattspercubicinch)
@@ -571,7 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerCubicMeter(double kilowattspercubicmeter)
@@ -586,7 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from KilowattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromKilowattsPerLiter(double kilowattsperliter)
@@ -601,7 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerCubicFoot(double megawattspercubicfoot)
@@ -616,7 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerCubicInch(double megawattspercubicinch)
@@ -631,7 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerCubicMeter(double megawattspercubicmeter)
@@ -646,7 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MegawattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMegawattsPerLiter(double megawattsperliter)
@@ -661,7 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerCubicFoot(double microwattspercubicfoot)
@@ -676,7 +676,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerCubicInch(double microwattspercubicinch)
@@ -691,7 +691,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerCubicMeter(double microwattspercubicmeter)
@@ -706,7 +706,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MicrowattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMicrowattsPerLiter(double microwattsperliter)
@@ -721,7 +721,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerCubicFoot(double milliwattspercubicfoot)
@@ -736,7 +736,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerCubicInch(double milliwattspercubicinch)
@@ -751,7 +751,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerCubicMeter(double milliwattspercubicmeter)
@@ -766,7 +766,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from MilliwattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromMilliwattsPerLiter(double milliwattsperliter)
@@ -781,7 +781,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerCubicFoot(double nanowattspercubicfoot)
@@ -796,7 +796,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerCubicInch(double nanowattspercubicinch)
@@ -811,7 +811,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerCubicMeter(double nanowattspercubicmeter)
@@ -826,7 +826,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from NanowattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromNanowattsPerLiter(double nanowattsperliter)
@@ -841,7 +841,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerCubicFoot(double picowattspercubicfoot)
@@ -856,7 +856,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerCubicInch(double picowattspercubicinch)
@@ -871,7 +871,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerCubicMeter(double picowattspercubicmeter)
@@ -886,7 +886,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from PicowattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromPicowattsPerLiter(double picowattsperliter)
@@ -901,7 +901,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerCubicFoot(double terawattspercubicfoot)
@@ -916,7 +916,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerCubicInch(double terawattspercubicinch)
@@ -931,7 +931,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerCubicMeter(double terawattspercubicmeter)
@@ -946,7 +946,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from TerawattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromTerawattsPerLiter(double terawattsperliter)
@@ -961,7 +961,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerCubicFoot(double wattspercubicfoot)
@@ -976,7 +976,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerCubicInch(double wattspercubicinch)
@@ -991,7 +991,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerCubicMeter(double wattspercubicmeter)
@@ -1006,7 +1006,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerDensity from WattsPerLiter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerDensity FromWattsPerLiter(double wattsperliter)

--- a/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -150,7 +150,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerRatio FromDecibelMilliwatts(double decibelmilliwatts)
@@ -165,7 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerRatio FromDecibelWatts(double decibelwatts)

--- a/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == PowerRatioUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -148,6 +150,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelMilliwatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerRatio FromDecibelMilliwatts(double decibelmilliwatts)
@@ -162,6 +165,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PowerRatio from DecibelWatts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PowerRatio FromDecibelWatts(double decibelwatts)

--- a/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Atmospheres.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromAtmospheres(double atmospheres)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromBars(double bars)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Centibars.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromCentibars(double centibars)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromDecapascals(double decapascals)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Decibars.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromDecibars(double decibars)
@@ -401,7 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromFeetOfHead(double feetofhead)
@@ -416,7 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Gigapascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromGigapascals(double gigapascals)
@@ -431,7 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromHectopascals(double hectopascals)
@@ -446,7 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from InchesOfMercury.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromInchesOfMercury(double inchesofmercury)
@@ -461,7 +461,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilobars(double kilobars)
@@ -476,7 +476,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilogramsForcePerSquareCentimeter(double kilogramsforcepersquarecentimeter)
@@ -491,7 +491,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilogramsForcePerSquareMeter(double kilogramsforcepersquaremeter)
@@ -506,7 +506,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilogramsForcePerSquareMillimeter(double kilogramsforcepersquaremillimeter)
@@ -521,7 +521,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilonewtonsPerSquareCentimeter(double kilonewtonspersquarecentimeter)
@@ -536,7 +536,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilonewtonsPerSquareMeter(double kilonewtonspersquaremeter)
@@ -551,7 +551,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilonewtonsPerSquareMillimeter(double kilonewtonspersquaremillimeter)
@@ -566,7 +566,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Kilopascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilopascals(double kilopascals)
@@ -581,7 +581,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilopoundsForcePerSquareFoot(double kilopoundsforcepersquarefoot)
@@ -596,7 +596,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilopoundsForcePerSquareInch(double kilopoundsforcepersquareinch)
@@ -611,7 +611,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMegabars(double megabars)
@@ -626,7 +626,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MeganewtonsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMeganewtonsPerSquareMeter(double meganewtonspersquaremeter)
@@ -641,7 +641,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Megapascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMegapascals(double megapascals)
@@ -656,7 +656,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMetersOfHead(double metersofhead)
@@ -671,7 +671,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Micropascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMicropascals(double micropascals)
@@ -686,7 +686,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMillibars(double millibars)
@@ -701,7 +701,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMillimetersOfMercury(double millimetersofmercury)
@@ -716,7 +716,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromNewtonsPerSquareCentimeter(double newtonspersquarecentimeter)
@@ -731,7 +731,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromNewtonsPerSquareMeter(double newtonspersquaremeter)
@@ -746,7 +746,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromNewtonsPerSquareMillimeter(double newtonspersquaremillimeter)
@@ -761,7 +761,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Pascals.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromPascals(double pascals)
@@ -776,7 +776,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromPoundsForcePerSquareFoot(double poundsforcepersquarefoot)
@@ -791,7 +791,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromPoundsForcePerSquareInch(double poundsforcepersquareinch)
@@ -806,7 +806,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTechnicalAtmospheres(double technicalatmospheres)
@@ -821,7 +821,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTonnesForcePerSquareCentimeter(double tonnesforcepersquarecentimeter)
@@ -836,7 +836,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTonnesForcePerSquareMeter(double tonnesforcepersquaremeter)
@@ -851,7 +851,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTonnesForcePerSquareMillimeter(double tonnesforcepersquaremillimeter)
@@ -866,7 +866,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Torrs.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTorrs(double torrs)

--- a/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == PressureUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -324,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Atmospheres.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromAtmospheres(double atmospheres)
@@ -338,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Bars.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromBars(double bars)
@@ -352,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Centibars.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromCentibars(double centibars)
@@ -366,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Decapascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromDecapascals(double decapascals)
@@ -380,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Decibars.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromDecibars(double decibars)
@@ -394,6 +401,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from FeetOfHead.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromFeetOfHead(double feetofhead)
@@ -408,6 +416,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Gigapascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromGigapascals(double gigapascals)
@@ -422,6 +431,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Hectopascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromHectopascals(double hectopascals)
@@ -436,6 +446,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from InchesOfMercury.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromInchesOfMercury(double inchesofmercury)
@@ -450,6 +461,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Kilobars.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilobars(double kilobars)
@@ -464,6 +476,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilogramsForcePerSquareCentimeter(double kilogramsforcepersquarecentimeter)
@@ -478,6 +491,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilogramsForcePerSquareMeter(double kilogramsforcepersquaremeter)
@@ -492,6 +506,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilogramsForcePerSquareMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilogramsForcePerSquareMillimeter(double kilogramsforcepersquaremillimeter)
@@ -506,6 +521,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilonewtonsPerSquareCentimeter(double kilonewtonspersquarecentimeter)
@@ -520,6 +536,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilonewtonsPerSquareMeter(double kilonewtonspersquaremeter)
@@ -534,6 +551,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilonewtonsPerSquareMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilonewtonsPerSquareMillimeter(double kilonewtonspersquaremillimeter)
@@ -548,6 +566,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Kilopascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilopascals(double kilopascals)
@@ -562,6 +581,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilopoundsForcePerSquareFoot(double kilopoundsforcepersquarefoot)
@@ -576,6 +596,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from KilopoundsForcePerSquareInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromKilopoundsForcePerSquareInch(double kilopoundsforcepersquareinch)
@@ -590,6 +611,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Megabars.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMegabars(double megabars)
@@ -604,6 +626,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MeganewtonsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMeganewtonsPerSquareMeter(double meganewtonspersquaremeter)
@@ -618,6 +641,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Megapascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMegapascals(double megapascals)
@@ -632,6 +656,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MetersOfHead.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMetersOfHead(double metersofhead)
@@ -646,6 +671,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Micropascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMicropascals(double micropascals)
@@ -660,6 +686,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Millibars.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMillibars(double millibars)
@@ -674,6 +701,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from MillimetersOfMercury.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromMillimetersOfMercury(double millimetersofmercury)
@@ -688,6 +716,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromNewtonsPerSquareCentimeter(double newtonspersquarecentimeter)
@@ -702,6 +731,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromNewtonsPerSquareMeter(double newtonspersquaremeter)
@@ -716,6 +746,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from NewtonsPerSquareMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromNewtonsPerSquareMillimeter(double newtonspersquaremillimeter)
@@ -730,6 +761,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Pascals.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromPascals(double pascals)
@@ -744,6 +776,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromPoundsForcePerSquareFoot(double poundsforcepersquarefoot)
@@ -758,6 +791,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from PoundsForcePerSquareInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromPoundsForcePerSquareInch(double poundsforcepersquareinch)
@@ -772,6 +806,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TechnicalAtmospheres.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTechnicalAtmospheres(double technicalatmospheres)
@@ -786,6 +821,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTonnesForcePerSquareCentimeter(double tonnesforcepersquarecentimeter)
@@ -800,6 +836,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTonnesForcePerSquareMeter(double tonnesforcepersquaremeter)
@@ -814,6 +851,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from TonnesForcePerSquareMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTonnesForcePerSquareMillimeter(double tonnesforcepersquaremillimeter)
@@ -828,6 +866,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Pressure from Torrs.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Pressure FromTorrs(double torrs)

--- a/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromAtmospheresPerSecond(double atmospherespersecond)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromKilopascalsPerSecond(double kilopascalspersecond)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromMegapascalsPerSecond(double megapascalspersecond)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromPascalsPerSecond(double pascalspersecond)

--- a/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == PressureChangeRateUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from AtmospheresPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromAtmospheresPerSecond(double atmospherespersecond)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from KilopascalsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromKilopascalsPerSecond(double kilopascalspersecond)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from MegapascalsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromMegapascalsPerSecond(double megapascalspersecond)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get PressureChangeRate from PascalsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static PressureChangeRate FromPascalsPerSecond(double pascalspersecond)

--- a/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -170,7 +170,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from DecimalFractions.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromDecimalFractions(double decimalfractions)
@@ -185,7 +185,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerBillion(double partsperbillion)
@@ -200,7 +200,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerMillion.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerMillion(double partspermillion)
@@ -215,7 +215,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerThousand(double partsperthousand)
@@ -230,7 +230,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerTrillion.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerTrillion(double partspertrillion)
@@ -245,7 +245,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPercent(double percent)

--- a/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == RatioUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -168,6 +170,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from DecimalFractions.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromDecimalFractions(double decimalfractions)
@@ -182,6 +185,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerBillion.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerBillion(double partsperbillion)
@@ -196,6 +200,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerMillion.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerMillion(double partspermillion)
@@ -210,6 +215,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerThousand.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerThousand(double partsperthousand)
@@ -224,6 +230,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from PartsPerTrillion.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPartsPerTrillion(double partspertrillion)
@@ -238,6 +245,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Ratio from Percent.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Ratio FromPercent(double percent)

--- a/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactiveEnergy from KilovoltampereReactiveHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactiveEnergy FromKilovoltampereReactiveHours(double kilovoltamperereactivehours)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactiveEnergy from MegavoltampereReactiveHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactiveEnergy FromMegavoltampereReactiveHours(double megavoltamperereactivehours)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactiveEnergy from VoltampereReactiveHours.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactiveEnergy FromVoltampereReactiveHours(double voltamperereactivehours)

--- a/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ReactiveEnergyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactiveEnergy from KilovoltampereReactiveHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactiveEnergy FromKilovoltampereReactiveHours(double kilovoltamperereactivehours)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactiveEnergy from MegavoltampereReactiveHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactiveEnergy FromMegavoltampereReactiveHours(double megavoltamperereactivehours)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactiveEnergy from VoltampereReactiveHours.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactiveEnergy FromVoltampereReactiveHours(double voltamperereactivehours)

--- a/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ReactivePowerUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -159,6 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from GigavoltamperesReactive.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromGigavoltamperesReactive(double gigavoltamperesreactive)
@@ -173,6 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromKilovoltamperesReactive(double kilovoltamperesreactive)
@@ -187,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromMegavoltamperesReactive(double megavoltamperesreactive)
@@ -201,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromVoltamperesReactive(double voltamperesreactive)

--- a/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -161,7 +161,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from GigavoltamperesReactive.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromGigavoltamperesReactive(double gigavoltamperesreactive)
@@ -176,7 +176,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from KilovoltamperesReactive.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromKilovoltamperesReactive(double kilovoltamperesreactive)
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from MegavoltamperesReactive.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromMegavoltamperesReactive(double megavoltamperesreactive)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ReactivePower from VoltamperesReactive.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ReactivePower FromVoltamperesReactive(double voltamperesreactive)

--- a/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == RotationalAccelerationUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalAcceleration FromDegreesPerSecondSquared(double degreespersecondsquared)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalAcceleration FromRadiansPerSecondSquared(double radianspersecondsquared)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from RevolutionsPerMinutePerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalAcceleration FromRevolutionsPerMinutePerSecond(double revolutionsperminutepersecond)

--- a/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from DegreesPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalAcceleration FromDegreesPerSecondSquared(double degreespersecondsquared)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from RadiansPerSecondSquared.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalAcceleration FromRadiansPerSecondSquared(double radianspersecondsquared)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalAcceleration from RevolutionsPerMinutePerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalAcceleration FromRevolutionsPerMinutePerSecond(double revolutionsperminutepersecond)

--- a/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromCentiradiansPerSecond(double centiradianspersecond)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromDeciradiansPerSecond(double deciradianspersecond)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromDegreesPerMinute(double degreesperminute)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromDegreesPerSecond(double degreespersecond)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMicrodegreesPerSecond(double microdegreespersecond)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMicroradiansPerSecond(double microradianspersecond)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMillidegreesPerSecond(double millidegreespersecond)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMilliradiansPerSecond(double milliradianspersecond)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromNanodegreesPerSecond(double nanodegreespersecond)
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromNanoradiansPerSecond(double nanoradianspersecond)
@@ -356,7 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromRadiansPerSecond(double radianspersecond)
@@ -371,7 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromRevolutionsPerMinute(double revolutionsperminute)
@@ -386,7 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromRevolutionsPerSecond(double revolutionspersecond)

--- a/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == RotationalSpeedUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -204,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from CentiradiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromCentiradiansPerSecond(double centiradianspersecond)
@@ -218,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DeciradiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromDeciradiansPerSecond(double deciradianspersecond)
@@ -232,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromDegreesPerMinute(double degreesperminute)
@@ -246,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from DegreesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromDegreesPerSecond(double degreespersecond)
@@ -260,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MicrodegreesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMicrodegreesPerSecond(double microdegreespersecond)
@@ -274,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MicroradiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMicroradiansPerSecond(double microradianspersecond)
@@ -288,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MillidegreesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMillidegreesPerSecond(double millidegreespersecond)
@@ -302,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from MilliradiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromMilliradiansPerSecond(double milliradianspersecond)
@@ -316,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from NanodegreesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromNanodegreesPerSecond(double nanodegreespersecond)
@@ -330,6 +341,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from NanoradiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromNanoradiansPerSecond(double nanoradianspersecond)
@@ -344,6 +356,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RadiansPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromRadiansPerSecond(double radianspersecond)
@@ -358,6 +371,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromRevolutionsPerMinute(double revolutionsperminute)
@@ -372,6 +386,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalSpeed from RevolutionsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalSpeed FromRevolutionsPerSecond(double revolutionspersecond)

--- a/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == RotationalStiffnessUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffness from KilonewtonMetersPerRadian.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffness FromKilonewtonMetersPerRadian(double kilonewtonmetersperradian)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffness from MeganewtonMetersPerRadian.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffness FromMeganewtonMetersPerRadian(double meganewtonmetersperradian)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffness from NewtonMetersPerRadian.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffness FromNewtonMetersPerRadian(double newtonmetersperradian)

--- a/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffness from KilonewtonMetersPerRadian.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffness FromKilonewtonMetersPerRadian(double kilonewtonmetersperradian)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffness from MeganewtonMetersPerRadian.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffness FromMeganewtonMetersPerRadian(double meganewtonmetersperradian)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffness from NewtonMetersPerRadian.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffness FromNewtonMetersPerRadian(double newtonmetersperradian)

--- a/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -156,7 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffnessPerLength from KilonewtonMetersPerRadianPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffnessPerLength FromKilonewtonMetersPerRadianPerMeter(double kilonewtonmetersperradianpermeter)
@@ -171,7 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffnessPerLength from MeganewtonMetersPerRadianPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffnessPerLength FromMeganewtonMetersPerRadianPerMeter(double meganewtonmetersperradianpermeter)
@@ -186,7 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffnessPerLength from NewtonMetersPerRadianPerMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffnessPerLength FromNewtonMetersPerRadianPerMeter(double newtonmetersperradianpermeter)

--- a/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == RotationalStiffnessPerLengthUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -154,6 +156,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffnessPerLength from KilonewtonMetersPerRadianPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffnessPerLength FromKilonewtonMetersPerRadianPerMeter(double kilonewtonmetersperradianpermeter)
@@ -168,6 +171,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffnessPerLength from MeganewtonMetersPerRadianPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffnessPerLength FromMeganewtonMetersPerRadianPerMeter(double meganewtonmetersperradianpermeter)
@@ -182,6 +186,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get RotationalStiffnessPerLength from NewtonMetersPerRadianPerMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static RotationalStiffnessPerLength FromNewtonMetersPerRadianPerMeter(double newtonmetersperradianpermeter)

--- a/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == SolidAngleUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -143,6 +145,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SolidAngle from Steradians.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SolidAngle FromSteradians(double steradians)

--- a/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -145,7 +145,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SolidAngle from Steradians.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SolidAngle FromSteradians(double steradians)

--- a/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromCaloriesPerGram(double caloriespergram)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromJoulesPerKilogram(double joulesperkilogram)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromKilocaloriesPerGram(double kilocaloriespergram)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromKilojoulesPerKilogram(double kilojoulesperkilogram)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromKilowattHoursPerKilogram(double kilowatthoursperkilogram)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromMegajoulesPerKilogram(double megajoulesperkilogram)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromMegawattHoursPerKilogram(double megawatthoursperkilogram)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromWattHoursPerKilogram(double watthoursperkilogram)

--- a/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == SpecificEnergyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from CaloriesPerGram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromCaloriesPerGram(double caloriespergram)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from JoulesPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromJoulesPerKilogram(double joulesperkilogram)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilocaloriesPerGram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromKilocaloriesPerGram(double kilocaloriespergram)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilojoulesPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromKilojoulesPerKilogram(double kilojoulesperkilogram)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from KilowattHoursPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromKilowattHoursPerKilogram(double kilowatthoursperkilogram)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from MegajoulesPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromMegajoulesPerKilogram(double megajoulesperkilogram)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from MegawattHoursPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromMegawattHoursPerKilogram(double megawatthoursperkilogram)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEnergy from WattHoursPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEnergy FromWattHoursPerKilogram(double watthoursperkilogram)

--- a/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == SpecificEntropyUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from CaloriesPerGramKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromCaloriesPerGramKelvin(double caloriespergramkelvin)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from JoulesPerKilogramDegreeCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromJoulesPerKilogramDegreeCelsius(double joulesperkilogramdegreecelsius)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from JoulesPerKilogramKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromJoulesPerKilogramKelvin(double joulesperkilogramkelvin)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from KilocaloriesPerGramKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromKilocaloriesPerGramKelvin(double kilocaloriespergramkelvin)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from KilojoulesPerKilogramDegreeCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromKilojoulesPerKilogramDegreeCelsius(double kilojoulesperkilogramdegreecelsius)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from KilojoulesPerKilogramKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromKilojoulesPerKilogramKelvin(double kilojoulesperkilogramkelvin)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from MegajoulesPerKilogramDegreeCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromMegajoulesPerKilogramDegreeCelsius(double megajoulesperkilogramdegreecelsius)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from MegajoulesPerKilogramKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromMegajoulesPerKilogramKelvin(double megajoulesperkilogramkelvin)

--- a/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from CaloriesPerGramKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromCaloriesPerGramKelvin(double caloriespergramkelvin)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from JoulesPerKilogramDegreeCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromJoulesPerKilogramDegreeCelsius(double joulesperkilogramdegreecelsius)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from JoulesPerKilogramKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromJoulesPerKilogramKelvin(double joulesperkilogramkelvin)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from KilocaloriesPerGramKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromKilocaloriesPerGramKelvin(double kilocaloriespergramkelvin)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from KilojoulesPerKilogramDegreeCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromKilojoulesPerKilogramDegreeCelsius(double kilojoulesperkilogramdegreecelsius)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from KilojoulesPerKilogramKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromKilojoulesPerKilogramKelvin(double kilojoulesperkilogramkelvin)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from MegajoulesPerKilogramDegreeCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromMegajoulesPerKilogramDegreeCelsius(double megajoulesperkilogramdegreecelsius)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificEntropy from MegajoulesPerKilogramKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificEntropy FromMegajoulesPerKilogramKelvin(double megajoulesperkilogramkelvin)

--- a/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -151,7 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificVolume from CubicFeetPerPound.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificVolume FromCubicFeetPerPound(double cubicfeetperpound)
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificVolume from CubicMetersPerKilogram.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificVolume FromCubicMetersPerKilogram(double cubicmetersperkilogram)

--- a/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == SpecificVolumeUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -149,6 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificVolume from CubicFeetPerPound.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificVolume FromCubicFeetPerPound(double cubicfeetperpound)
@@ -163,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificVolume from CubicMetersPerKilogram.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificVolume FromCubicMetersPerKilogram(double cubicmetersperkilogram)

--- a/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == SpecificWeightUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -224,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(double kilogramsforcepercubiccentimeter)
@@ -238,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilogramsForcePerCubicMeter(double kilogramsforcepercubicmeter)
@@ -252,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(double kilogramsforcepercubicmillimeter)
@@ -266,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(double kilonewtonspercubiccentimeter)
@@ -280,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilonewtonsPerCubicMeter(double kilonewtonspercubicmeter)
@@ -294,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(double kilonewtonspercubicmillimeter)
@@ -308,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(double kilopoundsforcepercubicfoot)
@@ -322,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilopoundsForcePerCubicInch(double kilopoundsforcepercubicinch)
@@ -336,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from MeganewtonsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromMeganewtonsPerCubicMeter(double meganewtonspercubicmeter)
@@ -350,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromNewtonsPerCubicCentimeter(double newtonspercubiccentimeter)
@@ -364,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromNewtonsPerCubicMeter(double newtonspercubicmeter)
@@ -378,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromNewtonsPerCubicMillimeter(double newtonspercubicmillimeter)
@@ -392,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromPoundsForcePerCubicFoot(double poundsforcepercubicfoot)
@@ -406,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromPoundsForcePerCubicInch(double poundsforcepercubicinch)
@@ -420,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(double tonnesforcepercubiccentimeter)
@@ -434,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromTonnesForcePerCubicMeter(double tonnesforcepercubicmeter)
@@ -448,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(double tonnesforcepercubicmillimeter)

--- a/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilogramsForcePerCubicCentimeter(double kilogramsforcepercubiccentimeter)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilogramsForcePerCubicMeter(double kilogramsforcepercubicmeter)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilogramsForcePerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilogramsForcePerCubicMillimeter(double kilogramsforcepercubicmillimeter)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilonewtonsPerCubicCentimeter(double kilonewtonspercubiccentimeter)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilonewtonsPerCubicMeter(double kilonewtonspercubicmeter)
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilonewtonsPerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilonewtonsPerCubicMillimeter(double kilonewtonspercubicmillimeter)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilopoundsForcePerCubicFoot(double kilopoundsforcepercubicfoot)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from KilopoundsForcePerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromKilopoundsForcePerCubicInch(double kilopoundsforcepercubicinch)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from MeganewtonsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromMeganewtonsPerCubicMeter(double meganewtonspercubicmeter)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromNewtonsPerCubicCentimeter(double newtonspercubiccentimeter)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromNewtonsPerCubicMeter(double newtonspercubicmeter)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from NewtonsPerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromNewtonsPerCubicMillimeter(double newtonspercubicmillimeter)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicFoot.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromPoundsForcePerCubicFoot(double poundsforcepercubicfoot)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from PoundsForcePerCubicInch.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromPoundsForcePerCubicInch(double poundsforcepercubicinch)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicCentimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromTonnesForcePerCubicCentimeter(double tonnesforcepercubiccentimeter)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromTonnesForcePerCubicMeter(double tonnesforcepercubicmeter)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get SpecificWeight from TonnesForcePerCubicMillimeter.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static SpecificWeight FromTonnesForcePerCubicMillimeter(double tonnesforcepercubicmillimeter)

--- a/Common/GeneratedCode/Quantities/Speed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Speed.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == SpeedUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -299,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromCentimetersPerHour(double centimetersperhour)
@@ -313,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromCentimetersPerMinutes(double centimetersperminutes)
@@ -327,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromCentimetersPerSecond(double centimeterspersecond)
@@ -341,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromDecimetersPerMinutes(double decimetersperminutes)
@@ -355,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from DecimetersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromDecimetersPerSecond(double decimeterspersecond)
@@ -369,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromFeetPerHour(double feetperhour)
@@ -383,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromFeetPerMinute(double feetperminute)
@@ -397,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromFeetPerSecond(double feetpersecond)
@@ -411,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from InchesPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromInchesPerHour(double inchesperhour)
@@ -425,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from InchesPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromInchesPerMinute(double inchesperminute)
@@ -439,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from InchesPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromInchesPerSecond(double inchespersecond)
@@ -453,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKilometersPerHour(double kilometersperhour)
@@ -467,6 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKilometersPerMinutes(double kilometersperminutes)
@@ -481,6 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKilometersPerSecond(double kilometerspersecond)
@@ -495,6 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKnots(double knots)
@@ -509,6 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMetersPerHour(double metersperhour)
@@ -523,6 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMetersPerMinutes(double metersperminutes)
@@ -537,6 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMetersPerSecond(double meterspersecond)
@@ -551,6 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMicrometersPerMinutes(double micrometersperminutes)
@@ -565,6 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MicrometersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMicrometersPerSecond(double micrometerspersecond)
@@ -579,6 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMilesPerHour(double milesperhour)
@@ -593,6 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMillimetersPerHour(double millimetersperhour)
@@ -607,6 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMillimetersPerMinutes(double millimetersperminutes)
@@ -621,6 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMillimetersPerSecond(double millimeterspersecond)
@@ -635,6 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromNanometersPerMinutes(double nanometersperminutes)
@@ -649,6 +676,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from NanometersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromNanometersPerSecond(double nanometerspersecond)
@@ -663,6 +691,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from UsSurveyFeetPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromUsSurveyFeetPerHour(double ussurveyfeetperhour)
@@ -677,6 +706,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from UsSurveyFeetPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromUsSurveyFeetPerMinute(double ussurveyfeetperminute)
@@ -691,6 +721,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from UsSurveyFeetPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromUsSurveyFeetPerSecond(double ussurveyfeetpersecond)
@@ -705,6 +736,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from YardsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromYardsPerHour(double yardsperhour)
@@ -719,6 +751,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from YardsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromYardsPerMinute(double yardsperminute)
@@ -733,6 +766,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from YardsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromYardsPerSecond(double yardspersecond)

--- a/Common/GeneratedCode/Quantities/Speed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Speed.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromCentimetersPerHour(double centimetersperhour)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromCentimetersPerMinutes(double centimetersperminutes)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from CentimetersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromCentimetersPerSecond(double centimeterspersecond)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from DecimetersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromDecimetersPerMinutes(double decimetersperminutes)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from DecimetersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromDecimetersPerSecond(double decimeterspersecond)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromFeetPerHour(double feetperhour)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromFeetPerMinute(double feetperminute)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from FeetPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromFeetPerSecond(double feetpersecond)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from InchesPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromInchesPerHour(double inchesperhour)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from InchesPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromInchesPerMinute(double inchesperminute)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from InchesPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromInchesPerSecond(double inchespersecond)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKilometersPerHour(double kilometersperhour)
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKilometersPerMinutes(double kilometersperminutes)
@@ -496,7 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from KilometersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKilometersPerSecond(double kilometerspersecond)
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from Knots.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromKnots(double knots)
@@ -526,7 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMetersPerHour(double metersperhour)
@@ -541,7 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMetersPerMinutes(double metersperminutes)
@@ -556,7 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MetersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMetersPerSecond(double meterspersecond)
@@ -571,7 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MicrometersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMicrometersPerMinutes(double micrometersperminutes)
@@ -586,7 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MicrometersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMicrometersPerSecond(double micrometerspersecond)
@@ -601,7 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MilesPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMilesPerHour(double milesperhour)
@@ -616,7 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMillimetersPerHour(double millimetersperhour)
@@ -631,7 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMillimetersPerMinutes(double millimetersperminutes)
@@ -646,7 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from MillimetersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromMillimetersPerSecond(double millimeterspersecond)
@@ -661,7 +661,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from NanometersPerMinutes.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromNanometersPerMinutes(double nanometersperminutes)
@@ -676,7 +676,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from NanometersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromNanometersPerSecond(double nanometerspersecond)
@@ -691,7 +691,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from UsSurveyFeetPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromUsSurveyFeetPerHour(double ussurveyfeetperhour)
@@ -706,7 +706,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from UsSurveyFeetPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromUsSurveyFeetPerMinute(double ussurveyfeetperminute)
@@ -721,7 +721,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from UsSurveyFeetPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromUsSurveyFeetPerSecond(double ussurveyfeetpersecond)
@@ -736,7 +736,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from YardsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromYardsPerHour(double yardsperhour)
@@ -751,7 +751,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from YardsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromYardsPerMinute(double yardsperminute)
@@ -766,7 +766,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Speed from YardsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Speed FromYardsPerSecond(double yardspersecond)

--- a/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == TemperatureUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -179,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesCelsius(double degreescelsius)
@@ -193,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesDelisle(double degreesdelisle)
@@ -207,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesFahrenheit(double degreesfahrenheit)
@@ -221,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesNewton(double degreesnewton)
@@ -235,6 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesRankine.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesRankine(double degreesrankine)
@@ -249,6 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesReaumur(double degreesreaumur)
@@ -263,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesRoemer.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesRoemer(double degreesroemer)
@@ -277,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromKelvins(double kelvins)

--- a/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesCelsius(double degreescelsius)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesDelisle.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesDelisle(double degreesdelisle)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesFahrenheit.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesFahrenheit(double degreesfahrenheit)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesNewton.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesNewton(double degreesnewton)
@@ -241,7 +241,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesRankine.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesRankine(double degreesrankine)
@@ -256,7 +256,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesReaumur.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesReaumur(double degreesreaumur)
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from DegreesRoemer.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromDegreesRoemer(double degreesroemer)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Temperature from Kelvins.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Temperature FromKelvins(double kelvins)

--- a/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -191,7 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(double centidegreescelsiuspersecond)
@@ -206,7 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(double decadegreescelsiuspersecond)
@@ -221,7 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(double decidegreescelsiuspersecond)
@@ -236,7 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(double degreescelsiusperminute)
@@ -251,7 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(double degreescelsiuspersecond)
@@ -266,7 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(double hectodegreescelsiuspersecond)
@@ -281,7 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(double kilodegreescelsiuspersecond)
@@ -296,7 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(double microdegreescelsiuspersecond)
@@ -311,7 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(double millidegreescelsiuspersecond)
@@ -326,7 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(double nanodegreescelsiuspersecond)

--- a/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == TemperatureChangeRateUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -189,6 +191,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from CentidegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromCentidegreesCelsiusPerSecond(double centidegreescelsiuspersecond)
@@ -203,6 +206,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DecadegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDecadegreesCelsiusPerSecond(double decadegreescelsiuspersecond)
@@ -217,6 +221,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DecidegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDecidegreesCelsiusPerSecond(double decidegreescelsiuspersecond)
@@ -231,6 +236,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDegreesCelsiusPerMinute(double degreescelsiusperminute)
@@ -245,6 +251,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from DegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromDegreesCelsiusPerSecond(double degreescelsiuspersecond)
@@ -259,6 +266,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from HectodegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromHectodegreesCelsiusPerSecond(double hectodegreescelsiuspersecond)
@@ -273,6 +281,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from KilodegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromKilodegreesCelsiusPerSecond(double kilodegreescelsiuspersecond)
@@ -287,6 +296,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from MicrodegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromMicrodegreesCelsiusPerSecond(double microdegreescelsiuspersecond)
@@ -301,6 +311,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from MillidegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromMillidegreesCelsiusPerSecond(double millidegreescelsiuspersecond)
@@ -315,6 +326,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureChangeRate from NanodegreesCelsiusPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureChangeRate FromNanodegreesCelsiusPerSecond(double nanodegreescelsiuspersecond)

--- a/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == TemperatureDeltaUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -178,6 +180,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesCelsius.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesCelsius(double degreescelsius)
@@ -192,6 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesDelisle.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesDelisle(double degreesdelisle)
@@ -206,6 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheit.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesFahrenheit(double degreesfahrenheit)
@@ -220,6 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesNewton.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesNewton(double degreesnewton)
@@ -234,6 +240,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesRankine.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesRankine(double degreesrankine)
@@ -248,6 +255,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesReaumur.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesReaumur(double degreesreaumur)
@@ -262,6 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesRoemer.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesRoemer(double degreesroemer)
@@ -276,6 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from Kelvins.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromKelvins(double kelvins)

--- a/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -180,7 +180,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesCelsius.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesCelsius(double degreescelsius)
@@ -195,7 +195,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesDelisle.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesDelisle(double degreesdelisle)
@@ -210,7 +210,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesFahrenheit.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesFahrenheit(double degreesfahrenheit)
@@ -225,7 +225,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesNewton.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesNewton(double degreesnewton)
@@ -240,7 +240,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesRankine.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesRankine(double degreesrankine)
@@ -255,7 +255,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesReaumur.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesReaumur(double degreesreaumur)
@@ -270,7 +270,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from DegreesRoemer.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromDegreesRoemer(double degreesroemer)
@@ -285,7 +285,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get TemperatureDelta from Kelvins.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static TemperatureDelta FromKelvins(double kelvins)

--- a/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ThermalConductivityUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -149,6 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalConductivity from BtusPerHourFootFahrenheit.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalConductivity FromBtusPerHourFootFahrenheit(double btusperhourfootfahrenheit)
@@ -163,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalConductivity from WattsPerMeterKelvin.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalConductivity FromWattsPerMeterKelvin(double wattspermeterkelvin)

--- a/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -151,7 +151,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalConductivity from BtusPerHourFootFahrenheit.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalConductivity FromBtusPerHourFootFahrenheit(double btusperhourfootfahrenheit)
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalConductivity from WattsPerMeterKelvin.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalConductivity FromWattsPerMeterKelvin(double wattspermeterkelvin)

--- a/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -166,7 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(double hoursquarefeetdegreesfahrenheitperbtu)
@@ -181,7 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(double squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -196,7 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(double squarecentimeterkelvinsperwatt)
@@ -211,7 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(double squaremeterdegreescelsiusperwatt)
@@ -226,7 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(double squaremeterkelvinsperkilowatt)

--- a/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == ThermalResistanceUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -164,6 +166,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from HourSquareFeetDegreesFahrenheitPerBtu.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromHourSquareFeetDegreesFahrenheitPerBtu(double hoursquarefeetdegreesfahrenheitperbtu)
@@ -178,6 +181,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterHourDegreesCelsiusPerKilocalorie.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareCentimeterHourDegreesCelsiusPerKilocalorie(double squarecentimeterhourdegreescelsiusperkilocalorie)
@@ -192,6 +196,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareCentimeterKelvinsPerWatt.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareCentimeterKelvinsPerWatt(double squarecentimeterkelvinsperwatt)
@@ -206,6 +211,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareMeterDegreesCelsiusPerWatt.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareMeterDegreesCelsiusPerWatt(double squaremeterdegreescelsiusperwatt)
@@ -220,6 +226,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get ThermalResistance from SquareMeterKelvinsPerKilowatt.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(double squaremeterkelvinsperkilowatt)

--- a/Common/GeneratedCode/Quantities/Torque.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Torque.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == TorqueUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -244,6 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilogramForceCentimeters(double kilogramforcecentimeters)
@@ -258,6 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilogramForceMeters(double kilogramforcemeters)
@@ -272,6 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilogramForceMillimeters(double kilogramforcemillimeters)
@@ -286,6 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilonewtonCentimeters(double kilonewtoncentimeters)
@@ -300,6 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilonewtonMeters(double kilonewtonmeters)
@@ -314,6 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilonewtonMillimeters(double kilonewtonmillimeters)
@@ -328,6 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilopoundForceFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilopoundForceFeet(double kilopoundforcefeet)
@@ -342,6 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilopoundForceInches(double kilopoundforceinches)
@@ -356,6 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MeganewtonCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMeganewtonCentimeters(double meganewtoncentimeters)
@@ -370,6 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MeganewtonMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMeganewtonMeters(double meganewtonmeters)
@@ -384,6 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MeganewtonMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMeganewtonMillimeters(double meganewtonmillimeters)
@@ -398,6 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MegapoundForceFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMegapoundForceFeet(double megapoundforcefeet)
@@ -412,6 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MegapoundForceInches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMegapoundForceInches(double megapoundforceinches)
@@ -426,6 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromNewtonCentimeters(double newtoncentimeters)
@@ -440,6 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromNewtonMeters(double newtonmeters)
@@ -454,6 +471,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromNewtonMillimeters(double newtonmillimeters)
@@ -468,6 +486,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromPoundForceFeet(double poundforcefeet)
@@ -482,6 +501,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from PoundForceInches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromPoundForceInches(double poundforceinches)
@@ -496,6 +516,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromTonneForceCentimeters(double tonneforcecentimeters)
@@ -510,6 +531,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromTonneForceMeters(double tonneforcemeters)
@@ -524,6 +546,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromTonneForceMillimeters(double tonneforcemillimeters)

--- a/Common/GeneratedCode/Quantities/Torque.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Torque.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -246,7 +246,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilogramForceCentimeters(double kilogramforcecentimeters)
@@ -261,7 +261,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilogramForceMeters(double kilogramforcemeters)
@@ -276,7 +276,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilogramForceMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilogramForceMillimeters(double kilogramforcemillimeters)
@@ -291,7 +291,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilonewtonCentimeters(double kilonewtoncentimeters)
@@ -306,7 +306,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilonewtonMeters(double kilonewtonmeters)
@@ -321,7 +321,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilonewtonMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilonewtonMillimeters(double kilonewtonmillimeters)
@@ -336,7 +336,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilopoundForceFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilopoundForceFeet(double kilopoundforcefeet)
@@ -351,7 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from KilopoundForceInches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromKilopoundForceInches(double kilopoundforceinches)
@@ -366,7 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MeganewtonCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMeganewtonCentimeters(double meganewtoncentimeters)
@@ -381,7 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MeganewtonMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMeganewtonMeters(double meganewtonmeters)
@@ -396,7 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MeganewtonMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMeganewtonMillimeters(double meganewtonmillimeters)
@@ -411,7 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MegapoundForceFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMegapoundForceFeet(double megapoundforcefeet)
@@ -426,7 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from MegapoundForceInches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromMegapoundForceInches(double megapoundforceinches)
@@ -441,7 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromNewtonCentimeters(double newtoncentimeters)
@@ -456,7 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromNewtonMeters(double newtonmeters)
@@ -471,7 +471,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from NewtonMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromNewtonMillimeters(double newtonmillimeters)
@@ -486,7 +486,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from PoundForceFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromPoundForceFeet(double poundforcefeet)
@@ -501,7 +501,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from PoundForceInches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromPoundForceInches(double poundforceinches)
@@ -516,7 +516,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromTonneForceCentimeters(double tonneforcecentimeters)
@@ -531,7 +531,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromTonneForceMeters(double tonneforcemeters)
@@ -546,7 +546,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Torque from TonneForceMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Torque FromTonneForceMillimeters(double tonneforcemillimeters)

--- a/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
@@ -88,7 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -145,7 +145,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VitaminA from InternationalUnits.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VitaminA FromInternationalUnits(double internationalunits)

--- a/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -87,6 +88,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -97,7 +99,7 @@ namespace UnitsNet
             if(unit == VitaminAUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -143,6 +145,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VitaminA from InternationalUnits.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VitaminA FromInternationalUnits(double internationalunits)

--- a/Common/GeneratedCode/Quantities/Volume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Volume.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == VolumeUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -349,6 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from AuTablespoons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromAuTablespoons(double autablespoons)
@@ -363,6 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCentiliters(double centiliters)
@@ -377,6 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicCentimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicCentimeters(double cubiccentimeters)
@@ -391,6 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicDecimeters(double cubicdecimeters)
@@ -405,6 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicFeet(double cubicfeet)
@@ -419,6 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicInches(double cubicinches)
@@ -433,6 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicKilometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicKilometers(double cubickilometers)
@@ -447,6 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMeters(double cubicmeters)
@@ -461,6 +471,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMicrometers.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMicrometers(double cubicmicrometers)
@@ -475,6 +486,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMiles(double cubicmiles)
@@ -489,6 +501,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMillimeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMillimeters(double cubicmillimeters)
@@ -503,6 +516,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicYards(double cubicyards)
@@ -517,6 +531,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Deciliters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromDeciliters(double deciliters)
@@ -531,6 +546,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromHectocubicFeet(double hectocubicfeet)
@@ -545,6 +561,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from HectocubicMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromHectocubicMeters(double hectocubicmeters)
@@ -559,6 +576,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromHectoliters(double hectoliters)
@@ -573,6 +591,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromImperialBeerBarrels(double imperialbeerbarrels)
@@ -587,6 +606,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromImperialGallons(double imperialgallons)
@@ -601,6 +621,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialOunces.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromImperialOunces(double imperialounces)
@@ -615,6 +636,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKilocubicFeet(double kilocubicfeet)
@@ -629,6 +651,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilocubicMeters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKilocubicMeters(double kilocubicmeters)
@@ -643,6 +666,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKiloimperialGallons(double kiloimperialgallons)
@@ -657,6 +681,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilousGallons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKilousGallons(double kilousgallons)
@@ -671,6 +696,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromLiters(double liters)
@@ -685,6 +711,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegacubicFeet.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMegacubicFeet(double megacubicfeet)
@@ -699,6 +726,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMegaimperialGallons(double megaimperialgallons)
@@ -713,6 +741,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegausGallons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMegausGallons(double megausgallons)
@@ -727,6 +756,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMetricCups(double metriccups)
@@ -741,6 +771,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MetricTeaspoons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMetricTeaspoons(double metricteaspoons)
@@ -755,6 +786,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMicroliters(double microliters)
@@ -769,6 +801,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMilliliters(double milliliters)
@@ -783,6 +816,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromOilBarrels(double oilbarrels)
@@ -797,6 +831,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUkTablespoons(double uktablespoons)
@@ -811,6 +846,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsBeerBarrels(double usbeerbarrels)
@@ -825,6 +861,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsCustomaryCups.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsCustomaryCups(double uscustomarycups)
@@ -839,6 +876,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsGallons(double usgallons)
@@ -853,6 +891,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsLegalCups.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsLegalCups(double uslegalcups)
@@ -867,6 +906,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsOunces(double usounces)
@@ -881,6 +921,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsPints.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsPints(double uspints)
@@ -895,6 +936,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsQuarts.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsQuarts(double usquarts)
@@ -909,6 +951,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsTablespoons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsTablespoons(double ustablespoons)
@@ -923,6 +966,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsTeaspoons(double usteaspoons)

--- a/Common/GeneratedCode/Quantities/Volume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Volume.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -351,7 +351,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from AuTablespoons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromAuTablespoons(double autablespoons)
@@ -366,7 +366,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Centiliters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCentiliters(double centiliters)
@@ -381,7 +381,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicCentimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicCentimeters(double cubiccentimeters)
@@ -396,7 +396,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicDecimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicDecimeters(double cubicdecimeters)
@@ -411,7 +411,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicFeet(double cubicfeet)
@@ -426,7 +426,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicInches.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicInches(double cubicinches)
@@ -441,7 +441,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicKilometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicKilometers(double cubickilometers)
@@ -456,7 +456,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMeters(double cubicmeters)
@@ -471,7 +471,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMicrometers.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMicrometers(double cubicmicrometers)
@@ -486,7 +486,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMiles.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMiles(double cubicmiles)
@@ -501,7 +501,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicMillimeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicMillimeters(double cubicmillimeters)
@@ -516,7 +516,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from CubicYards.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromCubicYards(double cubicyards)
@@ -531,7 +531,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Deciliters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromDeciliters(double deciliters)
@@ -546,7 +546,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from HectocubicFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromHectocubicFeet(double hectocubicfeet)
@@ -561,7 +561,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from HectocubicMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromHectocubicMeters(double hectocubicmeters)
@@ -576,7 +576,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Hectoliters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromHectoliters(double hectoliters)
@@ -591,7 +591,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromImperialBeerBarrels(double imperialbeerbarrels)
@@ -606,7 +606,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialGallons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromImperialGallons(double imperialgallons)
@@ -621,7 +621,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from ImperialOunces.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromImperialOunces(double imperialounces)
@@ -636,7 +636,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilocubicFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKilocubicFeet(double kilocubicfeet)
@@ -651,7 +651,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilocubicMeters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKilocubicMeters(double kilocubicmeters)
@@ -666,7 +666,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KiloimperialGallons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKiloimperialGallons(double kiloimperialgallons)
@@ -681,7 +681,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from KilousGallons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromKilousGallons(double kilousgallons)
@@ -696,7 +696,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Liters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromLiters(double liters)
@@ -711,7 +711,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegacubicFeet.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMegacubicFeet(double megacubicfeet)
@@ -726,7 +726,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegaimperialGallons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMegaimperialGallons(double megaimperialgallons)
@@ -741,7 +741,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MegausGallons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMegausGallons(double megausgallons)
@@ -756,7 +756,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MetricCups.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMetricCups(double metriccups)
@@ -771,7 +771,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from MetricTeaspoons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMetricTeaspoons(double metricteaspoons)
@@ -786,7 +786,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Microliters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMicroliters(double microliters)
@@ -801,7 +801,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromMilliliters(double milliliters)
@@ -816,7 +816,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from OilBarrels.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromOilBarrels(double oilbarrels)
@@ -831,7 +831,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUkTablespoons(double uktablespoons)
@@ -846,7 +846,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsBeerBarrels.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsBeerBarrels(double usbeerbarrels)
@@ -861,7 +861,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsCustomaryCups.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsCustomaryCups(double uscustomarycups)
@@ -876,7 +876,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsGallons(double usgallons)
@@ -891,7 +891,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsLegalCups.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsLegalCups(double uslegalcups)
@@ -906,7 +906,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsOunces.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsOunces(double usounces)
@@ -921,7 +921,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsPints.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsPints(double uspints)
@@ -936,7 +936,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsQuarts.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsQuarts(double usquarts)
@@ -951,7 +951,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsTablespoons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsTablespoons(double ustablespoons)
@@ -966,7 +966,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get Volume from UsTeaspoons.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static Volume FromUsTeaspoons(double usteaspoons)

--- a/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
@@ -89,7 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -271,7 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CentilitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCentilitersPerMinute(double centilitersperminute)
@@ -286,7 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicDecimetersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicDecimetersPerMinute(double cubicdecimetersperminute)
@@ -301,7 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicFeetPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicFeetPerHour(double cubicfeetperhour)
@@ -316,7 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicFeetPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicFeetPerMinute(double cubicfeetperminute)
@@ -331,7 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicFeetPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicFeetPerSecond(double cubicfeetpersecond)
@@ -346,7 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicMetersPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicMetersPerHour(double cubicmetersperhour)
@@ -361,7 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicMetersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicMetersPerMinute(double cubicmetersperminute)
@@ -376,7 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicMetersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicMetersPerSecond(double cubicmeterspersecond)
@@ -391,7 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicYardsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicYardsPerHour(double cubicyardsperhour)
@@ -406,7 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicYardsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicYardsPerMinute(double cubicyardsperminute)
@@ -421,7 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicYardsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicYardsPerSecond(double cubicyardspersecond)
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from DecilitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromDecilitersPerMinute(double decilitersperminute)
@@ -451,7 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from KilolitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromKilolitersPerMinute(double kilolitersperminute)
@@ -466,7 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from LitersPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromLitersPerHour(double litersperhour)
@@ -481,7 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from LitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromLitersPerMinute(double litersperminute)
@@ -496,7 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from LitersPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromLitersPerSecond(double literspersecond)
@@ -511,7 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from MicrolitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromMicrolitersPerMinute(double microlitersperminute)
@@ -526,7 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from MillilitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromMillilitersPerMinute(double millilitersperminute)
@@ -541,7 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from MillionUsGallonsPerDay.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromMillionUsGallonsPerDay(double millionusgallonsperday)
@@ -556,7 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from NanolitersPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromNanolitersPerMinute(double nanolitersperminute)
@@ -571,7 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from OilBarrelsPerDay.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromOilBarrelsPerDay(double oilbarrelsperday)
@@ -586,7 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from OilBarrelsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromOilBarrelsPerHour(double oilbarrelsperhour)
@@ -601,7 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from OilBarrelsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromOilBarrelsPerMinute(double oilbarrelsperminute)
@@ -616,7 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from UsGallonsPerHour.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromUsGallonsPerHour(double usgallonsperhour)
@@ -631,7 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from UsGallonsPerMinute.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromUsGallonsPerMinute(double usgallonsperminute)
@@ -646,7 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from UsGallonsPerSecond.
         /// </summary>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromUsGallonsPerSecond(double usgallonspersecond)

--- a/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
@@ -42,6 +42,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -88,6 +89,7 @@ namespace UnitsNet
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -98,7 +100,7 @@ namespace UnitsNet
             if(unit == VolumeFlowUnit.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
-            _value = numericValue;
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
             _unit = unit;
         }
 
@@ -269,6 +271,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CentilitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCentilitersPerMinute(double centilitersperminute)
@@ -283,6 +286,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicDecimetersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicDecimetersPerMinute(double cubicdecimetersperminute)
@@ -297,6 +301,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicFeetPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicFeetPerHour(double cubicfeetperhour)
@@ -311,6 +316,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicFeetPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicFeetPerMinute(double cubicfeetperminute)
@@ -325,6 +331,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicFeetPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicFeetPerSecond(double cubicfeetpersecond)
@@ -339,6 +346,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicMetersPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicMetersPerHour(double cubicmetersperhour)
@@ -353,6 +361,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicMetersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicMetersPerMinute(double cubicmetersperminute)
@@ -367,6 +376,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicMetersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicMetersPerSecond(double cubicmeterspersecond)
@@ -381,6 +391,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicYardsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicYardsPerHour(double cubicyardsperhour)
@@ -395,6 +406,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicYardsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicYardsPerMinute(double cubicyardsperminute)
@@ -409,6 +421,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from CubicYardsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromCubicYardsPerSecond(double cubicyardspersecond)
@@ -423,6 +436,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from DecilitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromDecilitersPerMinute(double decilitersperminute)
@@ -437,6 +451,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from KilolitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromKilolitersPerMinute(double kilolitersperminute)
@@ -451,6 +466,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from LitersPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromLitersPerHour(double litersperhour)
@@ -465,6 +481,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from LitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromLitersPerMinute(double litersperminute)
@@ -479,6 +496,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from LitersPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromLitersPerSecond(double literspersecond)
@@ -493,6 +511,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from MicrolitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromMicrolitersPerMinute(double microlitersperminute)
@@ -507,6 +526,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from MillilitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromMillilitersPerMinute(double millilitersperminute)
@@ -521,6 +541,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from MillionUsGallonsPerDay.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromMillionUsGallonsPerDay(double millionusgallonsperday)
@@ -535,6 +556,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from NanolitersPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromNanolitersPerMinute(double nanolitersperminute)
@@ -549,6 +571,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from OilBarrelsPerDay.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromOilBarrelsPerDay(double oilbarrelsperday)
@@ -563,6 +586,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from OilBarrelsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromOilBarrelsPerHour(double oilbarrelsperhour)
@@ -577,6 +601,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from OilBarrelsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromOilBarrelsPerMinute(double oilbarrelsperminute)
@@ -591,6 +616,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from UsGallonsPerHour.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromUsGallonsPerHour(double usgallonsperhour)
@@ -605,6 +631,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from UsGallonsPerMinute.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromUsGallonsPerMinute(double usgallonsperminute)
@@ -619,6 +646,7 @@ namespace UnitsNet
         /// <summary>
         ///     Get VolumeFlow from UsGallonsPerSecond.
         /// </summary>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static VolumeFlow FromUsGallonsPerSecond(double usgallonspersecond)

--- a/UnitsNet.Tests/GeneratedCode/AccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AccelerationTestsBase.g.cs
@@ -84,9 +84,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Acceleration((double)0.0, AccelerationUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Acceleration(double.PositiveInfinity, AccelerationUnit.MeterPerSecondSquared));
+            Assert.Throws<ArgumentException>(() => new Acceleration(double.NegativeInfinity, AccelerationUnit.MeterPerSecondSquared));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Acceleration(double.NaN, AccelerationUnit.MeterPerSecondSquared));
         }
 
         [Fact]
@@ -124,6 +137,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Acceleration.From(1, AccelerationUnit.MillimeterPerSecondSquared).MillimetersPerSecondSquared, MillimetersPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, Acceleration.From(1, AccelerationUnit.NanometerPerSecondSquared).NanometersPerSecondSquared, NanometersPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, Acceleration.From(1, AccelerationUnit.StandardGravity).StandardGravity, StandardGravityTolerance);
+        }
+
+        [Fact]
+        public void FromMetersPerSecondSquared_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Acceleration.FromMetersPerSecondSquared(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Acceleration.FromMetersPerSecondSquared(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromMetersPerSecondSquared_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Acceleration.FromMetersPerSecondSquared(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/AmountOfSubstanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AmountOfSubstanceTestsBase.g.cs
@@ -86,9 +86,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new AmountOfSubstance((double)0.0, AmountOfSubstanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AmountOfSubstance(double.PositiveInfinity, AmountOfSubstanceUnit.Mole));
+            Assert.Throws<ArgumentException>(() => new AmountOfSubstance(double.NegativeInfinity, AmountOfSubstanceUnit.Mole));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AmountOfSubstance(double.NaN, AmountOfSubstanceUnit.Mole));
         }
 
         [Fact]
@@ -128,6 +141,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, AmountOfSubstance.From(1, AmountOfSubstanceUnit.Nanomole).Nanomoles, NanomolesTolerance);
             AssertEx.EqualTolerance(1, AmountOfSubstance.From(1, AmountOfSubstanceUnit.NanopoundMole).NanopoundMoles, NanopoundMolesTolerance);
             AssertEx.EqualTolerance(1, AmountOfSubstance.From(1, AmountOfSubstanceUnit.PoundMole).PoundMoles, PoundMolesTolerance);
+        }
+
+        [Fact]
+        public void FromMoles_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AmountOfSubstance.FromMoles(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => AmountOfSubstance.FromMoles(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromMoles_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AmountOfSubstance.FromMoles(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new AmplitudeRatio((double)0.0, AmplitudeRatioUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AmplitudeRatio(double.PositiveInfinity, AmplitudeRatioUnit.DecibelVolt));
+            Assert.Throws<ArgumentException>(() => new AmplitudeRatio(double.NegativeInfinity, AmplitudeRatioUnit.DecibelVolt));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AmplitudeRatio(double.NaN, AmplitudeRatioUnit.DecibelVolt));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelMillivolt).DecibelMillivolts, DecibelMillivoltsTolerance);
             AssertEx.EqualTolerance(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelUnloaded).DecibelsUnloaded, DecibelsUnloadedTolerance);
             AssertEx.EqualTolerance(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelVolt).DecibelVolts, DecibelVoltsTolerance);
+        }
+
+        [Fact]
+        public void FromDecibelVolts_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AmplitudeRatio.FromDecibelVolts(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => AmplitudeRatio.FromDecibelVolts(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDecibelVolts_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AmplitudeRatio.FromDecibelVolts(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/AngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AngleTestsBase.g.cs
@@ -86,9 +86,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Angle((double)0.0, AngleUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Angle(double.PositiveInfinity, AngleUnit.Degree));
+            Assert.Throws<ArgumentException>(() => new Angle(double.NegativeInfinity, AngleUnit.Degree));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Angle(double.NaN, AngleUnit.Degree));
         }
 
         [Fact]
@@ -128,6 +141,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Angle.From(1, AngleUnit.Nanoradian).Nanoradians, NanoradiansTolerance);
             AssertEx.EqualTolerance(1, Angle.From(1, AngleUnit.Radian).Radians, RadiansTolerance);
             AssertEx.EqualTolerance(1, Angle.From(1, AngleUnit.Revolution).Revolutions, RevolutionsTolerance);
+        }
+
+        [Fact]
+        public void FromDegrees_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Angle.FromDegrees(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Angle.FromDegrees(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDegrees_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Angle.FromDegrees(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ApparentEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ApparentEnergyTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ApparentEnergy((double)0.0, ApparentEnergyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ApparentEnergy(double.PositiveInfinity, ApparentEnergyUnit.VoltampereHour));
+            Assert.Throws<ArgumentException>(() => new ApparentEnergy(double.NegativeInfinity, ApparentEnergyUnit.VoltampereHour));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ApparentEnergy(double.NaN, ApparentEnergyUnit.VoltampereHour));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ApparentEnergy.From(1, ApparentEnergyUnit.KilovoltampereHour).KilovoltampereHours, KilovoltampereHoursTolerance);
             AssertEx.EqualTolerance(1, ApparentEnergy.From(1, ApparentEnergyUnit.MegavoltampereHour).MegavoltampereHours, MegavoltampereHoursTolerance);
             AssertEx.EqualTolerance(1, ApparentEnergy.From(1, ApparentEnergyUnit.VoltampereHour).VoltampereHours, VoltampereHoursTolerance);
+        }
+
+        [Fact]
+        public void FromVoltampereHours_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ApparentEnergy.FromVoltampereHours(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ApparentEnergy.FromVoltampereHours(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltampereHours_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ApparentEnergy.FromVoltampereHours(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ApparentPowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ApparentPowerTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ApparentPower((double)0.0, ApparentPowerUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ApparentPower(double.PositiveInfinity, ApparentPowerUnit.Voltampere));
+            Assert.Throws<ArgumentException>(() => new ApparentPower(double.NegativeInfinity, ApparentPowerUnit.Voltampere));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ApparentPower(double.NaN, ApparentPowerUnit.Voltampere));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ApparentPower.From(1, ApparentPowerUnit.Kilovoltampere).Kilovoltamperes, KilovoltamperesTolerance);
             AssertEx.EqualTolerance(1, ApparentPower.From(1, ApparentPowerUnit.Megavoltampere).Megavoltamperes, MegavoltamperesTolerance);
             AssertEx.EqualTolerance(1, ApparentPower.From(1, ApparentPowerUnit.Voltampere).Voltamperes, VoltamperesTolerance);
+        }
+
+        [Fact]
+        public void FromVoltamperes_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ApparentPower.FromVoltamperes(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ApparentPower.FromVoltamperes(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltamperes_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ApparentPower.FromVoltamperes(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/AreaDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaDensityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new AreaDensity((double)0.0, AreaDensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AreaDensity(double.PositiveInfinity, AreaDensityUnit.KilogramPerSquareMeter));
+            Assert.Throws<ArgumentException>(() => new AreaDensity(double.NegativeInfinity, AreaDensityUnit.KilogramPerSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AreaDensity(double.NaN, AreaDensityUnit.KilogramPerSquareMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, AreaDensity.From(1, AreaDensityUnit.KilogramPerSquareMeter).KilogramsPerSquareMeter, KilogramsPerSquareMeterTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramsPerSquareMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AreaDensity.FromKilogramsPerSquareMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => AreaDensity.FromKilogramsPerSquareMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramsPerSquareMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AreaDensity.FromKilogramsPerSquareMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/AreaMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaMomentOfInertiaTestsBase.g.cs
@@ -70,9 +70,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new AreaMomentOfInertia((double)0.0, AreaMomentOfInertiaUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AreaMomentOfInertia(double.PositiveInfinity, AreaMomentOfInertiaUnit.MeterToTheFourth));
+            Assert.Throws<ArgumentException>(() => new AreaMomentOfInertia(double.NegativeInfinity, AreaMomentOfInertiaUnit.MeterToTheFourth));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new AreaMomentOfInertia(double.NaN, AreaMomentOfInertiaUnit.MeterToTheFourth));
         }
 
         [Fact]
@@ -96,6 +109,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, AreaMomentOfInertia.From(1, AreaMomentOfInertiaUnit.InchToTheFourth).InchesToTheFourth, InchesToTheFourthTolerance);
             AssertEx.EqualTolerance(1, AreaMomentOfInertia.From(1, AreaMomentOfInertiaUnit.MeterToTheFourth).MetersToTheFourth, MetersToTheFourthTolerance);
             AssertEx.EqualTolerance(1, AreaMomentOfInertia.From(1, AreaMomentOfInertiaUnit.MillimeterToTheFourth).MillimetersToTheFourth, MillimetersToTheFourthTolerance);
+        }
+
+        [Fact]
+        public void FromMetersToTheFourth_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AreaMomentOfInertia.FromMetersToTheFourth(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => AreaMomentOfInertia.FromMetersToTheFourth(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromMetersToTheFourth_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => AreaMomentOfInertia.FromMetersToTheFourth(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/AreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaTestsBase.g.cs
@@ -84,9 +84,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Area((double)0.0, AreaUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Area(double.PositiveInfinity, AreaUnit.SquareMeter));
+            Assert.Throws<ArgumentException>(() => new Area(double.NegativeInfinity, AreaUnit.SquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Area(double.NaN, AreaUnit.SquareMeter));
         }
 
         [Fact]
@@ -124,6 +137,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareMillimeter).SquareMillimeters, SquareMillimetersTolerance);
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareYard).SquareYards, SquareYardsTolerance);
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.UsSurveySquareFoot).UsSurveySquareFeet, UsSurveySquareFeetTolerance);
+        }
+
+        [Fact]
+        public void FromSquareMeters_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Area.FromSquareMeters(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Area.FromSquareMeters(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSquareMeters_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Area.FromSquareMeters(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/BitRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/BitRateTestsBase.g.cs
@@ -110,10 +110,11 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new BitRate((decimal)0.0, BitRateUnit.Undefined));
         }
+
 
         [Fact]
         public void BitPerSecondToBitRateUnits()
@@ -177,6 +178,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, BitRate.From(1, BitRateUnit.TerabitPerSecond).TerabitsPerSecond, TerabitsPerSecondTolerance);
             AssertEx.EqualTolerance(1, BitRate.From(1, BitRateUnit.TerabytePerSecond).TerabytesPerSecond, TerabytesPerSecondTolerance);
         }
+
 
         [Fact]
         public void As()

--- a/UnitsNet.Tests/GeneratedCode/BrakeSpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/BrakeSpecificFuelConsumptionTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new BrakeSpecificFuelConsumption((double)0.0, BrakeSpecificFuelConsumptionUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new BrakeSpecificFuelConsumption(double.PositiveInfinity, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule));
+            Assert.Throws<ArgumentException>(() => new BrakeSpecificFuelConsumption(double.NegativeInfinity, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new BrakeSpecificFuelConsumption(double.NaN, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, BrakeSpecificFuelConsumption.From(1, BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour).GramsPerKiloWattHour, GramsPerKiloWattHourTolerance);
             AssertEx.EqualTolerance(1, BrakeSpecificFuelConsumption.From(1, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).KilogramsPerJoule, KilogramsPerJouleTolerance);
             AssertEx.EqualTolerance(1, BrakeSpecificFuelConsumption.From(1, BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour).PoundsPerMechanicalHorsepowerHour, PoundsPerMechanicalHorsepowerHourTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramsPerJoule_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramsPerJoule_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => BrakeSpecificFuelConsumption.FromKilogramsPerJoule(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/CapacitanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/CapacitanceTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Capacitance((double)0.0, CapacitanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Capacitance(double.PositiveInfinity, CapacitanceUnit.Farad));
+            Assert.Throws<ArgumentException>(() => new Capacitance(double.NegativeInfinity, CapacitanceUnit.Farad));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Capacitance(double.NaN, CapacitanceUnit.Farad));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, Capacitance.From(1, CapacitanceUnit.Farad).Farads, FaradsTolerance);
+        }
+
+        [Fact]
+        public void FromFarads_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Capacitance.FromFarads(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Capacitance.FromFarads(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromFarads_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Capacitance.FromFarads(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/DensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/DensityTestsBase.g.cs
@@ -134,9 +134,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Density((double)0.0, DensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Density(double.PositiveInfinity, DensityUnit.KilogramPerCubicMeter));
+            Assert.Throws<ArgumentException>(() => new Density(double.NegativeInfinity, DensityUnit.KilogramPerCubicMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Density(double.NaN, DensityUnit.KilogramPerCubicMeter));
         }
 
         [Fact]
@@ -224,6 +237,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Density.From(1, DensityUnit.TonnePerCubicCentimeter).TonnesPerCubicCentimeter, TonnesPerCubicCentimeterTolerance);
             AssertEx.EqualTolerance(1, Density.From(1, DensityUnit.TonnePerCubicMeter).TonnesPerCubicMeter, TonnesPerCubicMeterTolerance);
             AssertEx.EqualTolerance(1, Density.From(1, DensityUnit.TonnePerCubicMillimeter).TonnesPerCubicMillimeter, TonnesPerCubicMillimeterTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramsPerCubicMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Density.FromKilogramsPerCubicMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Density.FromKilogramsPerCubicMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramsPerCubicMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Density.FromKilogramsPerCubicMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/DurationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/DurationTestsBase.g.cs
@@ -78,9 +78,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Duration((double)0.0, DurationUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Duration(double.PositiveInfinity, DurationUnit.Second));
+            Assert.Throws<ArgumentException>(() => new Duration(double.NegativeInfinity, DurationUnit.Second));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Duration(double.NaN, DurationUnit.Second));
         }
 
         [Fact]
@@ -112,6 +125,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Duration.From(1, DurationUnit.Second).Seconds, SecondsTolerance);
             AssertEx.EqualTolerance(1, Duration.From(1, DurationUnit.Week).Weeks, WeeksTolerance);
             AssertEx.EqualTolerance(1, Duration.From(1, DurationUnit.Year365).Years365, Years365Tolerance);
+        }
+
+        [Fact]
+        public void FromSeconds_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Duration.FromSeconds(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Duration.FromSeconds(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSeconds_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Duration.FromSeconds(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/DynamicViscosityTestsBase.g.cs
@@ -70,9 +70,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new DynamicViscosity((double)0.0, DynamicViscosityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new DynamicViscosity(double.PositiveInfinity, DynamicViscosityUnit.NewtonSecondPerMeterSquared));
+            Assert.Throws<ArgumentException>(() => new DynamicViscosity(double.NegativeInfinity, DynamicViscosityUnit.NewtonSecondPerMeterSquared));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new DynamicViscosity(double.NaN, DynamicViscosityUnit.NewtonSecondPerMeterSquared));
         }
 
         [Fact]
@@ -96,6 +109,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, DynamicViscosity.From(1, DynamicViscosityUnit.NewtonSecondPerMeterSquared).NewtonSecondsPerMeterSquared, NewtonSecondsPerMeterSquaredTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.From(1, DynamicViscosityUnit.PascalSecond).PascalSeconds, PascalSecondsTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.From(1, DynamicViscosityUnit.Poise).Poise, PoiseTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonSecondsPerMeterSquared_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => DynamicViscosity.FromNewtonSecondsPerMeterSquared(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => DynamicViscosity.FromNewtonSecondsPerMeterSquared(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonSecondsPerMeterSquared_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => DynamicViscosity.FromNewtonSecondsPerMeterSquared(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricAdmittanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricAdmittanceTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricAdmittance((double)0.0, ElectricAdmittanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricAdmittance(double.PositiveInfinity, ElectricAdmittanceUnit.Siemens));
+            Assert.Throws<ArgumentException>(() => new ElectricAdmittance(double.NegativeInfinity, ElectricAdmittanceUnit.Siemens));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricAdmittance(double.NaN, ElectricAdmittanceUnit.Siemens));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricAdmittance.From(1, ElectricAdmittanceUnit.Millisiemens).Millisiemens, MillisiemensTolerance);
             AssertEx.EqualTolerance(1, ElectricAdmittance.From(1, ElectricAdmittanceUnit.Nanosiemens).Nanosiemens, NanosiemensTolerance);
             AssertEx.EqualTolerance(1, ElectricAdmittance.From(1, ElectricAdmittanceUnit.Siemens).Siemens, SiemensTolerance);
+        }
+
+        [Fact]
+        public void FromSiemens_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricAdmittance.FromSiemens(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricAdmittance.FromSiemens(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSiemens_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricAdmittance.FromSiemens(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricChargeDensityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricChargeDensity((double)0.0, ElectricChargeDensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricChargeDensity(double.PositiveInfinity, ElectricChargeDensityUnit.CoulombPerCubicMeter));
+            Assert.Throws<ArgumentException>(() => new ElectricChargeDensity(double.NegativeInfinity, ElectricChargeDensityUnit.CoulombPerCubicMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricChargeDensity(double.NaN, ElectricChargeDensityUnit.CoulombPerCubicMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricChargeDensity.From(1, ElectricChargeDensityUnit.CoulombPerCubicMeter).CoulombsPerCubicMeter, CoulombsPerCubicMeterTolerance);
+        }
+
+        [Fact]
+        public void FromCoulombsPerCubicMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricChargeDensity.FromCoulombsPerCubicMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricChargeDensity.FromCoulombsPerCubicMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromCoulombsPerCubicMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricChargeDensity.FromCoulombsPerCubicMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricChargeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricChargeTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricCharge((double)0.0, ElectricChargeUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCharge(double.PositiveInfinity, ElectricChargeUnit.Coulomb));
+            Assert.Throws<ArgumentException>(() => new ElectricCharge(double.NegativeInfinity, ElectricChargeUnit.Coulomb));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCharge(double.NaN, ElectricChargeUnit.Coulomb));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricCharge.From(1, ElectricChargeUnit.Coulomb).Coulombs, CoulombsTolerance);
+        }
+
+        [Fact]
+        public void FromCoulombs_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCharge.FromCoulombs(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricCharge.FromCoulombs(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromCoulombs_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCharge.FromCoulombs(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricConductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricConductanceTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricConductance((double)0.0, ElectricConductanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricConductance(double.PositiveInfinity, ElectricConductanceUnit.Siemens));
+            Assert.Throws<ArgumentException>(() => new ElectricConductance(double.NegativeInfinity, ElectricConductanceUnit.Siemens));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricConductance(double.NaN, ElectricConductanceUnit.Siemens));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricConductance.From(1, ElectricConductanceUnit.Microsiemens).Microsiemens, MicrosiemensTolerance);
             AssertEx.EqualTolerance(1, ElectricConductance.From(1, ElectricConductanceUnit.Millisiemens).Millisiemens, MillisiemensTolerance);
             AssertEx.EqualTolerance(1, ElectricConductance.From(1, ElectricConductanceUnit.Siemens).Siemens, SiemensTolerance);
+        }
+
+        [Fact]
+        public void FromSiemens_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricConductance.FromSiemens(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricConductance.FromSiemens(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSiemens_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricConductance.FromSiemens(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricConductivityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricConductivity((double)0.0, ElectricConductivityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricConductivity(double.PositiveInfinity, ElectricConductivityUnit.SiemensPerMeter));
+            Assert.Throws<ArgumentException>(() => new ElectricConductivity(double.NegativeInfinity, ElectricConductivityUnit.SiemensPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricConductivity(double.NaN, ElectricConductivityUnit.SiemensPerMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerMeter).SiemensPerMeter, SiemensPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromSiemensPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricConductivity.FromSiemensPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricConductivity.FromSiemensPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSiemensPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricConductivity.FromSiemensPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricCurrentDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricCurrentDensityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricCurrentDensity((double)0.0, ElectricCurrentDensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCurrentDensity(double.PositiveInfinity, ElectricCurrentDensityUnit.AmperePerSquareMeter));
+            Assert.Throws<ArgumentException>(() => new ElectricCurrentDensity(double.NegativeInfinity, ElectricCurrentDensityUnit.AmperePerSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCurrentDensity(double.NaN, ElectricCurrentDensityUnit.AmperePerSquareMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricCurrentDensity.From(1, ElectricCurrentDensityUnit.AmperePerSquareMeter).AmperesPerSquareMeter, AmperesPerSquareMeterTolerance);
+        }
+
+        [Fact]
+        public void FromAmperesPerSquareMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCurrentDensity.FromAmperesPerSquareMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricCurrentDensity.FromAmperesPerSquareMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromAmperesPerSquareMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCurrentDensity.FromAmperesPerSquareMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricCurrentGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricCurrentGradientTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricCurrentGradient((double)0.0, ElectricCurrentGradientUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCurrentGradient(double.PositiveInfinity, ElectricCurrentGradientUnit.AmperePerSecond));
+            Assert.Throws<ArgumentException>(() => new ElectricCurrentGradient(double.NegativeInfinity, ElectricCurrentGradientUnit.AmperePerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCurrentGradient(double.NaN, ElectricCurrentGradientUnit.AmperePerSecond));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.AmperePerSecond).AmperesPerSecond, AmperesPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromAmperesPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCurrentGradient.FromAmperesPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricCurrentGradient.FromAmperesPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromAmperesPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCurrentGradient.FromAmperesPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricCurrentTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricCurrentTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricCurrent((double)0.0, ElectricCurrentUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCurrent(double.PositiveInfinity, ElectricCurrentUnit.Ampere));
+            Assert.Throws<ArgumentException>(() => new ElectricCurrent(double.NegativeInfinity, ElectricCurrentUnit.Ampere));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricCurrent(double.NaN, ElectricCurrentUnit.Ampere));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricCurrent.From(1, ElectricCurrentUnit.Milliampere).Milliamperes, MilliamperesTolerance);
             AssertEx.EqualTolerance(1, ElectricCurrent.From(1, ElectricCurrentUnit.Nanoampere).Nanoamperes, NanoamperesTolerance);
             AssertEx.EqualTolerance(1, ElectricCurrent.From(1, ElectricCurrentUnit.Picoampere).Picoamperes, PicoamperesTolerance);
+        }
+
+        [Fact]
+        public void FromAmperes_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCurrent.FromAmperes(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricCurrent.FromAmperes(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromAmperes_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricCurrent.FromAmperes(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricFieldTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricField((double)0.0, ElectricFieldUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricField(double.PositiveInfinity, ElectricFieldUnit.VoltPerMeter));
+            Assert.Throws<ArgumentException>(() => new ElectricField(double.NegativeInfinity, ElectricFieldUnit.VoltPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricField(double.NaN, ElectricFieldUnit.VoltPerMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricField.From(1, ElectricFieldUnit.VoltPerMeter).VoltsPerMeter, VoltsPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromVoltsPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricField.FromVoltsPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricField.FromVoltsPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltsPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricField.FromVoltsPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricInductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricInductanceTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricInductance((double)0.0, ElectricInductanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricInductance(double.PositiveInfinity, ElectricInductanceUnit.Henry));
+            Assert.Throws<ArgumentException>(() => new ElectricInductance(double.NegativeInfinity, ElectricInductanceUnit.Henry));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricInductance(double.NaN, ElectricInductanceUnit.Henry));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, ElectricInductance.From(1, ElectricInductanceUnit.Henry).Henries, HenriesTolerance);
+        }
+
+        [Fact]
+        public void FromHenries_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricInductance.FromHenries(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricInductance.FromHenries(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromHenries_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricInductance.FromHenries(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricPotentialAcTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricPotentialAcTestsBase.g.cs
@@ -68,9 +68,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricPotentialAc((double)0.0, ElectricPotentialAcUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricPotentialAc(double.PositiveInfinity, ElectricPotentialAcUnit.VoltAc));
+            Assert.Throws<ArgumentException>(() => new ElectricPotentialAc(double.NegativeInfinity, ElectricPotentialAcUnit.VoltAc));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricPotentialAc(double.NaN, ElectricPotentialAcUnit.VoltAc));
         }
 
         [Fact]
@@ -92,6 +105,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricPotentialAc.From(1, ElectricPotentialAcUnit.MicrovoltAc).MicrovoltsAc, MicrovoltsAcTolerance);
             AssertEx.EqualTolerance(1, ElectricPotentialAc.From(1, ElectricPotentialAcUnit.MillivoltAc).MillivoltsAc, MillivoltsAcTolerance);
             AssertEx.EqualTolerance(1, ElectricPotentialAc.From(1, ElectricPotentialAcUnit.VoltAc).VoltsAc, VoltsAcTolerance);
+        }
+
+        [Fact]
+        public void FromVoltsAc_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricPotentialAc.FromVoltsAc(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricPotentialAc.FromVoltsAc(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltsAc_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricPotentialAc.FromVoltsAc(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricPotentialDcTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricPotentialDcTestsBase.g.cs
@@ -68,9 +68,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricPotentialDc((double)0.0, ElectricPotentialDcUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricPotentialDc(double.PositiveInfinity, ElectricPotentialDcUnit.VoltDc));
+            Assert.Throws<ArgumentException>(() => new ElectricPotentialDc(double.NegativeInfinity, ElectricPotentialDcUnit.VoltDc));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricPotentialDc(double.NaN, ElectricPotentialDcUnit.VoltDc));
         }
 
         [Fact]
@@ -92,6 +105,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricPotentialDc.From(1, ElectricPotentialDcUnit.MicrovoltDc).MicrovoltsDc, MicrovoltsDcTolerance);
             AssertEx.EqualTolerance(1, ElectricPotentialDc.From(1, ElectricPotentialDcUnit.MillivoltDc).MillivoltsDc, MillivoltsDcTolerance);
             AssertEx.EqualTolerance(1, ElectricPotentialDc.From(1, ElectricPotentialDcUnit.VoltDc).VoltsDc, VoltsDcTolerance);
+        }
+
+        [Fact]
+        public void FromVoltsDc_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricPotentialDc.FromVoltsDc(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricPotentialDc.FromVoltsDc(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltsDc_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricPotentialDc.FromVoltsDc(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricPotentialTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricPotentialTestsBase.g.cs
@@ -68,9 +68,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricPotential((double)0.0, ElectricPotentialUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricPotential(double.PositiveInfinity, ElectricPotentialUnit.Volt));
+            Assert.Throws<ArgumentException>(() => new ElectricPotential(double.NegativeInfinity, ElectricPotentialUnit.Volt));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricPotential(double.NaN, ElectricPotentialUnit.Volt));
         }
 
         [Fact]
@@ -92,6 +105,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricPotential.From(1, ElectricPotentialUnit.Microvolt).Microvolts, MicrovoltsTolerance);
             AssertEx.EqualTolerance(1, ElectricPotential.From(1, ElectricPotentialUnit.Millivolt).Millivolts, MillivoltsTolerance);
             AssertEx.EqualTolerance(1, ElectricPotential.From(1, ElectricPotentialUnit.Volt).Volts, VoltsTolerance);
+        }
+
+        [Fact]
+        public void FromVolts_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricPotential.FromVolts(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricPotential.FromVolts(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVolts_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricPotential.FromVolts(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricResistanceTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricResistance((double)0.0, ElectricResistanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricResistance(double.PositiveInfinity, ElectricResistanceUnit.Ohm));
+            Assert.Throws<ArgumentException>(() => new ElectricResistance(double.NegativeInfinity, ElectricResistanceUnit.Ohm));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricResistance(double.NaN, ElectricResistanceUnit.Ohm));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricResistance.From(1, ElectricResistanceUnit.Megaohm).Megaohms, MegaohmsTolerance);
             AssertEx.EqualTolerance(1, ElectricResistance.From(1, ElectricResistanceUnit.Milliohm).Milliohms, MilliohmsTolerance);
             AssertEx.EqualTolerance(1, ElectricResistance.From(1, ElectricResistanceUnit.Ohm).Ohms, OhmsTolerance);
+        }
+
+        [Fact]
+        public void FromOhms_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricResistance.FromOhms(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricResistance.FromOhms(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromOhms_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricResistance.FromOhms(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ElectricResistivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ElectricResistivityTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ElectricResistivity((double)0.0, ElectricResistivityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricResistivity(double.PositiveInfinity, ElectricResistivityUnit.OhmMeter));
+            Assert.Throws<ArgumentException>(() => new ElectricResistivity(double.NegativeInfinity, ElectricResistivityUnit.OhmMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ElectricResistivity(double.NaN, ElectricResistivityUnit.OhmMeter));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ElectricResistivity.From(1, ElectricResistivityUnit.MilliohmMeter).MilliohmMeters, MilliohmMetersTolerance);
             AssertEx.EqualTolerance(1, ElectricResistivity.From(1, ElectricResistivityUnit.NanoohmMeter).NanoohmMeters, NanoohmMetersTolerance);
             AssertEx.EqualTolerance(1, ElectricResistivity.From(1, ElectricResistivityUnit.OhmMeter).OhmMeters, OhmMetersTolerance);
+        }
+
+        [Fact]
+        public void FromOhmMeters_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricResistivity.FromOhmMeters(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ElectricResistivity.FromOhmMeters(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromOhmMeters_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ElectricResistivity.FromOhmMeters(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/EnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/EnergyTestsBase.g.cs
@@ -102,9 +102,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Energy((double)0.0, EnergyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Energy(double.PositiveInfinity, EnergyUnit.Joule));
+            Assert.Throws<ArgumentException>(() => new Energy(double.NegativeInfinity, EnergyUnit.Joule));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Energy(double.NaN, EnergyUnit.Joule));
         }
 
         [Fact]
@@ -160,6 +173,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Energy.From(1, EnergyUnit.ThermImperial).ThermsImperial, ThermsImperialTolerance);
             AssertEx.EqualTolerance(1, Energy.From(1, EnergyUnit.ThermUs).ThermsUs, ThermsUsTolerance);
             AssertEx.EqualTolerance(1, Energy.From(1, EnergyUnit.WattHour).WattHours, WattHoursTolerance);
+        }
+
+        [Fact]
+        public void FromJoules_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Energy.FromJoules(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Energy.FromJoules(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoules_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Energy.FromJoules(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/EntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/EntropyTestsBase.g.cs
@@ -72,9 +72,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Entropy((double)0.0, EntropyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Entropy(double.PositiveInfinity, EntropyUnit.JoulePerKelvin));
+            Assert.Throws<ArgumentException>(() => new Entropy(double.NegativeInfinity, EntropyUnit.JoulePerKelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Entropy(double.NaN, EntropyUnit.JoulePerKelvin));
         }
 
         [Fact]
@@ -100,6 +113,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Entropy.From(1, EntropyUnit.KilojoulePerDegreeCelsius).KilojoulesPerDegreeCelsius, KilojoulesPerDegreeCelsiusTolerance);
             AssertEx.EqualTolerance(1, Entropy.From(1, EntropyUnit.KilojoulePerKelvin).KilojoulesPerKelvin, KilojoulesPerKelvinTolerance);
             AssertEx.EqualTolerance(1, Entropy.From(1, EntropyUnit.MegajoulePerKelvin).MegajoulesPerKelvin, MegajoulesPerKelvinTolerance);
+        }
+
+        [Fact]
+        public void FromJoulesPerKelvin_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Entropy.FromJoulesPerKelvin(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Entropy.FromJoulesPerKelvin(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoulesPerKelvin_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Entropy.FromJoulesPerKelvin(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ForceChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForceChangeRateTestsBase.g.cs
@@ -80,9 +80,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ForceChangeRate((double)0.0, ForceChangeRateUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ForceChangeRate(double.PositiveInfinity, ForceChangeRateUnit.NewtonPerSecond));
+            Assert.Throws<ArgumentException>(() => new ForceChangeRate(double.NegativeInfinity, ForceChangeRateUnit.NewtonPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ForceChangeRate(double.NaN, ForceChangeRateUnit.NewtonPerSecond));
         }
 
         [Fact]
@@ -116,6 +129,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ForceChangeRate.From(1, ForceChangeRateUnit.NanonewtonPerSecond).NanonewtonsPerSecond, NanonewtonsPerSecondTolerance);
             AssertEx.EqualTolerance(1, ForceChangeRate.From(1, ForceChangeRateUnit.NewtonPerMinute).NewtonsPerMinute, NewtonsPerMinuteTolerance);
             AssertEx.EqualTolerance(1, ForceChangeRate.From(1, ForceChangeRateUnit.NewtonPerSecond).NewtonsPerSecond, NewtonsPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonsPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ForceChangeRate.FromNewtonsPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ForceChangeRate.FromNewtonsPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonsPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ForceChangeRate.FromNewtonsPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ForcePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForcePerLengthTestsBase.g.cs
@@ -76,9 +76,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ForcePerLength((double)0.0, ForcePerLengthUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ForcePerLength(double.PositiveInfinity, ForcePerLengthUnit.NewtonPerMeter));
+            Assert.Throws<ArgumentException>(() => new ForcePerLength(double.NegativeInfinity, ForcePerLengthUnit.NewtonPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ForcePerLength(double.NaN, ForcePerLengthUnit.NewtonPerMeter));
         }
 
         [Fact]
@@ -108,6 +121,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.MillinewtonPerMeter).MillinewtonsPerMeter, MillinewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.NanonewtonPerMeter).NanonewtonsPerMeter, NanonewtonsPerMeterTolerance);
             AssertEx.EqualTolerance(1, ForcePerLength.From(1, ForcePerLengthUnit.NewtonPerMeter).NewtonsPerMeter, NewtonsPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonsPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ForcePerLength.FromNewtonsPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ForcePerLength.FromNewtonsPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonsPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ForcePerLength.FromNewtonsPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ForceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ForceTestsBase.g.cs
@@ -78,9 +78,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Force((double)0.0, ForceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Force(double.PositiveInfinity, ForceUnit.Newton));
+            Assert.Throws<ArgumentException>(() => new Force(double.NegativeInfinity, ForceUnit.Newton));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Force(double.NaN, ForceUnit.Newton));
         }
 
         [Fact]
@@ -112,6 +125,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Force.From(1, ForceUnit.Poundal).Poundals, PoundalsTolerance);
             AssertEx.EqualTolerance(1, Force.From(1, ForceUnit.PoundForce).PoundsForce, PoundsForceTolerance);
             AssertEx.EqualTolerance(1, Force.From(1, ForceUnit.TonneForce).TonnesForce, TonnesForceTolerance);
+        }
+
+        [Fact]
+        public void FromNewtons_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Force.FromNewtons(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Force.FromNewtons(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtons_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Force.FromNewtons(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/FrequencyTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Frequency((double)0.0, FrequencyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Frequency(double.PositiveInfinity, FrequencyUnit.Hertz));
+            Assert.Throws<ArgumentException>(() => new Frequency(double.NegativeInfinity, FrequencyUnit.Hertz));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Frequency(double.NaN, FrequencyUnit.Hertz));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Frequency.From(1, FrequencyUnit.Megahertz).Megahertz, MegahertzTolerance);
             AssertEx.EqualTolerance(1, Frequency.From(1, FrequencyUnit.RadianPerSecond).RadiansPerSecond, RadiansPerSecondTolerance);
             AssertEx.EqualTolerance(1, Frequency.From(1, FrequencyUnit.Terahertz).Terahertz, TerahertzTolerance);
+        }
+
+        [Fact]
+        public void FromHertz_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Frequency.FromHertz(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Frequency.FromHertz(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromHertz_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Frequency.FromHertz(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/HeatFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/HeatFluxTestsBase.g.cs
@@ -90,9 +90,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new HeatFlux((double)0.0, HeatFluxUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new HeatFlux(double.PositiveInfinity, HeatFluxUnit.WattPerSquareMeter));
+            Assert.Throws<ArgumentException>(() => new HeatFlux(double.NegativeInfinity, HeatFluxUnit.WattPerSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new HeatFlux(double.NaN, HeatFluxUnit.WattPerSquareMeter));
         }
 
         [Fact]
@@ -136,6 +149,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, HeatFlux.From(1, HeatFluxUnit.WattPerSquareFoot).WattsPerSquareFoot, WattsPerSquareFootTolerance);
             AssertEx.EqualTolerance(1, HeatFlux.From(1, HeatFluxUnit.WattPerSquareInch).WattsPerSquareInch, WattsPerSquareInchTolerance);
             AssertEx.EqualTolerance(1, HeatFlux.From(1, HeatFluxUnit.WattPerSquareMeter).WattsPerSquareMeter, WattsPerSquareMeterTolerance);
+        }
+
+        [Fact]
+        public void FromWattsPerSquareMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => HeatFlux.FromWattsPerSquareMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => HeatFlux.FromWattsPerSquareMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromWattsPerSquareMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => HeatFlux.FromWattsPerSquareMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/HeatTransferCoefficientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/HeatTransferCoefficientTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new HeatTransferCoefficient((double)0.0, HeatTransferCoefficientUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new HeatTransferCoefficient(double.PositiveInfinity, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin));
+            Assert.Throws<ArgumentException>(() => new HeatTransferCoefficient(double.NegativeInfinity, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new HeatTransferCoefficient(double.NaN, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, HeatTransferCoefficient.From(1, HeatTransferCoefficientUnit.WattPerSquareMeterCelsius).WattsPerSquareMeterCelsius, WattsPerSquareMeterCelsiusTolerance);
             AssertEx.EqualTolerance(1, HeatTransferCoefficient.From(1, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).WattsPerSquareMeterKelvin, WattsPerSquareMeterKelvinTolerance);
+        }
+
+        [Fact]
+        public void FromWattsPerSquareMeterKelvin_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromWattsPerSquareMeterKelvin_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => HeatTransferCoefficient.FromWattsPerSquareMeterKelvin(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/IlluminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IlluminanceTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Illuminance((double)0.0, IlluminanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Illuminance(double.PositiveInfinity, IlluminanceUnit.Lux));
+            Assert.Throws<ArgumentException>(() => new Illuminance(double.NegativeInfinity, IlluminanceUnit.Lux));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Illuminance(double.NaN, IlluminanceUnit.Lux));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Illuminance.From(1, IlluminanceUnit.Lux).Lux, LuxTolerance);
             AssertEx.EqualTolerance(1, Illuminance.From(1, IlluminanceUnit.Megalux).Megalux, MegaluxTolerance);
             AssertEx.EqualTolerance(1, Illuminance.From(1, IlluminanceUnit.Millilux).Millilux, MilliluxTolerance);
+        }
+
+        [Fact]
+        public void FromLux_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Illuminance.FromLux(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Illuminance.FromLux(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromLux_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Illuminance.FromLux(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/InformationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/InformationTestsBase.g.cs
@@ -110,10 +110,11 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Information((decimal)0.0, InformationUnit.Undefined));
         }
+
 
         [Fact]
         public void BitToInformationUnits()
@@ -177,6 +178,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Information.From(1, InformationUnit.Terabit).Terabits, TerabitsTolerance);
             AssertEx.EqualTolerance(1, Information.From(1, InformationUnit.Terabyte).Terabytes, TerabytesTolerance);
         }
+
 
         [Fact]
         public void As()

--- a/UnitsNet.Tests/GeneratedCode/IrradianceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IrradianceTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Irradiance((double)0.0, IrradianceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Irradiance(double.PositiveInfinity, IrradianceUnit.WattPerSquareMeter));
+            Assert.Throws<ArgumentException>(() => new Irradiance(double.NegativeInfinity, IrradianceUnit.WattPerSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Irradiance(double.NaN, IrradianceUnit.WattPerSquareMeter));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, Irradiance.From(1, IrradianceUnit.KilowattPerSquareMeter).KilowattsPerSquareMeter, KilowattsPerSquareMeterTolerance);
             AssertEx.EqualTolerance(1, Irradiance.From(1, IrradianceUnit.WattPerSquareMeter).WattsPerSquareMeter, WattsPerSquareMeterTolerance);
+        }
+
+        [Fact]
+        public void FromWattsPerSquareMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Irradiance.FromWattsPerSquareMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Irradiance.FromWattsPerSquareMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromWattsPerSquareMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Irradiance.FromWattsPerSquareMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/IrradiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IrradiationTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Irradiation((double)0.0, IrradiationUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Irradiation(double.PositiveInfinity, IrradiationUnit.JoulePerSquareMeter));
+            Assert.Throws<ArgumentException>(() => new Irradiation(double.NegativeInfinity, IrradiationUnit.JoulePerSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Irradiation(double.NaN, IrradiationUnit.JoulePerSquareMeter));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Irradiation.From(1, IrradiationUnit.JoulePerSquareMeter).JoulesPerSquareMeter, JoulesPerSquareMeterTolerance);
             AssertEx.EqualTolerance(1, Irradiation.From(1, IrradiationUnit.KilowattHourPerSquareMeter).KilowattHoursPerSquareMeter, KilowattHoursPerSquareMeterTolerance);
             AssertEx.EqualTolerance(1, Irradiation.From(1, IrradiationUnit.WattHourPerSquareMeter).WattHoursPerSquareMeter, WattHoursPerSquareMeterTolerance);
+        }
+
+        [Fact]
+        public void FromJoulesPerSquareMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Irradiation.FromJoulesPerSquareMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Irradiation.FromJoulesPerSquareMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoulesPerSquareMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Irradiation.FromJoulesPerSquareMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/KinematicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/KinematicViscosityTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new KinematicViscosity((double)0.0, KinematicViscosityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new KinematicViscosity(double.PositiveInfinity, KinematicViscosityUnit.SquareMeterPerSecond));
+            Assert.Throws<ArgumentException>(() => new KinematicViscosity(double.NegativeInfinity, KinematicViscosityUnit.SquareMeterPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new KinematicViscosity(double.NaN, KinematicViscosityUnit.SquareMeterPerSecond));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, KinematicViscosity.From(1, KinematicViscosityUnit.Nanostokes).Nanostokes, NanostokesTolerance);
             AssertEx.EqualTolerance(1, KinematicViscosity.From(1, KinematicViscosityUnit.SquareMeterPerSecond).SquareMetersPerSecond, SquareMetersPerSecondTolerance);
             AssertEx.EqualTolerance(1, KinematicViscosity.From(1, KinematicViscosityUnit.Stokes).Stokes, StokesTolerance);
+        }
+
+        [Fact]
+        public void FromSquareMetersPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => KinematicViscosity.FromSquareMetersPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => KinematicViscosity.FromSquareMetersPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSquareMetersPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => KinematicViscosity.FromSquareMetersPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/LapseRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LapseRateTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new LapseRate((double)0.0, LapseRateUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LapseRate(double.PositiveInfinity, LapseRateUnit.DegreeCelsiusPerKilometer));
+            Assert.Throws<ArgumentException>(() => new LapseRate(double.NegativeInfinity, LapseRateUnit.DegreeCelsiusPerKilometer));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LapseRate(double.NaN, LapseRateUnit.DegreeCelsiusPerKilometer));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, LapseRate.From(1, LapseRateUnit.DegreeCelsiusPerKilometer).DegreesCelciusPerKilometer, DegreesCelciusPerKilometerTolerance);
+        }
+
+        [Fact]
+        public void FromDegreesCelciusPerKilometer_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LapseRate.FromDegreesCelciusPerKilometer(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => LapseRate.FromDegreesCelciusPerKilometer(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDegreesCelciusPerKilometer_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LapseRate.FromDegreesCelciusPerKilometer(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/LengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LengthTestsBase.g.cs
@@ -102,9 +102,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Length((double)0.0, LengthUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Length(double.PositiveInfinity, LengthUnit.Meter));
+            Assert.Throws<ArgumentException>(() => new Length(double.NegativeInfinity, LengthUnit.Meter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Length(double.NaN, LengthUnit.Meter));
         }
 
         [Fact]
@@ -160,6 +173,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Length.From(1, LengthUnit.Twip).Twips, TwipsTolerance);
             AssertEx.EqualTolerance(1, Length.From(1, LengthUnit.UsSurveyFoot).UsSurveyFeet, UsSurveyFeetTolerance);
             AssertEx.EqualTolerance(1, Length.From(1, LengthUnit.Yard).Yards, YardsTolerance);
+        }
+
+        [Fact]
+        public void FromMeters_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Length.FromMeters(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Length.FromMeters(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromMeters_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Length.FromMeters(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/LevelTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LevelTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Level((double)0.0, LevelUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Level(double.PositiveInfinity, LevelUnit.Decibel));
+            Assert.Throws<ArgumentException>(() => new Level(double.NegativeInfinity, LevelUnit.Decibel));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Level(double.NaN, LevelUnit.Decibel));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, Level.From(1, LevelUnit.Decibel).Decibels, DecibelsTolerance);
             AssertEx.EqualTolerance(1, Level.From(1, LevelUnit.Neper).Nepers, NepersTolerance);
+        }
+
+        [Fact]
+        public void FromDecibels_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Level.FromDecibels(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Level.FromDecibels(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDecibels_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Level.FromDecibels(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/LinearDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LinearDensityTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new LinearDensity((double)0.0, LinearDensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LinearDensity(double.PositiveInfinity, LinearDensityUnit.KilogramPerMeter));
+            Assert.Throws<ArgumentException>(() => new LinearDensity(double.NegativeInfinity, LinearDensityUnit.KilogramPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LinearDensity(double.NaN, LinearDensityUnit.KilogramPerMeter));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, LinearDensity.From(1, LinearDensityUnit.GramPerMeter).GramsPerMeter, GramsPerMeterTolerance);
             AssertEx.EqualTolerance(1, LinearDensity.From(1, LinearDensityUnit.KilogramPerMeter).KilogramsPerMeter, KilogramsPerMeterTolerance);
             AssertEx.EqualTolerance(1, LinearDensity.From(1, LinearDensityUnit.PoundPerFoot).PoundsPerFoot, PoundsPerFootTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramsPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LinearDensity.FromKilogramsPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => LinearDensity.FromKilogramsPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramsPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LinearDensity.FromKilogramsPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/LuminousFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LuminousFluxTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new LuminousFlux((double)0.0, LuminousFluxUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LuminousFlux(double.PositiveInfinity, LuminousFluxUnit.Lumen));
+            Assert.Throws<ArgumentException>(() => new LuminousFlux(double.NegativeInfinity, LuminousFluxUnit.Lumen));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LuminousFlux(double.NaN, LuminousFluxUnit.Lumen));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, LuminousFlux.From(1, LuminousFluxUnit.Lumen).Lumens, LumensTolerance);
+        }
+
+        [Fact]
+        public void FromLumens_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LuminousFlux.FromLumens(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => LuminousFlux.FromLumens(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromLumens_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LuminousFlux.FromLumens(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/LuminousIntensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/LuminousIntensityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new LuminousIntensity((double)0.0, LuminousIntensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LuminousIntensity(double.PositiveInfinity, LuminousIntensityUnit.Candela));
+            Assert.Throws<ArgumentException>(() => new LuminousIntensity(double.NegativeInfinity, LuminousIntensityUnit.Candela));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new LuminousIntensity(double.NaN, LuminousIntensityUnit.Candela));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, LuminousIntensity.From(1, LuminousIntensityUnit.Candela).Candela, CandelaTolerance);
+        }
+
+        [Fact]
+        public void FromCandela_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LuminousIntensity.FromCandela(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => LuminousIntensity.FromCandela(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromCandela_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => LuminousIntensity.FromCandela(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MagneticFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MagneticFieldTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MagneticField((double)0.0, MagneticFieldUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MagneticField(double.PositiveInfinity, MagneticFieldUnit.Tesla));
+            Assert.Throws<ArgumentException>(() => new MagneticField(double.NegativeInfinity, MagneticFieldUnit.Tesla));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MagneticField(double.NaN, MagneticFieldUnit.Tesla));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, MagneticField.From(1, MagneticFieldUnit.Tesla).Teslas, TeslasTolerance);
+        }
+
+        [Fact]
+        public void FromTeslas_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MagneticField.FromTeslas(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MagneticField.FromTeslas(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromTeslas_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MagneticField.FromTeslas(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MagneticFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MagneticFluxTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MagneticFlux((double)0.0, MagneticFluxUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MagneticFlux(double.PositiveInfinity, MagneticFluxUnit.Weber));
+            Assert.Throws<ArgumentException>(() => new MagneticFlux(double.NegativeInfinity, MagneticFluxUnit.Weber));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MagneticFlux(double.NaN, MagneticFluxUnit.Weber));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, MagneticFlux.From(1, MagneticFluxUnit.Weber).Webers, WebersTolerance);
+        }
+
+        [Fact]
+        public void FromWebers_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MagneticFlux.FromWebers(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MagneticFlux.FromWebers(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromWebers_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MagneticFlux.FromWebers(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MagnetizationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MagnetizationTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Magnetization((double)0.0, MagnetizationUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Magnetization(double.PositiveInfinity, MagnetizationUnit.AmperePerMeter));
+            Assert.Throws<ArgumentException>(() => new Magnetization(double.NegativeInfinity, MagnetizationUnit.AmperePerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Magnetization(double.NaN, MagnetizationUnit.AmperePerMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, Magnetization.From(1, MagnetizationUnit.AmperePerMeter).AmperesPerMeter, AmperesPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromAmperesPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Magnetization.FromAmperesPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Magnetization.FromAmperesPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromAmperesPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Magnetization.FromAmperesPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MassFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassFlowTestsBase.g.cs
@@ -88,9 +88,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MassFlow((double)0.0, MassFlowUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MassFlow(double.PositiveInfinity, MassFlowUnit.GramPerSecond));
+            Assert.Throws<ArgumentException>(() => new MassFlow(double.NegativeInfinity, MassFlowUnit.GramPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MassFlow(double.NaN, MassFlowUnit.GramPerSecond));
         }
 
         [Fact]
@@ -132,6 +145,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, MassFlow.From(1, MassFlowUnit.ShortTonPerHour).ShortTonsPerHour, ShortTonsPerHourTolerance);
             AssertEx.EqualTolerance(1, MassFlow.From(1, MassFlowUnit.TonnePerDay).TonnesPerDay, TonnesPerDayTolerance);
             AssertEx.EqualTolerance(1, MassFlow.From(1, MassFlowUnit.TonnePerHour).TonnesPerHour, TonnesPerHourTolerance);
+        }
+
+        [Fact]
+        public void FromGramsPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MassFlow.FromGramsPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MassFlow.FromGramsPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromGramsPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MassFlow.FromGramsPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MassFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassFluxTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MassFlux((double)0.0, MassFluxUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MassFlux(double.PositiveInfinity, MassFluxUnit.KilogramPerSecondPerSquareMeter));
+            Assert.Throws<ArgumentException>(() => new MassFlux(double.NegativeInfinity, MassFluxUnit.KilogramPerSecondPerSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MassFlux(double.NaN, MassFluxUnit.KilogramPerSecondPerSquareMeter));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, MassFlux.From(1, MassFluxUnit.GramPerSecondPerSquareMeter).GramsPerSecondPerSquareMeter, GramsPerSecondPerSquareMeterTolerance);
             AssertEx.EqualTolerance(1, MassFlux.From(1, MassFluxUnit.KilogramPerSecondPerSquareMeter).KilogramsPerSecondPerSquareMeter, KilogramsPerSecondPerSquareMeterTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramsPerSecondPerSquareMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MassFlux.FromKilogramsPerSecondPerSquareMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MassFlux.FromKilogramsPerSecondPerSquareMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramsPerSecondPerSquareMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MassFlux.FromKilogramsPerSecondPerSquareMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MassMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassMomentOfInertiaTestsBase.g.cs
@@ -110,9 +110,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MassMomentOfInertia((double)0.0, MassMomentOfInertiaUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MassMomentOfInertia(double.PositiveInfinity, MassMomentOfInertiaUnit.KilogramSquareMeter));
+            Assert.Throws<ArgumentException>(() => new MassMomentOfInertia(double.NegativeInfinity, MassMomentOfInertiaUnit.KilogramSquareMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MassMomentOfInertia(double.NaN, MassMomentOfInertiaUnit.KilogramSquareMeter));
         }
 
         [Fact]
@@ -176,6 +189,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, MassMomentOfInertia.From(1, MassMomentOfInertiaUnit.TonneSquareDecimeter).TonneSquareDecimeters, TonneSquareDecimetersTolerance);
             AssertEx.EqualTolerance(1, MassMomentOfInertia.From(1, MassMomentOfInertiaUnit.TonneSquareMeter).TonneSquareMeters, TonneSquareMetersTolerance);
             AssertEx.EqualTolerance(1, MassMomentOfInertia.From(1, MassMomentOfInertiaUnit.TonneSquareMilimeter).TonneSquareMilimeters, TonneSquareMilimetersTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramSquareMeters_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MassMomentOfInertia.FromKilogramSquareMeters(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MassMomentOfInertia.FromKilogramSquareMeters(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramSquareMeters_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MassMomentOfInertia.FromKilogramSquareMeters(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MassTestsBase.g.cs
@@ -100,9 +100,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Mass((double)0.0, MassUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Mass(double.PositiveInfinity, MassUnit.Kilogram));
+            Assert.Throws<ArgumentException>(() => new Mass(double.NegativeInfinity, MassUnit.Kilogram));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Mass(double.NaN, MassUnit.Kilogram));
         }
 
         [Fact]
@@ -156,6 +169,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Mass.From(1, MassUnit.ShortTon).ShortTons, ShortTonsTolerance);
             AssertEx.EqualTolerance(1, Mass.From(1, MassUnit.Stone).Stone, StoneTolerance);
             AssertEx.EqualTolerance(1, Mass.From(1, MassUnit.Tonne).Tonnes, TonnesTolerance);
+        }
+
+        [Fact]
+        public void FromKilograms_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Mass.FromKilograms(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Mass.FromKilograms(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilograms_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Mass.FromKilograms(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MolarEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarEnergyTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MolarEnergy((double)0.0, MolarEnergyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MolarEnergy(double.PositiveInfinity, MolarEnergyUnit.JoulePerMole));
+            Assert.Throws<ArgumentException>(() => new MolarEnergy(double.NegativeInfinity, MolarEnergyUnit.JoulePerMole));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MolarEnergy(double.NaN, MolarEnergyUnit.JoulePerMole));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, MolarEnergy.From(1, MolarEnergyUnit.JoulePerMole).JoulesPerMole, JoulesPerMoleTolerance);
             AssertEx.EqualTolerance(1, MolarEnergy.From(1, MolarEnergyUnit.KilojoulePerMole).KilojoulesPerMole, KilojoulesPerMoleTolerance);
             AssertEx.EqualTolerance(1, MolarEnergy.From(1, MolarEnergyUnit.MegajoulePerMole).MegajoulesPerMole, MegajoulesPerMoleTolerance);
+        }
+
+        [Fact]
+        public void FromJoulesPerMole_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MolarEnergy.FromJoulesPerMole(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MolarEnergy.FromJoulesPerMole(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoulesPerMole_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MolarEnergy.FromJoulesPerMole(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MolarEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarEntropyTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MolarEntropy((double)0.0, MolarEntropyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MolarEntropy(double.PositiveInfinity, MolarEntropyUnit.JoulePerMoleKelvin));
+            Assert.Throws<ArgumentException>(() => new MolarEntropy(double.NegativeInfinity, MolarEntropyUnit.JoulePerMoleKelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MolarEntropy(double.NaN, MolarEntropyUnit.JoulePerMoleKelvin));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, MolarEntropy.From(1, MolarEntropyUnit.JoulePerMoleKelvin).JoulesPerMoleKelvin, JoulesPerMoleKelvinTolerance);
             AssertEx.EqualTolerance(1, MolarEntropy.From(1, MolarEntropyUnit.KilojoulePerMoleKelvin).KilojoulesPerMoleKelvin, KilojoulesPerMoleKelvinTolerance);
             AssertEx.EqualTolerance(1, MolarEntropy.From(1, MolarEntropyUnit.MegajoulePerMoleKelvin).MegajoulesPerMoleKelvin, MegajoulesPerMoleKelvinTolerance);
+        }
+
+        [Fact]
+        public void FromJoulesPerMoleKelvin_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MolarEntropy.FromJoulesPerMoleKelvin(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MolarEntropy.FromJoulesPerMoleKelvin(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoulesPerMoleKelvin_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MolarEntropy.FromJoulesPerMoleKelvin(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MolarMassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarMassTestsBase.g.cs
@@ -82,9 +82,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new MolarMass((double)0.0, MolarMassUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MolarMass(double.PositiveInfinity, MolarMassUnit.KilogramPerMole));
+            Assert.Throws<ArgumentException>(() => new MolarMass(double.NegativeInfinity, MolarMassUnit.KilogramPerMole));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new MolarMass(double.NaN, MolarMassUnit.KilogramPerMole));
         }
 
         [Fact]
@@ -120,6 +133,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, MolarMass.From(1, MolarMassUnit.MilligramPerMole).MilligramsPerMole, MilligramsPerMoleTolerance);
             AssertEx.EqualTolerance(1, MolarMass.From(1, MolarMassUnit.NanogramPerMole).NanogramsPerMole, NanogramsPerMoleTolerance);
             AssertEx.EqualTolerance(1, MolarMass.From(1, MolarMassUnit.PoundPerMole).PoundsPerMole, PoundsPerMoleTolerance);
+        }
+
+        [Fact]
+        public void FromKilogramsPerMole_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MolarMass.FromKilogramsPerMole(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => MolarMass.FromKilogramsPerMole(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKilogramsPerMole_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => MolarMass.FromKilogramsPerMole(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/MolarityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/MolarityTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Molarity((double)0.0, MolarityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Molarity(double.PositiveInfinity, MolarityUnit.MolesPerCubicMeter));
+            Assert.Throws<ArgumentException>(() => new Molarity(double.NegativeInfinity, MolarityUnit.MolesPerCubicMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Molarity(double.NaN, MolarityUnit.MolesPerCubicMeter));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Molarity.From(1, MolarityUnit.MolesPerLiter).MolesPerLiter, MolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.From(1, MolarityUnit.NanomolesPerLiter).NanomolesPerLiter, NanomolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.From(1, MolarityUnit.PicomolesPerLiter).PicomolesPerLiter, PicomolesPerLiterTolerance);
+        }
+
+        [Fact]
+        public void FromMolesPerCubicMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Molarity.FromMolesPerCubicMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Molarity.FromMolesPerCubicMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromMolesPerCubicMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Molarity.FromMolesPerCubicMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/PermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PermeabilityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Permeability((double)0.0, PermeabilityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Permeability(double.PositiveInfinity, PermeabilityUnit.HenryPerMeter));
+            Assert.Throws<ArgumentException>(() => new Permeability(double.NegativeInfinity, PermeabilityUnit.HenryPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Permeability(double.NaN, PermeabilityUnit.HenryPerMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, Permeability.From(1, PermeabilityUnit.HenryPerMeter).HenriesPerMeter, HenriesPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromHenriesPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Permeability.FromHenriesPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Permeability.FromHenriesPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromHenriesPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Permeability.FromHenriesPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/PermittivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PermittivityTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Permittivity((double)0.0, PermittivityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Permittivity(double.PositiveInfinity, PermittivityUnit.FaradPerMeter));
+            Assert.Throws<ArgumentException>(() => new Permittivity(double.NegativeInfinity, PermittivityUnit.FaradPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Permittivity(double.NaN, PermittivityUnit.FaradPerMeter));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, Permittivity.From(1, PermittivityUnit.FaradPerMeter).FaradsPerMeter, FaradsPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromFaradsPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Permittivity.FromFaradsPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Permittivity.FromFaradsPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromFaradsPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Permittivity.FromFaradsPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/PowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PowerDensityTestsBase.g.cs
@@ -146,9 +146,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new PowerDensity((double)0.0, PowerDensityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new PowerDensity(double.PositiveInfinity, PowerDensityUnit.WattPerCubicMeter));
+            Assert.Throws<ArgumentException>(() => new PowerDensity(double.NegativeInfinity, PowerDensityUnit.WattPerCubicMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new PowerDensity(double.NaN, PowerDensityUnit.WattPerCubicMeter));
         }
 
         [Fact]
@@ -248,6 +261,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, PowerDensity.From(1, PowerDensityUnit.WattPerCubicInch).WattsPerCubicInch, WattsPerCubicInchTolerance);
             AssertEx.EqualTolerance(1, PowerDensity.From(1, PowerDensityUnit.WattPerCubicMeter).WattsPerCubicMeter, WattsPerCubicMeterTolerance);
             AssertEx.EqualTolerance(1, PowerDensity.From(1, PowerDensityUnit.WattPerLiter).WattsPerLiter, WattsPerLiterTolerance);
+        }
+
+        [Fact]
+        public void FromWattsPerCubicMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PowerDensity.FromWattsPerCubicMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => PowerDensity.FromWattsPerCubicMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromWattsPerCubicMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PowerDensity.FromWattsPerCubicMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/PowerRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PowerRatioTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new PowerRatio((double)0.0, PowerRatioUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new PowerRatio(double.PositiveInfinity, PowerRatioUnit.DecibelWatt));
+            Assert.Throws<ArgumentException>(() => new PowerRatio(double.NegativeInfinity, PowerRatioUnit.DecibelWatt));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new PowerRatio(double.NaN, PowerRatioUnit.DecibelWatt));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, PowerRatio.From(1, PowerRatioUnit.DecibelMilliwatt).DecibelMilliwatts, DecibelMilliwattsTolerance);
             AssertEx.EqualTolerance(1, PowerRatio.From(1, PowerRatioUnit.DecibelWatt).DecibelWatts, DecibelWattsTolerance);
+        }
+
+        [Fact]
+        public void FromDecibelWatts_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PowerRatio.FromDecibelWatts(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => PowerRatio.FromDecibelWatts(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDecibelWatts_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PowerRatio.FromDecibelWatts(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/PowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PowerTestsBase.g.cs
@@ -98,10 +98,11 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Power((decimal)0.0, PowerUnit.Undefined));
         }
+
 
         [Fact]
         public void WattToPowerUnits()
@@ -153,6 +154,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Power.From(1, PowerUnit.Terawatt).Terawatts, TerawattsTolerance);
             AssertEx.EqualTolerance(1, Power.From(1, PowerUnit.Watt).Watts, WattsTolerance);
         }
+
 
         [Fact]
         public void As()

--- a/UnitsNet.Tests/GeneratedCode/PressureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PressureChangeRateTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new PressureChangeRate((double)0.0, PressureChangeRateUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new PressureChangeRate(double.PositiveInfinity, PressureChangeRateUnit.PascalPerSecond));
+            Assert.Throws<ArgumentException>(() => new PressureChangeRate(double.NegativeInfinity, PressureChangeRateUnit.PascalPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new PressureChangeRate(double.NaN, PressureChangeRateUnit.PascalPerSecond));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, PressureChangeRate.From(1, PressureChangeRateUnit.KilopascalPerSecond).KilopascalsPerSecond, KilopascalsPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.From(1, PressureChangeRateUnit.MegapascalPerSecond).MegapascalsPerSecond, MegapascalsPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.From(1, PressureChangeRateUnit.PascalPerSecond).PascalsPerSecond, PascalsPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromPascalsPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PressureChangeRate.FromPascalsPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => PressureChangeRate.FromPascalsPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromPascalsPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PressureChangeRate.FromPascalsPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/PressureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PressureTestsBase.g.cs
@@ -132,9 +132,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Pressure((double)0.0, PressureUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Pressure(double.PositiveInfinity, PressureUnit.Pascal));
+            Assert.Throws<ArgumentException>(() => new Pressure(double.NegativeInfinity, PressureUnit.Pascal));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Pressure(double.NaN, PressureUnit.Pascal));
         }
 
         [Fact]
@@ -220,6 +233,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Pressure.From(1, PressureUnit.TonneForcePerSquareMeter).TonnesForcePerSquareMeter, TonnesForcePerSquareMeterTolerance);
             AssertEx.EqualTolerance(1, Pressure.From(1, PressureUnit.TonneForcePerSquareMillimeter).TonnesForcePerSquareMillimeter, TonnesForcePerSquareMillimeterTolerance);
             AssertEx.EqualTolerance(1, Pressure.From(1, PressureUnit.Torr).Torrs, TorrsTolerance);
+        }
+
+        [Fact]
+        public void FromPascals_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Pressure.FromPascals(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Pressure.FromPascals(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromPascals_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Pressure.FromPascals(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/RatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RatioTestsBase.g.cs
@@ -70,9 +70,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Ratio((double)0.0, RatioUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Ratio(double.PositiveInfinity, RatioUnit.DecimalFraction));
+            Assert.Throws<ArgumentException>(() => new Ratio(double.NegativeInfinity, RatioUnit.DecimalFraction));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Ratio(double.NaN, RatioUnit.DecimalFraction));
         }
 
         [Fact]
@@ -96,6 +109,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Ratio.From(1, RatioUnit.PartPerThousand).PartsPerThousand, PartsPerThousandTolerance);
             AssertEx.EqualTolerance(1, Ratio.From(1, RatioUnit.PartPerTrillion).PartsPerTrillion, PartsPerTrillionTolerance);
             AssertEx.EqualTolerance(1, Ratio.From(1, RatioUnit.Percent).Percent, PercentTolerance);
+        }
+
+        [Fact]
+        public void FromDecimalFractions_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Ratio.FromDecimalFractions(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Ratio.FromDecimalFractions(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDecimalFractions_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Ratio.FromDecimalFractions(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ReactiveEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ReactiveEnergyTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ReactiveEnergy((double)0.0, ReactiveEnergyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ReactiveEnergy(double.PositiveInfinity, ReactiveEnergyUnit.VoltampereReactiveHour));
+            Assert.Throws<ArgumentException>(() => new ReactiveEnergy(double.NegativeInfinity, ReactiveEnergyUnit.VoltampereReactiveHour));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ReactiveEnergy(double.NaN, ReactiveEnergyUnit.VoltampereReactiveHour));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ReactiveEnergy.From(1, ReactiveEnergyUnit.KilovoltampereReactiveHour).KilovoltampereReactiveHours, KilovoltampereReactiveHoursTolerance);
             AssertEx.EqualTolerance(1, ReactiveEnergy.From(1, ReactiveEnergyUnit.MegavoltampereReactiveHour).MegavoltampereReactiveHours, MegavoltampereReactiveHoursTolerance);
             AssertEx.EqualTolerance(1, ReactiveEnergy.From(1, ReactiveEnergyUnit.VoltampereReactiveHour).VoltampereReactiveHours, VoltampereReactiveHoursTolerance);
+        }
+
+        [Fact]
+        public void FromVoltampereReactiveHours_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ReactiveEnergy.FromVoltampereReactiveHours(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ReactiveEnergy.FromVoltampereReactiveHours(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltampereReactiveHours_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ReactiveEnergy.FromVoltampereReactiveHours(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ReactivePowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ReactivePowerTestsBase.g.cs
@@ -66,9 +66,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ReactivePower((double)0.0, ReactivePowerUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ReactivePower(double.PositiveInfinity, ReactivePowerUnit.VoltampereReactive));
+            Assert.Throws<ArgumentException>(() => new ReactivePower(double.NegativeInfinity, ReactivePowerUnit.VoltampereReactive));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ReactivePower(double.NaN, ReactivePowerUnit.VoltampereReactive));
         }
 
         [Fact]
@@ -88,6 +101,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ReactivePower.From(1, ReactivePowerUnit.KilovoltampereReactive).KilovoltamperesReactive, KilovoltamperesReactiveTolerance);
             AssertEx.EqualTolerance(1, ReactivePower.From(1, ReactivePowerUnit.MegavoltampereReactive).MegavoltamperesReactive, MegavoltamperesReactiveTolerance);
             AssertEx.EqualTolerance(1, ReactivePower.From(1, ReactivePowerUnit.VoltampereReactive).VoltamperesReactive, VoltamperesReactiveTolerance);
+        }
+
+        [Fact]
+        public void FromVoltamperesReactive_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ReactivePower.FromVoltamperesReactive(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ReactivePower.FromVoltamperesReactive(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromVoltamperesReactive_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ReactivePower.FromVoltamperesReactive(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new RotationalAcceleration((double)0.0, RotationalAccelerationUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalAcceleration(double.PositiveInfinity, RotationalAccelerationUnit.RadianPerSecondSquared));
+            Assert.Throws<ArgumentException>(() => new RotationalAcceleration(double.NegativeInfinity, RotationalAccelerationUnit.RadianPerSecondSquared));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalAcceleration(double.NaN, RotationalAccelerationUnit.RadianPerSecondSquared));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.DegreePerSecondSquared).DegreesPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RadianPerSecondSquared).RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RevolutionPerMinutePerSecond).RevolutionsPerMinutePerSecond, RevolutionsPerMinutePerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromRadiansPerSecondSquared_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalAcceleration.FromRadiansPerSecondSquared(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => RotationalAcceleration.FromRadiansPerSecondSquared(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromRadiansPerSecondSquared_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalAcceleration.FromRadiansPerSecondSquared(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/RotationalSpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalSpeedTestsBase.g.cs
@@ -84,9 +84,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new RotationalSpeed((double)0.0, RotationalSpeedUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalSpeed(double.PositiveInfinity, RotationalSpeedUnit.RadianPerSecond));
+            Assert.Throws<ArgumentException>(() => new RotationalSpeed(double.NegativeInfinity, RotationalSpeedUnit.RadianPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalSpeed(double.NaN, RotationalSpeedUnit.RadianPerSecond));
         }
 
         [Fact]
@@ -124,6 +137,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalSpeed.From(1, RotationalSpeedUnit.RadianPerSecond).RadiansPerSecond, RadiansPerSecondTolerance);
             AssertEx.EqualTolerance(1, RotationalSpeed.From(1, RotationalSpeedUnit.RevolutionPerMinute).RevolutionsPerMinute, RevolutionsPerMinuteTolerance);
             AssertEx.EqualTolerance(1, RotationalSpeed.From(1, RotationalSpeedUnit.RevolutionPerSecond).RevolutionsPerSecond, RevolutionsPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromRadiansPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalSpeed.FromRadiansPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => RotationalSpeed.FromRadiansPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromRadiansPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalSpeed.FromRadiansPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/RotationalStiffnessPerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalStiffnessPerLengthTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new RotationalStiffnessPerLength((double)0.0, RotationalStiffnessPerLengthUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalStiffnessPerLength(double.PositiveInfinity, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter));
+            Assert.Throws<ArgumentException>(() => new RotationalStiffnessPerLength(double.NegativeInfinity, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalStiffnessPerLength(double.NaN, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalStiffnessPerLength.From(1, RotationalStiffnessPerLengthUnit.KilonewtonMeterPerRadianPerMeter).KilonewtonMetersPerRadianPerMeter, KilonewtonMetersPerRadianPerMeterTolerance);
             AssertEx.EqualTolerance(1, RotationalStiffnessPerLength.From(1, RotationalStiffnessPerLengthUnit.MeganewtonMeterPerRadianPerMeter).MeganewtonMetersPerRadianPerMeter, MeganewtonMetersPerRadianPerMeterTolerance);
             AssertEx.EqualTolerance(1, RotationalStiffnessPerLength.From(1, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).NewtonMetersPerRadianPerMeter, NewtonMetersPerRadianPerMeterTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonMetersPerRadianPerMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonMetersPerRadianPerMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/RotationalStiffnessTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalStiffnessTestsBase.g.cs
@@ -64,9 +64,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new RotationalStiffness((double)0.0, RotationalStiffnessUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalStiffness(double.PositiveInfinity, RotationalStiffnessUnit.NewtonMeterPerRadian));
+            Assert.Throws<ArgumentException>(() => new RotationalStiffness(double.NegativeInfinity, RotationalStiffnessUnit.NewtonMeterPerRadian));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new RotationalStiffness(double.NaN, RotationalStiffnessUnit.NewtonMeterPerRadian));
         }
 
         [Fact]
@@ -84,6 +97,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalStiffness.From(1, RotationalStiffnessUnit.KilonewtonMeterPerRadian).KilonewtonMetersPerRadian, KilonewtonMetersPerRadianTolerance);
             AssertEx.EqualTolerance(1, RotationalStiffness.From(1, RotationalStiffnessUnit.MeganewtonMeterPerRadian).MeganewtonMetersPerRadian, MeganewtonMetersPerRadianTolerance);
             AssertEx.EqualTolerance(1, RotationalStiffness.From(1, RotationalStiffnessUnit.NewtonMeterPerRadian).NewtonMetersPerRadian, NewtonMetersPerRadianTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonMetersPerRadian_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalStiffness.FromNewtonMetersPerRadian(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => RotationalStiffness.FromNewtonMetersPerRadian(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonMetersPerRadian_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => RotationalStiffness.FromNewtonMetersPerRadian(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/SolidAngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SolidAngleTestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new SolidAngle((double)0.0, SolidAngleUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SolidAngle(double.PositiveInfinity, SolidAngleUnit.Steradian));
+            Assert.Throws<ArgumentException>(() => new SolidAngle(double.NegativeInfinity, SolidAngleUnit.Steradian));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SolidAngle(double.NaN, SolidAngleUnit.Steradian));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, SolidAngle.From(1, SolidAngleUnit.Steradian).Steradians, SteradiansTolerance);
+        }
+
+        [Fact]
+        public void FromSteradians_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SolidAngle.FromSteradians(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => SolidAngle.FromSteradians(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSteradians_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SolidAngle.FromSteradians(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/SpecificEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificEnergyTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new SpecificEnergy((double)0.0, SpecificEnergyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificEnergy(double.PositiveInfinity, SpecificEnergyUnit.JoulePerKilogram));
+            Assert.Throws<ArgumentException>(() => new SpecificEnergy(double.NegativeInfinity, SpecificEnergyUnit.JoulePerKilogram));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificEnergy(double.NaN, SpecificEnergyUnit.JoulePerKilogram));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, SpecificEnergy.From(1, SpecificEnergyUnit.MegajoulePerKilogram).MegajoulesPerKilogram, MegajoulesPerKilogramTolerance);
             AssertEx.EqualTolerance(1, SpecificEnergy.From(1, SpecificEnergyUnit.MegawattHourPerKilogram).MegawattHoursPerKilogram, MegawattHoursPerKilogramTolerance);
             AssertEx.EqualTolerance(1, SpecificEnergy.From(1, SpecificEnergyUnit.WattHourPerKilogram).WattHoursPerKilogram, WattHoursPerKilogramTolerance);
+        }
+
+        [Fact]
+        public void FromJoulesPerKilogram_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificEnergy.FromJoulesPerKilogram(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => SpecificEnergy.FromJoulesPerKilogram(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoulesPerKilogram_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificEnergy.FromJoulesPerKilogram(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/SpecificEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificEntropyTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new SpecificEntropy((double)0.0, SpecificEntropyUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificEntropy(double.PositiveInfinity, SpecificEntropyUnit.JoulePerKilogramKelvin));
+            Assert.Throws<ArgumentException>(() => new SpecificEntropy(double.NegativeInfinity, SpecificEntropyUnit.JoulePerKilogramKelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificEntropy(double.NaN, SpecificEntropyUnit.JoulePerKilogramKelvin));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, SpecificEntropy.From(1, SpecificEntropyUnit.KilojoulePerKilogramKelvin).KilojoulesPerKilogramKelvin, KilojoulesPerKilogramKelvinTolerance);
             AssertEx.EqualTolerance(1, SpecificEntropy.From(1, SpecificEntropyUnit.MegajoulePerKilogramDegreeCelsius).MegajoulesPerKilogramDegreeCelsius, MegajoulesPerKilogramDegreeCelsiusTolerance);
             AssertEx.EqualTolerance(1, SpecificEntropy.From(1, SpecificEntropyUnit.MegajoulePerKilogramKelvin).MegajoulesPerKilogramKelvin, MegajoulesPerKilogramKelvinTolerance);
+        }
+
+        [Fact]
+        public void FromJoulesPerKilogramKelvin_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificEntropy.FromJoulesPerKilogramKelvin(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => SpecificEntropy.FromJoulesPerKilogramKelvin(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromJoulesPerKilogramKelvin_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificEntropy.FromJoulesPerKilogramKelvin(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/SpecificVolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificVolumeTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new SpecificVolume((double)0.0, SpecificVolumeUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificVolume(double.PositiveInfinity, SpecificVolumeUnit.CubicMeterPerKilogram));
+            Assert.Throws<ArgumentException>(() => new SpecificVolume(double.NegativeInfinity, SpecificVolumeUnit.CubicMeterPerKilogram));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificVolume(double.NaN, SpecificVolumeUnit.CubicMeterPerKilogram));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, SpecificVolume.From(1, SpecificVolumeUnit.CubicFootPerPound).CubicFeetPerPound, CubicFeetPerPoundTolerance);
             AssertEx.EqualTolerance(1, SpecificVolume.From(1, SpecificVolumeUnit.CubicMeterPerKilogram).CubicMetersPerKilogram, CubicMetersPerKilogramTolerance);
+        }
+
+        [Fact]
+        public void FromCubicMetersPerKilogram_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificVolume.FromCubicMetersPerKilogram(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => SpecificVolume.FromCubicMetersPerKilogram(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromCubicMetersPerKilogram_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificVolume.FromCubicMetersPerKilogram(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/SpecificWeightTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpecificWeightTestsBase.g.cs
@@ -92,9 +92,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new SpecificWeight((double)0.0, SpecificWeightUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificWeight(double.PositiveInfinity, SpecificWeightUnit.NewtonPerCubicMeter));
+            Assert.Throws<ArgumentException>(() => new SpecificWeight(double.NegativeInfinity, SpecificWeightUnit.NewtonPerCubicMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SpecificWeight(double.NaN, SpecificWeightUnit.NewtonPerCubicMeter));
         }
 
         [Fact]
@@ -140,6 +153,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, SpecificWeight.From(1, SpecificWeightUnit.TonneForcePerCubicCentimeter).TonnesForcePerCubicCentimeter, TonnesForcePerCubicCentimeterTolerance);
             AssertEx.EqualTolerance(1, SpecificWeight.From(1, SpecificWeightUnit.TonneForcePerCubicMeter).TonnesForcePerCubicMeter, TonnesForcePerCubicMeterTolerance);
             AssertEx.EqualTolerance(1, SpecificWeight.From(1, SpecificWeightUnit.TonneForcePerCubicMillimeter).TonnesForcePerCubicMillimeter, TonnesForcePerCubicMillimeterTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonsPerCubicMeter_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificWeight.FromNewtonsPerCubicMeter(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => SpecificWeight.FromNewtonsPerCubicMeter(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonsPerCubicMeter_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => SpecificWeight.FromNewtonsPerCubicMeter(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/SpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpeedTestsBase.g.cs
@@ -122,9 +122,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Speed((double)0.0, SpeedUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Speed(double.PositiveInfinity, SpeedUnit.MeterPerSecond));
+            Assert.Throws<ArgumentException>(() => new Speed(double.NegativeInfinity, SpeedUnit.MeterPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Speed(double.NaN, SpeedUnit.MeterPerSecond));
         }
 
         [Fact]
@@ -200,6 +213,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Speed.From(1, SpeedUnit.YardPerHour).YardsPerHour, YardsPerHourTolerance);
             AssertEx.EqualTolerance(1, Speed.From(1, SpeedUnit.YardPerMinute).YardsPerMinute, YardsPerMinuteTolerance);
             AssertEx.EqualTolerance(1, Speed.From(1, SpeedUnit.YardPerSecond).YardsPerSecond, YardsPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromMetersPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Speed.FromMetersPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Speed.FromMetersPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromMetersPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Speed.FromMetersPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TemperatureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TemperatureChangeRateTestsBase.g.cs
@@ -78,9 +78,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new TemperatureChangeRate((double)0.0, TemperatureChangeRateUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TemperatureChangeRate(double.PositiveInfinity, TemperatureChangeRateUnit.DegreeCelsiusPerSecond));
+            Assert.Throws<ArgumentException>(() => new TemperatureChangeRate(double.NegativeInfinity, TemperatureChangeRateUnit.DegreeCelsiusPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TemperatureChangeRate(double.NaN, TemperatureChangeRateUnit.DegreeCelsiusPerSecond));
         }
 
         [Fact]
@@ -112,6 +125,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, TemperatureChangeRate.From(1, TemperatureChangeRateUnit.MicrodegreeCelsiusPerSecond).MicrodegreesCelsiusPerSecond, MicrodegreesCelsiusPerSecondTolerance);
             AssertEx.EqualTolerance(1, TemperatureChangeRate.From(1, TemperatureChangeRateUnit.MillidegreeCelsiusPerSecond).MillidegreesCelsiusPerSecond, MillidegreesCelsiusPerSecondTolerance);
             AssertEx.EqualTolerance(1, TemperatureChangeRate.From(1, TemperatureChangeRateUnit.NanodegreeCelsiusPerSecond).NanodegreesCelsiusPerSecond, NanodegreesCelsiusPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromDegreesCelsiusPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => TemperatureChangeRate.FromDegreesCelsiusPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => TemperatureChangeRate.FromDegreesCelsiusPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromDegreesCelsiusPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => TemperatureChangeRate.FromDegreesCelsiusPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TemperatureDeltaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TemperatureDeltaTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new TemperatureDelta((double)0.0, TemperatureDeltaUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TemperatureDelta(double.PositiveInfinity, TemperatureDeltaUnit.Kelvin));
+            Assert.Throws<ArgumentException>(() => new TemperatureDelta(double.NegativeInfinity, TemperatureDeltaUnit.Kelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TemperatureDelta(double.NaN, TemperatureDeltaUnit.Kelvin));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, TemperatureDelta.From(1, TemperatureDeltaUnit.DegreeReaumur).DegreesReaumur, DegreesReaumurTolerance);
             AssertEx.EqualTolerance(1, TemperatureDelta.From(1, TemperatureDeltaUnit.DegreeRoemer).DegreesRoemer, DegreesRoemerTolerance);
             AssertEx.EqualTolerance(1, TemperatureDelta.From(1, TemperatureDeltaUnit.Kelvin).Kelvins, KelvinsTolerance);
+        }
+
+        [Fact]
+        public void FromKelvins_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => TemperatureDelta.FromKelvins(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => TemperatureDelta.FromKelvins(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKelvins_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => TemperatureDelta.FromKelvins(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TemperatureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TemperatureTestsBase.g.cs
@@ -74,9 +74,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Temperature((double)0.0, TemperatureUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Temperature(double.PositiveInfinity, TemperatureUnit.Kelvin));
+            Assert.Throws<ArgumentException>(() => new Temperature(double.NegativeInfinity, TemperatureUnit.Kelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Temperature(double.NaN, TemperatureUnit.Kelvin));
         }
 
         [Fact]
@@ -104,6 +117,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Temperature.From(1, TemperatureUnit.DegreeReaumur).DegreesReaumur, DegreesReaumurTolerance);
             AssertEx.EqualTolerance(1, Temperature.From(1, TemperatureUnit.DegreeRoemer).DegreesRoemer, DegreesRoemerTolerance);
             AssertEx.EqualTolerance(1, Temperature.From(1, TemperatureUnit.Kelvin).Kelvins, KelvinsTolerance);
+        }
+
+        [Fact]
+        public void FromKelvins_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Temperature.FromKelvins(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Temperature.FromKelvins(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromKelvins_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Temperature.FromKelvins(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ThermalConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ThermalConductivityTestsBase.g.cs
@@ -62,9 +62,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ThermalConductivity((double)0.0, ThermalConductivityUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ThermalConductivity(double.PositiveInfinity, ThermalConductivityUnit.WattPerMeterKelvin));
+            Assert.Throws<ArgumentException>(() => new ThermalConductivity(double.NegativeInfinity, ThermalConductivityUnit.WattPerMeterKelvin));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ThermalConductivity(double.NaN, ThermalConductivityUnit.WattPerMeterKelvin));
         }
 
         [Fact]
@@ -80,6 +93,19 @@ namespace UnitsNet.Tests
         {
             AssertEx.EqualTolerance(1, ThermalConductivity.From(1, ThermalConductivityUnit.BtuPerHourFootFahrenheit).BtusPerHourFootFahrenheit, BtusPerHourFootFahrenheitTolerance);
             AssertEx.EqualTolerance(1, ThermalConductivity.From(1, ThermalConductivityUnit.WattPerMeterKelvin).WattsPerMeterKelvin, WattsPerMeterKelvinTolerance);
+        }
+
+        [Fact]
+        public void FromWattsPerMeterKelvin_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ThermalConductivity.FromWattsPerMeterKelvin(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ThermalConductivity.FromWattsPerMeterKelvin(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromWattsPerMeterKelvin_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ThermalConductivity.FromWattsPerMeterKelvin(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/ThermalResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/ThermalResistanceTestsBase.g.cs
@@ -68,9 +68,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new ThermalResistance((double)0.0, ThermalResistanceUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ThermalResistance(double.PositiveInfinity, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt));
+            Assert.Throws<ArgumentException>(() => new ThermalResistance(double.NegativeInfinity, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new ThermalResistance(double.NaN, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt));
         }
 
         [Fact]
@@ -92,6 +105,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ThermalResistance.From(1, ThermalResistanceUnit.SquareCentimeterKelvinPerWatt).SquareCentimeterKelvinsPerWatt, SquareCentimeterKelvinsPerWattTolerance);
             AssertEx.EqualTolerance(1, ThermalResistance.From(1, ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt).SquareMeterDegreesCelsiusPerWatt, SquareMeterDegreesCelsiusPerWattTolerance);
             AssertEx.EqualTolerance(1, ThermalResistance.From(1, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt).SquareMeterKelvinsPerKilowatt, SquareMeterKelvinsPerKilowattTolerance);
+        }
+
+        [Fact]
+        public void FromSquareMeterKelvinsPerKilowatt_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromSquareMeterKelvinsPerKilowatt_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ThermalResistance.FromSquareMeterKelvinsPerKilowatt(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TorqueTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TorqueTestsBase.g.cs
@@ -100,9 +100,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Torque((double)0.0, TorqueUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Torque(double.PositiveInfinity, TorqueUnit.NewtonMeter));
+            Assert.Throws<ArgumentException>(() => new Torque(double.NegativeInfinity, TorqueUnit.NewtonMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Torque(double.NaN, TorqueUnit.NewtonMeter));
         }
 
         [Fact]
@@ -156,6 +169,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Torque.From(1, TorqueUnit.TonneForceCentimeter).TonneForceCentimeters, TonneForceCentimetersTolerance);
             AssertEx.EqualTolerance(1, Torque.From(1, TorqueUnit.TonneForceMeter).TonneForceMeters, TonneForceMetersTolerance);
             AssertEx.EqualTolerance(1, Torque.From(1, TorqueUnit.TonneForceMillimeter).TonneForceMillimeters, TonneForceMillimetersTolerance);
+        }
+
+        [Fact]
+        public void FromNewtonMeters_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Torque.FromNewtonMeters(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Torque.FromNewtonMeters(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromNewtonMeters_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Torque.FromNewtonMeters(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/VitaminATestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VitaminATestsBase.g.cs
@@ -60,9 +60,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new VitaminA((double)0.0, VitaminAUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new VitaminA(double.PositiveInfinity, VitaminAUnit.InternationalUnit));
+            Assert.Throws<ArgumentException>(() => new VitaminA(double.NegativeInfinity, VitaminAUnit.InternationalUnit));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new VitaminA(double.NaN, VitaminAUnit.InternationalUnit));
         }
 
         [Fact]
@@ -76,6 +89,19 @@ namespace UnitsNet.Tests
         public void FromValueAndUnit()
         {
             AssertEx.EqualTolerance(1, VitaminA.From(1, VitaminAUnit.InternationalUnit).InternationalUnits, InternationalUnitsTolerance);
+        }
+
+        [Fact]
+        public void FromInternationalUnits_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => VitaminA.FromInternationalUnits(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => VitaminA.FromInternationalUnits(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromInternationalUnits_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => VitaminA.FromInternationalUnits(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/VolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeFlowTestsBase.g.cs
@@ -110,9 +110,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new VolumeFlow((double)0.0, VolumeFlowUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new VolumeFlow(double.PositiveInfinity, VolumeFlowUnit.CubicMeterPerSecond));
+            Assert.Throws<ArgumentException>(() => new VolumeFlow(double.NegativeInfinity, VolumeFlowUnit.CubicMeterPerSecond));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new VolumeFlow(double.NaN, VolumeFlowUnit.CubicMeterPerSecond));
         }
 
         [Fact]
@@ -176,6 +189,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, VolumeFlow.From(1, VolumeFlowUnit.UsGallonPerHour).UsGallonsPerHour, UsGallonsPerHourTolerance);
             AssertEx.EqualTolerance(1, VolumeFlow.From(1, VolumeFlowUnit.UsGallonPerMinute).UsGallonsPerMinute, UsGallonsPerMinuteTolerance);
             AssertEx.EqualTolerance(1, VolumeFlow.From(1, VolumeFlowUnit.UsGallonPerSecond).UsGallonsPerSecond, UsGallonsPerSecondTolerance);
+        }
+
+        [Fact]
+        public void FromCubicMetersPerSecond_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => VolumeFlow.FromCubicMetersPerSecond(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => VolumeFlow.FromCubicMetersPerSecond(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromCubicMetersPerSecond_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => VolumeFlow.FromCubicMetersPerSecond(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
@@ -142,9 +142,22 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new Volume((double)0.0, VolumeUnit.Undefined));
+        }
+
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Volume(double.PositiveInfinity, VolumeUnit.CubicMeter));
+            Assert.Throws<ArgumentException>(() => new Volume(double.NegativeInfinity, VolumeUnit.CubicMeter));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Volume(double.NaN, VolumeUnit.CubicMeter));
         }
 
         [Fact]
@@ -240,6 +253,19 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsQuart).UsQuarts, UsQuartsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsTablespoon).UsTablespoons, UsTablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsTeaspoon).UsTeaspoons, UsTeaspoonsTolerance);
+        }
+
+        [Fact]
+        public void FromCubicMeters_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Volume.FromCubicMeters(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => Volume.FromCubicMeters(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void FromCubicMeters_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => Volume.FromCubicMeters(double.NaN));
         }
 
         [Fact]

--- a/UnitsNet.Tests/UnitSystemTests.cs
+++ b/UnitsNet.Tests/UnitSystemTests.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).
 // https://github.com/angularsen/UnitsNet
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -277,7 +277,7 @@ namespace UnitsNet.Tests
             Assert.Equal(VolumeUnit.CubicMicrometer, Volume.ParseUnit("\u00b5m³"));
             Assert.Equal(VolumeFlowUnit.MicroliterPerMinute, VolumeFlow.ParseUnit("\u00b5LPM"));
 
-            // "\u03bc" = Lower case greek letter 'Mu' 
+            // "\u03bc" = Lower case greek letter 'Mu'
             Assert.Throws<UnitNotFoundException>(() => Acceleration.ParseUnit("\u03bcm/s²"));
             Assert.Throws<UnitNotFoundException>(() => AmplitudeRatio.ParseUnit("dB\u03bcV"));
             Assert.Throws<UnitNotFoundException>(() => Angle.ParseUnit("\u03bc°"));
@@ -328,7 +328,7 @@ namespace UnitsNet.Tests
                 .ToList();
 
             // We want to flag if any localizations are missing, but not break the build
-            // or flag an error for pull requests. For now they are not considered 
+            // or flag an error for pull requests. For now they are not considered
             // critical and it is cumbersome to have a third person review the pull request
             // and add in any translations before merging it in.
             if (unitValuesMissingAbbreviations.Any())
@@ -410,7 +410,7 @@ namespace UnitsNet.Tests
             CultureInfo oldCurrentCulture = CultureInfo.CurrentCulture;
             CultureInfo oldCurrentUICulture = CultureInfo.CurrentUICulture;
 
-            try 
+            try
             {
                 // CurrentCulture affects number formatting, such as comma or dot as decimal separator.
                 // CurrentUICulture affects localization, in this case the abbreviation.
@@ -428,7 +428,7 @@ namespace UnitsNet.Tests
                 // Assert
                 Assert.Equal("US english abbreviation for Unit1", abbreviation);
             }
-            finally 
+            finally
             {
                 CultureInfo.CurrentCulture = oldCurrentCulture;
                 CultureInfo.CurrentUICulture = oldCurrentUICulture;
@@ -442,18 +442,6 @@ namespace UnitsNet.Tests
             unitSystem.MapUnitToAbbreviation(AreaUnit.SquareMeter, "m^2");
 
             Assert.Equal("m²", unitSystem.GetDefaultAbbreviation(AreaUnit.SquareMeter));
-        }
-
-        [Fact]
-        public void NegativeInfinityFormatting()
-        {
-            Assert.Equal("-Infinity m", Length.FromMeters(double.NegativeInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
-        }
-
-        [Fact]
-        public void NotANumberFormatting()
-        {
-            Assert.Equal("NaN m", Length.FromMeters(double.NaN).ToString());
         }
 
         [Fact]
@@ -478,12 +466,6 @@ namespace UnitsNet.Tests
             Volume unit = Volume.Parse("1 l");
 
             Assert.Equal(Volume.FromLiters(1), unit);
-        }
-
-        [Fact]
-        public void PositiveInfinityFormatting()
-        {
-            Assert.Equal("Infinity m", Length.FromMeters(double.PositiveInfinity).ToString(LengthUnit.Meter, CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/UnitsNet/InternalHelpers/Guard.cs
+++ b/UnitsNet/InternalHelpers/Guard.cs
@@ -29,9 +29,18 @@ namespace UnitsNet.InternalHelpers
     /// </summary>
     internal static class Guard
     {
-        internal static double EnsureNotNaN(double value, [InvokerParameterName] string paramName)
+        /// <summary>
+        ///     Throws <see cref="ArgumentException" /> if value is <see cref="double.NaN" />,
+        ///     <see cref="double.PositiveInfinity" /> or <see cref="double.NegativeInfinity" />.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="paramName">Name of parameter in calling method.</param>
+        /// <returns>The given <paramref name="value" /> if valid.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="value" /> is invalid.</exception>
+        internal static double EnsureValidNumber(double value, [InvokerParameterName] string paramName)
         {
-            if (double.IsNaN(value)) throw new ArgumentException("'NaN' is not a valid number.", paramName);
+            if (double.IsNaN(value)) throw new ArgumentException("NaN is not a valid number.", paramName);
+            if (double.IsInfinity(value)) throw new ArgumentException("PositiveInfinity or NegativeInfinity is not a valid number.", paramName);
             return value;
         }
     }

--- a/UnitsNet/InternalHelpers/Guard.cs
+++ b/UnitsNet/InternalHelpers/Guard.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).
+// https://github.com/angularsen/UnitsNet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using JetBrains.Annotations;
+
+namespace UnitsNet.InternalHelpers
+{
+    /// <summary>
+    ///     Guard methods to ensure parameter values satisfy pre-conditions and use a consistent exception message.
+    /// </summary>
+    internal static class Guard
+    {
+        internal static double EnsureNotNaN(double value, [InvokerParameterName] string paramName)
+        {
+            if (double.IsNaN(value)) throw new ArgumentException("'NaN' is not a valid number.", paramName);
+            return value;
+        }
+    }
+}

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -21,6 +21,8 @@
 
 // Operator overloads not supported in Windows Runtime Components, we use 'double' type instead
 
+using UnitsNet.InternalHelpers;
+
 #if !WINDOWS_UWP
 namespace UnitsNet
 {
@@ -55,7 +57,7 @@ namespace UnitsNet
 
         private QuantityValue(double val)
         {
-            _value = val;
+            _value = Guard.EnsureNotNaN(val, nameof(val));
             _valueDecimal = null;
         }
 

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -57,7 +57,7 @@ namespace UnitsNet
 
         private QuantityValue(double val)
         {
-            _value = Guard.EnsureNotNaN(val, nameof(val));
+            _value = Guard.EnsureValidNumber(val, nameof(val));
             _valueDecimal = null;
         }
 

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
@@ -123,7 +123,7 @@ if ($obsoleteAttribute)
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -202,7 +202,7 @@ if ($obsoleteAttribute)
         /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>$($obsoleteAttribute)
-        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static $quantityName From$($unit.PluralName)(double $valueParamName)

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
@@ -62,6 +62,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -122,6 +123,7 @@ if ($obsoleteAttribute)
         /// <param name="numericValue">The numeric value  to contruct this quantity with.</param>
         /// <param name="unit">The unit representation to contruct this quantity with.</param>
         /// <remarks>Value parameter cannot be named 'value' due to constraint when targeting Windows Runtime Component.</remarks>
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         private
 #else
@@ -132,7 +134,11 @@ if ($obsoleteAttribute)
             if(unit == $unitEnumName.Undefined)
               throw new ArgumentException("The quantity can not be created with an undefined unit.", nameof(unit));
 
+"@; if ($quantity.BaseType -eq "double") {@"
+            _value = Guard.EnsureValidNumber(numericValue, nameof(numericValue));
+"@; } else {@"
             _value = numericValue;
+"@; }@"
             _unit = unit;
         }
 
@@ -196,6 +202,7 @@ if ($obsoleteAttribute)
         /// <summary>
         ///     Get $quantityName from $($unit.PluralName).
         /// </summary>$($obsoleteAttribute)
+        /// <exception cref="ArgumentException>If value is NaN or Infinity.</exception>
 #if WINDOWS_UWP
         [Windows.Foundation.Metadata.DefaultOverload]
         public static $quantityName From$($unit.PluralName)(double $valueParamName)

--- a/UnitsNet/Scripts/Include-GenerateUnitTestBaseClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitTestBaseClassSourceCode.ps1
@@ -75,10 +75,25 @@ namespace UnitsNet.Tests
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
-        public void ConstructorWithUndefinedUnitThrowsArgumentException()
+        public void Ctor_WithUndefinedUnit_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() => new $quantityName(($baseType)0.0, $unitEnumName.Undefined));
         }
+
+"@; if ($quantity.BaseType -eq "double") {@"
+        [Fact]
+        public void Ctor_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new $quantityName(double.PositiveInfinity, $unitEnumName.$($baseUnit.SingularName)));
+            Assert.Throws<ArgumentException>(() => new $quantityName(double.NegativeInfinity, $unitEnumName.$($baseUnit.SingularName)));
+        }
+
+        [Fact]
+        public void Ctor_WithNaNValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new $quantityName(double.NaN, $unitEnumName.$($baseUnit.SingularName)));
+        }
+"@; }@"
 
         [Fact]
         public void $($baseUnit.SingularName)To$($quantityName)Units()
@@ -96,6 +111,21 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, $quantityName.From(1, $unitEnumName.$($unit.SingularName)).$($unit.PluralName), $($unit.PluralName)Tolerance);
 "@; }@"
         }
+
+"@; if ($quantity.BaseType -eq "double") {@"
+        [Fact]
+        public void From$($baseUnit.PluralName)_WithInfinityValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => $quantityName.From$($baseUnit.PluralName)(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => $quantityName.From$($baseUnit.PluralName)(double.NegativeInfinity));
+        }
+
+        [Fact]
+        public void From$($baseUnit.PluralName)_WithNanValue_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => $quantityName.From$($baseUnit.PluralName)(double.NaN));
+        }
+"@; }@"
 
         [Fact]
         public void As()


### PR DESCRIPTION
This prevents constructing any quantity with a NaN and Infinity floating point values, which is consistent with quantities using `decimal` value since that number type already does not allow such values.