### PR TITLE
Fixed parsing of NaN.

### DIFF
--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -41,6 +41,7 @@ namespace UnitsNet.Tests.CustomCode
         [InlineData("1e-3 km", 1)]
         [InlineData("5.5 m", 5.5)]
         [InlineData("500,005 m", 500005)]
+        [InlineData("NaN m", double.NaN)]
         public void ParseLengthToMetersUsEnglish(string s, double expected)
         {
             CultureInfo usEnglish = new CultureInfo("en-US");

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -63,7 +63,7 @@ namespace UnitsNet
             
             string unitsRegex = $"({String.Join("|", unitAbbreviations)})";
 
-            string regexString = string.Format(@"(?:\s*(?<value>[-+]?{0}{1}{2}{3})?{4}{5}",
+            string regexString = string.Format(@"(?:\s*(?<value>(?:[-+]?{0}{1}|NaN){2}{3})?{4}{5}",
                 numRegex, // capture base (integral) Quantity value
                 exponentialRegex, // capture exponential (if any), end of Quantity capturing
                 @"\s?", // ignore whitespace (allows both "1kg", "1 kg")


### PR DESCRIPTION
Fixes #537. Values of double.NaN can now be parsed from strings.