### PR TITLE
Fix parsing ambiguous abbreviations when lowercase

### DIFF
--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -66,6 +66,13 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void Parse_GivenAbbreviationsThatAreAmbiguousWhenLowerCase_ReturnsCorrectUnit()
+        {
+            Assert.Equal(PressureUnit.Megabar, Pressure.ParseUnit("Mbar"));
+            Assert.Equal(PressureUnit.Millibar, Pressure.ParseUnit("mbar"));
+        }
+
+        [Fact]
         public void Parse_UnknownAbbreviationThrowsUnitNotFoundException()
         {
             Assert.Throws<UnitNotFoundException>(() => UnitParser.Default.Parse<AreaUnit>("nonexistingunit"));

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -90,7 +90,11 @@ namespace UnitsNet
             if(!_unitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
                 throw new UnitNotFoundException($"No abbreviations defined for unit type [{unitType}] for culture [{formatProvider}].");
 
-            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation);
+            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation, ignoreCase: true);
+
+            // Narrow the search if too many hits, for example Megabar "Mbar" and Millibar "mbar" need to be distinguished
+            if (unitIntValues.Count > 1)
+                unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation, ignoreCase: false);
 
             switch (unitIntValues.Count)
             {
@@ -191,7 +195,12 @@ namespace UnitsNet
             if(!_unitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
                 return false;
 
-            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation);
+            var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation, ignoreCase: true);
+
+            // Narrow the search if too many hits, for example Megabar "Mbar" and Millibar "mbar" need to be distinguished
+            if (unitIntValues.Count > 1)
+                unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation, ignoreCase: false);
+
             if(unitIntValues.Count != 1)
                 return false;
 


### PR DESCRIPTION
Fixes #590 

- Add separate abbreviation-to-unit mapping that preserves case sensitivity
- Fall back to case sensitive mapping if more than 1 unit is found
- Add test

I'm sure we can optimize this with a single map, but I don't think we're talking any significant memory footprint here.