### PR TITLE
Copy reflection code to json lib (V3)

### DIFF
--- a/UnitsNet.Serialization.JsonNet/Internal/ReflectionHelper.cs
+++ b/UnitsNet.Serialization.JsonNet/Internal/ReflectionHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace UnitsNet.Serialization.JsonNet.Internal
+{
+    /// <summary>
+    ///     Helper for dealing with reflection, abstracting API differences between old and new .NET framework.
+    /// </summary>
+    internal static class ReflectionHelper
+    {
+        internal static PropertyInfo GetProperty(this Type type, string name)
+        {
+#if (NET40 || NET35 || NET20 || SILVERLIGHT)
+            return type.GetProperty(name);
+
+#else
+            return type.GetTypeInfo().GetDeclaredProperty(name);
+#endif
+        }
+
+        // Ambiguous method conflict with GetMethods() name WindowsRuntimeComponent, so use GetDeclaredMethods() instead
+        internal static IEnumerable<MethodInfo> GetDeclaredMethods(this Type someType)
+        {
+            Type t = someType;
+            while (t != null)
+            {
+#if (NET40 || NET35 || NET20 || SILVERLIGHT)
+                foreach (var m in t.GetMethods())
+                    yield return m;
+                t = t.BaseType;
+#else
+                TypeInfo ti = t.GetTypeInfo();
+                foreach (MethodInfo m in ti.DeclaredMethods)
+                    yield return m;
+                t = ti.BaseType;
+#endif
+            }
+        }
+    }
+}

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Common.props
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.Common.props
@@ -2,7 +2,7 @@
   <!-- NuGet properties -->
   <PropertyGroup>
     <PackageId>UnitsNet.Serialization.JsonNet</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Andreas Gullberg Larsen</Authors>
     <Title>Units.NET Serialization with Json.NET</Title>
     <Description>A helper library for serializing and deserializing types in Units.NET using Json.NET.</Description>

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -25,8 +25,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using UnitsNet.InternalHelpers;
-using UnitsNet.Units;
+using UnitsNet.Serialization.JsonNet.Internal;
 
 namespace UnitsNet.Serialization.JsonNet
 {
@@ -222,7 +221,7 @@ namespace UnitsNet.Serialization.JsonNet
         private static string GetUnitFullNameOfQuantity(object obj, Type quantityType)
         {
             // Get value of Unit property
-            PropertyInfo unitProperty = quantityType.GetPropety("Unit");
+            PropertyInfo unitProperty = quantityType.GetProperty("Unit");
             Enum quantityUnit = (Enum) unitProperty.GetValue(obj, null); // MassUnit.Kilogram
 
             Type unitType = quantityUnit.GetType(); // MassUnit
@@ -289,7 +288,7 @@ namespace UnitsNet.Serialization.JsonNet
             public double Value { get; [UsedImplicitly] set; }
         }
 
-#region Can Convert
+        #region Can Convert
 
         /// <summary>
         ///     Determines whether this instance can convert the specified object type.
@@ -332,6 +331,7 @@ namespace UnitsNet.Serialization.JsonNet
             return objectType.FullName != null && objectType.FullName.Contains(nameof(UnitsNet) + ".");
         }
 
-#endregion
+        #endregion
+
     }
 }

--- a/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
+++ b/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
@@ -46,24 +46,6 @@ namespace UnitsNet.InternalHelpers
 #endif
         }
 
-//        internal static bool IsSealed(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsSealed;
-//#else
-//            return type.IsSealed;
-//#endif
-//        }
-//
-//        internal static bool IsAbstract(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsAbstract;
-//#else
-//            return type.IsAbstract;
-//#endif
-//        }
-
         internal static bool IsEnum(this Type type)
         {
 #if !(NET40 || NET35 || NET20 || SILVERLIGHT)
@@ -73,92 +55,6 @@ namespace UnitsNet.InternalHelpers
 #endif
         }
 
-//        internal static bool IsClass(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsClass;
-//#else
-//            return type.IsClass;
-//#endif
-//        }
-//
-//        internal static bool IsPrimitive(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsPrimitive;
-//#else
-//            return type.IsPrimitive;
-//#endif
-//        }
-//
-//        internal static bool IsPublic(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsPublic;
-//#else
-//            return type.IsPublic;
-//#endif
-//        }
-//
-//        internal static bool IsNestedPublic(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsNestedPublic;
-//#else
-//            return type.IsNestedPublic;
-//#endif
-//        }
-//
-//        internal static bool IsFromLocalAssembly(this Type type)
-//        {
-//#if SILVERLIGHT
-//            string assemblyName = type.GetAssembly().FullName;
-//#else
-//            string assemblyName = type.GetAssembly().GetName().Name;
-//#endif
-//
-//            try
-//            {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//                Assembly.Load(new AssemblyName {Name = assemblyName});
-//#else
-//                Assembly.Load(assemblyName);
-//#endif
-//                return true;
-//            }
-//            catch
-//            {
-//                return false;
-//            }
-//        }
-//
-//        internal static bool IsGenericType(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsGenericType;
-//#else
-//            return type.IsGenericType;
-//#endif
-//        }
-//
-//        internal static bool IsInterface(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().IsInterface;
-//#else
-//            return type.IsInterface;
-//#endif
-//        }
-//
-//        internal static Type BaseType(this Type type)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            return type.GetTypeInfo().BaseType;
-//#else
-//            return type.BaseType;
-//#endif
-//        }
-
         internal static bool IsValueType(this Type type)
         {
 #if !(NET40 || NET35 || NET20 || SILVERLIGHT)
@@ -167,49 +63,6 @@ namespace UnitsNet.InternalHelpers
             return type.IsValueType;
 #endif
         }
-
-//        internal static T GetPropertyValue<T>(this Type type, string propertyName, object target)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            PropertyInfo property = type.GetTypeInfo().GetDeclaredProperty(propertyName);
-//            return (T) property.GetValue(target);
-//#else
-//            return (T) type.InvokeMember(propertyName, BindingFlags.GetProperty, null, target, null);
-//#endif
-//        }
-//
-//        internal static void SetPropertyValue(this Type type, string propertyName, object target, object value)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            PropertyInfo property = type.GetTypeInfo().GetDeclaredProperty(propertyName);
-//            property.SetValue(target, value);
-//#else
-//            type.InvokeMember(propertyName, BindingFlags.SetProperty, null, target, new object[] {value});
-//#endif
-//        }
-//
-//        internal static void SetFieldValue(this Type type, string fieldName, object target, object value)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            FieldInfo field = type.GetTypeInfo().GetDeclaredField(fieldName);
-//            if (field != null)
-//                field.SetValue(target, value);
-//            else
-//                type.SetPropertyValue(fieldName, target, value);
-//#else
-//            type.InvokeMember(fieldName, BindingFlags.SetField | BindingFlags.SetProperty, null, target, new object[] {value});
-//#endif
-//        }
-//
-//        internal static void InvokeMethod<T>(this Type type, string methodName, object target, T value)
-//        {
-//#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
-//            MethodInfo method = type.GetTypeInfo().GetDeclaredMethod(methodName);
-//            method.Invoke(target, new object[] {value});
-//#else
-//            type.InvokeMember(methodName, BindingFlags.InvokeMethod, null, target, new object[] {value});
-//#endif
-//        }
 
         internal static PropertyInfo GetPropety(this Type type, string name)
         {
@@ -234,32 +87,6 @@ namespace UnitsNet.InternalHelpers
                 t = ti.BaseType;
             }
         }
-
-//        internal static Type[] GetGenericArguments(this Type type)
-//        {
-//            return type.GetTypeInfo().GenericTypeArguments;
-//        }
-//
-//        /*
-//        internal static bool IsAssignableFrom(this Type type, Type otherType)
-//        {
-//            return type.GetTypeInfo().IsAssignableFrom(otherType.GetTypeInfo());
-//        }*/
-//
-//        internal static bool IsSubclassOf(this Type type, Type c)
-//        {
-//            return type.GetTypeInfo().IsSubclassOf(c);
-//        }
-//
-//        internal static Attribute[] GetCustomAttributes(this Type type)
-//        {
-//            return type.GetTypeInfo().GetCustomAttributes().ToArray();
-//        }
-//
-//        internal static Attribute[] GetCustomAttributes(this Type type, Type attributeType, bool inherit)
-//        {
-//            return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit).Cast<Attribute>().ToArray();
-//        }
 #else
 // Ambiguous method conflict with GetMethods() name WindowsRuntimeComponent, so use GetDeclaredMethods() instead
         internal static IEnumerable<MethodInfo> GetDeclaredMethods(this Type someType)


### PR DESCRIPTION
Remove dependency on internal code in UnitsNet, which broke in v4 branch trying to strong name sign the UnitsNet lib. Can also not remove InternalsVisibleTo for backwards compatibility reasons.