### PR TITLE
Deprecate signed packages (v3)

### DIFF
--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Signed.csproj
@@ -4,7 +4,8 @@
   <!-- Override some NuGet package properties -->
   <PropertyGroup>
     <PackageId>UnitsNet.Serialization.JsonNet.Signed</PackageId>
-    <Title>Units.NET Serialization with Json.NET (signed)</Title>
+    <Title>Units.NET Serialization with Json.NET (signed) - DEPRECATED</Title>
+    <Description>DEPRECATED! Use UnitsNet.Serialization.JsonNet 4.0.0 or later instead, which is now signed. This package will be unlisted sometime later. A helper library for serializing and deserializing types in Units.NET using Json.NET.</Description>
   </PropertyGroup>
 
   <!-- Enable strong name signing -->

--- a/UnitsNet/UnitsNet.Signed.csproj
+++ b/UnitsNet/UnitsNet.Signed.csproj
@@ -4,7 +4,8 @@
   <!-- Override some NuGet package properties -->
   <PropertyGroup>
     <PackageId>UnitsNet.Signed</PackageId>
-    <Title>Units.NET (signed)</Title>
+    <Title>Units.NET (signed) - DEPRECATED</Title>
+    <Description>DEPRECATED! Use UnitsNet 4.0.0 or later instead, which is now signed. This package will be unlisted sometime later. Get all the common units of measurement and the conversions between them. It is light-weight and thoroughly tested.</Description>
   </PropertyGroup>
 
   <!-- Enable strong name signing -->


### PR DESCRIPTION
As per the [recommendation](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming), we want to remove the `.Signed` variants of the nuget packages and instead sign all of them.

Title and description now reflects the deprecation and what package/version to use instead.
Bumped the patch version to push new nugets and their new titles/descriptions out.