### PR TITLE
Fixing nasty bug in GetHashCode where two quantities with the same nu…

### DIFF
--- a/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Acceleration.Common.g.cs
@@ -550,7 +550,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Acceleration.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Acceleration), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmountOfSubstance.Common.g.cs
@@ -569,7 +569,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current AmountOfSubstance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(AmountOfSubstance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AmplitudeRatio.Common.g.cs
@@ -378,7 +378,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current AmplitudeRatio.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(AmplitudeRatio), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Angle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Angle.Common.g.cs
@@ -568,7 +568,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Angle.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Angle), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentEnergy.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ApparentEnergy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ApparentEnergy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ApparentPower.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ApparentPower.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ApparentPower), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Area.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Area.Common.g.cs
@@ -550,7 +550,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Area.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Area), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaDensity.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current AreaDensity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(AreaDensity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/AreaMomentOfInertia.Common.g.cs
@@ -417,7 +417,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current AreaMomentOfInertia.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(AreaMomentOfInertia), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BitRate.Common.g.cs
@@ -795,7 +795,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current BitRate.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(BitRate), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current BrakeSpecificFuelConsumption.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(BrakeSpecificFuelConsumption), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Capacitance.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Capacitance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Capacitance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Density.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Density.Common.g.cs
@@ -1025,7 +1025,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Density.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Density), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Duration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Duration.Common.g.cs
@@ -535,7 +535,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Duration.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Duration), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/DynamicViscosity.Common.g.cs
@@ -417,7 +417,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current DynamicViscosity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(DynamicViscosity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricAdmittance.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricAdmittance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricAdmittance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCharge.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricCharge.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricCharge), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricChargeDensity.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricChargeDensity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricChargeDensity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductance.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricConductance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricConductance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricConductivity.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricConductivity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricConductivity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrent.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricCurrent.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricCurrent), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentDensity.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricCurrentDensity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricCurrentDensity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricCurrentGradient.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricCurrentGradient.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricCurrentGradient), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricField.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricField.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricField), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricInductance.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricInductance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricInductance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotential.Common.g.cs
@@ -398,7 +398,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricPotential.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricPotential), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialAc.Common.g.cs
@@ -397,7 +397,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricPotentialAc.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricPotentialAc), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricPotentialDc.Common.g.cs
@@ -397,7 +397,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricPotentialDc.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricPotentialDc), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistance.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricResistance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricResistance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ElectricResistivity.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ElectricResistivity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ElectricResistivity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Energy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Energy.Common.g.cs
@@ -721,7 +721,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Energy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Energy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Entropy.Common.g.cs
@@ -436,7 +436,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Entropy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Entropy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Flow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Flow.Common.g.cs
@@ -796,7 +796,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Flow.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Flow), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Force.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Force.Common.g.cs
@@ -550,7 +550,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Force.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Force), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForceChangeRate.Common.g.cs
@@ -512,7 +512,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ForceChangeRate.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ForceChangeRate), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ForcePerLength.Common.g.cs
@@ -474,7 +474,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ForcePerLength.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ForcePerLength), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Frequency.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Frequency.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Frequency), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatFlux.Common.g.cs
@@ -607,7 +607,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current HeatFlux.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(HeatFlux), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/HeatTransferCoefficient.Common.g.cs
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current HeatTransferCoefficient.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(HeatTransferCoefficient), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Illuminance.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Illuminance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Illuminance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Information.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Information.Common.g.cs
@@ -795,7 +795,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Information.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Information), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiance.Common.g.cs
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Irradiance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Irradiance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Irradiation.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Irradiation.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Irradiation), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/KinematicViscosity.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current KinematicViscosity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(KinematicViscosity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LapseRate.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current LapseRate.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(LapseRate), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Length.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Length.Common.g.cs
@@ -721,7 +721,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Length.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Length), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Level.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Level.Common.g.cs
@@ -340,7 +340,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Level.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Level), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LinearDensity.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current LinearDensity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(LinearDensity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousFlux.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current LuminousFlux.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(LuminousFlux), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/LuminousIntensity.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current LuminousIntensity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(LuminousIntensity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticField.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MagneticField.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MagneticField), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MagneticFlux.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MagneticFlux.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MagneticFlux), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Magnetization.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Magnetization.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Magnetization), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Mass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Mass.Common.g.cs
@@ -721,7 +721,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Mass.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Mass), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlow.Common.g.cs
@@ -588,7 +588,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MassFlow.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MassFlow), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassFlux.Common.g.cs
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MassFlux.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MassFlux), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MassMomentOfInertia.Common.g.cs
@@ -835,7 +835,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MassMomentOfInertia.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MassMomentOfInertia), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEnergy.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MolarEnergy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MolarEnergy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarEntropy.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MolarEntropy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MolarEntropy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/MolarMass.Common.g.cs
@@ -531,7 +531,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current MolarMass.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(MolarMass), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Molarity.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Molarity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Molarity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permeability.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Permeability.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Permeability), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Permittivity.Common.g.cs
@@ -322,7 +322,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Permittivity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Permittivity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Power.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Power.Common.g.cs
@@ -682,7 +682,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Power.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Power), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerDensity.Common.g.cs
@@ -1139,7 +1139,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current PowerDensity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(PowerDensity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PowerRatio.Common.g.cs
@@ -340,7 +340,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current PowerRatio.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(PowerRatio), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Pressure.Common.g.cs
@@ -1084,7 +1084,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Pressure.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Pressure), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/PressureChangeRate.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current PressureChangeRate.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(PressureChangeRate), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Ratio.Common.g.cs
@@ -416,7 +416,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Ratio.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Ratio), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactiveEnergy.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ReactiveEnergy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ReactiveEnergy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ReactivePower.Common.g.cs
@@ -379,7 +379,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ReactivePower.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ReactivePower), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalAcceleration.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current RotationalAcceleration.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(RotationalAcceleration), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalSpeed.Common.g.cs
@@ -550,7 +550,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current RotationalSpeed.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(RotationalSpeed), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffness.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current RotationalStiffness.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(RotationalStiffness), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/RotationalStiffnessPerLength.Common.g.cs
@@ -360,7 +360,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current RotationalStiffnessPerLength.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(RotationalStiffnessPerLength), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SolidAngle.Common.g.cs
@@ -321,7 +321,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current SolidAngle.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(SolidAngle), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEnergy.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current SpecificEnergy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(SpecificEnergy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificEntropy.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current SpecificEntropy.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(SpecificEntropy), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificVolume.Common.g.cs
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current SpecificVolume.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(SpecificVolume), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/SpecificWeight.Common.g.cs
@@ -626,7 +626,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current SpecificWeight.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(SpecificWeight), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Speed.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Speed.Common.g.cs
@@ -911,7 +911,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Speed.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Speed), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Temperature.Common.g.cs
@@ -455,7 +455,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Temperature.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Temperature), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureChangeRate.Common.g.cs
@@ -493,7 +493,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current TemperatureChangeRate.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(TemperatureChangeRate), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/TemperatureDelta.Common.g.cs
@@ -622,7 +622,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current TemperatureDelta.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(TemperatureDelta), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalConductivity.Common.g.cs
@@ -341,7 +341,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ThermalConductivity.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ThermalConductivity), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/ThermalResistance.Common.g.cs
@@ -398,7 +398,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current ThermalResistance.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(ThermalResistance), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Torque.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Torque.Common.g.cs
@@ -702,7 +702,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Torque.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Torque), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VitaminA.Common.g.cs
@@ -321,7 +321,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current VitaminA.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(VitaminA), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/Volume.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/Volume.Common.g.cs
@@ -1143,7 +1143,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current Volume.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(Volume), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
+++ b/Common/GeneratedCode/Quantities/VolumeFlow.Common.g.cs
@@ -797,7 +797,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current VolumeFlow.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof(VolumeFlow), Value, Unit }.GetHashCode();
         }
 
         #endregion

--- a/UnitsNet.Tests/QuantityTests.cs
+++ b/UnitsNet.Tests/QuantityTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).
+// https://github.com/angularsen/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Globalization;
+using UnitsNet.Units;
+using Xunit;
+
+namespace UnitsNet.Tests
+{
+    public partial class QuantityTests
+    {
+        [Fact]
+        public void GetHashCodeForDifferentQuantitiesWithSameValuesAreNotEqual()
+        {
+            var length = new Length( 1.0, (LengthUnit)2 );
+            var area = new Area( 1.0, (AreaUnit)2 );
+
+            Assert.NotEqual( length.GetHashCode(), area.GetHashCode() );
+        }
+    }
+}

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeCommon.ps1
@@ -395,7 +395,7 @@ if ($obsoleteAttribute)
         /// <returns>A hash code for the current $quantityName.</returns>
         public override int GetHashCode()
         {
-            return new { Value, Unit }.GetHashCode();
+            return new { type = typeof($quantityName), Value, Unit }.GetHashCode();
         }
 
         #endregion


### PR DESCRIPTION
Fixing nasty bug in GetHashCode where two quantities with the same numerical value/unit pair returned the same hash code. Type needed in GetHashCode implementation to guarantee uniqueness.

This is especially important now we have an IQuantity interface. If you had a HashSet<IQuantity>, Dictionary with IQuantity keys, etc., we need to avoid hash collisions.

Added test also.