### PR TITLE
Remove internal parse methods

### DIFF
--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
@@ -623,7 +623,7 @@ namespace UnitsNet
         /// </exception>
         public static Information Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -652,7 +652,11 @@ namespace UnitsNet
         public static Information Parse(string str, [CanBeNull] string cultureName)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<Information, InformationUnit>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -665,7 +669,7 @@ namespace UnitsNet
         /// </example>
         public static bool TryParse([CanBeNull] string str, out Information result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -681,7 +685,12 @@ namespace UnitsNet
         public static bool TryParse([CanBeNull] string str, [CanBeNull] string cultureName, out Information result)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<Information, InformationUnit>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -733,60 +742,6 @@ namespace UnitsNet
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static Information ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<Information, InformationUnit>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Information result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<Information, InformationUnit>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
@@ -655,7 +655,7 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Information, InformationUnit>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<InformationUnit>,
                 From);
         }
 
@@ -688,7 +688,7 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Information, InformationUnit>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<InformationUnit>,
                 From,
                 out result);
         }
@@ -704,7 +704,7 @@ namespace UnitsNet
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static InformationUnit ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -720,12 +720,12 @@ namespace UnitsNet
         public static InformationUnit ParseUnit(string str, [CanBeNull] string cultureName)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<InformationUnit>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out InformationUnit unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -741,60 +741,7 @@ namespace UnitsNet
         public static bool TryParseUnit(string str, [CanBeNull] string cultureName, out InformationUnit unit)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static InformationUnit ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<InformationUnit>(str.Trim(), provider);
-
-            if (unit == InformationUnit.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized InformationUnit.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out InformationUnit unit)
-        {
-            unit = InformationUnit.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<InformationUnit>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == InformationUnit.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<InformationUnit>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
@@ -655,7 +655,6 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Information, InformationUnit>(
                 str,
                 provider,
-                UnitParser.Default.Parse<InformationUnit>,
                 From);
         }
 
@@ -688,7 +687,6 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Information, InformationUnit>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<InformationUnit>,
                 From,
                 out result);
         }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
@@ -595,7 +595,7 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Length, LengthUnit>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<LengthUnit>,
                 From);
         }
 
@@ -628,7 +628,7 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Length, LengthUnit>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<LengthUnit>,
                 From,
                 out result);
         }
@@ -644,7 +644,7 @@ namespace UnitsNet
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static LengthUnit ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -660,12 +660,12 @@ namespace UnitsNet
         public static LengthUnit ParseUnit(string str, [CanBeNull] string cultureName)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<LengthUnit>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out LengthUnit unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -681,60 +681,7 @@ namespace UnitsNet
         public static bool TryParseUnit(string str, [CanBeNull] string cultureName, out LengthUnit unit)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static LengthUnit ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<LengthUnit>(str.Trim(), provider);
-
-            if (unit == LengthUnit.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized LengthUnit.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out LengthUnit unit)
-        {
-            unit = LengthUnit.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<LengthUnit>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == LengthUnit.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<LengthUnit>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
@@ -595,7 +595,6 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Length, LengthUnit>(
                 str,
                 provider,
-                UnitParser.Default.Parse<LengthUnit>,
                 From);
         }
 
@@ -628,7 +627,6 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Length, LengthUnit>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<LengthUnit>,
                 From,
                 out result);
         }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
@@ -563,7 +563,7 @@ namespace UnitsNet
         /// </exception>
         public static Length Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -592,7 +592,11 @@ namespace UnitsNet
         public static Length Parse(string str, [CanBeNull] string cultureName)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<Length, LengthUnit>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -605,7 +609,7 @@ namespace UnitsNet
         /// </example>
         public static bool TryParse([CanBeNull] string str, out Length result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -621,7 +625,12 @@ namespace UnitsNet
         public static bool TryParse([CanBeNull] string str, [CanBeNull] string cultureName, out Length result)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<Length, LengthUnit>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -673,60 +682,6 @@ namespace UnitsNet
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static Length ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<Length, LengthUnit>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Length result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<Length, LengthUnit>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
@@ -295,7 +295,7 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Level, LevelUnit>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<LevelUnit>,
                 From);
         }
 
@@ -328,7 +328,7 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Level, LevelUnit>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<LevelUnit>,
                 From,
                 out result);
         }
@@ -344,7 +344,7 @@ namespace UnitsNet
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static LevelUnit ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -360,12 +360,12 @@ namespace UnitsNet
         public static LevelUnit ParseUnit(string str, [CanBeNull] string cultureName)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<LevelUnit>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out LevelUnit unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -381,60 +381,7 @@ namespace UnitsNet
         public static bool TryParseUnit(string str, [CanBeNull] string cultureName, out LevelUnit unit)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static LevelUnit ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<LevelUnit>(str.Trim(), provider);
-
-            if (unit == LevelUnit.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized LevelUnit.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out LevelUnit unit)
-        {
-            unit = LevelUnit.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<LevelUnit>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == LevelUnit.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<LevelUnit>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
@@ -263,7 +263,7 @@ namespace UnitsNet
         /// </exception>
         public static Level Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -292,7 +292,11 @@ namespace UnitsNet
         public static Level Parse(string str, [CanBeNull] string cultureName)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<Level, LevelUnit>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -305,7 +309,7 @@ namespace UnitsNet
         /// </example>
         public static bool TryParse([CanBeNull] string str, out Level result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -321,7 +325,12 @@ namespace UnitsNet
         public static bool TryParse([CanBeNull] string str, [CanBeNull] string cultureName, out Level result)
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<Level, LevelUnit>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -373,60 +382,6 @@ namespace UnitsNet
         {
             IFormatProvider provider = GetFormatProviderFromCultureName(cultureName);
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static Level ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<Level, LevelUnit>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Level result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<Level, LevelUnit>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
@@ -295,7 +295,6 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Level, LevelUnit>(
                 str,
                 provider,
-                UnitParser.Default.Parse<LevelUnit>,
                 From);
         }
 
@@ -328,7 +327,6 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Level, LevelUnit>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<LevelUnit>,
                 From,
                 out result);
         }

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -104,7 +104,7 @@ namespace UnitsNet
         public static bool TryParseFeetInches(string str, out Length result, IFormatProvider formatProvider = null)
         {
             // This succeeds if only feet or inches are given, not both
-            if (TryParseInternal(str, formatProvider, out result))
+            if (TryParse(str, formatProvider, out result))
                 return true;
 
             var quantityParser = QuantityParser.Default;
@@ -119,8 +119,8 @@ namespace UnitsNet
 
             var feetGroup = match.Groups["feet"];
             var inchesGroup = match.Groups["inches"];
-            if (TryParseInternal(feetGroup.Value, formatProvider, out Length feet) &&
-                TryParseInternal(inchesGroup.Value, formatProvider, out Length inches))
+            if (TryParse(feetGroup.Value, formatProvider, out Length feet) &&
+                TryParse(inchesGroup.Value, formatProvider, out Length inches))
             {
                 result = feet + inches;
                 return true;

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -80,8 +80,9 @@ namespace UnitsNet
         /// <param name="str"></param>
         /// <param name="formatProvider">Optionally specify the culture format numbers and localize unit abbreviations. Defaults to thread's culture.</param>
         /// <returns>Parsed length.</returns>
-        public static Length ParseFeetInches(string str, IFormatProvider formatProvider = null)
+        public static Length ParseFeetInches([NotNull] string str, IFormatProvider formatProvider = null)
         {
+            if (str == null) throw new ArgumentNullException(nameof(str));
             if (!TryParseFeetInches(str, out Length result, formatProvider))
             {
                 // A bit lazy, but I didn't want to duplicate this edge case implementation just to get more narrow exception descriptions.
@@ -101,8 +102,16 @@ namespace UnitsNet
         /// <param name="str"></param>
         /// <param name="result">Parsed length.</param>
         /// <param name="formatProvider">Optionally specify the culture format numbers and localize unit abbreviations. Defaults to thread's culture.</param>
-        public static bool TryParseFeetInches(string str, out Length result, IFormatProvider formatProvider = null)
+        public static bool TryParseFeetInches([CanBeNull] string str, out Length result, IFormatProvider formatProvider = null)
         {
+            if (str == null)
+            {
+                result = default;
+                return false;
+            }
+
+            str = str.Trim();
+
             // This succeeds if only feet or inches are given, not both
             if (TryParse(str, formatProvider, out result))
                 return true;
@@ -114,7 +123,7 @@ namespace UnitsNet
             // Match entire string exactly
             string pattern = $@"^(?<feet>{footRegex})\s?(?<inches>{inchRegex})$";
 
-            var match = new Regex(pattern, RegexOptions.Singleline).Match(str.Trim());
+            var match = new Regex(pattern, RegexOptions.Singleline).Match(str);
             if (!match.Success) return false;
 
             var feetGroup = match.Groups["feet"];

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -30,8 +30,6 @@ using JetBrains.Annotations;
 // ReSharper disable once CheckNamespace
 namespace UnitsNet
 {
-    internal delegate TUnitType ParseUnitDelegate<out TUnitType>(string unitString, IFormatProvider formatProvider) where TUnitType : Enum;
-    internal delegate bool TryParseUnitDelegate<TUnitType>(string unitString, IFormatProvider formatProvider, out TUnitType unit) where TUnitType : Enum;
 
 #if !WINDOWS_UWP
     internal delegate TQuantity QuantityFromDelegate<out TQuantity, in TUnitType>(QuantityValue value, TUnitType fromUnit)
@@ -51,12 +49,14 @@ namespace UnitsNet
         private const NumberStyles ParseNumberStyles = NumberStyles.Number | NumberStyles.Float | NumberStyles.AllowExponent;
 
         private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
+        private UnitParser _unitParser;
 
         public static QuantityParser Default { get; }
 
         public QuantityParser(UnitAbbreviationsCache unitAbbreviationsCache)
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
+            _unitParser = new UnitParser(_unitAbbreviationsCache);
         }
 
         static QuantityParser()
@@ -67,13 +67,11 @@ namespace UnitsNet
         [SuppressMessage("ReSharper", "UseStringInterpolation")]
         internal TQuantity Parse<TQuantity, TUnitType>([NotNull] string str,
             [CanBeNull] IFormatProvider formatProvider,
-            [NotNull] ParseUnitDelegate<TUnitType> parseUnit,
             [NotNull] QuantityFromDelegate<TQuantity, TUnitType> fromDelegate)
             where TQuantity : IQuantity
             where TUnitType : Enum
         {
             if (str == null) throw new ArgumentNullException(nameof(str));
-            if (parseUnit == null) throw new ArgumentNullException(nameof(parseUnit));
 
             var numFormat = formatProvider != null
                 ? (NumberFormatInfo) formatProvider.GetFormat(typeof(NumberFormatInfo))
@@ -91,13 +89,12 @@ namespace UnitsNet
                 throw ex;
             }
 
-            return ParseWithRegex(valueString, unitString, parseUnit, fromDelegate, formatProvider);
+            return ParseWithRegex(valueString, unitString, fromDelegate, formatProvider);
         }
 
         [SuppressMessage("ReSharper", "UseStringInterpolation")]
         internal bool TryParse<TQuantity, TUnitType>([NotNull] string str,
             [CanBeNull] IFormatProvider formatProvider,
-            [NotNull] TryParseUnitDelegate<TUnitType> parseUnit,
             [NotNull] QuantityFromDelegate<TQuantity, TUnitType> fromDelegate,
             out TQuantity result)
             where TQuantity : IQuantity
@@ -119,7 +116,7 @@ namespace UnitsNet
             if (!ExtractValueAndUnit(regex, str, out var valueString, out var unitString))
                 return false;
 
-            return TryParseWithRegex(valueString, unitString, parseUnit, fromDelegate, formatProvider, out result);
+            return TryParseWithRegex(valueString, unitString, fromDelegate, formatProvider, out result);
         }
 
         internal string CreateRegexPatternForUnit<TUnitType>(
@@ -148,16 +145,15 @@ namespace UnitsNet
         ///     Parse a string given a particular regular expression.
         /// </summary>
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static TQuantity ParseWithRegex<TQuantity, TUnitType>(string valueString,
+        private TQuantity ParseWithRegex<TQuantity, TUnitType>(string valueString,
             string unitString,
-            ParseUnitDelegate<TUnitType> parseUnit,
             QuantityFromDelegate<TQuantity, TUnitType> fromDelegate,
             IFormatProvider formatProvider)
             where TQuantity : IQuantity
             where TUnitType : Enum
         {
             var value = double.Parse(valueString, ParseNumberStyles, formatProvider);
-            var parsedUnit = parseUnit(unitString, formatProvider);
+            var parsedUnit = _unitParser.Parse<TUnitType>(unitString, formatProvider);
             return fromDelegate(value, parsedUnit);
         }
 
@@ -165,9 +161,8 @@ namespace UnitsNet
         ///     Parse a string given a particular regular expression.
         /// </summary>
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static bool TryParseWithRegex<TQuantity, TUnitType>(string valueString,
+        private bool TryParseWithRegex<TQuantity, TUnitType>(string valueString,
             string unitString,
-            TryParseUnitDelegate<TUnitType> tryParseUnit,
             QuantityFromDelegate<TQuantity, TUnitType> fromDelegate,
             IFormatProvider formatProvider,
             out TQuantity result)
@@ -177,10 +172,10 @@ namespace UnitsNet
             result = default;
 
             if (!double.TryParse(valueString, ParseNumberStyles, formatProvider, out var value))
-                return false;
+                    return false;
 
-            if (!tryParseUnit(unitString, formatProvider, out var parsedUnit))
-                return false;
+            if (!_unitParser.TryParse<TUnitType>(unitString, formatProvider, out var parsedUnit))
+                    return false;
 
             result = fromDelegate(value, parsedUnit);
             return true;

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -72,6 +72,7 @@ namespace UnitsNet
             where TUnitType : Enum
         {
             if (str == null) throw new ArgumentNullException(nameof(str));
+            str = str.Trim();
 
             var numFormat = formatProvider != null
                 ? (NumberFormatInfo) formatProvider.GetFormat(typeof(NumberFormatInfo))
@@ -103,6 +104,7 @@ namespace UnitsNet
             result = default;
 
             if(string.IsNullOrWhiteSpace(str)) return false;
+            str = str.Trim();
 
             var numFormat = formatProvider != null
                 ? (NumberFormatInfo) formatProvider.GetFormat(typeof(NumberFormatInfo))
@@ -183,7 +185,7 @@ namespace UnitsNet
 
         private static bool ExtractValueAndUnit(Regex regex, string str, out string valueString, out string unitString)
         {
-            var match = regex.Match(str.Trim());
+            var match = regex.Match(str);
             var groups = match.Groups;
 
             var valueGroup = groups["value"];

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -82,12 +82,15 @@ namespace UnitsNet
 #else
         public
 #endif
-        object Parse(string unitAbbreviation, Type unitType, [CanBeNull] IFormatProvider formatProvider = null)
+        object Parse([NotNull] string unitAbbreviation, Type unitType, [CanBeNull] IFormatProvider formatProvider = null)
         {
+            if (unitAbbreviation == null) throw new ArgumentNullException(nameof(unitAbbreviation));
+            unitAbbreviation = unitAbbreviation.Trim();
+
             if(!_unitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
                 throw new UnitNotFoundException($"No abbreviations defined for unit type [{unitType}] for culture [{formatProvider}].");
 
-            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation.Trim());
+            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation);
 
             switch (unitIntValues.Count)
             {
@@ -176,12 +179,19 @@ namespace UnitsNet
 #endif
         bool TryParse(string unitAbbreviation, Type unitType, [CanBeNull] IFormatProvider formatProvider, out object unit)
         {
+            if (unitAbbreviation == null)
+            {
+                unit = default;
+                return false;
+            }
+
+            unitAbbreviation = unitAbbreviation.Trim();
             unit = GetDefault(unitType);
 
             if(!_unitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
                 return false;
 
-            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation.Trim());
+            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation);
             if(unitIntValues.Count != 1)
                 return false;
 

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -611,7 +611,6 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Information, InformationUnit>(
                 str,
                 provider,
-                UnitParser.Default.Parse<InformationUnit>,
                 From);
         }
 
@@ -643,7 +642,6 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Information, InformationUnit>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<InformationUnit>,
                 From,
                 out result);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -611,7 +611,7 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Information, InformationUnit>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<InformationUnit>,
                 From);
         }
 
@@ -643,7 +643,7 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Information, InformationUnit>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<InformationUnit>,
                 From,
                 out result);
         }
@@ -659,7 +659,7 @@ namespace UnitsNet
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static InformationUnit ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -674,12 +674,12 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static InformationUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<InformationUnit>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out InformationUnit unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -694,60 +694,7 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static bool TryParseUnit(string str, IFormatProvider provider, out InformationUnit unit)
         {
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static InformationUnit ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<InformationUnit>(str.Trim(), provider);
-
-            if (unit == InformationUnit.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized InformationUnit.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out InformationUnit unit)
-        {
-            unit = InformationUnit.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<InformationUnit>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == InformationUnit.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<InformationUnit>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -580,7 +580,7 @@ namespace UnitsNet
         /// </exception>
         public static Information Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -608,7 +608,11 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static Information Parse(string str, [CanBeNull] IFormatProvider provider)
         {
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<Information, InformationUnit>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -621,7 +625,7 @@ namespace UnitsNet
         /// </example>
         public static bool TryParse([CanBeNull] string str, out Information result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -636,7 +640,12 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static bool TryParse([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Information result)
         {
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<Information, InformationUnit>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -686,60 +695,6 @@ namespace UnitsNet
         public static bool TryParseUnit(string str, IFormatProvider provider, out InformationUnit unit)
         {
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static Information ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<Information, InformationUnit>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Information result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<Information, InformationUnit>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -555,7 +555,6 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Length, LengthUnit>(
                 str,
                 provider,
-                UnitParser.Default.Parse<LengthUnit>,
                 From);
         }
 
@@ -587,7 +586,6 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Length, LengthUnit>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<LengthUnit>,
                 From,
                 out result);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -524,7 +524,7 @@ namespace UnitsNet
         /// </exception>
         public static Length Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -552,7 +552,11 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static Length Parse(string str, [CanBeNull] IFormatProvider provider)
         {
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<Length, LengthUnit>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -565,7 +569,7 @@ namespace UnitsNet
         /// </example>
         public static bool TryParse([CanBeNull] string str, out Length result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -580,7 +584,12 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static bool TryParse([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Length result)
         {
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<Length, LengthUnit>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -630,60 +639,6 @@ namespace UnitsNet
         public static bool TryParseUnit(string str, IFormatProvider provider, out LengthUnit unit)
         {
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static Length ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<Length, LengthUnit>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Length result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<Length, LengthUnit>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -555,7 +555,7 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Length, LengthUnit>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<LengthUnit>,
                 From);
         }
 
@@ -587,7 +587,7 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Length, LengthUnit>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<LengthUnit>,
                 From,
                 out result);
         }
@@ -603,7 +603,7 @@ namespace UnitsNet
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static LengthUnit ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -618,12 +618,12 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static LengthUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<LengthUnit>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out LengthUnit unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -638,60 +638,7 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static bool TryParseUnit(string str, IFormatProvider provider, out LengthUnit unit)
         {
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static LengthUnit ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<LengthUnit>(str.Trim(), provider);
-
-            if (unit == LengthUnit.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized LengthUnit.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out LengthUnit unit)
-        {
-            unit = LengthUnit.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<LengthUnit>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == LengthUnit.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<LengthUnit>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -244,7 +244,7 @@ namespace UnitsNet
         /// </exception>
         public static Level Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -272,7 +272,11 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static Level Parse(string str, [CanBeNull] IFormatProvider provider)
         {
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<Level, LevelUnit>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -285,7 +289,7 @@ namespace UnitsNet
         /// </example>
         public static bool TryParse([CanBeNull] string str, out Level result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -300,7 +304,12 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static bool TryParse([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Level result)
         {
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<Level, LevelUnit>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -350,60 +359,6 @@ namespace UnitsNet
         public static bool TryParseUnit(string str, IFormatProvider provider, out LevelUnit unit)
         {
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static Level ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<Level, LevelUnit>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out Level result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<Level, LevelUnit>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -275,7 +275,6 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Level, LevelUnit>(
                 str,
                 provider,
-                UnitParser.Default.Parse<LevelUnit>,
                 From);
         }
 
@@ -307,7 +306,6 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Level, LevelUnit>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<LevelUnit>,
                 From,
                 out result);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -275,7 +275,7 @@ namespace UnitsNet
             return QuantityParser.Default.Parse<Level, LevelUnit>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<LevelUnit>,
                 From);
         }
 
@@ -307,7 +307,7 @@ namespace UnitsNet
             return QuantityParser.Default.TryParse<Level, LevelUnit>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<LevelUnit>,
                 From,
                 out result);
         }
@@ -323,7 +323,7 @@ namespace UnitsNet
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static LevelUnit ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -338,12 +338,12 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static LevelUnit ParseUnit(string str, IFormatProvider provider = null)
         {
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<LevelUnit>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out LevelUnit unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -358,60 +358,7 @@ namespace UnitsNet
         /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" /> if null.</param>
         public static bool TryParseUnit(string str, IFormatProvider provider, out LevelUnit unit)
         {
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static LevelUnit ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<LevelUnit>(str.Trim(), provider);
-
-            if (unit == LevelUnit.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized LevelUnit.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out LevelUnit unit)
-        {
-            unit = LevelUnit.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<LevelUnit>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == LevelUnit.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<LevelUnit>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
@@ -560,7 +560,7 @@ if ($wrc) {@"
             return QuantityParser.Default.Parse<$quantityName, $unitEnumName>(
                 str,
                 provider,
-                ParseUnitInternal,
+                UnitParser.Default.Parse<$unitEnumName>,
                 From);
         }
 
@@ -600,7 +600,7 @@ if ($wrc) {@"
             return QuantityParser.Default.TryParse<$quantityName, $unitEnumName>(
                 str,
                 provider,
-                TryParseUnitInternal,
+                UnitParser.Default.TryParse<$unitEnumName>,
                 From,
                 out result);
         }
@@ -616,7 +616,7 @@ if ($wrc) {@"
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         public static $unitEnumName ParseUnit(string str)
         {
-            return ParseUnitInternal(str, null);
+            return ParseUnit(str, null);
         }
 
         /// <summary>
@@ -639,12 +639,12 @@ if ($wrc) {@"
         public static $unitEnumName ParseUnit(string str, IFormatProvider provider = null)
         {
 "@; }@"
-            return ParseUnitInternal(str, provider);
+            return UnitParser.Default.Parse<$unitEnumName>(str, provider);
         }
 
         public static bool TryParseUnit(string str, out $unitEnumName unit)
         {
-            return TryParseUnitInternal(str, null, out unit);
+            return TryParseUnit(str, null, out unit);
         }
 
         /// <summary>
@@ -667,60 +667,7 @@ if ($wrc) {@"
         public static bool TryParseUnit(string str, IFormatProvider provider, out $unitEnumName unit)
         {
 "@; }@"
-            return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static $unitEnumName ParseUnitInternal(string str, IFormatProvider provider = null)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            var unit = UnitParser.Default.Parse<$unitEnumName>(str.Trim(), provider);
-
-            if (unit == $unitEnumName.Undefined)
-            {
-                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized $unitEnumName.");
-                newEx.Data["input"] = str;
-                newEx.Data["provider"] = provider?.ToString() ?? "(null)";
-                throw newEx;
-            }
-
-            return unit;
-        }
-
-        /// <summary>
-        ///     Parse a unit string.
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="unit">The parsed unit if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseUnitInternal(string str, IFormatProvider provider, out $unitEnumName unit)
-        {
-            unit = $unitEnumName.Undefined;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            if(!UnitParser.Default.TryParse<$unitEnumName>(str.Trim(), provider, out unit))
-                return false;
-
-            if(unit == $unitEnumName.Undefined)
-                return false;
-
-            return true;
+            return UnitParser.Default.TryParse<$unitEnumName>(str, provider, out unit);
         }
 
         #endregion

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
@@ -560,7 +560,6 @@ if ($wrc) {@"
             return QuantityParser.Default.Parse<$quantityName, $unitEnumName>(
                 str,
                 provider,
-                UnitParser.Default.Parse<$unitEnumName>,
                 From);
         }
 
@@ -600,7 +599,6 @@ if ($wrc) {@"
             return QuantityParser.Default.TryParse<$quantityName, $unitEnumName>(
                 str,
                 provider,
-                UnitParser.Default.TryParse<$unitEnumName>,
                 From,
                 out result);
         }

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
@@ -521,7 +521,7 @@ function GenerateStaticParseMethods([GeneratorArgs]$genArgs)
         /// </exception>
         public static $quantityName Parse(string str)
         {
-            return ParseInternal(str, null);
+            return Parse(str, null);
         }
 
         /// <summary>
@@ -557,7 +557,11 @@ if ($wrc) {@"
         public static $quantityName Parse(string str, [CanBeNull] IFormatProvider provider)
         {
 "@; }@"
-            return ParseInternal(str, provider);
+            return QuantityParser.Default.Parse<$quantityName, $unitEnumName>(
+                str,
+                provider,
+                ParseUnitInternal,
+                From);
         }
 
         /// <summary>
@@ -570,7 +574,7 @@ if ($wrc) {@"
         /// </example>
         public static bool TryParse([CanBeNull] string str, out $quantityName result)
         {
-            return TryParseInternal(str, null, out result);
+            return TryParse(str, null, out result);
         }
 
         /// <summary>
@@ -593,7 +597,12 @@ if ($wrc) {@"
         public static bool TryParse([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out $quantityName result)
         {
 "@; }@"
-            return TryParseInternal(str, provider, out result);
+            return QuantityParser.Default.TryParse<$quantityName, $unitEnumName>(
+                str,
+                provider,
+                TryParseUnitInternal,
+                From,
+                out result);
         }
 
         /// <summary>
@@ -659,60 +668,6 @@ if ($wrc) {@"
         {
 "@; }@"
             return TryParseUnitInternal(str, provider, out unit);
-        }
-
-        /// <summary>
-        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
-        /// <exception cref="ArgumentException">
-        ///     Expected string to have one or two pairs of quantity and unit in the format
-        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
-        /// </exception>
-        /// <exception cref="AmbiguousUnitParseException">
-        ///     More than one unit is represented by the specified unit abbreviation.
-        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
-        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
-        /// </exception>
-        /// <exception cref="UnitsNetException">
-        ///     If anything else goes wrong, typically due to a bug or unhandled case.
-        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
-        ///     Units.NET exceptions from other exceptions.
-        /// </exception>
-        private static $quantityName ParseInternal(string str, [CanBeNull] IFormatProvider provider)
-        {
-            if (str == null) throw new ArgumentNullException(nameof(str));
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.Parse<$quantityName, $unitEnumName>(str, provider, ParseUnitInternal, From);
-        }
-
-        /// <summary>
-        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
-        /// </summary>
-        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
-        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="GlobalConfiguration.DefaultCulture" />.</param>
-        /// <param name="result">Resulting unit quantity if successful.</param>
-        /// <returns>True if successful, otherwise false.</returns>
-        /// <example>
-        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
-        /// </example>
-        private static bool TryParseInternal([CanBeNull] string str, [CanBeNull] IFormatProvider provider, out $quantityName result)
-        {
-            result = default;
-
-            if(string.IsNullOrWhiteSpace(str))
-                return false;
-
-            provider = provider ?? GlobalConfiguration.DefaultCulture;
-
-            return QuantityParser.Default.TryParse<$quantityName, $unitEnumName>(str, provider, TryParseUnitInternal, From, out result);
         }
 
         /// <summary>


### PR DESCRIPTION
Based on #520 so merge that first.
Parse/TryParseInternal and Parse/TryParseUnitInternal methods are redundant since the same logic is already in QuantityParser.
Also use UnitParser with the given UnitAbbreviationsCache instead of external unit parsing code via delegates.

This saves method declarations for all our 80 quantities, reduces binary size and helps keep things more DRY.