### PR TITLE
Case insensitive unit parsing and conversion.

### DIFF
--- a/UnitsNet.Tests/UnitConverterTest.cs
+++ b/UnitsNet.Tests/UnitConverterTest.cs
@@ -37,13 +37,13 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void ConvertByName__QuantityCaseInsensitive()
+        public void ConvertByName_QuantityCaseInsensitive()
         {
             Assert.Equal(0, UnitConverter.ConvertByName(0, "length", "Meter", "Centimeter"));
         }
 
         [Fact]
-        public void ConvertByName__UnitTypeCaseInsensitive()
+        public void ConvertByName_UnitTypeCaseInsensitive()
         {
             Assert.Equal(0, UnitConverter.ConvertByName(0, "Length", "meter", "Centimeter"));
         }

--- a/UnitsNet.Tests/UnitConverterTest.cs
+++ b/UnitsNet.Tests/UnitConverterTest.cs
@@ -26,6 +26,7 @@ namespace UnitsNet.Tests
     public class UnitConverterTest
     {
         [Theory]
+        [InlineData(0, 0, "length", "meter", "centimeter")]
         [InlineData(0, 0, "Length", "Meter", "Centimeter")]
         [InlineData(100, 1, "Length", "Meter", "Centimeter")]
         [InlineData(1, 1000, "Mass", "Gram", "Kilogram")]
@@ -33,6 +34,18 @@ namespace UnitsNet.Tests
         public void ConvertByName_ConvertsTheValueToGivenUnit(double expectedValue, double inputValue, string quantityTypeName, string fromUnit, string toUnit)
         {
             Assert.Equal(expectedValue, UnitConverter.ConvertByName(inputValue, quantityTypeName, fromUnit, toUnit));
+        }
+
+        [Fact]
+        public void ConvertByName__QuantityCaseInsensitive()
+        {
+            Assert.Equal(0, UnitConverter.ConvertByName(0, "length", "Meter", "Centimeter"));
+        }
+
+        [Fact]
+        public void ConvertByName__UnitTypeCaseInsensitive()
+        {
+            Assert.Equal(0, UnitConverter.ConvertByName(0, "Length", "meter", "Centimeter"));
         }
 
         [Theory]

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -44,30 +44,24 @@ namespace UnitsNet.Tests
         [Fact]
         public void Parse_AbbreviationCaseInsensitive_Lowercase_years()
         {
-            // Arrange
             var abbreviation = "years";
             var expected = DurationUnit.Year365;
             var parser = UnitParser.Default;
 
-            // Act
             var actual = parser.Parse<DurationUnit>(abbreviation);
 
-            // Assert
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void Parse_AbbreviationCaseInsensitive_Uppercase_Years()
         {
-            // Arrange
             var abbreviation = "Years";
             var expected = DurationUnit.Year365;
             var parser = UnitParser.Default;
 
-            // Act
             var actual = parser.Parse<DurationUnit>(abbreviation);
 
-            // Assert
             Assert.Equal(expected, actual);
         }
 

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -42,19 +42,32 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void Parse_AbbreviationCaseInsensitive()
+        public void Parse_AbbreviationCaseInsensitive_Lowercase_years()
         {
+            // Arrange
             var abbreviation = "years";
             var expected = DurationUnit.Year365;
             var parser = UnitParser.Default;
 
+            // Act
             var actual = parser.Parse<DurationUnit>(abbreviation);
 
+            // Assert
             Assert.Equal(expected, actual);
+        }
 
-            abbreviation = "Years";
-            actual = parser.Parse<DurationUnit>(abbreviation);
+        [Fact]
+        public void Parse_AbbreviationCaseInsensitive_Uppercase_Years()
+        {
+            // Arrange
+            var abbreviation = "Years";
+            var expected = DurationUnit.Year365;
+            var parser = UnitParser.Default;
 
+            // Act
+            var actual = parser.Parse<DurationUnit>(abbreviation);
+
+            // Assert
             Assert.Equal(expected, actual);
         }
 

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -42,6 +42,23 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void Parse_AbbreviationCaseInsensitive()
+        {
+            var abbreviation = "years";
+            var expected = DurationUnit.Year365;
+            var parser = UnitParser.Default;
+
+            var actual = parser.Parse<DurationUnit>(abbreviation);
+
+            Assert.Equal(expected, actual);
+
+            abbreviation = "Years";
+            actual = parser.Parse<DurationUnit>(abbreviation);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void Parse_UnknownAbbreviationThrowsUnitNotFoundException()
         {
             Assert.Throws<UnitNotFoundException>(() => UnitParser.Default.Parse<AreaUnit>("nonexistingunit"));

--- a/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
+++ b/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
@@ -63,22 +63,21 @@ namespace UnitsNet
 
         internal List<int> GetUnitsForAbbreviation(string abbreviation)
         {
-            abbreviation = abbreviation.ToLower();
-            if(!abbreviationToUnitMap.TryGetValue(abbreviation, out var units))
-                abbreviationToUnitMap[abbreviation] = units = new List<int>();
+            var lowerCaseAbbreviation = abbreviation.ToLower();
+            if(!abbreviationToUnitMap.TryGetValue(lowerCaseAbbreviation, out var units))
+                abbreviationToUnitMap[lowerCaseAbbreviation] = units = new List<int>();
 
             return units.Distinct().ToList();
         }
 
         internal void Add(int unit, string abbreviation, bool setAsDefault = false)
         {
-            // abbreviation = abbreviation.ToLower();
-            var lower = abbreviation.ToLower();
+            var lowerCaseAbbreviation = abbreviation.ToLower();
             if(!unitToAbbreviationMap.TryGetValue(unit, out var abbreviationsForUnit))
                 abbreviationsForUnit = unitToAbbreviationMap[unit] = new List<string>();
 
-            if(!abbreviationToUnitMap.TryGetValue(lower, out var unitsForAbbreviation))
-                abbreviationToUnitMap[lower] = unitsForAbbreviation = new List<int>();
+            if(!abbreviationToUnitMap.TryGetValue(lowerCaseAbbreviation, out var unitsForAbbreviation))
+                abbreviationToUnitMap[lowerCaseAbbreviation] = unitsForAbbreviation = new List<int>();
 
             abbreviationsForUnit.Remove(abbreviation);
             unitsForAbbreviation.Remove(unit);

--- a/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
+++ b/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).
+// Copyright (c) 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).
 // https://github.com/angularsen/UnitsNet
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -65,7 +65,9 @@ namespace UnitsNet
         {
             return abbreviationToUnitMap
                 .Where(x => x.Key.Equals(abbreviation, StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Value).Distinct().ToList();
+                .SelectMany(x => x.Value)
+                .Distinct()
+                .ToList();
         }
 
         internal void Add(int unit, string abbreviation, bool setAsDefault = false)

--- a/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
+++ b/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
@@ -63,20 +63,22 @@ namespace UnitsNet
 
         internal List<int> GetUnitsForAbbreviation(string abbreviation)
         {
-            return abbreviationToUnitMap
-                .Where(x => x.Key.Equals(abbreviation, StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Value)
-                .Distinct()
-                .ToList();
+            abbreviation = abbreviation.ToLower();
+            if(!abbreviationToUnitMap.TryGetValue(abbreviation, out var units))
+                abbreviationToUnitMap[abbreviation] = units = new List<int>();
+
+            return units.Distinct().ToList();
         }
 
         internal void Add(int unit, string abbreviation, bool setAsDefault = false)
         {
+            // abbreviation = abbreviation.ToLower();
+            var lower = abbreviation.ToLower();
             if(!unitToAbbreviationMap.TryGetValue(unit, out var abbreviationsForUnit))
                 abbreviationsForUnit = unitToAbbreviationMap[unit] = new List<string>();
 
-            if(!abbreviationToUnitMap.TryGetValue(abbreviation, out var unitsForAbbreviation))
-                abbreviationToUnitMap[abbreviation] = unitsForAbbreviation = new List<int>();
+            if(!abbreviationToUnitMap.TryGetValue(lower, out var unitsForAbbreviation))
+                abbreviationToUnitMap[lower] = unitsForAbbreviation = new List<int>();
 
             abbreviationsForUnit.Remove(abbreviation);
             unitsForAbbreviation.Remove(unit);

--- a/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
+++ b/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
@@ -63,10 +63,9 @@ namespace UnitsNet
 
         internal List<int> GetUnitsForAbbreviation(string abbreviation)
         {
-            if(!abbreviationToUnitMap.TryGetValue(abbreviation, out var units))
-                abbreviationToUnitMap[abbreviation] = units = new List<int>();
-
-            return units.Distinct().ToList();
+            return abbreviationToUnitMap
+                .Where(x => x.Key.Equals(abbreviation, StringComparison.InvariantCultureIgnoreCase))
+                .SelectMany(x => x.Value).Distinct().ToList();
         }
 
         internal void Add(int unit, string abbreviation, bool setAsDefault = false)

--- a/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
+++ b/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
@@ -64,7 +64,7 @@ namespace UnitsNet
         internal List<int> GetUnitsForAbbreviation(string abbreviation)
         {
             return abbreviationToUnitMap
-                .Where(x => x.Key.Equals(abbreviation, StringComparison.InvariantCultureIgnoreCase))
+                .Where(x => x.Key.Equals(abbreviation, StringComparison.OrdinalIgnoreCase))
                 .SelectMany(x => x.Value).Distinct().ToList();
         }
 

--- a/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
+++ b/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
@@ -51,6 +51,15 @@ namespace UnitsNet.InternalHelpers
 #endif
         }
 
+        internal static bool IsClass(this Type type)
+        {
+#if !(NET40 || NET35 || NET20 || SILVERLIGHT)
+            return type.GetTypeInfo().IsClass;
+#else
+            return type.IsClass;
+#endif
+        }
+
         internal static bool IsValueType(this Type type)
         {
 #if !(NET40 || NET35 || NET20 || SILVERLIGHT)

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -45,6 +45,14 @@ namespace UnitsNet
         private static readonly string UnitTypeNamespace = typeof(LengthUnit).Namespace;
         private static readonly Assembly UnitsNetAssembly = typeof(Length).GetAssembly();
 
+        private static readonly List<Type> QuantityTypes = UnitsNetAssembly.GetTypes()
+            .Where(x => x.FullName.StartsWith(QuantityNamespace))
+            .ToList();
+
+        private static readonly List<Type> UnitTypes = UnitsNetAssembly.GetTypes()
+            .Where(x => x.FullName.StartsWith(UnitTypeNamespace))
+            .ToList();
+
         /// <summary>
         ///     Convert between any two quantity units by their names, such as converting a "Length" of N "Meter" to "Centimeter".
         ///     This is particularly useful for creating things like a generated unit conversion UI,
@@ -387,7 +395,7 @@ namespace UnitsNet
             unitValue = null;
             var eNames = Enum.GetNames(unitType);
             unitName = eNames.FirstOrDefault(x => x.Equals(unitName, StringComparison.OrdinalIgnoreCase));
-            if(unitName is null)
+            if(unitName == null)
                 return false;
 
             unitValue = Enum.Parse(unitType, unitName);
@@ -397,14 +405,10 @@ namespace UnitsNet
             return true;
         }
 
-        private static List<Type> UnitTypes = UnitsNetAssembly.GetTypes()
-            .Where(x => x.FullName.StartsWith(UnitTypeNamespace))
-            .ToList();
-
         private static bool TryGetUnitType(string quantityName, out Type unitType)
         {
             quantityName += "Unit";
-            unitType = QuantityTypes.FirstOrDefault(x => 
+            unitType = UnitTypes.FirstOrDefault(x => 
                 x.Name.Equals(quantityName, StringComparison.OrdinalIgnoreCase));
 
             if(unitType == null)
@@ -412,10 +416,6 @@ namespace UnitsNet
 
             return true;
         }
-
-        private static List<Type> QuantityTypes = UnitsNetAssembly.GetTypes()
-            .Where(x => x.FullName.StartsWith(QuantityNamespace))
-            .ToList();
 
         private static bool TryGetQuantityType(string quantityName, out Type quantityType)
         {

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -407,9 +407,9 @@ namespace UnitsNet
 
         private static bool TryGetUnitType(string quantityName, out Type unitType)
         {
-            var quantityTypeName = quantityName += "Unit"; // ex. LengthUnit
+            var unitTypeName = quantityName += "Unit"; // ex. LengthUnit
             unitType = UnitTypes.FirstOrDefault(x => 
-                x.Name.Equals(quantityTypeName, StringComparison.OrdinalIgnoreCase));
+                x.Name.Equals(unitTypeName, StringComparison.OrdinalIgnoreCase));
 
             if(unitType == null)
                 return false;

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -407,9 +407,9 @@ namespace UnitsNet
 
         private static bool TryGetUnitType(string quantityName, out Type unitType)
         {
-            quantityName += "Unit";
+            var quantityTypeName = quantityName += "Unit"; // ex. LengthUnit
             unitType = UnitTypes.FirstOrDefault(x => 
-                x.Name.Equals(quantityName, StringComparison.OrdinalIgnoreCase));
+                x.Name.Equals(quantityTypeName, StringComparison.OrdinalIgnoreCase));
 
             if(unitType == null)
                 return false;

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -45,13 +45,13 @@ namespace UnitsNet
         private static readonly string UnitTypeNamespace = typeof(LengthUnit).Namespace;
         private static readonly Assembly UnitsNetAssembly = typeof(Length).GetAssembly();
 
-        private static readonly List<Type> QuantityTypes = UnitsNetAssembly.GetTypes()
+        private static readonly Type[] QuantityTypes = UnitsNetAssembly.GetTypes()
             .Where(x => x.FullName.StartsWith(QuantityNamespace))
-            .ToList();
+            .ToArray();
 
-        private static readonly List<Type> UnitTypes = UnitsNetAssembly.GetTypes()
+        private static readonly Type[] UnitTypes = UnitsNetAssembly.GetTypes()
             .Where(x => x.FullName.StartsWith(UnitTypeNamespace))
-            .ToList();
+            .ToArray();
 
         /// <summary>
         ///     Convert between any two quantity units by their names, such as converting a "Length" of N "Meter" to "Centimeter".

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -386,7 +386,7 @@ namespace UnitsNet
         {
             unitValue = null;
             var eNames = Enum.GetNames(unitType);
-            unitName = eNames.FirstOrDefault(x => x.Equals(unitName, StringComparison.InvariantCultureIgnoreCase));
+            unitName = eNames.FirstOrDefault(x => x.Equals(unitName, StringComparison.OrdinalIgnoreCase));
             if(unitName is null)
                 return false;
 
@@ -405,7 +405,7 @@ namespace UnitsNet
         {
             quantityName += "Unit";
             unitType = QuantityTypes.FirstOrDefault(x => 
-                x.Name.Equals(quantityName, StringComparison.InvariantCultureIgnoreCase));
+                x.Name.Equals(quantityName, StringComparison.OrdinalIgnoreCase));
 
             if(unitType == null)
                 return false;
@@ -419,7 +419,7 @@ namespace UnitsNet
 
         private static bool TryGetQuantityType(string quantityName, out Type quantityType)
         {
-            quantityType = QuantityTypes.FirstOrDefault(x => x.Name.Equals(quantityName, StringComparison.InvariantCultureIgnoreCase));
+            quantityType = QuantityTypes.FirstOrDefault(x => x.Name.Equals(quantityName, StringComparison.OrdinalIgnoreCase));
             
             if(quantityType == null)
                 return false;

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -397,7 +397,7 @@ namespace UnitsNet
             return true;
         }
 
-        private static List<Type> UnitTypes = UnitsNetAssembly.ExportedTypes
+        private static List<Type> UnitTypes = UnitsNetAssembly.GetTypes()
             .Where(x => x.FullName.StartsWith(UnitTypeNamespace))
             .ToList();
 
@@ -413,7 +413,7 @@ namespace UnitsNet
             return true;
         }
 
-        private static List<Type> QuantityTypes = UnitsNetAssembly.ExportedTypes
+        private static List<Type> QuantityTypes = UnitsNetAssembly.GetTypes()
             .Where(x => x.FullName.StartsWith(QuantityNamespace))
             .ToList();
 

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -384,8 +385,9 @@ namespace UnitsNet
         private static bool TryParseUnit(Type unitType, string unitName, out object unitValue)
         {
             unitValue = null;
-
-            if(!Enum.IsDefined(unitType, unitName))
+            var eNames = Enum.GetNames(unitType);
+            unitName = eNames.FirstOrDefault(x => x.Equals(unitName, StringComparison.InvariantCultureIgnoreCase));
+            if(unitName is null)
                 return false;
 
             unitValue = Enum.Parse(unitType, unitName);
@@ -395,22 +397,30 @@ namespace UnitsNet
             return true;
         }
 
+        private static List<Type> UnitTypes = UnitsNetAssembly.ExportedTypes
+            .Where(x => x.FullName.StartsWith(UnitTypeNamespace))
+            .ToList();
+
         private static bool TryGetUnitType(string quantityName, out Type unitType)
         {
-            string unitTypeName = $"{UnitTypeNamespace}.{quantityName}Unit";
+            quantityName += "Unit";
+            unitType = QuantityTypes.FirstOrDefault(x => 
+                x.Name.Equals(quantityName, StringComparison.InvariantCultureIgnoreCase));
 
-            unitType = UnitsNetAssembly.GetType(unitTypeName); // ex: UnitsNet.Units.LengthUnit enum
             if(unitType == null)
                 return false;
 
             return true;
         }
 
+        private static List<Type> QuantityTypes = UnitsNetAssembly.ExportedTypes
+            .Where(x => x.FullName.StartsWith(QuantityNamespace))
+            .ToList();
+
         private static bool TryGetQuantityType(string quantityName, out Type quantityType)
         {
-            string quantityTypeName = $"{QuantityNamespace}.{quantityName}";
-
-            quantityType = UnitsNetAssembly.GetType(quantityTypeName); // ex: UnitsNet.Length struct
+            quantityType = QuantityTypes.FirstOrDefault(x => x.Name.Equals(quantityName, StringComparison.InvariantCultureIgnoreCase));
+            
             if(quantityType == null)
                 return false;
 

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -46,11 +46,12 @@ namespace UnitsNet
         private static readonly Assembly UnitsNetAssembly = typeof(Length).GetAssembly();
 
         private static readonly Type[] QuantityTypes = UnitsNetAssembly.GetTypes()
-            .Where(x => x.FullName.StartsWith(QuantityNamespace))
+            .Where(typeof(IQuantity).IsAssignableFrom)
+            .Where(x => x.IsClass || x.IsValueType) // Future-proofing: we are discussing changing quantities from struct to class
             .ToArray();
 
         private static readonly Type[] UnitTypes = UnitsNetAssembly.GetTypes()
-            .Where(x => x.FullName.StartsWith(UnitTypeNamespace))
+            .Where(x => x.Namespace == UnitTypeNamespace && x.IsEnum && x.Name.EndsWith("Unit"))
             .ToArray();
 
         /// <summary>


### PR DESCRIPTION
The purpose of this is to allow this library to allow for "year" and "Year" in the unit parser and UnitConverter without adding different casing to every abbreviation in the unit definitions.