### PR TITLE
Remove InternalsVisibleTo in reflection helper (v3)

### DIFF
--- a/UnitsNet.Serialization.JsonNet/Internal/ReflectionHelper.cs
+++ b/UnitsNet.Serialization.JsonNet/Internal/ReflectionHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace UnitsNet.Serialization.JsonNet.Internal
+{
+    /// <summary>
+    ///     Helper for dealing with reflection, abstracting API differences between old and new .NET framework.
+    /// </summary>
+    internal static class ReflectionHelper
+    {
+        internal static PropertyInfo GetProperty(this Type type, string name)
+        {
+#if (NET40 || NET35 || NET20 || SILVERLIGHT)
+            return type.GetProperty(name);
+
+#else
+            return type.GetTypeInfo().GetDeclaredProperty(name);
+#endif
+        }
+
+        // Ambiguous method conflict with GetMethods() name WindowsRuntimeComponent, so use GetDeclaredMethods() instead
+        internal static IEnumerable<MethodInfo> GetDeclaredMethods(this Type someType)
+        {
+            Type t = someType;
+            while (t != null)
+            {
+#if (NET40 || NET35 || NET20 || SILVERLIGHT)
+                foreach (var m in t.GetMethods())
+                    yield return m;
+                t = t.BaseType;
+#else
+                TypeInfo ti = t.GetTypeInfo();
+                foreach (MethodInfo m in ti.DeclaredMethods)
+                    yield return m;
+                t = ti.BaseType;
+#endif
+            }
+        }
+    }
+}

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -25,8 +25,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using UnitsNet.InternalHelpers;
-using UnitsNet.Units;
+using UnitsNet.Serialization.JsonNet.Internal;
 
 namespace UnitsNet.Serialization.JsonNet
 {
@@ -222,7 +221,7 @@ namespace UnitsNet.Serialization.JsonNet
         private static string GetUnitFullNameOfQuantity(object obj, Type quantityType)
         {
             // Get value of Unit property
-            PropertyInfo unitProperty = quantityType.GetPropety("Unit");
+            PropertyInfo unitProperty = quantityType.GetProperty("Unit");
             Enum quantityUnit = (Enum) unitProperty.GetValue(obj, null); // MassUnit.Kilogram
 
             Type unitType = quantityUnit.GetType(); // MassUnit
@@ -289,7 +288,7 @@ namespace UnitsNet.Serialization.JsonNet
             public double Value { get; [UsedImplicitly] set; }
         }
 
-#region Can Convert
+        #region Can Convert
 
         /// <summary>
         ///     Determines whether this instance can convert the specified object type.
@@ -332,6 +331,7 @@ namespace UnitsNet.Serialization.JsonNet
             return objectType.FullName != null && objectType.FullName.Contains(nameof(UnitsNet) + ".");
         }
 
-#endregion
+        #endregion
+
     }
 }

--- a/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
+++ b/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
@@ -19,16 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-
-#if SIGNED
-[assembly: InternalsVisibleTo("UnitsNet.Serialization.JsonNet.Signed, PublicKey=002400000480000094000000060200000024000052534131000400000100010089abdcb0025f7d1c4c766686dd852b978ca5bb9fd80bba9d3539e8399b01170ae0ea10c0c3baa301b1d13090d5aff770532de00c88b67c4b24669fde7f9d87218f1c6c073a09016cbb2f87119b94227c2301f4e2a096043e30f7c47c872bbd8e0b80d924952e6b36990f13f847e83e9efb107ec2121fe39d7edaaa4e235af8c4")]
-#else
-[assembly: InternalsVisibleTo("UnitsNet.Serialization.JsonNet")]
-#endif
 
 // Based on
 // https://github.com/StefH/ReflectionBridge/blob/c1e34e57fe3fc93507e83d5cebc1677396645397/ReflectionBridge/src/ReflectionBridge/Extensions/ReflectionBridgeExtensions.cs

--- a/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
+++ b/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
@@ -39,24 +39,6 @@ namespace UnitsNet.InternalHelpers
 #endif
         }
 
-//        internal static bool IsSealed(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsSealed;
-//#else
-//            return type.IsSealed;
-//#endif
-//        }
-//
-//        internal static bool IsAbstract(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsAbstract;
-//#else
-//            return type.IsAbstract;
-//#endif
-//        }
-
         internal static bool IsEnum(this Type type)
         {
 #if !(NET40 || NET35 || NET20 || SILVERLIGHT)
@@ -66,92 +48,6 @@ namespace UnitsNet.InternalHelpers
 #endif
         }
 
-//        internal static bool IsClass(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsClass;
-//#else
-//            return type.IsClass;
-//#endif
-//        }
-//
-//        internal static bool IsPrimitive(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsPrimitive;
-//#else
-//            return type.IsPrimitive;
-//#endif
-//        }
-//
-//        internal static bool IsPublic(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsPublic;
-//#else
-//            return type.IsPublic;
-//#endif
-//        }
-//
-//        internal static bool IsNestedPublic(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsNestedPublic;
-//#else
-//            return type.IsNestedPublic;
-//#endif
-//        }
-//
-//        internal static bool IsFromLocalAssembly(this Type type)
-//        {
-//#if SILVERLIGHT
-//            string assemblyName = type.GetAssembly().FullName;
-//#else
-//            string assemblyName = type.GetAssembly().GetName().Name;
-//#endif
-//
-//            try
-//            {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//                Assembly.Load(new AssemblyName {Name = assemblyName});
-//#else
-//                Assembly.Load(assemblyName);
-//#endif
-//                return true;
-//            }
-//            catch
-//            {
-//                return false;
-//            }
-//        }
-//
-//        internal static bool IsGenericType(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsGenericType;
-//#else
-//            return type.IsGenericType;
-//#endif
-//        }
-//
-//        internal static bool IsInterface(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsInterface;
-//#else
-//            return type.IsInterface;
-//#endif
-//        }
-//
-//        internal static Type BaseType(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().BaseType;
-//#else
-//            return type.BaseType;
-//#endif
-//        }
-
         internal static bool IsValueType(this Type type)
         {
 #if !(NET40 || NET35 || NET20 || SILVERLIGHT)
@@ -160,49 +56,6 @@ namespace UnitsNet.InternalHelpers
             return type.IsValueType;
 #endif
         }
-
-//        internal static T GetPropertyValue<T>(this Type type, string propertyName, object target)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            PropertyInfo property = type.GetTypeInfo().GetDeclaredProperty(propertyName);
-//            return (T) property.GetValue(target);
-//#else
-//            return (T) type.InvokeMember(propertyName, BindingFlags.GetProperty, null, target, null);
-//#endif
-//        }
-//
-//        internal static void SetPropertyValue(this Type type, string propertyName, object target, object value)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            PropertyInfo property = type.GetTypeInfo().GetDeclaredProperty(propertyName);
-//            property.SetValue(target, value);
-//#else
-//            type.InvokeMember(propertyName, BindingFlags.SetProperty, null, target, new object[] {value});
-//#endif
-//        }
-//
-//        internal static void SetFieldValue(this Type type, string fieldName, object target, object value)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            FieldInfo field = type.GetTypeInfo().GetDeclaredField(fieldName);
-//            if (field != null)
-//                field.SetValue(target, value);
-//            else
-//                type.SetPropertyValue(fieldName, target, value);
-//#else
-//            type.InvokeMember(fieldName, BindingFlags.SetField | BindingFlags.SetProperty, null, target, new object[] {value});
-//#endif
-//        }
-//
-//        internal static void InvokeMethod<T>(this Type type, string methodName, object target, T value)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            MethodInfo method = type.GetTypeInfo().GetDeclaredMethod(methodName);
-//            method.Invoke(target, new object[] {value});
-//#else
-//            type.InvokeMember(methodName, BindingFlags.InvokeMethod, null, target, new object[] {value});
-//#endif
-//        }
 
         internal static PropertyInfo GetPropety(this Type type, string name)
         {
@@ -227,32 +80,6 @@ namespace UnitsNet.InternalHelpers
                 t = ti.BaseType;
             }
         }
-
-//        internal static Type[] GetGenericArguments(this Type type)
-//        {
-//            return type.GetTypeInfo().GenericTypeArguments;
-//        }
-//
-//        /*
-//        internal static bool IsAssignableFrom(this Type type, Type otherType)
-//        {
-//            return type.GetTypeInfo().IsAssignableFrom(otherType.GetTypeInfo());
-//        }*/
-//
-//        internal static bool IsSubclassOf(this Type type, Type c)
-//        {
-//            return type.GetTypeInfo().IsSubclassOf(c);
-//        }
-//
-//        internal static Attribute[] GetCustomAttributes(this Type type)
-//        {
-//            return type.GetTypeInfo().GetCustomAttributes().ToArray();
-//        }
-//
-//        internal static Attribute[] GetCustomAttributes(this Type type, Type attributeType, bool inherit)
-//        {
-//            return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit).Cast<Attribute>().ToArray();
-//        }
 #else
 // Ambiguous method conflict with GetMethods() name WindowsRuntimeComponent, so use GetDeclaredMethods() instead
         internal static IEnumerable<MethodInfo> GetDeclaredMethods(this Type someType)


### PR DESCRIPTION
Instead copy dependency into JSON lib.
We have had enough problems with sharing this tiny bit of code, with strong name signing and what not.
It broke the compatibility tests in v4 branch for instance.