### PR TITLE
Update test apps to work with v4

### DIFF
--- a/UnitsNet.TestApps.Uwp.Csharp/MainPage.xaml.cs
+++ b/UnitsNet.TestApps.Uwp.Csharp/MainPage.xaml.cs
@@ -19,9 +19,9 @@ namespace UWP
             InitializeComponent();
 
             // Test some variations, From() constructors, Parse(), As()
-            string celsius = Temperature.FromDegreesCelsius(100).ToString(TemperatureUnit.DegreeCelsius);
-            string fahrenheit = Temperature.Parse("100 °C").ToString(TemperatureUnit.DegreeFahrenheit);
-            string kelvin = Temperature.FromDegreesCelsius(Temperature.Parse(fahrenheit).As(TemperatureUnit.DegreeCelsius)).ToString(TemperatureUnit.Kelvin);
+            string celsius = Temperature.FromDegreesCelsius(100).ToUnit(TemperatureUnit.DegreeCelsius).ToString();
+            string fahrenheit = Temperature.Parse("100 °C").ToUnit(TemperatureUnit.DegreeFahrenheit).ToString();
+            string kelvin = Temperature.FromDegreesCelsius(Temperature.Parse(fahrenheit).As(TemperatureUnit.DegreeCelsius)).ToUnit(TemperatureUnit.Kelvin).ToString();
 
             // Arithmetic operators not allowed in WinRT Components, but SHOULD be allowed in UWP C# apps
             // new Temperature(5) + new Temperature(6)

--- a/UnitsNet.TestApps.Uwp.Csharp/UnitsNet.TestApps.Uwp.Csharp.csproj
+++ b/UnitsNet.TestApps.Uwp.Csharp/UnitsNet.TestApps.Uwp.Csharp.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/UnitsNet.TestApps.Uwp.Csharp/project.json
+++ b/UnitsNet.TestApps.Uwp.Csharp/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.1.9",
     "UnitsNet.WindowsRuntimeComponent": "3.40.0"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/UnitsNet.TestApps.Uwp.Csharp/project.json
+++ b/UnitsNet.TestApps.Uwp.Csharp/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.1.9",
-    "UnitsNet.WindowsRuntimeComponent": "3.40.0"
+    "UnitsNet.WindowsRuntimeComponent": "4.0.0-alpha5"
   },
   "frameworks": {
     "uap10.0.16299": {}

--- a/UnitsNet.TestApps.Uwp.Csharp/project.json
+++ b/UnitsNet.TestApps.Uwp.Csharp/project.json
@@ -4,7 +4,7 @@
     "UnitsNet.WindowsRuntimeComponent": "3.40.0"
   },
   "frameworks": {
-    "uap10.0.10240": {}
+    "uap10.0.16299": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/UnitsNet.TestApps.Uwp.WinJS/UnitsNet.TestApps.Uwp.WinJS.jsproj
+++ b/UnitsNet.TestApps.Uwp.WinJS/UnitsNet.TestApps.Uwp.WinJS.jsproj
@@ -76,14 +76,6 @@
     <Content Include="project.json" />
     <None Include="UnitsNet.TestApps.Uwp.WinJS_TemporaryKey.pfx" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="UnitsNet">
-      <HintPath>..\packages\UnitsNet.WindowsRuntimeComponent.3.64.0\lib\uap10.0\UnitsNet.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-      <CopyLocal>True</CopyLocal>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\$(WMSJSProjectDirectory)\Microsoft.VisualStudio.$(WMSJSProject).targets" />
   <!-- To modify your build process, add your task inside one of the targets below then uncomment
        that target and the DisableFastUpToDateCheck PropertyGroup.

--- a/UnitsNet.TestApps.Uwp.WinJS/js/main.js
+++ b/UnitsNet.TestApps.Uwp.WinJS/js/main.js
@@ -43,7 +43,7 @@
 
         var t = UnitsNet.Temperature.fromDegreesCelsius(100);
         var unit = UnitsNet.Units.TemperatureUnit;
-        document.getElementById('label').innerHTML = t.toString(unit.degreeCelsius) + ' = ' + t.toString(unit.degreeFahrenheit) + ' = ' + t.toString(unit.kelvin);
+        document.getElementById('label').innerHTML = t.toUnit(unit.degreeCelsius).toString() + ' = ' + t.toUnit(unit.degreeFahrenheit).toString() + ' = ' + t.toUnit(unit.kelvin).toString();
 
 
 		isFirstActivation = false;

--- a/UnitsNet.TestApps.Uwp.WinJS/project.json
+++ b/UnitsNet.TestApps.Uwp.WinJS/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.1.9",
-    "UnitsNet.WindowsRuntimeComponent": "3.64.0"
+    "System.ValueTuple": "4.5.0",
+    "UnitsNet.WindowsRuntimeComponent": "4.0.0-alpha5"
   },
   "frameworks": {
     "uap10.0": {}

--- a/UnitsNet.TestApps.Uwp.WinJS/project.json
+++ b/UnitsNet.TestApps.Uwp.WinJS/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.6",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.1.9",
     "UnitsNet.WindowsRuntimeComponent": "3.64.0"
   },
   "frameworks": {

--- a/UnitsNet.Tests/BaseDimensionsTests.cs
+++ b/UnitsNet.Tests/BaseDimensionsTests.cs
@@ -710,13 +710,13 @@ namespace UnitsNet.Tests
             var hashSet = new HashSet<BaseDimensions>();
 
             hashSet.Add(baseDimensions1);
-            Assert.True(hashSet.Contains(baseDimensions1));
+            Assert.Contains(baseDimensions1, hashSet);
 
             hashSet.Add(baseDimensions2);
-            Assert.True(hashSet.Contains(baseDimensions2));
+            Assert.Contains(baseDimensions2, hashSet);
 
             // Should be the same as baseDimensions1
-            Assert.True(hashSet.Contains(baseDimensions3));
+            Assert.Contains(baseDimensions3, hashSet);
 
             Assert.True(baseDimensions1.GetHashCode() != baseDimensions2.GetHashCode());
             Assert.True(baseDimensions1.GetHashCode() == baseDimensions3.GetHashCode());


### PR DESCRIPTION
- Use `ToUnit().ToString()` to output for a given unit
- Upgrade UWP nuget
- Upgrade UWP framework to 16299 (Fall Creator Update), to support netstandard 2.0
- Upgrade to UnitsNet 4.0.0-alpha5

Bonus:
- Fix xunit build warning

With these changes both the C# and the WinJS apps ran successfully with new v4 nuget.